### PR TITLE
Evaluate Shannon Markdown extraction candidates

### DIFF
--- a/docs/SHANNON_MARKDOWN_EVALUATION.md
+++ b/docs/SHANNON_MARKDOWN_EVALUATION.md
@@ -29,6 +29,12 @@ order, paragraph continuity, equations, footnotes, table topology,
 omission/duplication, evidence, latency, memory, and artifact size separate. It
 never blends them into an overall score.
 
+Equation anchors must occur on their declared source page, in order, within a
+200-character span, with token boundaries. Table-header terms must occur in the
+actual Markdown header row rather than elsewhere in a table. The source PDF and
+candidate executable run from private verified snapshots; the PDF Tools runtime
+files are revalidated after every repetition.
+
 The sampled oracle is deliberately narrow. A missing anchor can identify a
 regression, but a passing anchor set cannot prove complete 55-page fidelity.
 

--- a/docs/SHANNON_MARKDOWN_EVALUATION.md
+++ b/docs/SHANNON_MARKDOWN_EVALUATION.md
@@ -1,0 +1,69 @@
+# Shannon Markdown evaluation
+
+This companion evaluates deterministic Markdown extraction against Claude
+Shannon's 1948 paper, *A Mathematical Theory of Communication*. It exists to
+reproduce concrete extraction failures reported against `pdf-inspector`; it is
+not a public benchmark, a complete ground truth, or authorization to add an
+external dependency.
+
+The paper is not redistributed. The manifest binds the external Harvard-hosted
+PDF by URL, byte count, page count, and SHA-256. The runner refuses a different
+file. It also binds `pdf-inspector` to an exact Git revision, generated
+`Cargo.lock`, release binary, and MIT license declaration. Generated Markdown
+and reports must be written to a new private directory outside this repository.
+
+## What is compared
+
+The initial candidate slots are:
+
+- `control.current_product.v0`: PDF Tools' shipped
+  `convert_pdf_to_markdown` path, called in six bounded page ranges;
+- `candidate.direct_pdf.v1`: the pinned `pdf-inspector` `pdf2md` binary, for
+  evaluation only;
+- `candidate.layout_ir.v1`: reserved for a stronger layout-aware reference and
+  explicitly `not_run` until a Shannon-specific hash-bound handoff exists.
+
+Each runnable candidate starts in a fresh process three times. Output must be
+byte-deterministic across repetitions. The report keeps headings, reading
+order, paragraph continuity, equations, footnotes, table topology,
+omission/duplication, evidence, latency, memory, and artifact size separate. It
+never blends them into an overall score.
+
+The sampled oracle is deliberately narrow. A missing anchor can identify a
+regression, but a passing anchor set cannot prove complete 55-page fidelity.
+
+## Reproduction
+
+Download the PDF and clone/build the candidate outside the repository. Verify
+their bytes against `test/fixtures/eval/shannon/manifest.v1.json`, then run:
+
+```sh
+node scripts/eval-run-shannon-markdown-bakeoff.mjs \
+  --source /absolute/path/to/shannon-entropy.pdf \
+  --pdf-inspector-root /absolute/path/to/pdf-inspector-pinned \
+  --output-dir /absolute/new/private/output-directory
+```
+
+The upstream project does not commit `Cargo.lock`. The evaluated lock must be
+generated at the pinned revision and must match the manifest before building
+with `cargo build --release --locked --bin pdf2md --bin detect-pdf`.
+
+The runner is initially restricted to macOS arm64 because its resource
+observation uses `/usr/bin/time -l`. It does not impose a hard memory limit or
+syscall-level network isolation, and reports those limitations explicitly.
+
+## Decision boundary
+
+Use the report to decide whether to keep ideas, investigate a focused product
+fix, or run a stronger candidate. Do not infer any of the following from a
+successful run:
+
+- that `pdf-inspector` should be bundled or added as a dependency;
+- that PDF Tools or another candidate is state of the art;
+- that a packed MCPB, desktop host, or release artifact passed;
+- that an external maintainer should be told the reported extraction problem
+  is solved.
+
+An external reply requires a public commit that materially fixes the reported
+failure modes, a rerun bound to that code, and a candid description of any
+remaining hierarchy, equation, table, ordering, or fidelity gaps.

--- a/docs/evidence/shannon-markdown-bakeoff-2026-08.md
+++ b/docs/evidence/shannon-markdown-bakeoff-2026-08.md
@@ -1,0 +1,88 @@
+# Shannon Markdown bakeoff evidence — 2026-08
+
+## Outcome
+
+Do not add `pdf-inspector` as a product dependency and do not claim that PDF
+Tools has solved the reported Shannon extraction failures.
+
+The exercise did find and fix a PDF Tools correctness bug: a source-order line
+could pass incremental baseline checks and then fail the final Extraction IR
+invariant. The regression is covered by a synthetic mixed-font-size case. At
+the clean evaluated commit, PDF Tools processes all 55 pages deterministically
+instead of aborting on page 3.
+
+The remaining quality tradeoffs are material. PDF Tools retains stronger page,
+gap, and canonical-coordinate evidence and more sampled reading-order anchors.
+The pinned `pdf-inspector` candidate is much faster and finds nearly all sampled
+major headings, but it turns many equations into headings and provides none of
+PDF Tools' evidence surfaces. Neither candidate reconstructs the sampled table,
+and both miss the same sampled paragraph and equation coverage.
+
+## Bound run
+
+- PDF Tools commit: `60e13bcb78d74126ef8310f75498e6b02fac601f`
+- PDF Tools runtime source set SHA-256:
+  `f0d9aad0163a2b1a055469f8c34814ea81b3b7a0def6f4a52e321ed2bd1a166a`
+- Runtime files clean at execution: `true`
+- Shannon source SHA-256:
+  `6e4e3411984f3edf99dbfe8b941cb5e8a321379ff0cae6ae5c1f592ad8882ca8`
+- Manifest SHA-256:
+  `8b732875a8073f306cf67bc8532f7a4bca54cba968588d2977f3e5aae29f6fbf`
+- `pdf-inspector` revision:
+  `1c32e4bd691bde83778ffef235019c8feac0c0c5`
+- Generated `Cargo.lock` SHA-256:
+  `d976c94ada1b91ab3c2fd65f3ba24b93854d4622ad59760891be4ce26becd982`
+- `pdf2md` binary SHA-256:
+  `62a670b0e9bc5d47ea8f4e626540e83740b92a95d0ce0baad4426f2a5bc11cf8`
+- Private report SHA-256:
+  `a5d468f897dbbe9931b5b4b4e3fa6da17cd1b99bede5111fd7888e3a9a1a5a38`
+- Host: macOS arm64, Node `v26.3.1`
+- Repetitions: three fresh processes per candidate; Markdown was byte-identical
+  within each candidate.
+
+The source PDF, candidate checkout, generated Markdown, and full report remain
+outside the repository. The source manifest declares the paper
+`external_only`; no source or extracted paper text is committed here.
+
+## Results
+
+| Metric | PDF Tools | `pdf-inspector` |
+| --- | ---: | ---: |
+| Median elapsed time | 3329.448 ms | 94.342 ms |
+| Median maximum RSS | 279,592,960 bytes | 26,804,224 bytes |
+| Markdown bytes | 169,490 | 156,449 |
+| Expected headings found | 0 / 14 | 13 / 14 |
+| Wrong-level expected headings | 0 | 7 |
+| Equation-like false headings | 0 | 28 |
+| Malformed or fragmentary false headings | 227 | 0 |
+| Complete ordered-anchor groups | 4 / 6 | 1 / 6 |
+| Ordered anchors retained | 22 / 24 | 19 / 24 |
+| Paragraph-continuity anchors | 1 / 4 | 1 / 4 |
+| Equation anchors | 2 / 4 | 2 / 4 |
+| Footnote anchors | 4 / 4 | 4 / 4 |
+| Sampled Table I topology | absent | absent |
+| Page identity evidence | present | absent |
+| Typed coverage gaps | present | absent |
+| Canonical coordinates | present | absent |
+
+PDF Tools reports every ten-page chunk as `partial`, with 71 typed gaps across
+the document. The `pdf-inspector` output contains 40 Markdown-shaped tables,
+but none satisfies the sampled Table I topology contract. A Markdown table
+count is therefore not table-reconstruction credit.
+
+## Decision
+
+Keep `pdf-inspector` evaluation-only. Its speed and heading heuristics are useful
+design signals, especially as inputs to the existing extraction-intelligence
+work, but the current output is not a fidelity reference and does not justify a
+dependency or product pivot.
+
+The next product work should be local and typed: eliminate replacement-glyph
+heading promotion, recover major headings without promoting equations, improve
+drop-cap and dehyphenation continuity, and add a defensible table-topology lane.
+Rerun this exact harness after those changes. Add a stronger layout-reference
+candidate only through a separate Shannon-specific, hash-bound handoff.
+
+This is a sampled adversarial evaluation, not a complete 55-page transcript
+ground truth, public benchmark, packed MCPB qualification, or comparative
+marketing claim.

--- a/docs/evidence/shannon-markdown-bakeoff-2026-08.md
+++ b/docs/evidence/shannon-markdown-bakeoff-2026-08.md
@@ -12,22 +12,23 @@ the clean evaluated commit, PDF Tools processes all 55 pages deterministically
 instead of aborting on page 3.
 
 The remaining quality tradeoffs are material. PDF Tools retains stronger page,
-gap, and canonical-coordinate evidence and more sampled reading-order anchors.
-The pinned `pdf-inspector` candidate is much faster and finds nearly all sampled
-major headings, but it turns many equations into headings and provides none of
-PDF Tools' evidence surfaces. Neither candidate reconstructs the sampled table,
-and both miss the same sampled paragraph and equation coverage.
+gap, and canonical-coordinate evidence, more sampled reading-order anchors, and
+one more page-local sampled equation. The pinned `pdf-inspector` candidate is
+much faster and finds nearly all sampled major headings, but it turns many
+equations into headings and provides none of PDF Tools' evidence surfaces.
+Neither candidate reconstructs the sampled table, and both miss the same
+sampled paragraph coverage.
 
 ## Bound run
 
-- PDF Tools commit: `60e13bcb78d74126ef8310f75498e6b02fac601f`
+- PDF Tools commit: `277f8a99229e54774782bf1544ab871f6a540106`
 - PDF Tools runtime source set SHA-256:
   `f0d9aad0163a2b1a055469f8c34814ea81b3b7a0def6f4a52e321ed2bd1a166a`
 - Runtime files clean at execution: `true`
 - Shannon source SHA-256:
   `6e4e3411984f3edf99dbfe8b941cb5e8a321379ff0cae6ae5c1f592ad8882ca8`
 - Manifest SHA-256:
-  `8b732875a8073f306cf67bc8532f7a4bca54cba968588d2977f3e5aae29f6fbf`
+  `0b01d892bc0e33d8ff5d9425c874cab695ac0c2c3722641d808b2edda828fff9`
 - `pdf-inspector` revision:
   `1c32e4bd691bde83778ffef235019c8feac0c0c5`
 - Generated `Cargo.lock` SHA-256:
