### PR TITLE
Recover strong document headings

### DIFF
--- a/docs/evidence/shannon-real-headings-2026-08.md
+++ b/docs/evidence/shannon-real-headings-2026-08.md
@@ -2,9 +2,9 @@
 
 ## Outcome
 
-PDF Tools now recognizes conservative, source-backed document structure for a
-first-page title, `INTRODUCTION`, numbered or Roman-numeral `APPENDIX` markers,
-and uppercase `PART` markers with titles. The renderer identity is now
+PDF Tools now recognizes conservative, source-backed document structure for at
+most one strongest first-page title, `INTRODUCTION`, numbered or Roman-numeral
+`APPENDIX` markers, and uppercase `PART` markers with titles. The renderer identity is now
 `pdf-tools.layout-markdown-renderer` version `1.4.0`.
 
 On the same hash-bound 55-page Shannon document used by the preceding runs,
@@ -19,17 +19,17 @@ external dependency.
 
 ## Clean run
 
-- Evaluated commit: `73ee358`
+- Evaluated commit: `9b56f0b`
 - Source PDF SHA-256:
   `6e4e3411984f3edf99dbfe8b941cb5e8a321379ff0cae6ae5c1f592ad8882ca8`
 - Heading-guardrail report SHA-256:
   `4489c23f5c19d17e93f8a4d689cc6106e26390082b945fb7b2cebb42ea2a03fd`
 - Real-heading report SHA-256:
-  `dee4bc622597c6036a0293eed93094715f0af2bb26c74ee86fb1e6f15b5d7e63`
+  `4a6bdad3000026603f47cb6c1146cde0481d572fc950259957d46d8cef049a68`
 - Repetitions: three fresh processes per candidate
 - PDF Tools Markdown deterministic across repetitions: `true`
-- Median PDF Tools elapsed time: 3720.48 ms
-- Median PDF Tools maximum RSS: 287,064,064 bytes
+- Median PDF Tools elapsed time: 4426.301 ms
+- Median PDF Tools maximum RSS: 295,993,344 bytes
 
 ## Metric comparison
 

--- a/docs/evidence/shannon-real-headings-2026-08.md
+++ b/docs/evidence/shannon-real-headings-2026-08.md
@@ -1,0 +1,52 @@
+# Shannon real-heading recovery — 2026-08
+
+## Outcome
+
+PDF Tools now recognizes conservative, source-backed document structure for a
+first-page title, `INTRODUCTION`, numbered or Roman-numeral `APPENDIX` markers,
+and uppercase `PART` markers with titles. The renderer identity is now
+`pdf-tools.layout-markdown-renderer` version `1.4.0`.
+
+On the same hash-bound 55-page Shannon document used by the preceding runs,
+expected heading recovery improved from 0 of 14 to 14 of 14. All headings used
+the expected level. Malformed, fragmentary, and equation-like false headings
+remained at zero. The sampled reading-order, continuity, equation, footnote,
+table, omission, and evidence results did not regress.
+
+The rules are document-generic and source-preserving. They do not contain
+Shannon-specific title text, repair extracted text, call a model, or add an
+external dependency.
+
+## Clean run
+
+- Evaluated commit: `73ee358`
+- Source PDF SHA-256:
+  `6e4e3411984f3edf99dbfe8b941cb5e8a321379ff0cae6ae5c1f592ad8882ca8`
+- Heading-guardrail report SHA-256:
+  `4489c23f5c19d17e93f8a4d689cc6106e26390082b945fb7b2cebb42ea2a03fd`
+- Real-heading report SHA-256:
+  `dee4bc622597c6036a0293eed93094715f0af2bb26c74ee86fb1e6f15b5d7e63`
+- Repetitions: three fresh processes per candidate
+- PDF Tools Markdown deterministic across repetitions: `true`
+- Median PDF Tools elapsed time: 3720.48 ms
+- Median PDF Tools maximum RSS: 287,064,064 bytes
+
+## Metric comparison
+
+| Sampled PDF Tools metric | Before | After |
+| --- | ---: | ---: |
+| Intended headings found | 0 / 14 | 14 / 14 |
+| Wrong-level intended headings | 0 | 0 |
+| Malformed or fragmentary false headings | 0 | 0 |
+| Equation-like false headings | 0 | 0 |
+| Ordered anchors retained | 22 / 24 | 22 / 24 |
+| Complete ordered-anchor groups | 4 / 6 | 4 / 6 |
+| Paragraph-continuity anchors | 1 / 4 | 1 / 4 |
+| Equation anchors | 2 / 4 | 2 / 4 |
+| Footnote anchors | 4 / 4 | 4 / 4 |
+| Sampled Table I topology | absent | absent |
+
+This is a sampled adversarial evaluation, not a complete transcript ground
+truth, public benchmark, release qualification, or claim that all PDF heading
+styles are recognized. Paragraph continuity, equation fidelity, and table
+topology remain separate product targets.

--- a/docs/evidence/shannon-real-headings-2026-08.md
+++ b/docs/evidence/shannon-real-headings-2026-08.md
@@ -4,8 +4,10 @@
 
 PDF Tools now recognizes conservative, source-backed document structure for at
 most one strongest first-page title, `INTRODUCTION`, numbered or Roman-numeral
-`APPENDIX` markers, and uppercase `PART` markers with titles. The renderer identity is now
-`pdf-tools.layout-markdown-renderer` version `1.4.0`.
+`APPENDIX` markers, and uppercase `PART` markers with titles. These narrow
+English-language rules also require centering and section-spacing evidence.
+The renderer identity is now `pdf-tools.layout-markdown-renderer` version
+`1.4.0`.
 
 On the same hash-bound 55-page Shannon document used by the preceding runs,
 expected heading recovery improved from 0 of 14 to 14 of 14. All headings used
@@ -13,23 +15,23 @@ the expected level. Malformed, fragmentary, and equation-like false headings
 remained at zero. The sampled reading-order, continuity, equation, footnote,
 table, omission, and evidence results did not regress.
 
-The rules are document-generic and source-preserving. They do not contain
-Shannon-specific title text, repair extracted text, call a model, or add an
-external dependency.
+The rules are not Shannon-specific and remain source-preserving, but they are
+deliberately not a universal or multilingual heading recognizer. They do not
+repair extracted text, call a model, or add an external dependency.
 
 ## Clean run
 
-- Evaluated commit: `9b56f0b`
+- Evaluated commit: `4788515aee8fa70075d7b85bf8c2867ff35e2d26`
 - Source PDF SHA-256:
   `6e4e3411984f3edf99dbfe8b941cb5e8a321379ff0cae6ae5c1f592ad8882ca8`
 - Heading-guardrail report SHA-256:
