### PR TITLE
Reject malformed Markdown heading candidates

### DIFF
--- a/docs/evidence/shannon-heading-guardrails-2026-08.md
+++ b/docs/evidence/shannon-heading-guardrails-2026-08.md
@@ -18,17 +18,17 @@ promoting equations is separate follow-up work.
 
 ## Clean run
 
-- Evaluated commit: `e3f5615`
+- Evaluated commit: `c96ecbd064ff815c88eae5acb0a78f68e428fa23`
 - Source PDF SHA-256:
   `6e4e3411984f3edf99dbfe8b941cb5e8a321379ff0cae6ae5c1f592ad8882ca8`
 - Baseline report SHA-256:
-  `a5d468f897dbbe9931b5b4b4e3fa6da17cd1b99bede5111fd7888e3a9a1a5a38`
+  `0c4b7caa8bbb7b60ef88fb644dae6a563c0dee3b51a0a47e14331de831b26d01`
 - Guardrail report SHA-256:
-  `4489c23f5c19d17e93f8a4d689cc6106e26390082b945fb7b2cebb42ea2a03fd`
+  `04d1af01c27a6f76d4db3fdcb6c21f3614598aed590db32bccf3abcab8bff2c1`
 - Repetitions: three fresh processes per candidate
 - PDF Tools Markdown deterministic across repetitions: `true`
-- Median PDF Tools elapsed time: 3415.627 ms
-- Median PDF Tools maximum RSS: 284,229,632 bytes
+- Median PDF Tools elapsed time: 3502.845 ms
+- Median PDF Tools maximum RSS: 317,407,232 bytes
 
 ## Metric comparison
 

--- a/docs/evidence/shannon-heading-guardrails-2026-08.md
+++ b/docs/evidence/shannon-heading-guardrails-2026-08.md
@@ -1,0 +1,48 @@
+# Shannon heading guardrails — 2026-08
+
+## Outcome
+
+PDF Tools no longer promotes unreadable glyphs, lone characters, or obvious
+equation fragments into Markdown headings. Their source text remains present as
+escaped body text. The renderer identity is now
+`pdf-tools.layout-markdown-renderer` version `1.3.0`.
+
+On the same hash-bound 55-page Shannon document used by the preceding bakeoff,
+malformed or fragmentary false headings fell from 227 to 0. The sampled reading
+order, paragraph continuity, equation, footnote, table, omission, and evidence
+results did not regress.
+
+This is a precision fix, not a complete hierarchy fix. PDF Tools still finds
+0 of the 14 sampled intended major headings. Recovering real headings without
+promoting equations is separate follow-up work.
+
+## Clean run
+
+- Evaluated commit: `e3f5615`
+- Source PDF SHA-256:
+  `6e4e3411984f3edf99dbfe8b941cb5e8a321379ff0cae6ae5c1f592ad8882ca8`
+- Baseline report SHA-256:
+  `a5d468f897dbbe9931b5b4b4e3fa6da17cd1b99bede5111fd7888e3a9a1a5a38`
+- Guardrail report SHA-256:
+  `4489c23f5c19d17e93f8a4d689cc6106e26390082b945fb7b2cebb42ea2a03fd`
+- Repetitions: three fresh processes per candidate
+- PDF Tools Markdown deterministic across repetitions: `true`
+- Median PDF Tools elapsed time: 3415.627 ms
+- Median PDF Tools maximum RSS: 284,229,632 bytes
+
+## Metric comparison
+
+| Sampled PDF Tools metric | Before | After |
+| --- | ---: | ---: |
+| Malformed or fragmentary false headings | 227 | 0 |
+| Intended headings found | 0 / 14 | 0 / 14 |
+| Ordered anchors retained | 22 / 24 | 22 / 24 |
+| Complete ordered-anchor groups | 4 / 6 | 4 / 6 |
+| Paragraph-continuity anchors | 1 / 4 | 1 / 4 |
+| Equation anchors | 2 / 4 | 2 / 4 |
+| Footnote anchors | 4 / 4 | 4 / 4 |
+| Sampled Table I topology | absent | absent |
+
+The report remains a sampled adversarial evaluation, not a complete transcript
+ground truth, public benchmark, release qualification, or claim that the
+reported extraction problem is solved.

--- a/pdf-toolkit-mcp-share/server/markdown-conversion.js
+++ b/pdf-toolkit-mcp-share/server/markdown-conversion.js
@@ -6,7 +6,7 @@ import {
 
 const RENDERER = Object.freeze({
   name: "pdf-tools.layout-markdown-renderer",
-  version: "1.2.0",
+  version: "1.3.0",
 });
 
 // Bounded geometric table inference. A run of adjacent lines is treated as a
@@ -155,6 +155,14 @@ function lineFontEvidence(page) {
   });
 }
 