@@ -35,21 +36,23 @@ and both miss the same sampled paragraph and equation coverage.
 - `pdf2md` binary SHA-256:
   `62a670b0e9bc5d47ea8f4e626540e83740b92a95d0ce0baad4426f2a5bc11cf8`
 - Private report SHA-256:
-  `a5d468f897dbbe9931b5b4b4e3fa6da17cd1b99bede5111fd7888e3a9a1a5a38`
+  `0c4b7caa8bbb7b60ef88fb644dae6a563c0dee3b51a0a47e14331de831b26d01`
 - Host: macOS arm64, Node `v26.3.1`
 - Repetitions: three fresh processes per candidate; Markdown was byte-identical
   within each candidate.
 
 The source PDF, candidate checkout, generated Markdown, and full report remain
-outside the repository. The source manifest declares the paper
-`external_only`; no source or extracted paper text is committed here.
+outside the repository. Candidate execution uses private verified snapshots of
+the source PDF and executable, and revalidates the PDF Tools runtime files after
+each repetition. The source manifest declares the paper `external_only`; no
+source or extracted paper text is committed here.
 
 ## Results
 
 | Metric | PDF Tools | `pdf-inspector` |
 | --- | ---: | ---: |
-| Median elapsed time | 3329.448 ms | 94.342 ms |
-| Median maximum RSS | 279,592,960 bytes | 26,804,224 bytes |
+| Median elapsed time | 3426.416 ms | 105.85 ms |
+| Median maximum RSS | 280,117,248 bytes | 26,853,376 bytes |
 | Markdown bytes | 169,490 | 156,449 |
 | Expected headings found | 0 / 14 | 13 / 14 |
 | Wrong-level expected headings | 0 | 7 |
@@ -58,7 +61,7 @@ outside the repository. The source manifest declares the paper
 | Complete ordered-anchor groups | 4 / 6 | 1 / 6 |
 | Ordered anchors retained | 22 / 24 | 19 / 24 |
 | Paragraph-continuity anchors | 1 / 4 | 1 / 4 |
-| Equation anchors | 2 / 4 | 2 / 4 |
+| Page-local equation anchors | 2 / 4 | 1 / 4 |
 | Footnote anchors | 4 / 4 | 4 / 4 |
 | Sampled Table I topology | absent | absent |
 | Page identity evidence | present | absent |
@@ -67,8 +70,9 @@ outside the repository. The source manifest declares the paper
 
 PDF Tools reports every ten-page chunk as `partial`, with 71 typed gaps across
 the document. The `pdf-inspector` output contains 40 Markdown-shaped tables,
-but none satisfies the sampled Table I topology contract. A Markdown table
-count is therefore not table-reconstruction credit.
+but none has the required terms in its actual header row and satisfies the
+sampled Table I topology contract. A Markdown table count is therefore not
+table-reconstruction credit.
 
 ## Decision
 

--- a/pdf-toolkit-mcp-share/server/layout-extraction.js
+++ b/pdf-toolkit-mcp-share/server/layout-extraction.js
@@ -332,19 +332,6 @@ function itemBaselineCenter(item) {
   return item.y + item.height / 2;
 }
 