-  `4489c23f5c19d17e93f8a4d689cc6106e26390082b945fb7b2cebb42ea2a03fd`
+  `04d1af01c27a6f76d4db3fdcb6c21f3614598aed590db32bccf3abcab8bff2c1`
 - Real-heading report SHA-256:
-  `4a6bdad3000026603f47cb6c1146cde0481d572fc950259957d46d8cef049a68`
+  `63efa43f8cb6ba2f0198c74b00e4b21a34622fc0cb814b92f86c8e0306653a53`
 - Repetitions: three fresh processes per candidate
 - PDF Tools Markdown deterministic across repetitions: `true`
-- Median PDF Tools elapsed time: 4426.301 ms
-- Median PDF Tools maximum RSS: 295,993,344 bytes
+- Median PDF Tools elapsed time: 3552.053 ms
+- Median PDF Tools maximum RSS: 297,271,296 bytes
 
 ## Metric comparison
 
@@ -42,7 +44,7 @@ external dependency.
 | Ordered anchors retained | 22 / 24 | 22 / 24 |
 | Complete ordered-anchor groups | 4 / 6 | 4 / 6 |
 | Paragraph-continuity anchors | 1 / 4 | 1 / 4 |
-| Equation anchors | 2 / 4 | 2 / 4 |
+| Page-local equation anchors | 2 / 4 | 2 / 4 |
 | Footnote anchors | 4 / 4 | 4 / 4 |
 | Sampled Table I topology | absent | absent |
 