+function headingTextEligible(value) {
+  const text = String(value).trim();
+  const alphanumericCharacters = text.match(/[\p{L}\p{N}]/gu) ?? [];
+  return !text.includes("\uFFFD")
+    && alphanumericCharacters.length >= 3
+    && !/[=∑∫∞≤≥≈≠±×÷√]/u.test(text);
+}
+
 function headingLevels(page) {
   const evidence = lineFontEvidence(page);
   const heights = evidence.map(value => value.height).filter(Number.isFinite);
@@ -168,6 +176,7 @@ function headingLevels(page) {
       && height >= bodyHeight * 1.5
       && line.text.length > 0
       && line.text.length <= 120
+      && headingTextEligible(line.text)
       && !/[.!?;]$/u.test(line.text)
       && !/^\s*(?:[\u2022\u2023\u25e6\u2043\u2219]|\d{1,3}[.)])\s+/u.test(line.text)
   ));

--- a/pdf-toolkit-mcp-share/server/output-schemas.js
+++ b/pdf-toolkit-mcp-share/server/output-schemas.js
@@ -552,7 +552,7 @@ export const TOOL_SUCCESS_OUTPUT_SCHEMAS = Object.freeze({
   convert_pdf_to_markdown: object({
     renderer: object({
       name: { const: "pdf-tools.layout-markdown-renderer" },
-      version: { const: "1.2.0" },
+      version: { const: "1.3.0" },
     }),
     conversion_status: enumString(["complete", "partial", "failed"]),
     markdown: string,

--- a/scripts/eval-run-markdown-bakeoff.mjs
+++ b/scripts/eval-run-markdown-bakeoff.mjs
@@ -190,7 +190,7 @@ export function validateMarkdownResult(result, binding) {
     throw new Error(`Markdown conversion failed for ${binding.fixture.id}`);
   }
   const value = result.structuredContent;
-  if (value.renderer?.name !== "pdf-tools.layout-markdown-renderer" || value.renderer?.version !== "1.2.0"
+  if (value.renderer?.name !== "pdf-tools.layout-markdown-renderer" || value.renderer?.version !== "1.3.0"
     || value.options?.include_page_boundaries !== true || value.limits?.max_markdown_bytes !== 200000
     || value.provenance?.source?.file_name !== binding.retained.filename
     || value.provenance?.source?.sha256 !== binding.retained.sha256

--- a/scripts/smoke-mcpb.mjs
+++ b/scripts/smoke-mcpb.mjs
@@ -146,7 +146,7 @@ async function main() {
       arguments: { pdf_path: fixturePath, max_markdown_bytes: 200000 },
     });
     if (markdown.isError
-      || markdown.structuredContent?.renderer?.version !== "1.2.0"
+      || markdown.structuredContent?.renderer?.version !== "1.3.0"
       || markdown.structuredContent?.markdown_bytes !== Buffer.byteLength(markdown.structuredContent?.markdown || "", "utf8")
       || markdown.structuredContent?.markdown_sha256 !== sha256(Buffer.from(markdown.structuredContent?.markdown || "", "utf8"))) {
       throw new Error("Packed convert_pdf_to_markdown contract smoke failed");

--- a/scripts/test-share-contract.mjs
+++ b/scripts/test-share-contract.mjs
@@ -837,7 +837,7 @@ async function main() {
       arguments: { pdf_path: fixturePath, max_markdown_bytes: 200000 },
     });
     if (markdown.isError
-      || markdown.structuredContent?.renderer?.version !== "1.2.0"
+      || markdown.structuredContent?.renderer?.version !== "1.3.0"
       || markdown.structuredContent?.markdown_bytes !== Buffer.byteLength(markdown.structuredContent?.markdown || "", "utf8")
       || markdown.structuredContent?.markdown_sha256 !== sha256(Buffer.from(markdown.structuredContent?.markdown || "", "utf8"))) {
       throw new Error("Share convert_pdf_to_markdown contract smoke failed");

--- a/server/markdown-conversion.js
+++ b/server/markdown-conversion.js
@@ -6,7 +6,7 @@ import {
 
 const RENDERER = Object.freeze({
   name: "pdf-tools.layout-markdown-renderer",
-  version: "1.2.0",
+  version: "1.3.0",
 });
 
 // Bounded geometric table inference. A run of adjacent lines is treated as a
@@ -155,6 +155,14 @@ function lineFontEvidence(page) {
   });
 }
 
+function headingTextEligible(value) {
+  const text = String(value).trim();
+  const alphanumericCharacters = text.match(/[\p{L}\p{N}]/gu) ?? [];
+  return !text.includes("\uFFFD")
+    && alphanumericCharacters.length >= 3
+    && !/[=∑∫∞≤≥≈≠±×÷√]/u.test(text);
+}
+
 function headingLevels(page) {
   const evidence = lineFontEvidence(page);
   const heights = evidence.map(value => value.height).filter(Number.isFinite);
@@ -168,6 +176,7 @@ function headingLevels(page) {
       && height >= bodyHeight * 1.5
       && line.text.length > 0
       && line.text.length <= 120
+      && headingTextEligible(line.text)
       && !/[.!?;]$/u.test(line.text)
       && !/^\s*(?:[\u2022\u2023\u25e6\u2043\u2219]|\d{1,3}[.)])\s+/u.test(line.text)
   ));

--- a/server/output-schemas.js
+++ b/server/output-schemas.js
@@ -552,7 +552,7 @@ export const TOOL_SUCCESS_OUTPUT_SCHEMAS = Object.freeze({
   convert_pdf_to_markdown: object({
     renderer: object({
       name: { const: "pdf-tools.layout-markdown-renderer" },
-      version: { const: "1.2.0" },
+      version: { const: "1.3.0" },
     }),
     conversion_status: enumString(["complete", "partial", "failed"]),
     markdown: string,

--- a/test/convert-pdf-to-markdown.test.js
+++ b/test/convert-pdf-to-markdown.test.js
@@ -305,7 +305,7 @@ describe("convert_pdf_to_markdown MCP tool", () => {
     expect(first.isError).not.toBe(true);
     expect(second.structuredContent).toEqual(first.structuredContent);
     expect(first.structuredContent).toMatchObject({
-      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.2.0" },
+      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.3.0" },
       conversion_status: "complete",
       saved_output: null,
       provenance: {

--- a/test/eval/markdown-bakeoff.test.js
+++ b/test/eval/markdown-bakeoff.test.js
@@ -64,7 +64,7 @@ async function handle(message) {
     const pageBoundaries = Array.from({ length: pageCount }, (_, index) => "<!-- PDF page " + (index + 1) + " -->");
     const markdown = pageBoundaries.join("\n\n") + "\n\nINV-1001 fixture evidence\n";
     const value = {
-      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.2.0" },
+      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.3.0" },
       conversion_status: "complete",
       markdown,
       markdown_sha256: digest(Buffer.from(markdown)),
@@ -143,7 +143,7 @@ function resultFor(binding) {
   const markdown = "<!-- PDF page 1 -->\n\nFixture text\n";
   return {
     structuredContent: {
-      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.2.0" },
+      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.3.0" },
       conversion_status: "complete",
       markdown,
       markdown_sha256: sha256(Buffer.from(markdown)),
@@ -231,8 +231,8 @@ describe("Markdown bakeoff renderer version binding", () => {
   });
 
   it("accepts the current renderer version and rejects the superseded one", () => {
-    expect(validateMarkdownResult(resultFor("1.2.0"), binding).renderer.version).toBe("1.2.0");
-    for (const stale of ["1.0.0", "1.1.0"]) {
+    expect(validateMarkdownResult(resultFor("1.3.0"), binding).renderer.version).toBe("1.3.0");
+    for (const stale of ["1.0.0", "1.1.0", "1.2.0"]) {
       expect(() => validateMarkdownResult(resultFor(stale), binding), stale)
         .toThrow(/Markdown result evidence is invalid/u);
     }

--- a/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
+++ b/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
@@ -61,14 +61,14 @@
     {
       "role": "markdown_conversion_module",
       "path": "server/markdown-conversion.js",
-      "bytes": 36742,
-      "sha256": "67b597921e21c8d78dbfdc11029694473cd38e1684dfb5b02b75bc0b67ac1476"
+      "bytes": 37062,
+      "sha256": "f6603c2e461053d71a40dfd1a0958705dd67bbe79a06832534ca0c59585b0446"
     },
     {
       "role": "output_schemas_module",
       "path": "server/output-schemas.js",
       "bytes": 29954,
-      "sha256": "dfb1f11100458c096e6eeb3d35e2f5e9ef09e0d80c57695aa77bcee22a7e5f0e"
+      "sha256": "c860fb09d08870336b7a1dee890cb06aca40d6ba8097409fcbed00e26f6bdba6"
     },
     {
       "role": "package_json",
@@ -95,7 +95,7 @@
       "sha256": "6e4429db62fcbe1dd73141d8c20a48b564d41f8bf8920d88775846995e1daf94"
     }
   ],
-  "validator_source_set_sha256": "1b4823995d320df4c2bf11b528099be39d10069091193baa777b9d11fa8d2bf6",
+  "validator_source_set_sha256": "83735c769cd23f88e2fadeb8349e76ec4ab54b4b127a97966a52967fd57cc372",
   "pdfjs_version": "5.4.624",
   "generation_contract": {
     "source_path": "source.pdf",

--- a/test/fixtures/eval/shannon/manifest.v1.json
+++ b/test/fixtures/eval/shannon/manifest.v1.json
@@ -22,7 +22,7 @@
     "pdf_tools": {
       "slot": "control.current_product.v0",
       "renderer_name": "pdf-tools.layout-markdown-renderer",
-      "renderer_version": "1.2.0",
+      "renderer_version": "1.3.0",
       "parser_name": "pdfjs-dist",
       "parser_version": "5.4.624"
     },

--- a/test/markdown-conversion.test.js
+++ b/test/markdown-conversion.test.js
@@ -141,6 +141,29 @@ describe("layout Markdown renderer", () => {
     expect(result.options.include_page_boundaries).toBe(false);
   });
 
+  it("keeps unreadable glyphs, lone characters, and equation fragments out of headings", async () => {
+    const page = candidate => ({
+      items: [
+        textItem(candidate, { top: 50, fontSize: 24 }),
+        textItem("First body line", { top: 100 }),
+        textItem("Second body line", { top: 130 }),
+        textItem("Third body line", { top: 160 }),
+        textItem("Fourth body line", { top: 190 }),
+      ],
+    });
+    const layout = await validatedSyntheticLayout([
+      page("�"),
+      page("T"),
+      page("H = p log p"),
+    ]);
+    const result = renderPdfLayoutToMarkdown(layout, { includePageBoundaries: false });
+
+    expect(result.markdown).toContain("�\n");
+    expect(result.markdown).toContain("T\n");
+    expect(result.markdown).toContain("H = p log p\n");
+    expect(result.markdown).not.toMatch(/^#{1,6}\s+(?:�|T|H = p log p)$/gmu);
+  });
+
   it("neutralizes hostile Markdown, HTML, table, autolink, and control syntax", async () => {
     const layout = await validatedSyntheticLayout([{
       items: [

--- a/test/mcp-contract.test.js
+++ b/test/mcp-contract.test.js
@@ -37,7 +37,11 @@ const EXAMPLE_PDF = path.join(REPO_ROOT, "example-fw9.pdf");
 // gap enum. The renderer throws on the byte limit rather than truncating, so
 // that code was unreachable and misdescribed the contract. Previously
 // 3993365ec0868e80afc629cbb8661566a363fe543acc928992ad36bcee4db86f.
-const TOOL_CONTRACT_SHA256 = "07b2f6035903e699d3d4f023137fc14d4316a214e789d45ed22a4dc804a1184b";
+// 2026-08-03: convert_pdf_to_markdown renderer 1.3.0 rejects unreadable,
+// fragmentary, and equation-like heading candidates while retaining their
+// source text as escaped body text. Previously
+// 07b2f6035903e699d3d4f023137fc14d4316a214e789d45ed22a4dc804a1184b.
+const TOOL_CONTRACT_SHA256 = "a7619f2d4b07b855e8625578be66f5c61c54af2a2881a33545deed7e7b008de0";
 
 const CLOSED_READ = Object.freeze({
   readOnlyHint: true,


### PR DESCRIPTION
## Summary

- Require readable, non-fragmentary content before font geometry can promote a line to a heading.
- Keep rejected candidates as escaped source-backed body text.
- Reject obvious equation-like candidates.
- Advance the deterministic Markdown renderer contract to 1.3.0.
- Retain a clean three-run Shannon comparison.

## Reviewed result

- Sampled malformed or fragmentary false headings fell from 227 to 0.
- Intended headings remain 0/14 here; their recovery is isolated in the next draft.
- Ordered anchors remain 22/24.
- Page-local equations remain 2/4, footnotes remain 4/4, and sampled Table I remains absent.
- Renderer, packaged copy, schema, smoke, and evaluation version pins agree.

## Evidence and verification

- Evidence report SHA-256: 04d1af01c27a6f76d4db3fdcb6c21f3614598aed590db32bccf3abcab8bff2c1
- Reviewed top-of-stack Vitest: 1,864 passed, 79 skipped, with one unrelated pre-existing macOS permission assertion.
- Node-native: 62 passed, 9 intentional skips.
- Bead: pdf-toolkit-mcp-hyh, closed.

No dependency, interface, bundle, or release change.