-function baselineCompatible(lineItems, candidate, toleranceFactor) {
-  if (lineItems.length === 0) return true;
-  const centers = lineItems.map(itemBaselineCenter);
-  const candidateCenter = itemBaselineCenter(candidate);
-  const heights = lineItems.map(item => item.line_height).filter(Number.isFinite);
-  const referenceHeight = heights.length > 0 ? medianNumber(heights) : 8;
-  const tolerance = Math.max(2, Math.min(referenceHeight, candidate.line_height ?? referenceHeight) * toleranceFactor);
-  const nextCenters = [...centers, candidateCenter];
-  return Math.abs(candidateCenter - centers[0]) <= tolerance
-    && Math.abs(candidateCenter - medianNumber(centers)) <= tolerance
-    && Math.max(...nextCenters) - Math.min(...nextCenters) <= tolerance;
-}
-
 function baselineInvariant(lineItems, toleranceFactor) {
   if (lineItems.length <= 1) return true;
   const centers = lineItems.map(itemBaselineCenter);
@@ -370,7 +357,7 @@ function groupLines(items, pageNumber) {
     let bestDistance = Infinity;
     for (const line of lines) {
       if (line.direction !== item.direction || line.hard_segment !== item.hard_segment) continue;
-      if (!baselineCompatible(line.items, item, 0.35)) continue;
+      if (!baselineInvariant([...line.items, item], 0.35)) continue;
       const distance = Math.abs(center - medianNumber(line.items.map(itemBaselineCenter)));
       const lineLeft = Math.min(...line.items.map(value => value.x));
       const lineRight = Math.max(...line.items.map(value => value.x + value.width));
@@ -408,7 +395,7 @@ function sourceOrderLines(items, pageNumber) {
     if (!current
       || current.hard_segment !== item.hard_segment
       || current.direction !== item.direction
-      || !baselineCompatible(current.items, item, 0.5)) {
+      || !baselineInvariant([...current.items, item], 0.5)) {
       current = { hard_segment: item.hard_segment, direction: item.direction, items: [] };
       segments.push(current);
     }

--- a/scripts/eval-run-shannon-markdown-bakeoff.mjs
+++ b/scripts/eval-run-shannon-markdown-bakeoff.mjs
@@ -135,6 +135,21 @@ export function validateShannonManifest(manifest) {
     || !Array.isArray(manifest.oracle.exactly_once_anchors)) {
     throw new Error("Shannon sampled oracle is invalid");
   }
+  if (!Number.isSafeInteger(manifest.oracle.equation_max_span_characters)
+    || manifest.oracle.equation_max_span_characters < 20
+    || manifest.oracle.equation_max_span_characters > 500
+    || manifest.oracle.equation_anchors.some(anchor => {
+      try {
+        exactKeys(anchor, ["page", "tokens"], "Shannon equation anchor");
+      } catch {
+        return true;
+      }
+      return !Number.isSafeInteger(anchor.page) || anchor.page < 1 || anchor.page > source.page_count
+        || !Array.isArray(anchor.tokens) || anchor.tokens.length < 2
+        || anchor.tokens.some(token => typeof token !== "string" || token.trim().length < 1);
+    })) {
+    throw new Error("Shannon sampled oracle is invalid");
+  }
   return manifest;
 }
 
@@ -447,6 +462,11 @@ async function writePrivate(filename, bytes) {
   await fs.chmod(filename, 0o600);
 }
 
+async function writePrivateExecutable(filename, bytes) {
+  await fs.writeFile(filename, bytes, { mode: 0o700, flag: "wx" });
+  await fs.chmod(filename, 0o700);
+}
+
 async function run(options) {
   if (process.platform !== "darwin" || process.arch !== "arm64") {
     throw new Error("The initial Shannon bakeoff is intentionally calibrated only for macOS arm64");
@@ -488,35 +508,59 @@ async function run(options) {
   const pdfToolsSource = await runtimeSourceIdentity();
   const attempts = { pdf_tools: [], pdf_inspector: [] };
   const markdownByCandidate = { pdf_tools: [], pdf_inspector: [] };
+  const inputRoot = await fs.mkdtemp(path.join(canonicalOutput, ".verified-inputs-"));
+  await fs.chmod(inputRoot, 0o700);
+  const executionSourcePath = path.join(inputRoot, "shannon-source.pdf");
+  const executionBinaryPath = path.join(inputRoot, "pdf2md");
+  await writePrivate(executionSourcePath, source.bytes);
+  await writePrivateExecutable(executionBinaryPath, binary.bytes);
+  try {
+    for (let repetition = 1; repetition <= manifest.execution.repetitions; repetition += 1) {
+      const sourceBefore = await canonicalRegular(executionSourcePath, 16 * 1024 * 1024, "Shannon source snapshot before attempt");
+      const inspector = await runPdfInspector({ binary: executionBinaryPath, sourcePath: executionSourcePath, manifest });
+      const stateRoot = await fs.mkdtemp(path.join(canonicalOutput, `.pdf-tools-state-r${repetition}-`));
+      await fs.chmod(stateRoot, 0o700);
+      let current;
+      try {
+        current = await runPdfTools({ sourcePath: executionSourcePath, source, manifest, stateRoot });
+      } finally {
+        await fs.rm(stateRoot, { recursive: true, force: true });
+      }
+      const [sourceAfter, binaryAfter, runtimeAfter] = await Promise.all([
+        canonicalRegular(executionSourcePath, 16 * 1024 * 1024, "Shannon source snapshot after attempt"),
+        canonicalRegular(executionBinaryPath, 64 * 1024 * 1024, "pdf-inspector binary snapshot after attempt"),
+        runtimeSourceIdentity(),
+      ]);
+      if (sourceBefore.sha256 !== sourceAfter.sha256 || sourceBefore.size_bytes !== sourceAfter.size_bytes
+        || sourceAfter.sha256 !== source.sha256 || binaryAfter.sha256 !== binary.sha256
+        || canonicalJson(runtimeAfter) !== canonicalJson(pdfToolsSource)) {
+        throw new Error("A verified candidate input changed during execution");
+      }
+      for (const [candidate, result] of [["pdf_inspector", inspector], ["pdf_tools", current]]) {
+        const markdownBytes = Buffer.from(result.markdown, "utf8");
+        const filename = `${candidate.replaceAll("_", "-")}-r${repetition}.md`;
+        await writePrivate(path.join(canonicalOutput, filename), markdownBytes);
+        attempts[candidate].push({
+          repetition,
+          output_file: filename,
+          markdown_sha256: sha256(markdownBytes),
+          markdown_bytes: markdownBytes.length,
+          ...result.attempt,
+        });
+        markdownByCandidate[candidate].push(result.markdown);
+      }
+    }
+  } finally {
+    await fs.rm(inputRoot, { recursive: true, force: true });
+  }
 
-  for (let repetition = 1; repetition <= manifest.execution.repetitions; repetition += 1) {
-    const sourceBefore = await canonicalRegular(sourcePath, 16 * 1024 * 1024, "Shannon source before attempt");
-    const inspector = await runPdfInspector({ binary: binaryPath, sourcePath, manifest });
-    const stateRoot = await fs.mkdtemp(path.join(canonicalOutput, `.pdf-tools-state-r${repetition}-`));
-    await fs.chmod(stateRoot, 0o700);
-    let current;
-    try {
-      current = await runPdfTools({ sourcePath, source, manifest, stateRoot });
-    } finally {
-      await fs.rm(stateRoot, { recursive: true, force: true });
-    }
-    const sourceAfter = await canonicalRegular(sourcePath, 16 * 1024 * 1024, "Shannon source after attempt");
-    if (sourceBefore.sha256 !== sourceAfter.sha256 || sourceBefore.size_bytes !== sourceAfter.size_bytes) {
-      throw new Error("Shannon source changed during candidate execution");
-    }
-    for (const [candidate, result] of [["pdf_inspector", inspector], ["pdf_tools", current]]) {
-      const markdownBytes = Buffer.from(result.markdown, "utf8");
-      const filename = `${candidate.replaceAll("_", "-")}-r${repetition}.md`;
-      await writePrivate(path.join(canonicalOutput, filename), markdownBytes);
-      attempts[candidate].push({
-        repetition,
-        output_file: filename,
-        markdown_sha256: sha256(markdownBytes),
-        markdown_bytes: markdownBytes.length,
-        ...result.attempt,
-      });
-      markdownByCandidate[candidate].push(result.markdown);
-    }
+  const [finalRevision, finalTrackedStatus, finalLock] = await Promise.all([
+    gitValue(inspectorRoot, ["rev-parse", "HEAD"]),
+    gitValue(inspectorRoot, ["status", "--porcelain", "--untracked-files=no"]),
+    canonicalRegular(path.join(inspectorRoot, "Cargo.lock"), 4 * 1024 * 1024, "pdf-inspector resolved lock after execution"),
+  ]);
+  if (finalRevision !== revision || finalTrackedStatus !== trackedStatus || finalLock.sha256 !== lock.sha256) {
+    throw new Error("pdf-inspector reviewed source binding changed during execution");
   }
 
   for (const candidate of Object.keys(attempts)) {
@@ -580,6 +624,8 @@ async function run(options) {
     },
     execution_boundary: {
       fresh_process_per_repetition: true,
+      verified_input_snapshots: true,
+      runtime_sources_revalidated_after_each_repetition: true,
       network_isolation: false,
       hard_memory_limit: false,
       source_reopened_before_and_after: true,
@@ -601,6 +647,7 @@ async function run(options) {
       "No metric families are blended into an overall score.",
       "PDF Tools ran from the named source checkout, not a packed MCPB artifact.",
       "The stronger layout-reference slot was not run because no Shannon-specific hash-bound handoff exists.",
+      "The source PDF and pdf-inspector executable run from private verified snapshots. PDF Tools JavaScript and dependency paths run from the named checkout and are revalidated after each repetition rather than executed from a filesystem-isolated snapshot.",
       "Network inactivity is intended by the candidate commands but is not syscall-isolated.",
       "Maximum RSS is observed from the macOS time wrapper and is not a hard memory limit.",
       "A successful evaluation does not authorize bundling, release, or a comparative product claim.",

--- a/scripts/eval-run-shannon-markdown-bakeoff.mjs
+++ b/scripts/eval-run-shannon-markdown-bakeoff.mjs
@@ -1,0 +1,629 @@
+#!/usr/bin/env node
+
+import { execFile, spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { constants as fsConstants } from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
+import { scoreShannonMarkdown } from "../test/eval/shannon-markdown-scorer.js";
+
+const execFileAsync = promisify(execFile);
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const DEFAULT_MANIFEST = path.join(REPO_ROOT, "test", "fixtures", "eval", "shannon", "manifest.v1.json");
+const SHA256 = /^[a-f0-9]{64}$/u;
+const GIT_SHA1 = /^[a-f0-9]{40}$/u;
+const OPTIONS = ["--manifest", "--source", "--pdf-inspector-root", "--output-dir"];
+const RUNTIME_SOURCE_FILES = [
+  "package.json",
+  "package-lock.json",
+  "server/index.js",
+  "server/output-schemas.js",
+  "server/layout-extraction.js",
+  "server/markdown-conversion.js",
+  "server/markdown-output-transaction.js",
+];
+
+export function canonicalJson(value) {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value).sort().map(key => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function exactOptions(argv) {
+  if (argv.length === 0) return { "--manifest": DEFAULT_MANIFEST };
+  if (argv.length % 2 !== 0) throw new Error(`Expected option/value pairs: ${OPTIONS.join(", ")}`);
+  const values = {};
+  for (let index = 0; index < argv.length; index += 2) {
+    const name = argv[index];
+    const value = argv[index + 1];
+    if (!OPTIONS.includes(name) || Object.hasOwn(values, name) || !value) {
+      throw new Error(`Unknown, duplicate, or empty option: ${name}`);
+    }
+    values[name] = value;
+  }
+  return values;
+}
+
+async function canonicalRegular(filename, maximumBytes, label) {
+  if (!path.isAbsolute(filename) || path.resolve(filename) !== filename || typeof fsConstants.O_NOFOLLOW !== "number") {
+    throw new Error(`${label} must be an absolute normalized regular-file path`);
+  }
+  if (await fs.realpath(filename) !== filename) throw new Error(`${label} must be canonical`);
+  const before = await fs.lstat(filename, { bigint: true });
+  if (!before.isFile() || before.isSymbolicLink() || before.nlink !== 1n || before.size < 1n
+    || before.size > BigInt(maximumBytes)) {
+    throw new Error(`${label} violates its bounded single-link regular-file contract`);
+  }
+  const handle = await fs.open(filename, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+  try {
+    const descriptorBefore = await handle.stat({ bigint: true });
+    const bytes = await handle.readFile();
+    const [descriptorAfter, after] = await Promise.all([handle.stat({ bigint: true }), fs.lstat(filename, { bigint: true })]);
+    const identity = value => ["dev", "ino", "size", "mtimeNs", "ctimeNs"].map(key => String(value[key])).join(":");
+    if (identity(before) !== identity(descriptorBefore) || identity(before) !== identity(descriptorAfter)
+      || identity(before) !== identity(after) || BigInt(bytes.length) !== before.size) {
+      throw new Error(`${label} changed while it was read`);
+    }
+    return { bytes, size_bytes: bytes.length, sha256: sha256(bytes) };
+  } finally {
+    await handle.close();
+  }
+}
+
+async function canonicalDirectory(filename, label) {
+  if (!path.isAbsolute(filename) || path.resolve(filename) !== filename || await fs.realpath(filename) !== filename) {
+    throw new Error(`${label} must be an absolute canonical directory`);
+  }
+  const metadata = await fs.lstat(filename);
+  if (!metadata.isDirectory() || metadata.isSymbolicLink()) throw new Error(`${label} must be a directory`);
+  return filename;
+}
+
+function exactKeys(value, keys, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)
+    || canonicalJson(Object.keys(value).sort()) !== canonicalJson([...keys].sort())) {
+    throw new Error(`${label} has unexpected keys`);
+  }
+}
+
+export function validateShannonManifest(manifest) {
+  exactKeys(manifest, [
+    "suite_id", "suite_version", "benchmark_claim_ready", "calibration_claim_ready",
+    "source", "execution", "candidates", "oracle",
+  ], "Shannon manifest");
+  if (manifest.suite_id !== "pdf-tools.shannon-markdown-adversarial.v1" || manifest.suite_version !== 1
+    || manifest.benchmark_claim_ready !== false || manifest.calibration_claim_ready !== false) {
+    throw new Error("Shannon manifest claim boundary is invalid");
+  }
+  const source = manifest.source;
+  if (!source || source.redistribution !== "external_only" || !/^https:\/\//u.test(source.url)
+    || !SHA256.test(source.sha256) || !Number.isSafeInteger(source.size_bytes) || source.size_bytes < 1
+    || source.page_count !== 55) {
+    throw new Error("Shannon external source binding is invalid");
+  }
+  const execution = manifest.execution;
+  if (execution?.repetitions !== 3 || execution.pdf_tools_page_span !== 10
+    || !Number.isSafeInteger(execution.deadline_ms) || execution.deadline_ms < 1000
+    || !Number.isSafeInteger(execution.max_stdout_bytes) || execution.max_stdout_bytes < 200000
+    || !Number.isSafeInteger(execution.max_stderr_bytes) || execution.max_stderr_bytes < 1000) {
+    throw new Error("Shannon execution contract is invalid");
+  }
+  const pdfInspector = manifest.candidates?.pdf_inspector;
+  if (pdfInspector?.slot !== "candidate.direct_pdf.v1" || !GIT_SHA1.test(pdfInspector.revision)
+    || !SHA256.test(pdfInspector.resolved_lock_sha256) || pdfInspector.license !== "MIT") {
+    throw new Error("pdf-inspector candidate binding is invalid");
+  }
+  if (manifest.candidates?.pdf_tools?.slot !== "control.current_product.v0"
+    || manifest.candidates?.layout_reference?.slot !== "candidate.layout_ir.v1"
+    || manifest.candidates.layout_reference.status !== "not_run") {
+    throw new Error("Candidate slot projection is invalid");
+  }
+  if (!manifest.oracle || !Array.isArray(manifest.oracle.expected_headings)
+    || !Array.isArray(manifest.oracle.ordered_anchor_groups)
+    || !Array.isArray(manifest.oracle.paragraph_continuity)
+    || !Array.isArray(manifest.oracle.equation_anchors)
+    || !Array.isArray(manifest.oracle.footnote_anchors)
+    || !Array.isArray(manifest.oracle.exactly_once_anchors)) {
+    throw new Error("Shannon sampled oracle is invalid");
+  }
+  return manifest;
+}
+
+function appendBounded(chunks, state, chunk, maximumBytes, label, onOverflow) {
+  state.observed += chunk.length;
+  if (state.observed > maximumBytes) {
+    if (!state.error) {
+      state.error = new Error(`${label} exceeded ${maximumBytes} bytes`);
+      onOverflow(state.error);
+    }
+    return;
+  }
+  chunks.push(chunk);
+}
+
+function parseMaximumRss(stderr) {
+  const matches = [...stderr.matchAll(/(?:^|\n)\s*(\d+)\s+maximum resident set size\b/gu)];
+  if (matches.length !== 1) return null;
+  const bytes = Number(matches[0][1]);
+  return Number.isSafeInteger(bytes) && bytes > 0 ? bytes : null;
+}
+
+async function waitForExit(child, deadlineMs, label) {
+  let timer;
+  try {
+    return await Promise.race([
+      new Promise((resolve, reject) => {
+        child.once("error", reject);
+        child.once("close", (code, signal) => resolve({ code, signal }));
+      }),
+      new Promise((_, reject) => {
+        timer = setTimeout(() => {
+          child.kill("SIGTERM");
+          reject(new Error(`${label} exceeded its wall-clock deadline`));
+        }, deadlineMs);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function runPdfInspector({ binary, sourcePath, manifest }) {
+  const stdout = [];
+  const stderr = [];
+  const stdoutState = { observed: 0 };
+  const stderrState = { observed: 0 };
+  const started = process.hrtime.bigint();
+  const child = spawn("/usr/bin/time", ["-l", binary, sourcePath, "--json", "--pages"], {
+    cwd: path.dirname(binary),
+    env: { LANG: "C", LC_ALL: "C", PATH: "/usr/bin:/bin" },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const exitPromise = waitForExit(child, manifest.execution.deadline_ms, "pdf-inspector");
+  const terminate = () => child.kill("SIGTERM");
+  child.stdout.on("data", chunk => appendBounded(stdout, stdoutState, chunk, manifest.execution.max_stdout_bytes, "pdf-inspector stdout", terminate));
+  child.stderr.on("data", chunk => appendBounded(stderr, stderrState, chunk, manifest.execution.max_stderr_bytes, "pdf-inspector stderr", terminate));
+  const exit = await exitPromise;
+  const elapsedMs = Number(process.hrtime.bigint() - started) / 1e6;
+  const stdoutBytes = Buffer.concat(stdout);
+  const stderrText = Buffer.concat(stderr).toString("utf8");
+  if (stdoutState.error) throw stdoutState.error;
+  if (stderrState.error) throw stderrState.error;
+  if (exit.code !== 0 || exit.signal !== null) throw new Error(`pdf-inspector exited with code ${exit.code} and signal ${exit.signal}`);
+  let response;
+  try {
+    response = JSON.parse(stdoutBytes.toString("utf8"));
+  } catch (error) {
+    throw new Error(`pdf-inspector did not return one JSON value: ${error.message}`);
+  }
+  if (response.pdf_type !== "text_based" || response.page_count !== manifest.source.page_count
+    || response.has_text !== true || !Array.isArray(response.pages_needing_ocr)
+    || response.pages_needing_ocr.length !== 0 || typeof response.markdown !== "string" || response.markdown.length < 1) {
+    throw new Error("pdf-inspector response violates the Shannon candidate contract");
+  }
+  return {
+    markdown: response.markdown,
+    attempt: {
+      elapsed_ms: Math.round(elapsedMs * 1000) / 1000,
+      maximum_resident_set_size_bytes: parseMaximumRss(stderrText),
+      stdout_bytes: stdoutBytes.length,
+      stderr_bytes: Buffer.byteLength(stderrText),
+      reported_processing_time_ms: response.processing_time_ms,
+      pdf_type: response.pdf_type,
+      pages_needing_ocr: response.pages_needing_ocr,
+      is_complex: response.is_complex,
+      pages_with_tables: response.pages_with_tables,
+      pages_with_columns: response.pages_with_columns,
+      has_encoding_issues: response.has_encoding_issues,
+    },
+  };
+}
+
+function createJsonRpc(child, maximumBytes) {
+  let pending = "";
+  let observed = 0;
+  let nextId = 1;
+  const waiting = new Map();
+  child.stdout.setEncoding("utf8");
+  child.stdout.on("data", chunk => {
+    observed += Buffer.byteLength(chunk);
+    if (observed > maximumBytes) {
+      for (const { reject } of waiting.values()) reject(new Error("PDF Tools MCP stdout exceeded its retained byte ceiling"));
+      waiting.clear();
+      child.kill("SIGTERM");
+      return;
+    }
+    pending += chunk;
+    while (pending.includes("\n")) {
+      const boundary = pending.indexOf("\n");
+      const line = pending.slice(0, boundary);
+      pending = pending.slice(boundary + 1);
+      if (!line) continue;
+      let message;
+      try {
+        message = JSON.parse(line);
+      } catch (error) {
+        for (const { reject } of waiting.values()) reject(new Error(`PDF Tools emitted invalid JSON-RPC: ${error.message}`));
+        waiting.clear();
+        continue;
+      }
+      if (!Object.hasOwn(message, "id") || !waiting.has(message.id)) continue;
+      const waiter = waiting.get(message.id);
+      waiting.delete(message.id);
+      if (message.error) waiter.reject(new Error(`PDF Tools JSON-RPC error ${message.error.code}: ${message.error.message}`));
+      else waiter.resolve(message.result);
+    }
+  });
+  child.once("close", (code, signal) => {
+    for (const { reject } of waiting.values()) {
+      reject(new Error(`PDF Tools MCP server closed with code ${code} and signal ${signal}`));
+    }
+    waiting.clear();
+  });
+  const send = value => child.stdin.write(`${JSON.stringify(value)}\n`);
+  return {
+    get observedBytes() { return observed; },
+    notify(method, params = {}) { send({ jsonrpc: "2.0", method, params }); },
+    request(method, params, deadlineMs) {
+      const id = nextId;
+      nextId += 1;
+      return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+          waiting.delete(id);
+          reject(new Error(`PDF Tools ${method} request timed out`));
+        }, deadlineMs);
+        waiting.set(id, {
+          resolve: value => { clearTimeout(timer); resolve(value); },
+          reject: error => { clearTimeout(timer); reject(error); },
+        });
+        send({ jsonrpc: "2.0", id, method, params });
+      });
+    },
+  };
+}
+
+function validatePdfToolsChunk(result, { source, startPage, endPage, manifest }) {
+  const value = result?.structuredContent;
+  if (result?.isError === true || !value || typeof value.markdown !== "string" || value.markdown.length < 1
+    || value.renderer?.name !== manifest.candidates.pdf_tools.renderer_name
+    || value.renderer?.version !== manifest.candidates.pdf_tools.renderer_version
+    || value.provenance?.layout?.parser_name !== manifest.candidates.pdf_tools.parser_name
+    || value.provenance?.layout?.parser_version !== manifest.candidates.pdf_tools.parser_version
+    || value.provenance?.source?.sha256 !== source.sha256
+    || value.provenance?.source?.size_bytes !== source.size_bytes
+    || value.provenance?.layout?.page_range?.start_page !== startPage
+    || value.provenance?.layout?.page_range?.end_page !== endPage
+    || value.provenance?.layout?.page_range?.total_pages !== manifest.source.page_count
+    || value.markdown_sha256 !== sha256(Buffer.from(value.markdown, "utf8"))
+    || value.markdown_bytes !== Buffer.byteLength(value.markdown, "utf8")
+    || !Array.isArray(value.gaps) || !Array.isArray(value.pages)) {
+    throw new Error(`PDF Tools Markdown evidence is invalid for pages ${startPage}-${endPage}: ${JSON.stringify({
+      is_error: result?.isError ?? null,
+      error_text: result?.isError === true && typeof result?.content?.[0]?.text === "string"
+        ? result.content[0].text.slice(0, 1000)
+        : null,
+      has_structured_content: Boolean(value),
+      renderer: value?.renderer ?? null,
+      provenance: value?.provenance ?? null,
+      markdown_bytes_valid: typeof value?.markdown === "string"
+        && value.markdown_bytes === Buffer.byteLength(value.markdown, "utf8"),
+      markdown_sha256_valid: typeof value?.markdown === "string"
+        && value.markdown_sha256 === sha256(Buffer.from(value.markdown, "utf8")),
+      gaps_array: Array.isArray(value?.gaps),
+      pages_array: Array.isArray(value?.pages),
+    })}`);
+  }
+  return value;
+}
+
+async function runPdfTools({ sourcePath, source, manifest, stateRoot }) {
+  const stderr = [];
+  const stderrState = { observed: 0 };
+  const serverEntry = path.join(REPO_ROOT, "server", "index.js");
+  const child = spawn("/usr/bin/time", ["-l", process.execPath, serverEntry], {
+    cwd: REPO_ROOT,
+    env: {
+      ALLOWED_DIRECTORIES: path.dirname(sourcePath),
+      DEFAULT_DOWNLOAD_DIR: stateRoot,
+      DEFAULT_PDF_DIR: path.dirname(sourcePath),
+      DEFAULT_PROFILES_DIR: path.join(stateRoot, "profiles"),
+      LANG: "C",
+      LC_ALL: "C",
+      PATH: "/usr/bin:/bin",
+      PDF_TOOLS_DISABLE_SYSTEM_RENDERER: "1",
+    },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  const exitPromise = waitForExit(child, manifest.execution.deadline_ms + 30000, "PDF Tools MCP server");
+  child.stderr.on("data", chunk => appendBounded(
+    stderr,
+    stderrState,
+    chunk,
+    manifest.execution.max_stderr_bytes,
+    "PDF Tools stderr",
+    () => child.kill("SIGTERM"),
+  ));
+  const rpc = createJsonRpc(child, manifest.execution.max_stdout_bytes);
+  const started = process.hrtime.bigint();
+  let chunks;
+  let forcedShutdown;
+  try {
+    await rpc.request("initialize", {
+      protocolVersion: "2025-06-18",
+      capabilities: {},
+      clientInfo: { name: "pdf-tools-shannon-bakeoff", version: "1.0.0" },
+    }, 30000);
+    rpc.notify("notifications/initialized");
+    chunks = [];
+    for (let startPage = 1; startPage <= manifest.source.page_count; startPage += manifest.execution.pdf_tools_page_span) {
+      const endPage = Math.min(manifest.source.page_count, startPage + manifest.execution.pdf_tools_page_span - 1);
+      const result = await rpc.request("tools/call", {
+        name: "convert_pdf_to_markdown",
+        arguments: {
+          pdf_path: sourcePath,
+          start_page: startPage,
+          end_page: endPage,
+          max_items: 5000,
+          max_characters: 100000,
+          max_markdown_bytes: 200000,
+          include_page_boundaries: true,
+        },
+      }, manifest.execution.deadline_ms);
+      chunks.push(validatePdfToolsChunk(result, { source, startPage, endPage, manifest }));
+    }
+  } finally {
+    child.stdin.end();
+    forcedShutdown = setTimeout(() => child.kill("SIGTERM"), 5000);
+  }
+  const exit = await exitPromise.finally(() => clearTimeout(forcedShutdown));
+  const elapsedMs = Number(process.hrtime.bigint() - started) / 1e6;
+  const stderrText = Buffer.concat(stderr).toString("utf8");
+  if (stderrState.error) throw stderrState.error;
+  if (exit.code !== 0 && exit.code !== 143 && exit.signal !== "SIGTERM") {
+    throw new Error(`PDF Tools server exited with code ${exit.code} and signal ${exit.signal}`);
+  }
+  const markdown = chunks.map(chunk => chunk.markdown).join("\n\n");
+  return {
+    markdown,
+    attempt: {
+      elapsed_ms: Math.round(elapsedMs * 1000) / 1000,
+      maximum_resident_set_size_bytes: parseMaximumRss(stderrText),
+      stdout_bytes: rpc.observedBytes,
+      stderr_bytes: Buffer.byteLength(stderrText),
+      page_calls: chunks.map(chunk => ({
+        start_page: chunk.provenance.layout.page_range.start_page,
+        end_page: chunk.provenance.layout.page_range.end_page,
+        conversion_status: chunk.conversion_status,
+        markdown_bytes: chunk.markdown_bytes,
+        gap_count: chunk.gaps.length,
+      })),
+      conversion_statuses: [...new Set(chunks.map(chunk => chunk.conversion_status))].sort(),
+      total_gap_count: chunks.reduce((total, chunk) => total + chunk.gaps.length, 0),
+    },
+  };
+}
+
+function median(values) {
+  const sorted = [...values].sort((left, right) => left - right);
+  return sorted[Math.floor(sorted.length / 2)];
+}
+
+async function gitValue(root, args) {
+  const { stdout } = await execFileAsync("/usr/bin/git", ["-C", root, ...args], { encoding: "utf8", maxBuffer: 1024 * 1024 });
+  return stdout.trim();
+}
+
+async function runtimeSourceIdentity() {
+  const files = [];
+  for (const relativePath of RUNTIME_SOURCE_FILES) {
+    const retained = await canonicalRegular(path.join(REPO_ROOT, relativePath), 32 * 1024 * 1024, `PDF Tools runtime source ${relativePath}`);
+    files.push({ path: relativePath, sha256: retained.sha256, size_bytes: retained.size_bytes });
+  }
+  const trackedRuntimeStatus = await gitValue(REPO_ROOT, [
+    "status", "--porcelain", "--untracked-files=no", "--", ...RUNTIME_SOURCE_FILES,
+  ]);
+  return {
+    git_revision: await gitValue(REPO_ROOT, ["rev-parse", "HEAD"]),
+    tracked_runtime_files_clean: trackedRuntimeStatus === "",
+    tracked_runtime_status_sha256: trackedRuntimeStatus === ""
+      ? null
+      : sha256(Buffer.from(trackedRuntimeStatus, "utf8")),
+    files,
+    source_set_sha256: sha256(Buffer.from(canonicalJson(files))),
+  };
+}
+
+async function writePrivate(filename, bytes) {
+  await fs.writeFile(filename, bytes, { mode: 0o600, flag: "wx" });
+  await fs.chmod(filename, 0o600);
+}
+
+async function run(options) {
+  if (process.platform !== "darwin" || process.arch !== "arm64") {
+    throw new Error("The initial Shannon bakeoff is intentionally calibrated only for macOS arm64");
+  }
+  const manifestPath = path.resolve(options["--manifest"] ?? DEFAULT_MANIFEST);
+  const manifestFile = await canonicalRegular(manifestPath, 1024 * 1024, "Shannon manifest");
+  const manifest = validateShannonManifest(JSON.parse(manifestFile.bytes.toString("utf8")));
+  const sourcePath = path.resolve(options["--source"] ?? "");
+  const inspectorRoot = path.resolve(options["--pdf-inspector-root"] ?? "");
+  const outputDir = path.resolve(options["--output-dir"] ?? "");
+  if (!sourcePath || !inspectorRoot || !outputDir) {
+    throw new Error("--source, --pdf-inspector-root, and --output-dir are required");
+  }
+  await canonicalDirectory(inspectorRoot, "pdf-inspector source root");
+  const repositoryReal = await fs.realpath(REPO_ROOT);
+  if (outputDir === repositoryReal || outputDir.startsWith(`${repositoryReal}${path.sep}`)) {
+    throw new Error("Shannon output must remain outside the repository and package boundary");
+  }
+  await fs.mkdir(outputDir, { mode: 0o700, recursive: false });
+  await fs.chmod(outputDir, 0o700);
+  const canonicalOutput = await canonicalDirectory(outputDir, "Shannon output directory");
+  const source = await canonicalRegular(sourcePath, 16 * 1024 * 1024, "Shannon source PDF");
+  if (source.sha256 !== manifest.source.sha256 || source.size_bytes !== manifest.source.size_bytes) {
+    throw new Error("Shannon source bytes do not match the non-redistributed manifest binding");
+  }
+  const [revision, trackedStatus] = await Promise.all([
+    gitValue(inspectorRoot, ["rev-parse", "HEAD"]),
+    gitValue(inspectorRoot, ["status", "--porcelain", "--untracked-files=no"]),
+  ]);
+  if (revision !== manifest.candidates.pdf_inspector.revision || trackedStatus !== "") {
+    throw new Error("pdf-inspector source checkout is not the exact clean pinned revision");
+  }
+  const lock = await canonicalRegular(path.join(inspectorRoot, "Cargo.lock"), 4 * 1024 * 1024, "pdf-inspector resolved lock");
+  if (lock.sha256 !== manifest.candidates.pdf_inspector.resolved_lock_sha256) {
+    throw new Error("pdf-inspector resolved lock differs from the reviewed pin");
+  }
+  const binaryPath = path.join(inspectorRoot, "target", "release", "pdf2md");
+  const binary = await canonicalRegular(binaryPath, 64 * 1024 * 1024, "pdf-inspector binary");
+  const pdfToolsSource = await runtimeSourceIdentity();
+  const attempts = { pdf_tools: [], pdf_inspector: [] };
+  const markdownByCandidate = { pdf_tools: [], pdf_inspector: [] };
+
+  for (let repetition = 1; repetition <= manifest.execution.repetitions; repetition += 1) {
+    const sourceBefore = await canonicalRegular(sourcePath, 16 * 1024 * 1024, "Shannon source before attempt");
+    const inspector = await runPdfInspector({ binary: binaryPath, sourcePath, manifest });
+    const stateRoot = await fs.mkdtemp(path.join(canonicalOutput, `.pdf-tools-state-r${repetition}-`));
+    await fs.chmod(stateRoot, 0o700);
+    let current;
+    try {
+      current = await runPdfTools({ sourcePath, source, manifest, stateRoot });
+    } finally {
+      await fs.rm(stateRoot, { recursive: true, force: true });
+    }
+    const sourceAfter = await canonicalRegular(sourcePath, 16 * 1024 * 1024, "Shannon source after attempt");
+    if (sourceBefore.sha256 !== sourceAfter.sha256 || sourceBefore.size_bytes !== sourceAfter.size_bytes) {
+      throw new Error("Shannon source changed during candidate execution");
+    }
+    for (const [candidate, result] of [["pdf_inspector", inspector], ["pdf_tools", current]]) {
+      const markdownBytes = Buffer.from(result.markdown, "utf8");
+      const filename = `${candidate.replaceAll("_", "-")}-r${repetition}.md`;
+      await writePrivate(path.join(canonicalOutput, filename), markdownBytes);
+      attempts[candidate].push({
+        repetition,
+        output_file: filename,
+        markdown_sha256: sha256(markdownBytes),
+        markdown_bytes: markdownBytes.length,
+        ...result.attempt,
+      });
+      markdownByCandidate[candidate].push(result.markdown);
+    }
+  }
+
+  for (const candidate of Object.keys(attempts)) {
+    if (new Set(attempts[candidate].map(attempt => attempt.markdown_sha256)).size !== 1) {
+      throw new Error(`${candidate} Markdown changed across fresh-process repetitions`);
+    }
+  }
+
+  const metrics = {
+    pdf_tools: scoreShannonMarkdown({
+      markdown: markdownByCandidate.pdf_tools[0],
+      oracle: manifest.oracle,
+      evidence: { page_identity: true, typed_coverage_gaps: true, canonical_coordinates: true, engine_native_coordinates: false },
+    }),
+    pdf_inspector: scoreShannonMarkdown({
+      markdown: markdownByCandidate.pdf_inspector[0],
+      oracle: manifest.oracle,
+      evidence: { page_identity: false, typed_coverage_gaps: false, canonical_coordinates: false, engine_native_coordinates: false },
+    }),
+  };
+  const report = {
+    report_id: "pdf-tools.shannon-markdown-bakeoff-report.v1",
+    report_version: 1,
+    benchmark_claim_ready: false,
+    calibration_claim_ready: false,
+    generated_at: new Date().toISOString(),
+    host: {
+      hostname_sha256: sha256(Buffer.from(os.hostname())),
+      platform: process.platform,
+      architecture: process.arch,
+      os_release: os.release(),
+      node_version: process.version,
+    },
+    source: {
+      id: manifest.source.id,
+      url: manifest.source.url,
+      redistribution: manifest.source.redistribution,
+      sha256: source.sha256,
+      size_bytes: source.size_bytes,
+      page_count: manifest.source.page_count,
+    },
+    manifest: { sha256: manifestFile.sha256, size_bytes: manifestFile.size_bytes },
+    candidates: {
+      pdf_tools: {
+        slot: manifest.candidates.pdf_tools.slot,
+        packaging_status: "source_checkout_not_packed_mcpb",
+        ...pdfToolsSource,
+      },
+      pdf_inspector: {
+        slot: manifest.candidates.pdf_inspector.slot,
+        repository: manifest.candidates.pdf_inspector.repository,
+        revision,
+        crate_version: manifest.candidates.pdf_inspector.crate_version,
+        license: manifest.candidates.pdf_inspector.license,
+        resolved_lock_sha256: lock.sha256,
+        binary_sha256: binary.sha256,
+        binary_size_bytes: binary.size_bytes,
+        packaging_status: "external_evaluation_only",
+      },
+      layout_reference: manifest.candidates.layout_reference,
+    },
+    execution_boundary: {
+      fresh_process_per_repetition: true,
+      network_isolation: false,
+      hard_memory_limit: false,
+      source_reopened_before_and_after: true,
+      pdf_tools_page_span: manifest.execution.pdf_tools_page_span,
+    },
+    attempts,
+    aggregates: Object.fromEntries(Object.entries(attempts).map(([candidate, records]) => [candidate, {
+      repetitions: records.length,
+      deterministic_markdown: new Set(records.map(record => record.markdown_sha256)).size === 1,
+      median_elapsed_ms: median(records.map(record => record.elapsed_ms)),
+      median_maximum_resident_set_size_bytes: records.every(record => record.maximum_resident_set_size_bytes !== null)
+        ? median(records.map(record => record.maximum_resident_set_size_bytes))
+        : null,
+      artifact_or_runtime_size_bytes: candidate === "pdf_inspector" ? binary.size_bytes : null,
+    }])),
+    metrics,
+    limitations: [
+      "The oracle is a sampled structural-anchor contract, not a complete manually transcribed 55-page ground truth.",
+      "No metric families are blended into an overall score.",
+      "PDF Tools ran from the named source checkout, not a packed MCPB artifact.",
+      "The stronger layout-reference slot was not run because no Shannon-specific hash-bound handoff exists.",
+      "Network inactivity is intended by the candidate commands but is not syscall-isolated.",
+      "Maximum RSS is observed from the macOS time wrapper and is not a hard memory limit.",
+      "A successful evaluation does not authorize bundling, release, or a comparative product claim.",
+    ],
+  };
+  const reportBytes = Buffer.from(`${JSON.stringify(report, null, 2)}\n`, "utf8");
+  await writePrivate(path.join(canonicalOutput, "report.v1.json"), reportBytes);
+  return { report, report_sha256: sha256(reportBytes), output_dir: canonicalOutput };
+}
+
+export async function runShannonMarkdownBakeoff(options) {
+  return run(options);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  run(exactOptions(process.argv.slice(2)))
+    .then(result => process.stdout.write(`${JSON.stringify({
+      output_dir: result.output_dir,
+      report_sha256: result.report_sha256,
+      aggregates: result.report.aggregates,
+    }, null, 2)}\n`))
+    .catch(error => {
+      process.stderr.write(`${error.stack ?? error.message}\n`);
+      process.exitCode = 1;
+    });
+}

--- a/server/layout-extraction.js
+++ b/server/layout-extraction.js
@@ -332,19 +332,6 @@ function itemBaselineCenter(item) {
   return item.y + item.height / 2;
 }
 
-function baselineCompatible(lineItems, candidate, toleranceFactor) {
-  if (lineItems.length === 0) return true;
-  const centers = lineItems.map(itemBaselineCenter);
-  const candidateCenter = itemBaselineCenter(candidate);
-  const heights = lineItems.map(item => item.line_height).filter(Number.isFinite);
-  const referenceHeight = heights.length > 0 ? medianNumber(heights) : 8;
-  const tolerance = Math.max(2, Math.min(referenceHeight, candidate.line_height ?? referenceHeight) * toleranceFactor);
-  const nextCenters = [...centers, candidateCenter];
-  return Math.abs(candidateCenter - centers[0]) <= tolerance
-    && Math.abs(candidateCenter - medianNumber(centers)) <= tolerance
-    && Math.max(...nextCenters) - Math.min(...nextCenters) <= tolerance;
-}
-
 function baselineInvariant(lineItems, toleranceFactor) {
   if (lineItems.length <= 1) return true;
   const centers = lineItems.map(itemBaselineCenter);
@@ -370,7 +357,7 @@ function groupLines(items, pageNumber) {
     let bestDistance = Infinity;
     for (const line of lines) {
       if (line.direction !== item.direction || line.hard_segment !== item.hard_segment) continue;
-      if (!baselineCompatible(line.items, item, 0.35)) continue;
+      if (!baselineInvariant([...line.items, item], 0.35)) continue;
       const distance = Math.abs(center - medianNumber(line.items.map(itemBaselineCenter)));
       const lineLeft = Math.min(...line.items.map(value => value.x));
       const lineRight = Math.max(...line.items.map(value => value.x + value.width));
@@ -408,7 +395,7 @@ function sourceOrderLines(items, pageNumber) {
     if (!current
       || current.hard_segment !== item.hard_segment
       || current.direction !== item.direction
-      || !baselineCompatible(current.items, item, 0.5)) {
+      || !baselineInvariant([...current.items, item], 0.5)) {
       current = { hard_segment: item.hard_segment, direction: item.direction, items: [] };
       segments.push(current);
     }

--- a/test/eval/shannon-markdown-bakeoff.test.js
+++ b/test/eval/shannon-markdown-bakeoff.test.js
@@ -1,0 +1,46 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { validateShannonManifest } from "../../scripts/eval-run-shannon-markdown-bakeoff.mjs";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const MANIFEST = path.join(REPO_ROOT, "test/fixtures/eval/shannon/manifest.v1.json");
+
+async function manifest() {
+  return JSON.parse(await fs.readFile(MANIFEST, "utf8"));
+}
+
+describe("Shannon Markdown bakeoff manifest", () => {
+  it("accepts the committed external-only source and exact candidate pins", async () => {
+    expect(validateShannonManifest(await manifest())).toMatchObject({
+      benchmark_claim_ready: false,
+      calibration_claim_ready: false,
+      source: { redistribution: "external_only", page_count: 55 },
+      candidates: {
+        pdf_inspector: { slot: "candidate.direct_pdf.v1" },
+        layout_reference: { status: "not_run" },
+      },
+    });
+  });
+
+  it("rejects a non-Git revision or a public benchmark claim", async () => {
+    const badRevision = await manifest();
+    badRevision.candidates.pdf_inspector.revision = "a".repeat(64);
+    expect(() => validateShannonManifest(badRevision)).toThrow("pdf-inspector candidate binding is invalid");
+
+    const publicClaim = await manifest();
+    publicClaim.benchmark_claim_ready = true;
+    expect(() => validateShannonManifest(publicClaim)).toThrow("Shannon manifest claim boundary is invalid");
+  });
+
+  it("rejects redistribution and layout-reference overclaims", async () => {
+    const redistributed = await manifest();
+    redistributed.source.redistribution = "repository_fixture";
+    expect(() => validateShannonManifest(redistributed)).toThrow("Shannon external source binding is invalid");
+
+    const inventedReference = await manifest();
+    inventedReference.candidates.layout_reference.status = "complete";
+    expect(() => validateShannonManifest(inventedReference)).toThrow("Candidate slot projection is invalid");
+  });
+});

--- a/test/eval/shannon-markdown-bakeoff.test.js
+++ b/test/eval/shannon-markdown-bakeoff.test.js
@@ -43,4 +43,14 @@ describe("Shannon Markdown bakeoff manifest", () => {
     inventedReference.candidates.layout_reference.status = "complete";
     expect(() => validateShannonManifest(inventedReference)).toThrow("Candidate slot projection is invalid");
   });
+
+  it("rejects equation anchors without bounded page-local evidence", async () => {
+    const missingPage = await manifest();
+    delete missingPage.oracle.equation_anchors[0].page;
+    expect(() => validateShannonManifest(missingPage)).toThrow("Shannon sampled oracle is invalid");
+
+    const unbounded = await manifest();
+    unbounded.oracle.equation_max_span_characters = 10000;
+    expect(() => validateShannonManifest(unbounded)).toThrow("Shannon sampled oracle is invalid");
+  });
 });

--- a/test/eval/shannon-markdown-scorer.js
+++ b/test/eval/shannon-markdown-scorer.js
@@ -112,17 +112,55 @@ function scorePresence(normalized, values, key) {
   return { expected: details.length, found: details.filter(item => item.present).length, details };
 }
 
-function scoreEquations(normalized, oracle) {
-  const details = oracle.equation_anchors.map(tokens => {
+function markdownPages(markdown) {
+  const source = String(markdown ?? "");
+  const markers = [...source.matchAll(/<!--\s*(?:PDF\s+)?page\s+(\d+)\s*-->/giu)];
+  return new Map(markers.map((marker, index) => [
+    Number(marker[1]),
+    normalizeShannonText(source.slice(marker.index, markers[index + 1]?.index ?? source.length)),
+  ]));
+}
+
+function normalizedTokenIndex(haystack, needle, offset) {
+  const isWordCharacter = value => typeof value === "string" && /[\p{L}\p{N}]/u.test(value);
+  let cursor = offset;
+  while (cursor <= haystack.length - needle.length) {
+    const found = haystack.indexOf(needle, cursor);
+    if (found < 0) return -1;
+    const leftBoundary = !isWordCharacter(needle[0]) || !isWordCharacter(haystack[found - 1]);
+    const rightBoundary = !isWordCharacter(needle.at(-1)) || !isWordCharacter(haystack[found + needle.length]);
+    if (leftBoundary && rightBoundary) return found;
+    cursor = found + 1;
+  }
+  return -1;
+}
+
+function scoreEquations(markdown, oracle) {
+  const pages = markdownPages(markdown);
+  const maximumSpan = oracle.equation_max_span_characters;
+  const details = oracle.equation_anchors.map(anchor => {
+    const normalized = pages.get(anchor.page) ?? "";
+    const targets = anchor.tokens.map(normalizeShannonText);
     let cursor = 0;
+    let firstOffset = null;
     const missing = [];
-    for (const token of tokens) {
-      const target = normalizeShannonText(token);
-      const found = normalized.indexOf(target, cursor);
-      if (found < 0) missing.push(token);
-      else cursor = found + target.length;
+    for (const [index, target] of targets.entries()) {
+      const found = normalizedTokenIndex(normalized, target, cursor);
+      if (found < 0 || (firstOffset !== null && found + target.length - firstOffset > maximumSpan)) {
+        missing.push(anchor.tokens[index]);
+      } else {
+        if (firstOffset === null) firstOffset = found;
+        cursor = found + target.length;
+      }
     }
-    return { tokens, present_in_order: missing.length === 0, missing_or_reordered: missing };
+    return {
+      page: anchor.page,
+      tokens: anchor.tokens,
+      maximum_span_characters: maximumSpan,
+      observed_span_characters: missing.length === 0 && firstOffset !== null ? cursor - firstOffset : null,
+      present_in_order: missing.length === 0,
+      missing_or_reordered: missing,
+    };
   });
   return { expected: details.length, found: details.filter(item => item.present_in_order).length, details };
 }
@@ -152,8 +190,10 @@ function scoreTable(markdown, normalized, oracle) {
     term,
     present: normalized.includes(normalizeShannonText(term)),
   }));
-  const qualifying = tables.filter(table => oracle.table.required_header_terms
-    .every(term => table.normalized.includes(normalizeShannonText(term))));
+  const qualifying = tables.filter(table => {
+    const normalizedHeader = normalizeShannonText(table.rows[0]);
+    return oracle.table.required_header_terms.every(term => normalizedHeader.includes(normalizeShannonText(term)));
+  });
   return {
     label_present: labelOffset >= 0,
     markdown_table_count: tables.length,
@@ -189,7 +229,7 @@ export function scoreShannonMarkdown({ markdown, oracle, evidence }) {
     heading_hierarchy: scoreHeadings(markdown, oracle),
     reading_order: scoreOrderedAnchors(normalized, oracle),
     paragraph_continuity: scorePresence(normalized, oracle.paragraph_continuity, "phrase"),
-    equations: scoreEquations(normalized, oracle),
+    equations: scoreEquations(markdown, oracle),
     footnotes: scorePresence(normalized, oracle.footnote_anchors, "anchor"),
     table_topology: scoreTable(markdown, normalized, oracle),
     omissions_and_duplication: scoreDuplication(normalized, oracle),

--- a/test/eval/shannon-markdown-scorer.js
+++ b/test/eval/shannon-markdown-scorer.js
@@ -1,0 +1,203 @@
+function stripMarkdown(value) {
+  return value
+    .replace(/<!--[^]*?-->/gu, " ")
+    .replace(/!\[([^\]]*)\]\([^)]*\)/gu, "$1")
+    .replace(/\[([^\]]+)\]\([^)]*\)/gu, "$1")
+    .replace(/[*_`~]/gu, "");
+}
+
+export function normalizeShannonText(value) {
+  return stripMarkdown(String(value ?? ""))
+    .normalize("NFKC")
+    .replace(/[‐‑‒–—−]/gu, "-")
+    .replace(/[“”]/gu, '"')
+    .replace(/[‘’]/gu, "'")
+    .replace(/\s+/gu, " ")
+    .trim()
+    .toLocaleLowerCase("en-US");
+}
+
+function normalizedCount(haystack, needle) {
+  const target = normalizeShannonText(needle);
+  if (!target) return 0;
+  const isWordCharacter = value => typeof value === "string" && /[\p{L}\p{N}]/u.test(value);
+  let count = 0;
+  let offset = 0;
+  while (offset <= haystack.length - target.length) {
+    const found = haystack.indexOf(target, offset);
+    if (found < 0) break;
+    const leftBoundary = !isWordCharacter(target[0]) || !isWordCharacter(haystack[found - 1]);
+    const rightBoundary = !isWordCharacter(target.at(-1)) || !isWordCharacter(haystack[found + target.length]);
+    if (leftBoundary && rightBoundary) count += 1;
+    offset = found + target.length;
+  }
+  return count;
+}
+
+function headingRecords(markdown) {
+  return String(markdown ?? "")
+    .split(/\r?\n/u)
+    .map(line => /^(#{1,6})\s+(.+?)\s*#*\s*$/u.exec(line))
+    .filter(Boolean)
+    .map(match => ({ level: match[1].length, text: stripMarkdown(match[2]).trim() }));
+}
+
+function looksLikeEquationHeading(heading, expected) {
+  const normalized = normalizeShannonText(heading.text);
+  if (expected.has(normalized)) return false;
+  return /[=∑∞≤≥]|\b(?:lim|log|exp|sin|cos|max|min)\b|\b[hpcrn]\s*\([^)]*\)/iu.test(heading.text)
+    || (/\d/u.test(heading.text) && /[+*/^]/u.test(heading.text));
+}
+
+function looksMalformedOrFragmentary(heading, expected) {
+  const normalized = normalizeShannonText(heading.text);
+  if (expected.has(normalized)) return false;
+  return heading.text.includes("\uFFFD") || normalized.length <= 2;
+}
+
+function scoreHeadings(markdown, oracle) {
+  const headings = headingRecords(markdown);
+  const expected = new Map(oracle.expected_headings.map(item => [normalizeShannonText(item.text), item]));
+  const found = [];
+  const wrongLevel = [];
+  for (const [normalized, item] of expected) {
+    const matches = headings.filter(heading => normalizeShannonText(heading.text) === normalized);
+    if (matches.length > 0) found.push(item.text);
+    if (matches.length > 0 && matches.every(heading => heading.level !== item.level)) {
+      wrongLevel.push({ text: item.text, expected_level: item.level, observed_levels: [...new Set(matches.map(match => match.level))] });
+    }
+  }
+  const equationLikeFalsePositives = headings
+    .filter(heading => looksLikeEquationHeading(heading, expected))
+    .slice(0, 100);
+  const malformedOrFragmentaryFalsePositives = headings
+    .filter(heading => looksMalformedOrFragmentary(heading, expected))
+    .slice(0, 100);
+  return {
+    expected: expected.size,
+    found: found.length,
+    missing: [...expected.values()].map(item => item.text).filter(text => !found.includes(text)),
+    wrong_level: wrongLevel,
+    equation_like_false_positive_count: headings.filter(heading => looksLikeEquationHeading(heading, expected)).length,
+    equation_like_false_positives: equationLikeFalsePositives,
+    malformed_or_fragmentary_false_positive_count: headings
+      .filter(heading => looksMalformedOrFragmentary(heading, expected)).length,
+    malformed_or_fragmentary_false_positives: malformedOrFragmentaryFalsePositives,
+  };
+}
+
+function scoreOrderedAnchors(normalized, oracle) {
+  const groups = oracle.ordered_anchor_groups.map(group => {
+    let cursor = 0;
+    const missing = [];
+    for (const anchor of group) {
+      const target = normalizeShannonText(anchor);
+      const found = normalized.indexOf(target, cursor);
+      if (found < 0) missing.push(anchor);
+      else cursor = found + target.length;
+    }
+    return { anchors: group.length, in_order: group.length - missing.length, missing_or_reordered: missing };
+  });
+  return {
+    groups: groups.length,
+    complete_groups: groups.filter(group => group.in_order === group.anchors).length,
+    anchors: groups.reduce((total, group) => total + group.anchors, 0),
+    in_order: groups.reduce((total, group) => total + group.in_order, 0),
+    details: groups,
+  };
+}
+
+function scorePresence(normalized, values, key) {
+  const details = values.map(value => ({ [key]: value, present: normalized.includes(normalizeShannonText(value)) }));
+  return { expected: details.length, found: details.filter(item => item.present).length, details };
+}
+
+function scoreEquations(normalized, oracle) {
+  const details = oracle.equation_anchors.map(tokens => {
+    let cursor = 0;
+    const missing = [];
+    for (const token of tokens) {
+      const target = normalizeShannonText(token);
+      const found = normalized.indexOf(target, cursor);
+      if (found < 0) missing.push(token);
+      else cursor = found + target.length;
+    }
+    return { tokens, present_in_order: missing.length === 0, missing_or_reordered: missing };
+  });
+  return { expected: details.length, found: details.filter(item => item.present_in_order).length, details };
+}
+
+function parseMarkdownTables(markdown) {
+  const lines = String(markdown ?? "").split(/\r?\n/u);
+  const tables = [];
+  for (let index = 0; index < lines.length - 1; index += 1) {
+    if (!/^\s*\|.*\|\s*$/u.test(lines[index]) || !/^\s*\|(?:\s*:?-{3,}:?\s*\|)+\s*$/u.test(lines[index + 1])) continue;
+    const rows = [lines[index]];
+    let next = index + 2;
+    while (next < lines.length && /^\s*\|.*\|\s*$/u.test(lines[next])) {
+      rows.push(lines[next]);
+      next += 1;
+    }
+    tables.push({ start_line: index + 1, rows, normalized: normalizeShannonText(rows.join(" ")) });
+    index = next - 1;
+  }
+  return tables;
+}
+
+function scoreTable(markdown, normalized, oracle) {
+  const tables = parseMarkdownTables(markdown);
+  const label = normalizeShannonText(oracle.table.label);
+  const labelOffset = normalized.indexOf(label);
+  const headerTerms = oracle.table.required_header_terms.map(term => ({
+    term,
+    present: normalized.includes(normalizeShannonText(term)),
+  }));
+  const qualifying = tables.filter(table => oracle.table.required_header_terms
+    .every(term => table.normalized.includes(normalizeShannonText(term))));
+  return {
+    label_present: labelOffset >= 0,
+    markdown_table_count: tables.length,
+    required_header_terms: headerTerms,
+    qualifying_table_count: qualifying.length,
+    minimum_data_rows: oracle.table.minimum_data_rows,
+    topology_present: qualifying.some(table => table.rows.length - 1 >= oracle.table.minimum_data_rows),
+  };
+}
+
+function scoreDuplication(normalized, oracle) {
+  const details = oracle.exactly_once_anchors.map(anchor => ({
+    anchor,
+    count: normalizedCount(normalized, anchor),
+  }));
+  return {
+    expected: details.length,
+    exactly_once: details.filter(item => item.count === 1).length,
+    omitted: details.filter(item => item.count === 0).map(item => item.anchor),
+    duplicated: details.filter(item => item.count > 1),
+    details,
+  };
+}
+
+export function scoreShannonMarkdown({ markdown, oracle, evidence }) {
+  if (typeof markdown !== "string" || markdown.length < 1 || !oracle || typeof oracle !== "object") {
+    throw new Error("Shannon scorer requires non-empty Markdown and a declared oracle");
+  }
+  const normalized = normalizeShannonText(markdown);
+  return {
+    scorer: { name: "pdf-tools.shannon-markdown-scorer", version: 1 },
+    scope: oracle.scope,
+    heading_hierarchy: scoreHeadings(markdown, oracle),
+    reading_order: scoreOrderedAnchors(normalized, oracle),
+    paragraph_continuity: scorePresence(normalized, oracle.paragraph_continuity, "phrase"),
+    equations: scoreEquations(normalized, oracle),
+    footnotes: scorePresence(normalized, oracle.footnote_anchors, "anchor"),
+    table_topology: scoreTable(markdown, normalized, oracle),
+    omissions_and_duplication: scoreDuplication(normalized, oracle),
+    evidence: {
+      page_identity: evidence?.page_identity === true,
+      typed_coverage_gaps: evidence?.typed_coverage_gaps === true,
+      canonical_coordinates: evidence?.canonical_coordinates === true,
+      engine_native_coordinates: evidence?.engine_native_coordinates === true,
+    },
+  };
+}

--- a/test/eval/shannon-markdown-scorer.test.js
+++ b/test/eval/shannon-markdown-scorer.test.js
@@ -1,0 +1,90 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { normalizeShannonText, scoreShannonMarkdown } from "./shannon-markdown-scorer.js";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const MANIFEST = path.join(REPO_ROOT, "test/fixtures/eval/shannon/manifest.v1.json");
+
+async function oracle() {
+  return JSON.parse(await fs.readFile(MANIFEST, "utf8")).oracle;
+}
+
+describe("Shannon Markdown adversarial scorer", () => {
+  it("normalizes presentation punctuation without repairing displaced text", () => {
+    expect(normalizeShannonText("A—B  *C*\nD")).toBe("a-b c d");
+    expect(normalizeShannonText("HE recent T bandwidth")).not.toContain("the recent");
+  });
+
+  it("keeps metric families separate and exposes equation-like false headings", async () => {
+    const result = scoreShannonMarkdown({
+      markdown: [
+        "# A Mathematical Theory of Communication",
+        "## PART I: DISCRETE NOISELESS SYSTEMS",
+        "### H = pi log pi",
+        "# �",
+        "# X",
+        "The recent development of various methods of modulation such as PCM and PPM which exchange bandwidth for signal-to-noise ratio.",
+        "The fundamental problem of communication is that of reproducing at one point either exactly or approximately a message selected at another point.",
+        "Certain Factors Affecting Telegraph Speed. Transmission of Information.",
+        "TABLE I",
+      ].join("\n\n"),
+      oracle: await oracle(),
+      evidence: { page_identity: true, typed_coverage_gaps: true },
+    });
+    expect(result).not.toHaveProperty("overall_score");
+    expect(result.heading_hierarchy.equation_like_false_positive_count).toBe(1);
+    expect(result.heading_hierarchy.malformed_or_fragmentary_false_positive_count).toBe(2);
+    expect(result.paragraph_continuity.found).toBeGreaterThanOrEqual(2);
+    expect(result.evidence).toEqual({
+      page_identity: true,
+      typed_coverage_gaps: true,
+      canonical_coordinates: false,
+      engine_native_coordinates: false,
+    });
+  });
+
+  it("does not award reading-order or table credit to mere token presence", async () => {
+    const result = scoreShannonMarkdown({
+      markdown: [
+        "Theorem 12",
+        "Representation of a noisy discrete channel",
+        "PART II: THE DISCRETE CHANNEL WITH NOISE",
+        "TABLE I",
+        "entropy gain in decibels impulse response gain factor entropy power factor",
+        "| value | value |",
+        "|---|---|",
+        "| 1 | 2 |",
+      ].join("\n"),
+      oracle: await oracle(),
+      evidence: {},
+    });
+    expect(result.reading_order.complete_groups).toBe(0);
+    expect(result.table_topology.qualifying_table_count).toBe(0);
+    expect(result.table_topology.topology_present).toBe(false);
+  });
+
+  it("reports omissions and duplications independently", async () => {
+    const manifestOracle = await oracle();
+    const repeated = manifestOracle.exactly_once_anchors[0];
+    const result = scoreShannonMarkdown({
+      markdown: `${repeated}\n${repeated}\n`,
+      oracle: manifestOracle,
+      evidence: {},
+    });
+    expect(result.omissions_and_duplication.duplicated).toEqual([{ anchor: repeated, count: 2 }]);
+    expect(result.omissions_and_duplication.omitted.length).toBe(manifestOracle.exactly_once_anchors.length - 1);
+  });
+
+  it("does not count a shorter Roman-numeral label inside a longer one", async () => {
+    const manifestOracle = await oracle();
+    const result = scoreShannonMarkdown({
+      markdown: "TABLE I\nTABLE II\nTABLE III\n",
+      oracle: manifestOracle,
+      evidence: {},
+    });
+    const table = result.omissions_and_duplication.details.find(item => item.anchor === "TABLE I");
+    expect(table.count).toBe(1);
+  });
+});

--- a/test/eval/shannon-markdown-scorer.test.js
+++ b/test/eval/shannon-markdown-scorer.test.js
@@ -65,6 +65,29 @@ describe("Shannon Markdown adversarial scorer", () => {
     expect(result.table_topology.topology_present).toBe(false);
   });
 
+  it("does not award equation credit to scattered prose or header terms in table data rows", async () => {
+    const result = scoreShannonMarkdown({
+      markdown: [
+        "<!-- PDF page 1 -->",
+        "C appears in prose.",
+        "x".repeat(250),
+        "W log P N appear much later.",
+        "| junk | header |",
+        "|---|---|",
+        "| impulse response | gain factor |",
+        "| entropy power factor | entropy gain in decibels |",
+        "| value | value |",
+        "| value | value |",
+        "| value | value |",
+      ].join("\n"),
+      oracle: await oracle(),
+      evidence: {},
+    });
+    expect(result.equations.found).toBe(0);
+    expect(result.table_topology.qualifying_table_count).toBe(0);
+    expect(result.table_topology.topology_present).toBe(false);
+  });
+
   it("reports omissions and duplications independently", async () => {
     const manifestOracle = await oracle();
     const repeated = manifestOracle.exactly_once_anchors[0];

--- a/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
+++ b/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
@@ -49,8 +49,8 @@
     {
       "role": "layout_extraction_module",
       "path": "server/layout-extraction.js",
-      "bytes": 100819,
-      "sha256": "f545fb3d566b7fa1edfb8abce327527a81c76e4d88e566f27a29c14ec859a99f"
+      "bytes": 100717,
+      "sha256": "3112e46b04373eed55abaed630da3adca7a74612f9dc503701422f84d6e5f0f9"
     },
     {
       "role": "layout_oracle_schema",
@@ -95,7 +95,7 @@
       "sha256": "6e4429db62fcbe1dd73141d8c20a48b564d41f8bf8920d88775846995e1daf94"
     }
   ],
-  "validator_source_set_sha256": "6825723a56d9408d0ea4f496eedda8b45e5fee3e96a6033b607d38afb620757c",
+  "validator_source_set_sha256": "1b4823995d320df4c2bf11b528099be39d10069091193baa777b9d11fa8d2bf6",
   "pdfjs_version": "5.4.624",
   "generation_contract": {
     "source_path": "source.pdf",

--- a/test/fixtures/eval/shannon/manifest.v1.json
+++ b/test/fixtures/eval/shannon/manifest.v1.json
@@ -103,11 +103,12 @@
       "A decimal digit is about 3 1/3 bits",
       "The final entropy power is the initial entropy power multiplied by the geometric mean gain of the filter"
     ],
+    "equation_max_span_characters": 200,
     "equation_anchors": [
-      ["log2 M", "log10 M", "log10 2"],
-      ["C", "Lim", "log N(T)", "T"],
-      ["H", "pi", "log pi"],
-      ["C", "W", "log", "P", "N"]
+      { "page": 1, "tokens": ["log2 M", "log10 M", "log10 2"] },
+      { "page": 3, "tokens": ["C", "Lim", "log N(T)", "T"] },
+      { "page": 11, "tokens": ["H", "pi", "log pi"] },
+      { "page": 45, "tokens": ["C", "W", "log", "P", "N"] }
     ],
     "footnote_anchors": [
       "Certain Factors Affecting Telegraph Speed",

--- a/test/fixtures/eval/shannon/manifest.v1.json
+++ b/test/fixtures/eval/shannon/manifest.v1.json
@@ -1,0 +1,138 @@
+{
+  "suite_id": "pdf-tools.shannon-markdown-adversarial.v1",
+  "suite_version": 1,
+  "benchmark_claim_ready": false,
+  "calibration_claim_ready": false,
+  "source": {
+    "id": "shannon-1948-mathematical-theory-of-communication",
+    "url": "https://people.math.harvard.edu/~ctm/home/text/others/shannon/entropy/entropy.pdf",
+    "redistribution": "external_only",
+    "sha256": "6e4e3411984f3edf99dbfe8b941cb5e8a321379ff0cae6ae5c1f592ad8882ca8",
+    "size_bytes": 366296,
+    "page_count": 55
+  },
+  "execution": {
+    "repetitions": 3,
+    "deadline_ms": 120000,
+    "max_stdout_bytes": 2097152,
+    "max_stderr_bytes": 1048576,
+    "pdf_tools_page_span": 10
+  },
+  "candidates": {
+    "pdf_tools": {
+      "slot": "control.current_product.v0",
+      "renderer_name": "pdf-tools.layout-markdown-renderer",
+      "renderer_version": "1.2.0",
+      "parser_name": "pdfjs-dist",
+      "parser_version": "5.4.624"
+    },
+    "pdf_inspector": {
+      "slot": "candidate.direct_pdf.v1",
+      "repository": "https://github.com/firecrawl/pdf-inspector",
+      "revision": "1c32e4bd691bde83778ffef235019c8feac0c0c5",
+      "crate_name": "pdf-inspector",
+      "crate_version": "0.1.7",
+      "license": "MIT",
+      "resolved_lock_sha256": "d976c94ada1b91ab3c2fd65f3ba24b93854d4622ad59760891be4ce26becd982"
+    },
+    "layout_reference": {
+      "slot": "candidate.layout_ir.v1",
+      "status": "not_run",
+      "reason": "No Shannon-specific, hash-bound layout-reference handoff is configured. Existing Docling evidence is bound to the separate Phase 0 corpus."
+    }
+  },
+  "oracle": {
+    "scope": "sampled_structural_anchors_not_full_transcript_ground_truth",
+    "expected_headings": [
+      { "text": "A Mathematical Theory of Communication", "level": 1 },
+      { "text": "INTRODUCTION", "level": 2 },
+      { "text": "PART I: DISCRETE NOISELESS SYSTEMS", "level": 2 },
+      { "text": "PART II: THE DISCRETE CHANNEL WITH NOISE", "level": 2 },
+      { "text": "PART III: MATHEMATICAL PRELIMINARIES", "level": 2 },
+      { "text": "PART IV: THE CONTINUOUS CHANNEL", "level": 2 },
+      { "text": "PART V: THE RATE FOR A CONTINUOUS SOURCE", "level": 2 },
+      { "text": "APPENDIX 1", "level": 2 },
+      { "text": "APPENDIX 2", "level": 2 },
+      { "text": "APPENDIX 3", "level": 2 },
+      { "text": "APPENDIX 4", "level": 2 },
+      { "text": "APPENDIX 5", "level": 2 },
+      { "text": "APPENDIX 6", "level": 2 },
+      { "text": "APPENDIX 7", "level": 2 }
+    ],
+    "ordered_anchor_groups": [
+      [
+        "A Mathematical Theory of Communication",
+        "The recent development of various methods of modulation",
+        "The fundamental problem of communication",
+        "The logarithmic measure is more convenient",
+        "Schematic diagram of a general communication system"
+      ],
+      [
+        "PART I: DISCRETE NOISELESS SYSTEMS",
+        "The capacity C of a discrete channel is given by",
+        "Theorem 1",
+        "The discrete source of information"
+      ],
+      [
+        "PART II: THE DISCRETE CHANNEL WITH NOISE",
+        "Representation of a noisy discrete channel",
+        "Theorem 10",
+        "Theorem 12"
+      ],
+      [
+        "PART III: MATHEMATICAL PRELIMINARIES",
+        "Sets and ensembles of functions",
+        "Entropy of a continuous distribution",
+        "Entropy of an ensemble of functions"
+      ],
+      [
+        "TABLE I",
+        "The final entropy power is the initial entropy power",
+        "Entropy of a sum of two ensembles"
+      ],
+      [
+        "PART IV: THE CONTINUOUS CHANNEL",
+        "The capacity of a continuous channel",
+        "Theorem 20",
+        "PART V: THE RATE FOR A CONTINUOUS SOURCE"
+      ]
+    ],
+    "paragraph_continuity": [
+      "The recent development of various methods of modulation such as PCM and PPM which exchange bandwidth for signal-to-noise ratio",
+      "The fundamental problem of communication is that of reproducing at one point either exactly or approximately a message selected at another point",
+      "A decimal digit is about 3 1/3 bits",
+      "The final entropy power is the initial entropy power multiplied by the geometric mean gain of the filter"
+    ],
+    "equation_anchors": [
+      ["log2 M", "log10 M", "log10 2"],
+      ["C", "Lim", "log N(T)", "T"],
+      ["H", "pi", "log pi"],
+      ["C", "W", "log", "P", "N"]
+    ],
+    "footnote_anchors": [
+      "Certain Factors Affecting Telegraph Speed",
+      "Transmission of Information",
+      "Tables of Random Sampling Numbers",
+      "Communication in the Presence of Noise"
+    ],
+    "table": {
+      "label": "TABLE I",
+      "required_header_terms": [
+        "impulse response",
+        "gain factor",
+        "entropy power factor",
+        "entropy gain in decibels"
+      ],
+      "minimum_data_rows": 5
+    },
+    "exactly_once_anchors": [
+      "A Mathematical Theory of Communication",
+      "Schematic diagram of a general communication system",
+      "PART II: THE DISCRETE CHANNEL WITH NOISE",
+      "PART III: MATHEMATICAL PRELIMINARIES",
+      "TABLE I",
+      "PART IV: THE CONTINUOUS CHANNEL",
+      "PART V: THE RATE FOR A CONTINUOUS SOURCE"
+    ]
+  }
+}

--- a/test/read-pdf-layout.test.js
+++ b/test/read-pdf-layout.test.js
@@ -1753,4 +1753,30 @@ describe("Extraction IR hostile reconstruction", () => {
     page.spatial_text = `[${merged.id} x=${merged.x} y=${merged.y} w=${merged.width} h=${merged.height}] ${merged.text}`;
     expect(() => validatePdfLayoutSemantics(mutant)).toThrow(/baseline spread mismatch/);
   });
+
+  it("splits source-order runs when a small first glyph would make the final baseline spread invalid", async () => {
+    const item = (text, x, top, size, hasEOL) => ({
+      ...textItem({
+        text,
+        x,
+        top,
+        width: 10,
+        hasEOL,
+        transform: [size, 0, 0, size, x, 792 - top - size],
+      }),
+      height: size,
+    });
+    const { result } = await runFake([{ items: [
+      item("A", 10, 98.6, 2, false),
+      item("B", 25, 87, 20, false),
+      item("C", 50, 89, 20, true),
+    ] }]);
+
+    expect(result.pages[0].reading_order.strategy).toBe("source_order_fallback");
+    expect(result.pages[0].lines.map(line => line.item_ids)).toEqual([
+      ["p0001-i000001", "p0001-i000002"],
+      ["p0001-i000003"],
+    ]);
+    expect(() => validatePdfLayoutSemantics(result)).not.toThrow();
+  });
 });


### PR DESCRIPTION
## Summary

- Add an external-only, hash-pinned Shannon comparison for PDF Tools and pdf-inspector.
- Fix a line-grouping bug that made PDF Tools stop on page 3.
- Keep hierarchy, order, paragraphs, equations, footnotes, tables, omissions, evidence, speed, memory, and size as separate results.
- Require equation evidence to be together on the declared page and table-header evidence to be in the actual header row.
- Run the source PDF and candidate executable from verified private copies and recheck PDF Tools runtime files after every repetition.
- Keep pdf-inspector evaluation-only; this does not authorize a dependency, product claim, bundle, or release.

## Reviewed result

- The crash repair passed independent review.
- PDF Tools completes all 55 pages deterministically.
- Page-local sampled equations: PDF Tools 2/4; pdf-inspector 1/4.
- Neither candidate reconstructs the sampled Table I.
- The measuring system no longer awards equation credit to scattered prose or table-header credit to ordinary data rows.

## Evidence and verification

- Clean evaluated runtime: 277f8a99229e54774782bf1544ab871f6a540106
- Private report SHA-256: 0c4b7caa8bbb7b60ef88fb644dae6a563c0dee3b51a0a47e14331de831b26d01
- Focused review checks: 38 passed.
- Reviewed top-of-stack Vitest: 1,864 passed, 79 skipped, with one unrelated pre-existing macOS permission assertion.
- Node-native: 62 passed, 9 intentional skips.
- Bead: pdf-toolkit-mcp-aod, closed.

No interface, dependency, bundle, release, or comparative marketing change.