--- a/pdf-toolkit-mcp-share/server/markdown-conversion.js
+++ b/pdf-toolkit-mcp-share/server/markdown-conversion.js
@@ -43,7 +43,7 @@ const GAP_CODES = new Set([
 ]);
 
 const LIMITATIONS = Object.freeze([
-  "Headings are emitted only when a short line has consistent font metrics and is at least 1.5 times the page's median line height.",
+  "Headings are emitted only from consistent enlarged font metrics or centered English-language source structure with section spacing for a first-page title, introduction, part, or appendix. Ambiguous, very short, or unsupported heading styles remain body text.",
   "Lists are emitted only for literal bullet glyphs or decimal markers present in the source text.",
   "Links are emitted only for source-validated http or https annotation targets that map to exactly one contiguous run of text on one line. Internal destinations, actions, other schemes, ambiguous or partially covered labels, and links inside reconstructed tables remain escaped text reported as a conversion gap, and URL-looking source text is escaped to resist host autolinking.",
   "Tables are reconstructed only from text-item column geometry, and only when every row fills every detected column and the first row is typographically distinct enough to evidence a header, because a Markdown table imposes header semantics. Ruling lines and merged or spanning cells are not interpreted, and table-like content that fails either test remains escaped reading-order text reported as a conversion gap.",

--- a/pdf-toolkit-mcp-share/server/markdown-conversion.js
+++ b/pdf-toolkit-mcp-share/server/markdown-conversion.js
@@ -6,7 +6,7 @@ import {
 
 const RENDERER = Object.freeze({
   name: "pdf-tools.layout-markdown-renderer",
-  version: "1.3.0",
+  version: "1.4.0",
 });
 
 // Bounded geometric table inference. A run of adjacent lines is treated as a
@@ -163,13 +163,40 @@ function headingTextEligible(value) {
     && !/[=∑∫∞≤≥≈≠±×÷√]/u.test(text);
 }
 
+function titleCaseHeading(value) {
+  const words = String(value).trim().match(/[\p{L}\p{N}]+/gu) ?? [];
+  if (words.length < 3 || words.length > 15) return false;
+  const minorWords = new Set(["a", "an", "and", "as", "at", "by", "for", "in", "of", "on", "or", "the", "to"]);
+  return words.every((word, index) => {
+    const lower = word.toLocaleLowerCase("en-US");
+    if (index > 0 && minorWords.has(lower)) return true;
+    const first = [...word][0];
+    return first === first.toLocaleUpperCase("en-US")
+      && first !== first.toLocaleLowerCase("en-US");
+  });
+}
+
+function structuralHeadingLevel(page, line, index) {
+  const text = line.text.trim();
+  if (!headingTextEligible(text)) return null;
+  if (page.page === 1 && index <= 2 && titleCaseHeading(text)) return 1;
+  if (text === "INTRODUCTION") return 2;
+  if (/^PART\s+[IVXLCDM]+:\s+.+$/u.test(text) && text === text.toLocaleUpperCase("en-US")) return 2;
+  if (/^APPENDIX\s+(?:\d+|[IVXLCDM]+)$/u.test(text)) return 2;
+  return null;
+}
+
 function headingLevels(page) {
   const evidence = lineFontEvidence(page);
+  const structural = new Map(evidence.flatMap(({ line }, index) => {
+    const level = structuralHeadingLevel(page, line, index);
+    return level === null ? [] : [[line.id, level]];
+  }));
   const heights = evidence.map(value => value.height).filter(Number.isFinite);
-  if (heights.length < 4) return new Map();
+  if (heights.length < 4) return structural;
   const bodyHeight = median(heights);
   const bodyEvidence = heights.filter(height => Math.abs(height - bodyHeight) <= bodyHeight * 0.1);
-  if (bodyEvidence.length < 3) return new Map();
+  if (bodyEvidence.length < 3) return structural;
   const candidates = evidence.filter(({ line, height, consistentHeight, consistentFont }) => (
     consistentHeight
       && consistentFont
@@ -181,7 +208,8 @@ function headingLevels(page) {
       && !/^\s*(?:[\u2022\u2023\u25e6\u2043\u2219]|\d{1,3}[.)])\s+/u.test(line.text)
   ));
   const levels = [...new Set(candidates.map(value => value.height))].sort((left, right) => right - left);
-  return new Map(candidates.map(({ line, height }) => [line.id, Math.min(6, levels.indexOf(height) + 1)]));
+  const geometric = candidates.map(({ line, height }) => [line.id, Math.min(6, levels.indexOf(height) + 1)]);
+  return new Map([...geometric, ...structural]);
 }
 
 /**

--- a/pdf-toolkit-mcp-share/server/markdown-conversion.js
+++ b/pdf-toolkit-mcp-share/server/markdown-conversion.js
@@ -176,22 +176,39 @@ function titleCaseHeading(value) {
   });
 }
 
-function structuralHeadingLevel(page, line, index) {
+function structuralHeadingLevel(line) {
   const text = line.text.trim();
   if (!headingTextEligible(text)) return null;
-  if (page.page === 1 && index <= 2 && titleCaseHeading(text)) return 1;
   if (text === "INTRODUCTION") return 2;
   if (/^PART\s+[IVXLCDM]+:\s+.+$/u.test(text) && text === text.toLocaleUpperCase("en-US")) return 2;
   if (/^APPENDIX\s+(?:\d+|[IVXLCDM]+)$/u.test(text)) return 2;
   return null;
 }
 
-function headingLevels(page) {
-  const evidence = lineFontEvidence(page);
-  const structural = new Map(evidence.flatMap(({ line }, index) => {
-    const level = structuralHeadingLevel(page, line, index);
+function structuralHeadingLevels(page, evidence) {
+  const structural = new Map(evidence.flatMap(({ line }) => {
+    const level = structuralHeadingLevel(line);
     return level === null ? [] : [[line.id, level]];
   }));
+  if (page.page !== 1) return structural;
+  const titleCandidates = evidence.slice(0, 3).filter(({ line }) => (
+    headingTextEligible(line.text) && titleCaseHeading(line.text)
+  ));
+  const ranked = [...titleCandidates].sort((left, right) => (
+    (right.height ?? 0) - (left.height ?? 0)
+    || right.line.text.length - left.line.text.length
+  ));
+  const winner = ranked[0];
+  const runnerUp = ranked[1];
+  if (winner && (!runnerUp || (winner.height ?? 0) > (runnerUp.height ?? 0))) {
+    structural.set(winner.line.id, 1);
+  }
+  return structural;
+}
+
+function headingLevels(page) {
+  const evidence = lineFontEvidence(page);
+  const structural = structuralHeadingLevels(page, evidence);
   const heights = evidence.map(value => value.height).filter(Number.isFinite);
   if (heights.length < 4) return structural;
   const bodyHeight = median(heights);

--- a/pdf-toolkit-mcp-share/server/markdown-conversion.js
+++ b/pdf-toolkit-mcp-share/server/markdown-conversion.js
@@ -176,42 +176,63 @@ function titleCaseHeading(value) {
   });
 }
 
-function structuralHeadingLevel(line) {
+function lineIsCentered(page, line) {
+  const pageWidth = page.geometry?.display_width;
+  return Number.isFinite(pageWidth)
+    && Math.abs(line.x + line.width / 2 - pageWidth / 2) <= Math.max(4, line.height);
+}
+
+function hasSectionBreakBefore(page, evidence, index, bodyHeight) {
+  const line = evidence[index].line;
+  if (index === 0) {
+    return Number.isFinite(page.geometry?.display_height)
+      && line.y >= page.geometry.display_height * 0.07;
+  }
+  const previous = evidence[index - 1].line;
+  const gap = line.y - (previous.y + previous.height);
+  return gap >= Math.max(line.height, bodyHeight) * 1.15;
+}
+
+function structuralHeadingLevel(page, evidence, index, bodyHeight) {
+  const line = evidence[index].line;
   const text = line.text.trim();
-  if (!headingTextEligible(text)) return null;
-  if (text === "INTRODUCTION") return 2;
+  if (!headingTextEligible(text) || !lineIsCentered(page, line)
+    || !hasSectionBreakBefore(page, evidence, index, bodyHeight)) return null;
+  if (page.page === 1 && text === "INTRODUCTION") return 2;
   if (/^PART\s+[IVXLCDM]+:\s+.+$/u.test(text) && text === text.toLocaleUpperCase("en-US")) return 2;
   if (/^APPENDIX\s+(?:\d+|[IVXLCDM]+)$/u.test(text)) return 2;
   return null;
 }
 
-function structuralHeadingLevels(page, evidence) {
-  const structural = new Map(evidence.flatMap(({ line }) => {
-    const level = structuralHeadingLevel(line);
+function structuralHeadingLevels(page, evidence, bodyHeight) {
+  const structural = new Map(evidence.flatMap(({ line }, index) => {
+    const level = structuralHeadingLevel(page, evidence, index, bodyHeight);
     return level === null ? [] : [[line.id, level]];
   }));
   if (page.page !== 1) return structural;
-  const titleCandidates = evidence.slice(0, 3).filter(({ line }) => (
-    headingTextEligible(line.text) && titleCaseHeading(line.text)
+  const titleCandidates = evidence.slice(0, 3).filter(({ line, height }) => (
+    headingTextEligible(line.text)
+    && titleCaseHeading(line.text)
+    && lineIsCentered(page, line)
+    && Number.isFinite(height)
+    && height >= bodyHeight * 1.2
   ));
   const ranked = [...titleCandidates].sort((left, right) => (
     (right.height ?? 0) - (left.height ?? 0)
-    || right.line.text.length - left.line.text.length
+    || evidence.findIndex(item => item.line.id === left.line.id)
+      - evidence.findIndex(item => item.line.id === right.line.id)
   ));
   const winner = ranked[0];
-  const runnerUp = ranked[1];
-  if (winner && (!runnerUp || (winner.height ?? 0) > (runnerUp.height ?? 0))) {
-    structural.set(winner.line.id, 1);
-  }
+  if (winner) structural.set(winner.line.id, 1);
   return structural;
 }
 
 function headingLevels(page) {
   const evidence = lineFontEvidence(page);
-  const structural = structuralHeadingLevels(page, evidence);
   const heights = evidence.map(value => value.height).filter(Number.isFinite);
-  if (heights.length < 4) return structural;
+  if (heights.length < 4) return new Map();
   const bodyHeight = median(heights);
+  const structural = structuralHeadingLevels(page, evidence, bodyHeight);
   const bodyEvidence = heights.filter(height => Math.abs(height - bodyHeight) <= bodyHeight * 0.1);
   if (bodyEvidence.length < 3) return structural;
   const candidates = evidence.filter(({ line, height, consistentHeight, consistentFont }) => (
@@ -226,7 +247,15 @@ function headingLevels(page) {
   ));
   const levels = [...new Set(candidates.map(value => value.height))].sort((left, right) => right - left);
   const geometric = candidates.map(({ line, height }) => [line.id, Math.min(6, levels.indexOf(height) + 1)]);
-  return new Map([...geometric, ...structural]);
+  const combined = new Map([...geometric, ...structural]);
+  if (page.page === 1) {
+    const h1 = evidence.filter(({ line }) => combined.get(line.id) === 1);
+    const preferred = h1.find(({ line }) => structural.get(line.id) === 1) ?? h1[0];
+    for (const { line } of h1) {
+      if (line.id !== preferred?.line.id) combined.set(line.id, 2);
+    }
+  }
+  return combined;
 }
 
 /**

--- a/pdf-toolkit-mcp-share/server/output-schemas.js
+++ b/pdf-toolkit-mcp-share/server/output-schemas.js
@@ -552,7 +552,7 @@ export const TOOL_SUCCESS_OUTPUT_SCHEMAS = Object.freeze({
   convert_pdf_to_markdown: object({
     renderer: object({
       name: { const: "pdf-tools.layout-markdown-renderer" },
-      version: { const: "1.3.0" },
+      version: { const: "1.4.0" },
     }),
     conversion_status: enumString(["complete", "partial", "failed"]),
     markdown: string,

--- a/scripts/eval-run-markdown-bakeoff.mjs
+++ b/scripts/eval-run-markdown-bakeoff.mjs
@@ -190,7 +190,7 @@ export function validateMarkdownResult(result, binding) {
     throw new Error(`Markdown conversion failed for ${binding.fixture.id}`);
   }
   const value = result.structuredContent;
-  if (value.renderer?.name !== "pdf-tools.layout-markdown-renderer" || value.renderer?.version !== "1.3.0"
+  if (value.renderer?.name !== "pdf-tools.layout-markdown-renderer" || value.renderer?.version !== "1.4.0"
     || value.options?.include_page_boundaries !== true || value.limits?.max_markdown_bytes !== 200000
     || value.provenance?.source?.file_name !== binding.retained.filename
     || value.provenance?.source?.sha256 !== binding.retained.sha256

--- a/scripts/smoke-mcpb.mjs
+++ b/scripts/smoke-mcpb.mjs
@@ -146,7 +146,7 @@ async function main() {
       arguments: { pdf_path: fixturePath, max_markdown_bytes: 200000 },
     });
     if (markdown.isError
-      || markdown.structuredContent?.renderer?.version !== "1.3.0"
+      || markdown.structuredContent?.renderer?.version !== "1.4.0"
       || markdown.structuredContent?.markdown_bytes !== Buffer.byteLength(markdown.structuredContent?.markdown || "", "utf8")
       || markdown.structuredContent?.markdown_sha256 !== sha256(Buffer.from(markdown.structuredContent?.markdown || "", "utf8"))) {
       throw new Error("Packed convert_pdf_to_markdown contract smoke failed");

--- a/scripts/test-share-contract.mjs
+++ b/scripts/test-share-contract.mjs
@@ -837,7 +837,7 @@ async function main() {
       arguments: { pdf_path: fixturePath, max_markdown_bytes: 200000 },
     });
     if (markdown.isError
-      || markdown.structuredContent?.renderer?.version !== "1.3.0"
+      || markdown.structuredContent?.renderer?.version !== "1.4.0"
       || markdown.structuredContent?.markdown_bytes !== Buffer.byteLength(markdown.structuredContent?.markdown || "", "utf8")
       || markdown.structuredContent?.markdown_sha256 !== sha256(Buffer.from(markdown.structuredContent?.markdown || "", "utf8"))) {
       throw new Error("Share convert_pdf_to_markdown contract smoke failed");

--- a/server/markdown-conversion.js
+++ b/server/markdown-conversion.js
@@ -43,7 +43,7 @@ const GAP_CODES = new Set([
 ]);
 
 const LIMITATIONS = Object.freeze([
-  "Headings are emitted only when a short line has consistent font metrics and is at least 1.5 times the page's median line height.",
+  "Headings are emitted only from consistent enlarged font metrics or centered English-language source structure with section spacing for a first-page title, introduction, part, or appendix. Ambiguous, very short, or unsupported heading styles remain body text.",
   "Lists are emitted only for literal bullet glyphs or decimal markers present in the source text.",
   "Links are emitted only for source-validated http or https annotation targets that map to exactly one contiguous run of text on one line. Internal destinations, actions, other schemes, ambiguous or partially covered labels, and links inside reconstructed tables remain escaped text reported as a conversion gap, and URL-looking source text is escaped to resist host autolinking.",
   "Tables are reconstructed only from text-item column geometry, and only when every row fills every detected column and the first row is typographically distinct enough to evidence a header, because a Markdown table imposes header semantics. Ruling lines and merged or spanning cells are not interpreted, and table-like content that fails either test remains escaped reading-order text reported as a conversion gap.",

--- a/server/markdown-conversion.js
+++ b/server/markdown-conversion.js
@@ -6,7 +6,7 @@ import {
 
 const RENDERER = Object.freeze({
   name: "pdf-tools.layout-markdown-renderer",
-  version: "1.3.0",
+  version: "1.4.0",
 });
 
 // Bounded geometric table inference. A run of adjacent lines is treated as a
@@ -163,13 +163,40 @@ function headingTextEligible(value) {
     && !/[=∑∫∞≤≥≈≠±×÷√]/u.test(text);
 }
 
+function titleCaseHeading(value) {
+  const words = String(value).trim().match(/[\p{L}\p{N}]+/gu) ?? [];
+  if (words.length < 3 || words.length > 15) return false;
+  const minorWords = new Set(["a", "an", "and", "as", "at", "by", "for", "in", "of", "on", "or", "the", "to"]);
+  return words.every((word, index) => {
+    const lower = word.toLocaleLowerCase("en-US");
+    if (index > 0 && minorWords.has(lower)) return true;
+    const first = [...word][0];
+    return first === first.toLocaleUpperCase("en-US")
+      && first !== first.toLocaleLowerCase("en-US");
+  });
+}
+
+function structuralHeadingLevel(page, line, index) {
+  const text = line.text.trim();
+  if (!headingTextEligible(text)) return null;
+  if (page.page === 1 && index <= 2 && titleCaseHeading(text)) return 1;
+  if (text === "INTRODUCTION") return 2;
+  if (/^PART\s+[IVXLCDM]+:\s+.+$/u.test(text) && text === text.toLocaleUpperCase("en-US")) return 2;
+  if (/^APPENDIX\s+(?:\d+|[IVXLCDM]+)$/u.test(text)) return 2;
+  return null;
+}
+
 function headingLevels(page) {
   const evidence = lineFontEvidence(page);
+  const structural = new Map(evidence.flatMap(({ line }, index) => {
+    const level = structuralHeadingLevel(page, line, index);
+    return level === null ? [] : [[line.id, level]];
+  }));
   const heights = evidence.map(value => value.height).filter(Number.isFinite);
-  if (heights.length < 4) return new Map();
+  if (heights.length < 4) return structural;
   const bodyHeight = median(heights);
   const bodyEvidence = heights.filter(height => Math.abs(height - bodyHeight) <= bodyHeight * 0.1);
-  if (bodyEvidence.length < 3) return new Map();
+  if (bodyEvidence.length < 3) return structural;
   const candidates = evidence.filter(({ line, height, consistentHeight, consistentFont }) => (
     consistentHeight
       && consistentFont
@@ -181,7 +208,8 @@ function headingLevels(page) {
       && !/^\s*(?:[\u2022\u2023\u25e6\u2043\u2219]|\d{1,3}[.)])\s+/u.test(line.text)
   ));
   const levels = [...new Set(candidates.map(value => value.height))].sort((left, right) => right - left);
-  return new Map(candidates.map(({ line, height }) => [line.id, Math.min(6, levels.indexOf(height) + 1)]));
+  const geometric = candidates.map(({ line, height }) => [line.id, Math.min(6, levels.indexOf(height) + 1)]);
+  return new Map([...geometric, ...structural]);
 }
 
 /**

--- a/server/markdown-conversion.js
+++ b/server/markdown-conversion.js
@@ -176,22 +176,39 @@ function titleCaseHeading(value) {
   });
 }
 
-function structuralHeadingLevel(page, line, index) {
+function structuralHeadingLevel(line) {
   const text = line.text.trim();
   if (!headingTextEligible(text)) return null;
-  if (page.page === 1 && index <= 2 && titleCaseHeading(text)) return 1;
   if (text === "INTRODUCTION") return 2;
   if (/^PART\s+[IVXLCDM]+:\s+.+$/u.test(text) && text === text.toLocaleUpperCase("en-US")) return 2;
   if (/^APPENDIX\s+(?:\d+|[IVXLCDM]+)$/u.test(text)) return 2;
   return null;
 }
 
-function headingLevels(page) {
-  const evidence = lineFontEvidence(page);
-  const structural = new Map(evidence.flatMap(({ line }, index) => {
-    const level = structuralHeadingLevel(page, line, index);
+function structuralHeadingLevels(page, evidence) {
+  const structural = new Map(evidence.flatMap(({ line }) => {
+    const level = structuralHeadingLevel(line);
     return level === null ? [] : [[line.id, level]];
   }));
+  if (page.page !== 1) return structural;
+  const titleCandidates = evidence.slice(0, 3).filter(({ line }) => (
+    headingTextEligible(line.text) && titleCaseHeading(line.text)
+  ));
+  const ranked = [...titleCandidates].sort((left, right) => (
+    (right.height ?? 0) - (left.height ?? 0)
+    || right.line.text.length - left.line.text.length
+  ));
+  const winner = ranked[0];
+  const runnerUp = ranked[1];
+  if (winner && (!runnerUp || (winner.height ?? 0) > (runnerUp.height ?? 0))) {
+    structural.set(winner.line.id, 1);
+  }
+  return structural;
+}
+
+function headingLevels(page) {
+  const evidence = lineFontEvidence(page);
+  const structural = structuralHeadingLevels(page, evidence);
   const heights = evidence.map(value => value.height).filter(Number.isFinite);
   if (heights.length < 4) return structural;
   const bodyHeight = median(heights);

--- a/server/markdown-conversion.js
+++ b/server/markdown-conversion.js
@@ -176,42 +176,63 @@ function titleCaseHeading(value) {
   });
 }
 
-function structuralHeadingLevel(line) {
+function lineIsCentered(page, line) {
+  const pageWidth = page.geometry?.display_width;
+  return Number.isFinite(pageWidth)
+    && Math.abs(line.x + line.width / 2 - pageWidth / 2) <= Math.max(4, line.height);
+}
+
+function hasSectionBreakBefore(page, evidence, index, bodyHeight) {
+  const line = evidence[index].line;
+  if (index === 0) {
+    return Number.isFinite(page.geometry?.display_height)
+      && line.y >= page.geometry.display_height * 0.07;
+  }
+  const previous = evidence[index - 1].line;
+  const gap = line.y - (previous.y + previous.height);
+  return gap >= Math.max(line.height, bodyHeight) * 1.15;
+}
+
+function structuralHeadingLevel(page, evidence, index, bodyHeight) {
+  const line = evidence[index].line;
   const text = line.text.trim();
-  if (!headingTextEligible(text)) return null;
-  if (text === "INTRODUCTION") return 2;
+  if (!headingTextEligible(text) || !lineIsCentered(page, line)
+    || !hasSectionBreakBefore(page, evidence, index, bodyHeight)) return null;
+  if (page.page === 1 && text === "INTRODUCTION") return 2;
   if (/^PART\s+[IVXLCDM]+:\s+.+$/u.test(text) && text === text.toLocaleUpperCase("en-US")) return 2;
   if (/^APPENDIX\s+(?:\d+|[IVXLCDM]+)$/u.test(text)) return 2;
   return null;
 }
 
-function structuralHeadingLevels(page, evidence) {
-  const structural = new Map(evidence.flatMap(({ line }) => {
-    const level = structuralHeadingLevel(line);
+function structuralHeadingLevels(page, evidence, bodyHeight) {
+  const structural = new Map(evidence.flatMap(({ line }, index) => {
+    const level = structuralHeadingLevel(page, evidence, index, bodyHeight);
     return level === null ? [] : [[line.id, level]];
   }));
   if (page.page !== 1) return structural;
-  const titleCandidates = evidence.slice(0, 3).filter(({ line }) => (
-    headingTextEligible(line.text) && titleCaseHeading(line.text)
+  const titleCandidates = evidence.slice(0, 3).filter(({ line, height }) => (
+    headingTextEligible(line.text)
+    && titleCaseHeading(line.text)
+    && lineIsCentered(page, line)
+    && Number.isFinite(height)
+    && height >= bodyHeight * 1.2
   ));
   const ranked = [...titleCandidates].sort((left, right) => (
     (right.height ?? 0) - (left.height ?? 0)
-    || right.line.text.length - left.line.text.length
+    || evidence.findIndex(item => item.line.id === left.line.id)
+      - evidence.findIndex(item => item.line.id === right.line.id)
   ));
   const winner = ranked[0];
-  const runnerUp = ranked[1];
-  if (winner && (!runnerUp || (winner.height ?? 0) > (runnerUp.height ?? 0))) {
-    structural.set(winner.line.id, 1);
-  }
+  if (winner) structural.set(winner.line.id, 1);
   return structural;
 }
 
 function headingLevels(page) {
   const evidence = lineFontEvidence(page);
-  const structural = structuralHeadingLevels(page, evidence);
   const heights = evidence.map(value => value.height).filter(Number.isFinite);
-  if (heights.length < 4) return structural;
+  if (heights.length < 4) return new Map();
   const bodyHeight = median(heights);
+  const structural = structuralHeadingLevels(page, evidence, bodyHeight);
   const bodyEvidence = heights.filter(height => Math.abs(height - bodyHeight) <= bodyHeight * 0.1);
   if (bodyEvidence.length < 3) return structural;
   const candidates = evidence.filter(({ line, height, consistentHeight, consistentFont }) => (
@@ -226,7 +247,15 @@ function headingLevels(page) {
   ));
   const levels = [...new Set(candidates.map(value => value.height))].sort((left, right) => right - left);
   const geometric = candidates.map(({ line, height }) => [line.id, Math.min(6, levels.indexOf(height) + 1)]);
-  return new Map([...geometric, ...structural]);
+  const combined = new Map([...geometric, ...structural]);
+  if (page.page === 1) {
+    const h1 = evidence.filter(({ line }) => combined.get(line.id) === 1);
+    const preferred = h1.find(({ line }) => structural.get(line.id) === 1) ?? h1[0];
+    for (const { line } of h1) {
+      if (line.id !== preferred?.line.id) combined.set(line.id, 2);
+    }
+  }
+  return combined;
 }
 
 /**

--- a/server/output-schemas.js
+++ b/server/output-schemas.js
@@ -552,7 +552,7 @@ export const TOOL_SUCCESS_OUTPUT_SCHEMAS = Object.freeze({
   convert_pdf_to_markdown: object({
     renderer: object({
       name: { const: "pdf-tools.layout-markdown-renderer" },
-      version: { const: "1.3.0" },
+      version: { const: "1.4.0" },
     }),
     conversion_status: enumString(["complete", "partial", "failed"]),
     markdown: string,

--- a/test/convert-pdf-to-markdown.test.js
+++ b/test/convert-pdf-to-markdown.test.js
@@ -305,7 +305,7 @@ describe("convert_pdf_to_markdown MCP tool", () => {
     expect(first.isError).not.toBe(true);
     expect(second.structuredContent).toEqual(first.structuredContent);
     expect(first.structuredContent).toMatchObject({
-      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.3.0" },
+      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.4.0" },
       conversion_status: "complete",
       saved_output: null,
       provenance: {

--- a/test/eval/markdown-bakeoff.test.js
+++ b/test/eval/markdown-bakeoff.test.js
@@ -64,7 +64,7 @@ async function handle(message) {
     const pageBoundaries = Array.from({ length: pageCount }, (_, index) => "<!-- PDF page " + (index + 1) + " -->");
     const markdown = pageBoundaries.join("\n\n") + "\n\nINV-1001 fixture evidence\n";
     const value = {
-      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.3.0" },
+      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.4.0" },
       conversion_status: "complete",
       markdown,
       markdown_sha256: digest(Buffer.from(markdown)),
@@ -143,7 +143,7 @@ function resultFor(binding) {
   const markdown = "<!-- PDF page 1 -->\n\nFixture text\n";
   return {
     structuredContent: {
-      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.3.0" },
+      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.4.0" },
       conversion_status: "complete",
       markdown,
       markdown_sha256: sha256(Buffer.from(markdown)),
@@ -231,8 +231,8 @@ describe("Markdown bakeoff renderer version binding", () => {
   });
 
   it("accepts the current renderer version and rejects the superseded one", () => {
-    expect(validateMarkdownResult(resultFor("1.3.0"), binding).renderer.version).toBe("1.3.0");
-    for (const stale of ["1.0.0", "1.1.0", "1.2.0"]) {
+    expect(validateMarkdownResult(resultFor("1.4.0"), binding).renderer.version).toBe("1.4.0");
+    for (const stale of ["1.0.0", "1.1.0", "1.2.0", "1.3.0"]) {
       expect(() => validateMarkdownResult(resultFor(stale), binding), stale)
         .toThrow(/Markdown result evidence is invalid/u);
     }

--- a/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
+++ b/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
@@ -61,14 +61,14 @@
     {
       "role": "markdown_conversion_module",
       "path": "server/markdown-conversion.js",
-      "bytes": 37062,
-      "sha256": "f6603c2e461053d71a40dfd1a0958705dd67bbe79a06832534ca0c59585b0446"
+      "bytes": 38305,
+      "sha256": "1e91981af6230ec686b9dcf47e3c7fd0cd54ec0d7b2e84afb9b85dfefa41a9be"
     },
     {
       "role": "output_schemas_module",
       "path": "server/output-schemas.js",
       "bytes": 29954,
-      "sha256": "c860fb09d08870336b7a1dee890cb06aca40d6ba8097409fcbed00e26f6bdba6"
+      "sha256": "698c45842fa6b3b6f93259a96ff0c82c111631f5ddfc226027540f50ce78473f"
     },
     {
       "role": "package_json",
@@ -95,7 +95,7 @@
       "sha256": "6e4429db62fcbe1dd73141d8c20a48b564d41f8bf8920d88775846995e1daf94"
     }
   ],
-  "validator_source_set_sha256": "83735c769cd23f88e2fadeb8349e76ec4ab54b4b127a97966a52967fd57cc372",
+  "validator_source_set_sha256": "ca62831283a72d51ea0c6818997986af52ea5bb52bbc3a7ee8994351fa34e1df",
   "pdfjs_version": "5.4.624",
   "generation_contract": {
     "source_path": "source.pdf",

--- a/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
+++ b/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
@@ -61,8 +61,8 @@
     {
       "role": "markdown_conversion_module",
       "path": "server/markdown-conversion.js",
-      "bytes": 38305,
-      "sha256": "1e91981af6230ec686b9dcf47e3c7fd0cd54ec0d7b2e84afb9b85dfefa41a9be"
+      "bytes": 38868,
+      "sha256": "799252fd3f7c918baf2a76a00f3027bd2d6921154fa50ecb9aa484e70ca5daf0"
     },
     {
       "role": "output_schemas_module",
@@ -95,7 +95,7 @@
       "sha256": "6e4429db62fcbe1dd73141d8c20a48b564d41f8bf8920d88775846995e1daf94"
     }
   ],
-  "validator_source_set_sha256": "ca62831283a72d51ea0c6818997986af52ea5bb52bbc3a7ee8994351fa34e1df",
+  "validator_source_set_sha256": "270eb357c9fa8216c41622c39a8e9b3ee267eb48ea1314ccda1a9224698661d7",
   "pdfjs_version": "5.4.624",
   "generation_contract": {
     "source_path": "source.pdf",

--- a/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
+++ b/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
@@ -61,8 +61,8 @@
     {
       "role": "markdown_conversion_module",
       "path": "server/markdown-conversion.js",
-      "bytes": 40136,
-      "sha256": "5542d8e4efb44f8b29be07c03ed147a4320e6a79f5f9c2e75054418fc1377b61"
+      "bytes": 40266,
+      "sha256": "41d813e3004dd7f8ced1b51ea1ce63cdb3e58934d98b6c28121a8aa783fe8265"
     },
     {
       "role": "output_schemas_module",
@@ -95,7 +95,7 @@
       "sha256": "6e4429db62fcbe1dd73141d8c20a48b564d41f8bf8920d88775846995e1daf94"
     }
   ],
-  "validator_source_set_sha256": "474fee791658a040927b5a8de288104f36aadfdbfbca3194194d3ad2be767e7a",
+  "validator_source_set_sha256": "46c4f1a7a584640e6dff05d51557f5dffec6f81f932a1512836332f8ed15fbc8",
   "pdfjs_version": "5.4.624",
   "generation_contract": {
     "source_path": "source.pdf",

--- a/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
+++ b/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
@@ -61,8 +61,8 @@
     {
       "role": "markdown_conversion_module",
       "path": "server/markdown-conversion.js",
-      "bytes": 38868,
-      "sha256": "799252fd3f7c918baf2a76a00f3027bd2d6921154fa50ecb9aa484e70ca5daf0"
+      "bytes": 40136,
+      "sha256": "5542d8e4efb44f8b29be07c03ed147a4320e6a79f5f9c2e75054418fc1377b61"
     },
     {
       "role": "output_schemas_module",
@@ -95,7 +95,7 @@
       "sha256": "6e4429db62fcbe1dd73141d8c20a48b564d41f8bf8920d88775846995e1daf94"
     }
   ],
-  "validator_source_set_sha256": "270eb357c9fa8216c41622c39a8e9b3ee267eb48ea1314ccda1a9224698661d7",
+  "validator_source_set_sha256": "474fee791658a040927b5a8de288104f36aadfdbfbca3194194d3ad2be767e7a",
   "pdfjs_version": "5.4.624",
   "generation_contract": {
     "source_path": "source.pdf",

--- a/test/fixtures/eval/shannon/manifest.v1.json
+++ b/test/fixtures/eval/shannon/manifest.v1.json
@@ -22,7 +22,7 @@
     "pdf_tools": {
       "slot": "control.current_product.v0",
       "renderer_name": "pdf-tools.layout-markdown-renderer",
-      "renderer_version": "1.3.0",
+      "renderer_version": "1.4.0",
       "parser_name": "pdfjs-dist",
       "parser_version": "5.4.624"
     },

--- a/test/markdown-conversion.test.js
+++ b/test/markdown-conversion.test.js
@@ -37,6 +37,11 @@ function textItem(text, { top, fontSize = 12, left = 50, eol = true } = {}) {
   };
 }
 
+function centeredTextItem(text, { top, fontSize = 12 } = {}) {
+  const width = Math.max(20, text.length * fontSize * 0.5);
+  return textItem(text, { top, fontSize, left: (612 - width) / 2 });
+}
+
 function fakePdfjs(pageConfigs) {
   const pages = pageConfigs.map(config => ({
     view: [0, 0, 612, 792],
@@ -175,12 +180,12 @@ describe("layout Markdown renderer", () => {
       { items: [
         textItem("Reprinted with corrections from the journal", { top: 20 }),
         textItem("Volume 27, July 1948", { top: 35 }),
-        textItem("A Mathematical Theory of Communication", { top: 50 }),
-        textItem("INTRODUCTION", { top: 90 }),
+        centeredTextItem("A Mathematical Theory of Communication", { top: 50, fontSize: 16 }),
+        centeredTextItem("INTRODUCTION", { top: 90 }),
         ...body(130),
       ] },
-      { items: [textItem("PART IV: THE CONTINUOUS CHANNEL", { top: 50 }), ...body(90)] },
-      { items: [textItem("APPENDIX 7", { top: 50 }), ...body(90)] },
+      { items: [centeredTextItem("PART IV: THE CONTINUOUS CHANNEL", { top: 60 }), ...body(100)] },
+      { items: [centeredTextItem("APPENDIX 7", { top: 60 }), ...body(100)] },
       { items: [
         textItem("PART I = H", { top: 50, fontSize: 24 }),
         textItem("INTRODUCTION = H", { top: 90, fontSize: 24 }),
@@ -196,12 +201,11 @@ describe("layout Markdown renderer", () => {
     expect(result.markdown).not.toMatch(/^#{1,6}\s+(?:PART I = H|INTRODUCTION = H)$/gmu);
   });
 
-  it("chooses at most one strongest first-page title candidate", async () => {
+  it("emits at most one first-page H1 when a title and subtitle share the strongest style", async () => {
     const layout = await validatedSyntheticLayout([{
       items: [
-        textItem("Prepared For Journal Readers", { top: 20 }),
-        textItem("A Preliminary Edition Note", { top: 35 }),
-        textItem("A Mathematical Theory of Communication", { top: 55, fontSize: 16 }),
+        centeredTextItem("Annual Financial Report", { top: 30, fontSize: 18 }),
+        centeredTextItem("For Shareholders and Partners", { top: 60, fontSize: 18 }),
         textItem("First body line", { top: 100 }),
         textItem("Second body line", { top: 130 }),
         textItem("Third body line", { top: 160 }),
@@ -210,8 +214,29 @@ describe("layout Markdown renderer", () => {
     }]);
     const result = renderPdfLayoutToMarkdown(layout, { includePageBoundaries: false });
 
-    expect(result.markdown).toMatch(/^# A Mathematical Theory of Communication$/mu);
-    expect(result.markdown).not.toMatch(/^#{1,6}\s+(?:Prepared For Journal Readers|A Preliminary Edition Note)$/gmu);
+    expect(result.markdown.match(/^#\s+/gmu)).toHaveLength(1);
+    expect(result.markdown).toMatch(/^## (?:Annual Financial Report|For Shareholders and Partners)$/mu);
+  });
+
+  it("does not promote repeated page labels or contents-like entries without layout support", async () => {
+    const body = top => [
+      textItem("First body line", { top }),
+      textItem("Second body line", { top: top + 30 }),
+      textItem("Third body line", { top: top + 60 }),
+      textItem("Fourth body line", { top: top + 90 }),
+    ];
+    const layout = await validatedSyntheticLayout([
+      { items: [centeredTextItem("INTRODUCTION", { top: 20 }), ...body(50)] },
+      { items: [
+        textItem("Contents entry", { top: 80 }),
+        centeredTextItem("APPENDIX 1", { top: 98 }),
+        ...body(120),
+      ] },
+      { items: [textItem("PART I: REPEATED PAGE LABEL", { top: 20 }), ...body(50)] },
+    ]);
+    const result = renderPdfLayoutToMarkdown(layout, { includePageBoundaries: false });
+
+    expect(result.markdown).not.toMatch(/^#{1,6}\s+(?:INTRODUCTION|APPENDIX 1|PART I: REPEATED PAGE LABEL)$/gmu);
   });
 
   it("neutralizes hostile Markdown, HTML, table, autolink, and control syntax", async () => {

--- a/test/markdown-conversion.test.js
+++ b/test/markdown-conversion.test.js
@@ -196,6 +196,24 @@ describe("layout Markdown renderer", () => {
     expect(result.markdown).not.toMatch(/^#{1,6}\s+(?:PART I = H|INTRODUCTION = H)$/gmu);
   });
 
+  it("chooses at most one strongest first-page title candidate", async () => {
+    const layout = await validatedSyntheticLayout([{
+      items: [
+        textItem("Prepared For Journal Readers", { top: 20 }),
+        textItem("A Preliminary Edition Note", { top: 35 }),
+        textItem("A Mathematical Theory of Communication", { top: 55, fontSize: 16 }),
+        textItem("First body line", { top: 100 }),
+        textItem("Second body line", { top: 130 }),
+        textItem("Third body line", { top: 160 }),
+        textItem("Fourth body line", { top: 190 }),
+      ],
+    }]);
+    const result = renderPdfLayoutToMarkdown(layout, { includePageBoundaries: false });
+
+    expect(result.markdown).toMatch(/^# A Mathematical Theory of Communication$/mu);
+    expect(result.markdown).not.toMatch(/^#{1,6}\s+(?:Prepared For Journal Readers|A Preliminary Edition Note)$/gmu);
+  });
+
   it("neutralizes hostile Markdown, HTML, table, autolink, and control syntax", async () => {
     const layout = await validatedSyntheticLayout([{
       items: [

--- a/test/markdown-conversion.test.js
+++ b/test/markdown-conversion.test.js
@@ -164,6 +164,38 @@ describe("layout Markdown renderer", () => {
     expect(result.markdown).not.toMatch(/^#{1,6}\s+(?:�|T|H = p log p)$/gmu);
   });
 
+  it("recognizes conservative document structure without promoting lookalike equations", async () => {
+    const body = top => [
+      textItem("First body line", { top }),
+      textItem("Second body line", { top: top + 30 }),
+      textItem("Third body line", { top: top + 60 }),
+      textItem("Fourth body line", { top: top + 90 }),
+    ];
+    const layout = await validatedSyntheticLayout([
+      { items: [
+        textItem("Reprinted with corrections from the journal", { top: 20 }),
+        textItem("Volume 27, July 1948", { top: 35 }),
+        textItem("A Mathematical Theory of Communication", { top: 50 }),
+        textItem("INTRODUCTION", { top: 90 }),
+        ...body(130),
+      ] },
+      { items: [textItem("PART IV: THE CONTINUOUS CHANNEL", { top: 50 }), ...body(90)] },
+      { items: [textItem("APPENDIX 7", { top: 50 }), ...body(90)] },
+      { items: [
+        textItem("PART I = H", { top: 50, fontSize: 24 }),
+        textItem("INTRODUCTION = H", { top: 90, fontSize: 24 }),
+        ...body(130),
+      ] },
+    ]);
+    const result = renderPdfLayoutToMarkdown(layout, { includePageBoundaries: false });
+
+    expect(result.markdown).toMatch(/^# A Mathematical Theory of Communication$/mu);
+    expect(result.markdown).toMatch(/^## INTRODUCTION$/mu);
+    expect(result.markdown).toMatch(/^## PART IV: THE CONTINUOUS CHANNEL$/mu);
+    expect(result.markdown).toMatch(/^## APPENDIX 7$/mu);
+    expect(result.markdown).not.toMatch(/^#{1,6}\s+(?:PART I = H|INTRODUCTION = H)$/gmu);
+  });
+
   it("neutralizes hostile Markdown, HTML, table, autolink, and control syntax", async () => {
     const layout = await validatedSyntheticLayout([{
       items: [

--- a/test/mcp-contract.test.js
+++ b/test/mcp-contract.test.js
@@ -41,7 +41,10 @@ const EXAMPLE_PDF = path.join(REPO_ROOT, "example-fw9.pdf");
 // fragmentary, and equation-like heading candidates while retaining their
 // source text as escaped body text. Previously
 // 07b2f6035903e699d3d4f023137fc14d4316a214e789d45ed22a4dc804a1184b.
-const TOOL_CONTRACT_SHA256 = "a7619f2d4b07b855e8625578be66f5c61c54af2a2881a33545deed7e7b008de0";
+// 2026-08-03: convert_pdf_to_markdown renderer 1.4.0 adds conservative
+// source-backed title, introduction, part, and appendix structure. Previously
+// a7619f2d4b07b855e8625578be66f5c61c54af2a2881a33545deed7e7b008de0.
+const TOOL_CONTRACT_SHA256 = "fc757dc89b8aaf25b22f05b07863a4b8be1e09b6a544764a1b4afc8cdca3d6dd";
 
 const CLOSED_READ = Object.freeze({
   readOnlyHint: true,


### PR DESCRIPTION
## Summary

- Recognize a narrow set of source-backed English document structures: one strongest first-page title, introduction, part, and appendix markers.
- Require centering and section-spacing evidence so repeated page labels and contents-like entries remain ordinary text.
- Allow only one first-page H1; a same-style subtitle is demoted.
- Preserve the 1.3 protections against unreadable, fragmentary, and obvious equation-like headings.
- Advance the deterministic Markdown renderer contract to 1.4.0.

## Reviewed result

- Expected Shannon heading recovery improves from 0/14 to 14/14 at the expected levels.
- Sampled malformed, fragmentary, and equation-like false headings remain 0.
- Adversarial checks cover repeated labels, contents-like entries, title/subtitle competition, and equation lookalikes.
- Ordered anchors remain 22/24; paragraphs remain 1/4; page-local equations remain 2/4; footnotes remain 4/4.
- This is deliberately not described as a universal or multilingual heading recognizer.

## Evidence and verification

- Evidence report SHA-256: 63efa43f8cb6ba2f0198c74b00e4b21a34622fc0cb814b92f86c8e0306653a53
- Focused renderer and dependent checks: 104 passed, 6 skipped.
- Reviewed top-of-stack Vitest: 1,864 passed, 79 skipped, with one unrelated pre-existing macOS permission assertion.
- Node-native: 62 passed, 9 intentional skips.
- Bead: pdf-toolkit-mcp-cpp, closed.

No external model, dependency, source-text repair, interface, bundle, or release change.