### PR TITLE
Improve deterministic paragraph continuity

### DIFF
--- a/docs/evidence/shannon-paragraph-continuity-2026-08.md
+++ b/docs/evidence/shannon-paragraph-continuity-2026-08.md
@@ -1,0 +1,56 @@
+# Shannon paragraph continuity — 2026-08
+
+## Outcome
+
+PDF Tools now performs two bounded, source-backed paragraph-flow repairs:
+
+- a large initial capital can join an overlapping uppercase word remainder;
+- a lowercase word split across consecutive same-column body lines by a
+  line-end hyphen can be dehyphenated.
+
+Headings, lists, links, tables, different columns, and ambiguous geometry remain
+separate. The original lines remain available in the Extraction IR. The
+Markdown renderer identity is now `pdf-tools.layout-markdown-renderer` version
+`1.5.0`.
+
+On the hash-bound 55-page Shannon document, sampled paragraph-continuity
+recovery improved from 1 of 4 anchors to 3 of 4. Sampled ordered anchors also
+improved from 22 of 24 to 23 of 24. Heading recovery remained 14 of 14 with
+zero malformed, fragmentary, or equation-like false headings. The sampled
+equation, footnote, table, omission, and evidence results did not regress.
+
+The remaining continuity miss is a vertically stacked printed fraction. It is
+not treated as ordinary paragraph joining and remains for a separate math-layout
+evaluation.
+
+## Clean run
+
+- Evaluated commit: `060979c`
+- Source PDF SHA-256:
+  `6e4e3411984f3edf99dbfe8b941cb5e8a321379ff0cae6ae5c1f592ad8882ca8`
+- Real-heading report SHA-256:
+  `dee4bc622597c6036a0293eed93094715f0af2bb26c74ee86fb1e6f15b5d7e63`
+- Paragraph-continuity report SHA-256:
+  `c521e6701cfb64a2758827a878b13457f86801a3fc02c23ce42254883e5aa5db`
+- Repetitions: three fresh processes per candidate
+- PDF Tools Markdown deterministic across repetitions: `true`
+- Median PDF Tools elapsed time: 3727.857 ms
+- Median PDF Tools maximum RSS: 294,158,336 bytes
+
+## Metric comparison
+
+| Sampled PDF Tools metric | Before | After |
+| --- | ---: | ---: |
+| Paragraph-continuity anchors | 1 / 4 | 3 / 4 |
+| Ordered anchors retained | 22 / 24 | 23 / 24 |
+| Complete ordered-anchor groups | 4 / 6 | 5 / 6 |
+| Intended headings found | 14 / 14 | 14 / 14 |
+| Malformed or fragmentary false headings | 0 | 0 |
+| Equation-like false headings | 0 | 0 |
+| Equation anchors | 2 / 4 | 2 / 4 |
+| Footnote anchors | 4 / 4 | 4 / 4 |
+| Sampled Table I topology | absent | absent |
+
+The rules use no dictionary, model, Shannon-specific replacement, external
+dependency, or hidden OCR. This remains a sampled adversarial evaluation rather
+than a complete transcript ground truth, public benchmark, or release claim.

--- a/docs/evidence/shannon-paragraph-continuity-2026-08.md
+++ b/docs/evidence/shannon-paragraph-continuity-2026-08.md
@@ -2,55 +2,55 @@
 
 ## Outcome
 
-PDF Tools now performs two bounded, source-backed paragraph-flow repairs:
-
-- a large initial capital can join an overlapping uppercase word remainder;
-- a lowercase word split across consecutive same-column body lines by a
-  line-end hyphen can be dehyphenated.
+PDF Tools now performs one bounded, source-backed paragraph-flow repair: a
+large initial capital can join an overlapping uppercase word remainder when it
+opens a sufficiently long left-to-right paragraph after a structural boundary.
 
 Headings, lists, links, tables, different columns, and ambiguous geometry remain
-separate. The original lines remain available in the Extraction IR. The
-Markdown renderer identity is now `pdf-tools.layout-markdown-renderer` version
-`1.5.0`.
+separate. Ordinary printed line-end hyphens are deliberately preserved because
+the source geometry cannot distinguish a split word from an intentional compound.
+The original lines remain available in the Extraction IR. The Markdown renderer
+identity is now `pdf-tools.layout-markdown-renderer` version `1.5.0`.
 
 On the hash-bound 55-page Shannon document, sampled paragraph-continuity
-recovery improved from 1 of 4 anchors to 3 of 4. Sampled ordered anchors also
+recovery improved from 1 of 4 anchors to 2 of 4. Sampled ordered anchors also
 improved from 22 of 24 to 23 of 24. Heading recovery remained 14 of 14 with
 zero malformed, fragmentary, or equation-like false headings. The sampled
 equation, footnote, table, omission, and evidence results did not regress.
 
-The remaining continuity miss is a vertically stacked printed fraction. It is
-not treated as ordinary paragraph joining and remains for a separate math-layout
-evaluation.
+The remaining continuity misses are an ordinary printed hyphen whose intended
+meaning is ambiguous and a vertically stacked printed fraction. Neither is
+silently rewritten; the fraction remains for a separate math-layout evaluation.
 
 ## Clean run
 
-- Evaluated commit: `060979c`
+- Evaluated commit: `56f45fac4fb300339e8831c8a353ea9d6903ab9b`
 - Source PDF SHA-256:
   `6e4e3411984f3edf99dbfe8b941cb5e8a321379ff0cae6ae5c1f592ad8882ca8`
 - Real-heading report SHA-256:
-  `dee4bc622597c6036a0293eed93094715f0af2bb26c74ee86fb1e6f15b5d7e63`
+  `63efa43f8cb6ba2f0198c74b00e4b21a34622fc0cb814b92f86c8e0306653a53`
 - Paragraph-continuity report SHA-256:
-  `c521e6701cfb64a2758827a878b13457f86801a3fc02c23ce42254883e5aa5db`
+  `0dcc8284d18b960b1a63bdeba6f91f4cf28ae7ab5aad0b20f9b623f34961fc06`
 - Repetitions: three fresh processes per candidate
 - PDF Tools Markdown deterministic across repetitions: `true`
-- Median PDF Tools elapsed time: 3727.857 ms
-- Median PDF Tools maximum RSS: 294,158,336 bytes
+- Median PDF Tools elapsed time: 3699.092 ms
+- Median PDF Tools maximum RSS: 291,241,984 bytes
 
 ## Metric comparison
 
 | Sampled PDF Tools metric | Before | After |
 | --- | ---: | ---: |
-| Paragraph-continuity anchors | 1 / 4 | 3 / 4 |
+| Paragraph-continuity anchors | 1 / 4 | 2 / 4 |
 | Ordered anchors retained | 22 / 24 | 23 / 24 |
 | Complete ordered-anchor groups | 4 / 6 | 5 / 6 |
 | Intended headings found | 14 / 14 | 14 / 14 |
 | Malformed or fragmentary false headings | 0 | 0 |
 | Equation-like false headings | 0 | 0 |
-| Equation anchors | 2 / 4 | 2 / 4 |
+| Page-local equation anchors | 2 / 4 | 2 / 4 |
 | Footnote anchors | 4 / 4 | 4 / 4 |
 | Sampled Table I topology | absent | absent |
 
 The rules use no dictionary, model, Shannon-specific replacement, external
-dependency, or hidden OCR. This remains a sampled adversarial evaluation rather
-than a complete transcript ground truth, public benchmark, or release claim.
+dependency, hidden OCR, or silent hard-hyphen deletion. This remains a sampled
+adversarial evaluation rather than a complete transcript ground truth, public
+benchmark, or release claim.

--- a/pdf-toolkit-mcp-share/server/markdown-conversion.js
+++ b/pdf-toolkit-mcp-share/server/markdown-conversion.js
@@ -6,7 +6,7 @@ import {
 
 const RENDERER = Object.freeze({
   name: "pdf-tools.layout-markdown-renderer",
-  version: "1.4.0",
+  version: "1.5.0",
 });
 
 // Bounded geometric table inference. A run of adjacent lines is treated as a
@@ -44,6 +44,7 @@ const GAP_CODES = new Set([
 
 const LIMITATIONS = Object.freeze([
   "Headings are emitted only from consistent enlarged font metrics or centered English-language source structure with section spacing for a first-page title, introduction, part, or appendix. Ambiguous, very short, or unsupported heading styles remain body text.",
+  "A geometrically overlapping initial capital may be joined to its following uppercase word remainder, and a lowercase word split by a line-end hyphen may be dehyphenated only across consecutive body lines in the same flow column. The source Extraction IR retains the original lines.",
   "Lists are emitted only for literal bullet glyphs or decimal markers present in the source text.",
   "Links are emitted only for source-validated http or https annotation targets that map to exactly one contiguous run of text on one line. Internal destinations, actions, other schemes, ambiguous or partially covered labels, and links inside reconstructed tables remain escaped text reported as a conversion gap, and URL-looking source text is escaped to resist host autolinking.",
   "Tables are reconstructed only from text-item column geometry, and only when every row fills every detected column and the first row is typographically distinct enough to evidence a header, because a Markdown table imposes header semantics. Ruling lines and merged or spanning cells are not interpreted, and table-like content that fails either test remains escaped reading-order text reported as a conversion gap.",
@@ -730,23 +731,76 @@ function pageStatus(page, gaps) {
   return gaps.length > 0 ? "partial" : "complete";
 }
 
+function sameFlow(left, right) {
+  return left?.joinable === true
+    && right?.joinable === true
+    && left.line.column_index === right.line.column_index;
+}
+
+function dropCapContinuation(left, right) {
+  if (!sameFlow(left, right)) return false;
+  const leftText = left.line.text.trim();
+  const rightText = right.line.text.trim();
+  const verticalOverlap = Math.min(left.line.y + left.line.height, right.line.y + right.line.height)
+    - Math.max(left.line.y, right.line.y);
+  const horizontalGap = right.line.x - (left.line.x + left.line.width);
+  return /^\p{Lu}$/u.test(leftText)
+    && /^\p{Lu}{2,}(?:\s|$)/u.test(rightText)
+    && left.line.height >= right.line.height * 1.5
+    && verticalOverlap > 0
+    && horizontalGap >= -1
+    && horizontalGap <= Math.max(4, right.line.height);
+}
+
+function lineEndHyphenContinuation(left, right) {
+  if (!sameFlow(left, right)) return false;
+  const leftText = left.line.text.trim();
+  const rightText = right.line.text.trim();
+  const verticalGap = right.line.y - (left.line.y + left.line.height);
+  return /\p{Ll}{2,}-$/u.test(leftText)
+    && /^\p{Ll}{2,}/u.test(rightText)
+    && right.line.y > left.line.y
+    && verticalGap <= Math.max(left.line.height, right.line.height) * 2.5;
+}
+
+function joinParagraphContinuity(records) {
+  const lines = [];
+  let previous = null;
+  for (const record of records) {
+    if (previous && dropCapContinuation(previous, record)) {
+      lines[lines.length - 1] += record.text;
+    } else if (previous && lineEndHyphenContinuation(previous, record)) {
+      lines[lines.length - 1] = `${lines[lines.length - 1].slice(0, -1)}${record.text}`;
+    } else {
+      lines.push(record.text);
+    }
+    previous = record;
+  }
+  return lines;
+}
+
 function renderPage(page) {
   const headings = headingLevels(page);
   const analysis = segmentPageLines(page);
   const linkState = analyzePageLinks(page, analysis, headings);
-  const lines = analysis.segments.flatMap(segment => (
+  const records = analysis.segments.flatMap(segment => (
     segment.kind === "table"
-      ? renderTable(segment.grid)
+      ? renderTable(segment.grid).map(text => ({ text, line: null, joinable: false }))
       : segment.rows.map(({ line }) => {
         const spans = linkState.spansByLine.get(line.id);
         const offsets = linkState.offsetsByLine.get(line.id);
         if (spans && spans.length > 0 && offsets && !headings.get(line.id)) {
           const linked = renderLinkedLine(line, offsets, spans);
-          if (linked !== null) return linked;
+          if (linked !== null) return { text: linked, line, joinable: false };
         }
-        return renderLine(line, headings.get(line.id));
+        return {
+          text: renderLine(line, headings.get(line.id)),
+          line,
+          joinable: !headings.get(line.id) && !rewritesLineStructure(line),
+        };
       })
   ));
+  const lines = joinParagraphContinuity(records);
   const markdown = lines.length > 0
     ? lines.join("\n")
     : "[No source-backed text was available on this page.]";

--- a/pdf-toolkit-mcp-share/server/markdown-conversion.js
+++ b/pdf-toolkit-mcp-share/server/markdown-conversion.js
@@ -44,7 +44,7 @@ const GAP_CODES = new Set([
 
 const LIMITATIONS = Object.freeze([
   "Headings are emitted only from consistent enlarged font metrics or centered English-language source structure with section spacing for a first-page title, introduction, part, or appendix. Ambiguous, very short, or unsupported heading styles remain body text.",
-  "A geometrically overlapping initial capital may be joined to its following uppercase word remainder, and a lowercase word split by a line-end hyphen may be dehyphenated only across consecutive body lines in the same flow column. The source Extraction IR retains the original lines.",
+  "A geometrically overlapping initial capital may be joined to its following uppercase word remainder. Line-end hyphens are preserved because source geometry cannot reliably distinguish a split word from an intentional compound. The source Extraction IR retains the original lines.",
   "Lists are emitted only for literal bullet glyphs or decimal markers present in the source text.",
   "Links are emitted only for source-validated http or https annotation targets that map to exactly one contiguous run of text on one line. Internal destinations, actions, other schemes, ambiguous or partially covered labels, and links inside reconstructed tables remain escaped text reported as a conversion gap, and URL-looking source text is escaped to resist host autolinking.",
   "Tables are reconstructed only from text-item column geometry, and only when every row fills every detected column and the first row is typographically distinct enough to evidence a header, because a Markdown table imposes header semantics. Ruling lines and merged or spanning cells are not interpreted, and table-like content that fails either test remains escaped reading-order text reported as a conversion gap.",
@@ -737,44 +737,37 @@ function sameFlow(left, right) {
     && left.line.column_index === right.line.column_index;
 }
 
-function dropCapContinuation(left, right) {
+function dropCapContinuation(preceding, left, right) {
   if (!sameFlow(left, right)) return false;
   const leftText = left.line.text.trim();
   const rightText = right.line.text.trim();
+  const rightWords = rightText.match(/[\p{L}\p{N}]+/gu) ?? [];
   const verticalOverlap = Math.min(left.line.y + left.line.height, right.line.y + right.line.height)
     - Math.max(left.line.y, right.line.y);
   const horizontalGap = right.line.x - (left.line.x + left.line.width);
-  return /^\p{Lu}$/u.test(leftText)
+  return (preceding === null || preceding.joinable === false)
+    && left.line.direction === "ltr"
+    && right.line.direction === "ltr"
+    && /^\p{Lu}$/u.test(leftText)
     && /^\p{Lu}{2,}(?:\s|$)/u.test(rightText)
+    && rightWords.length >= 5
+    && /\p{Ll}/u.test(rightText)
     && left.line.height >= right.line.height * 1.5
     && verticalOverlap > 0
     && horizontalGap >= -1
     && horizontalGap <= Math.max(4, right.line.height);
 }
 
-function lineEndHyphenContinuation(left, right) {
-  if (!sameFlow(left, right)) return false;
-  const leftText = left.line.text.trim();
-  const rightText = right.line.text.trim();
-  const verticalGap = right.line.y - (left.line.y + left.line.height);
-  return /\p{Ll}{2,}-$/u.test(leftText)
-    && /^\p{Ll}{2,}/u.test(rightText)
-    && right.line.y > left.line.y
-    && verticalGap <= Math.max(left.line.height, right.line.height) * 2.5;
-}
-
 function joinParagraphContinuity(records) {
   const lines = [];
-  let previous = null;
-  for (const record of records) {
-    if (previous && dropCapContinuation(previous, record)) {
+  for (const [index, record] of records.entries()) {
+    const previous = records[index - 1] ?? null;
+    const preceding = records[index - 2] ?? null;
+    if (previous && dropCapContinuation(preceding, previous, record)) {
       lines[lines.length - 1] += record.text;
-    } else if (previous && lineEndHyphenContinuation(previous, record)) {
-      lines[lines.length - 1] = `${lines[lines.length - 1].slice(0, -1)}${record.text}`;
     } else {
       lines.push(record.text);
     }
-    previous = record;
   }
   return lines;
 }

--- a/pdf-toolkit-mcp-share/server/output-schemas.js
+++ b/pdf-toolkit-mcp-share/server/output-schemas.js
@@ -552,7 +552,7 @@ export const TOOL_SUCCESS_OUTPUT_SCHEMAS = Object.freeze({
   convert_pdf_to_markdown: object({
     renderer: object({
       name: { const: "pdf-tools.layout-markdown-renderer" },
-      version: { const: "1.4.0" },
+      version: { const: "1.5.0" },
     }),
     conversion_status: enumString(["complete", "partial", "failed"]),
     markdown: string,

--- a/scripts/eval-run-markdown-bakeoff.mjs
+++ b/scripts/eval-run-markdown-bakeoff.mjs
@@ -190,7 +190,7 @@ export function validateMarkdownResult(result, binding) {
     throw new Error(`Markdown conversion failed for ${binding.fixture.id}`);
   }
   const value = result.structuredContent;
-  if (value.renderer?.name !== "pdf-tools.layout-markdown-renderer" || value.renderer?.version !== "1.4.0"
+  if (value.renderer?.name !== "pdf-tools.layout-markdown-renderer" || value.renderer?.version !== "1.5.0"
     || value.options?.include_page_boundaries !== true || value.limits?.max_markdown_bytes !== 200000
     || value.provenance?.source?.file_name !== binding.retained.filename
     || value.provenance?.source?.sha256 !== binding.retained.sha256

--- a/scripts/smoke-mcpb.mjs
+++ b/scripts/smoke-mcpb.mjs
@@ -146,7 +146,7 @@ async function main() {
       arguments: { pdf_path: fixturePath, max_markdown_bytes: 200000 },
     });
     if (markdown.isError
-      || markdown.structuredContent?.renderer?.version !== "1.4.0"
+      || markdown.structuredContent?.renderer?.version !== "1.5.0"
       || markdown.structuredContent?.markdown_bytes !== Buffer.byteLength(markdown.structuredContent?.markdown || "", "utf8")
       || markdown.structuredContent?.markdown_sha256 !== sha256(Buffer.from(markdown.structuredContent?.markdown || "", "utf8"))) {
       throw new Error("Packed convert_pdf_to_markdown contract smoke failed");

--- a/scripts/test-share-contract.mjs
+++ b/scripts/test-share-contract.mjs
@@ -837,7 +837,7 @@ async function main() {
       arguments: { pdf_path: fixturePath, max_markdown_bytes: 200000 },
     });
     if (markdown.isError
-      || markdown.structuredContent?.renderer?.version !== "1.4.0"
+      || markdown.structuredContent?.renderer?.version !== "1.5.0"
       || markdown.structuredContent?.markdown_bytes !== Buffer.byteLength(markdown.structuredContent?.markdown || "", "utf8")
       || markdown.structuredContent?.markdown_sha256 !== sha256(Buffer.from(markdown.structuredContent?.markdown || "", "utf8"))) {
       throw new Error("Share convert_pdf_to_markdown contract smoke failed");

--- a/server/markdown-conversion.js
+++ b/server/markdown-conversion.js
@@ -6,7 +6,7 @@ import {
 
 const RENDERER = Object.freeze({
   name: "pdf-tools.layout-markdown-renderer",
-  version: "1.4.0",
+  version: "1.5.0",
 });
 
 // Bounded geometric table inference. A run of adjacent lines is treated as a
@@ -44,6 +44,7 @@ const GAP_CODES = new Set([
 
 const LIMITATIONS = Object.freeze([
   "Headings are emitted only from consistent enlarged font metrics or centered English-language source structure with section spacing for a first-page title, introduction, part, or appendix. Ambiguous, very short, or unsupported heading styles remain body text.",
+  "A geometrically overlapping initial capital may be joined to its following uppercase word remainder, and a lowercase word split by a line-end hyphen may be dehyphenated only across consecutive body lines in the same flow column. The source Extraction IR retains the original lines.",
   "Lists are emitted only for literal bullet glyphs or decimal markers present in the source text.",
   "Links are emitted only for source-validated http or https annotation targets that map to exactly one contiguous run of text on one line. Internal destinations, actions, other schemes, ambiguous or partially covered labels, and links inside reconstructed tables remain escaped text reported as a conversion gap, and URL-looking source text is escaped to resist host autolinking.",
   "Tables are reconstructed only from text-item column geometry, and only when every row fills every detected column and the first row is typographically distinct enough to evidence a header, because a Markdown table imposes header semantics. Ruling lines and merged or spanning cells are not interpreted, and table-like content that fails either test remains escaped reading-order text reported as a conversion gap.",
@@ -730,23 +731,76 @@ function pageStatus(page, gaps) {
   return gaps.length > 0 ? "partial" : "complete";
 }
 
+function sameFlow(left, right) {
+  return left?.joinable === true
+    && right?.joinable === true
+    && left.line.column_index === right.line.column_index;
+}
+
+function dropCapContinuation(left, right) {
+  if (!sameFlow(left, right)) return false;
+  const leftText = left.line.text.trim();
+  const rightText = right.line.text.trim();
+  const verticalOverlap = Math.min(left.line.y + left.line.height, right.line.y + right.line.height)
+    - Math.max(left.line.y, right.line.y);
+  const horizontalGap = right.line.x - (left.line.x + left.line.width);
+  return /^\p{Lu}$/u.test(leftText)
+    && /^\p{Lu}{2,}(?:\s|$)/u.test(rightText)
+    && left.line.height >= right.line.height * 1.5
+    && verticalOverlap > 0
+    && horizontalGap >= -1
+    && horizontalGap <= Math.max(4, right.line.height);
+}
+
+function lineEndHyphenContinuation(left, right) {
+  if (!sameFlow(left, right)) return false;
+  const leftText = left.line.text.trim();
+  const rightText = right.line.text.trim();
+  const verticalGap = right.line.y - (left.line.y + left.line.height);
+  return /\p{Ll}{2,}-$/u.test(leftText)
+    && /^\p{Ll}{2,}/u.test(rightText)
+    && right.line.y > left.line.y
+    && verticalGap <= Math.max(left.line.height, right.line.height) * 2.5;
+}
+
+function joinParagraphContinuity(records) {
+  const lines = [];
+  let previous = null;
+  for (const record of records) {
+    if (previous && dropCapContinuation(previous, record)) {
+      lines[lines.length - 1] += record.text;
+    } else if (previous && lineEndHyphenContinuation(previous, record)) {
+      lines[lines.length - 1] = `${lines[lines.length - 1].slice(0, -1)}${record.text}`;
+    } else {
+      lines.push(record.text);
+    }
+    previous = record;
+  }
+  return lines;
+}
+
 function renderPage(page) {
   const headings = headingLevels(page);
   const analysis = segmentPageLines(page);
   const linkState = analyzePageLinks(page, analysis, headings);
-  const lines = analysis.segments.flatMap(segment => (
+  const records = analysis.segments.flatMap(segment => (
     segment.kind === "table"
-      ? renderTable(segment.grid)
+      ? renderTable(segment.grid).map(text => ({ text, line: null, joinable: false }))
       : segment.rows.map(({ line }) => {
         const spans = linkState.spansByLine.get(line.id);
         const offsets = linkState.offsetsByLine.get(line.id);
         if (spans && spans.length > 0 && offsets && !headings.get(line.id)) {
           const linked = renderLinkedLine(line, offsets, spans);
-          if (linked !== null) return linked;
+          if (linked !== null) return { text: linked, line, joinable: false };
         }
-        return renderLine(line, headings.get(line.id));
+        return {
+          text: renderLine(line, headings.get(line.id)),
+          line,
+          joinable: !headings.get(line.id) && !rewritesLineStructure(line),
+        };
       })
   ));
+  const lines = joinParagraphContinuity(records);
   const markdown = lines.length > 0
     ? lines.join("\n")
     : "[No source-backed text was available on this page.]";

--- a/server/markdown-conversion.js
+++ b/server/markdown-conversion.js
@@ -44,7 +44,7 @@ const GAP_CODES = new Set([
 
 const LIMITATIONS = Object.freeze([
   "Headings are emitted only from consistent enlarged font metrics or centered English-language source structure with section spacing for a first-page title, introduction, part, or appendix. Ambiguous, very short, or unsupported heading styles remain body text.",
-  "A geometrically overlapping initial capital may be joined to its following uppercase word remainder, and a lowercase word split by a line-end hyphen may be dehyphenated only across consecutive body lines in the same flow column. The source Extraction IR retains the original lines.",
+  "A geometrically overlapping initial capital may be joined to its following uppercase word remainder. Line-end hyphens are preserved because source geometry cannot reliably distinguish a split word from an intentional compound. The source Extraction IR retains the original lines.",
   "Lists are emitted only for literal bullet glyphs or decimal markers present in the source text.",
   "Links are emitted only for source-validated http or https annotation targets that map to exactly one contiguous run of text on one line. Internal destinations, actions, other schemes, ambiguous or partially covered labels, and links inside reconstructed tables remain escaped text reported as a conversion gap, and URL-looking source text is escaped to resist host autolinking.",
   "Tables are reconstructed only from text-item column geometry, and only when every row fills every detected column and the first row is typographically distinct enough to evidence a header, because a Markdown table imposes header semantics. Ruling lines and merged or spanning cells are not interpreted, and table-like content that fails either test remains escaped reading-order text reported as a conversion gap.",
@@ -737,44 +737,37 @@ function sameFlow(left, right) {
     && left.line.column_index === right.line.column_index;
 }
 
-function dropCapContinuation(left, right) {
+function dropCapContinuation(preceding, left, right) {
   if (!sameFlow(left, right)) return false;
   const leftText = left.line.text.trim();
   const rightText = right.line.text.trim();
+  const rightWords = rightText.match(/[\p{L}\p{N}]+/gu) ?? [];
   const verticalOverlap = Math.min(left.line.y + left.line.height, right.line.y + right.line.height)
     - Math.max(left.line.y, right.line.y);
   const horizontalGap = right.line.x - (left.line.x + left.line.width);
-  return /^\p{Lu}$/u.test(leftText)
+  return (preceding === null || preceding.joinable === false)
+    && left.line.direction === "ltr"
+    && right.line.direction === "ltr"
+    && /^\p{Lu}$/u.test(leftText)
     && /^\p{Lu}{2,}(?:\s|$)/u.test(rightText)
+    && rightWords.length >= 5
+    && /\p{Ll}/u.test(rightText)
     && left.line.height >= right.line.height * 1.5
     && verticalOverlap > 0
     && horizontalGap >= -1
     && horizontalGap <= Math.max(4, right.line.height);
 }
 
-function lineEndHyphenContinuation(left, right) {
-  if (!sameFlow(left, right)) return false;
-  const leftText = left.line.text.trim();
-  const rightText = right.line.text.trim();
-  const verticalGap = right.line.y - (left.line.y + left.line.height);
-  return /\p{Ll}{2,}-$/u.test(leftText)
-    && /^\p{Ll}{2,}/u.test(rightText)
-    && right.line.y > left.line.y
-    && verticalGap <= Math.max(left.line.height, right.line.height) * 2.5;
-}
-
 function joinParagraphContinuity(records) {
   const lines = [];
-  let previous = null;
-  for (const record of records) {
-    if (previous && dropCapContinuation(previous, record)) {
+  for (const [index, record] of records.entries()) {
+    const previous = records[index - 1] ?? null;
+    const preceding = records[index - 2] ?? null;
+    if (previous && dropCapContinuation(preceding, previous, record)) {
       lines[lines.length - 1] += record.text;
-    } else if (previous && lineEndHyphenContinuation(previous, record)) {
-      lines[lines.length - 1] = `${lines[lines.length - 1].slice(0, -1)}${record.text}`;
     } else {
       lines.push(record.text);
     }
-    previous = record;
   }
   return lines;
 }

--- a/server/output-schemas.js
+++ b/server/output-schemas.js
@@ -552,7 +552,7 @@ export const TOOL_SUCCESS_OUTPUT_SCHEMAS = Object.freeze({
   convert_pdf_to_markdown: object({
     renderer: object({
       name: { const: "pdf-tools.layout-markdown-renderer" },
-      version: { const: "1.4.0" },
+      version: { const: "1.5.0" },
     }),
     conversion_status: enumString(["complete", "partial", "failed"]),
     markdown: string,

--- a/test/convert-pdf-to-markdown.test.js
+++ b/test/convert-pdf-to-markdown.test.js
@@ -305,7 +305,7 @@ describe("convert_pdf_to_markdown MCP tool", () => {
     expect(first.isError).not.toBe(true);
     expect(second.structuredContent).toEqual(first.structuredContent);
     expect(first.structuredContent).toMatchObject({
-      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.4.0" },
+      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.5.0" },
       conversion_status: "complete",
       saved_output: null,
       provenance: {

--- a/test/eval/markdown-bakeoff.test.js
+++ b/test/eval/markdown-bakeoff.test.js
@@ -64,7 +64,7 @@ async function handle(message) {
     const pageBoundaries = Array.from({ length: pageCount }, (_, index) => "<!-- PDF page " + (index + 1) + " -->");
     const markdown = pageBoundaries.join("\n\n") + "\n\nINV-1001 fixture evidence\n";
     const value = {
-      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.4.0" },
+      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.5.0" },
       conversion_status: "complete",
       markdown,
       markdown_sha256: digest(Buffer.from(markdown)),
@@ -143,7 +143,7 @@ function resultFor(binding) {
   const markdown = "<!-- PDF page 1 -->\n\nFixture text\n";
   return {
     structuredContent: {
-      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.4.0" },
+      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.5.0" },
       conversion_status: "complete",
       markdown,
       markdown_sha256: sha256(Buffer.from(markdown)),
@@ -231,8 +231,8 @@ describe("Markdown bakeoff renderer version binding", () => {
   });
 
   it("accepts the current renderer version and rejects the superseded one", () => {
-    expect(validateMarkdownResult(resultFor("1.4.0"), binding).renderer.version).toBe("1.4.0");
-    for (const stale of ["1.0.0", "1.1.0", "1.2.0", "1.3.0"]) {
+    expect(validateMarkdownResult(resultFor("1.5.0"), binding).renderer.version).toBe("1.5.0");
+    for (const stale of ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0"]) {
       expect(() => validateMarkdownResult(resultFor(stale), binding), stale)
         .toThrow(/Markdown result evidence is invalid/u);
     }

--- a/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
+++ b/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
@@ -61,8 +61,8 @@
     {
       "role": "markdown_conversion_module",
       "path": "server/markdown-conversion.js",
-      "bytes": 40911,
-      "sha256": "8b08f1ed68983061c8b57a33d7828e1eed5b72052913eefbaaf0ca8d46d7db3d"
+      "bytes": 42285,
+      "sha256": "39f17d0d6a1224a15ca344d5f10c2e880ec1fcef83b30de06a5aa87c0e34b822"
     },
     {
       "role": "output_schemas_module",
@@ -95,7 +95,7 @@
       "sha256": "6e4429db62fcbe1dd73141d8c20a48b564d41f8bf8920d88775846995e1daf94"
     }
   ],
-  "validator_source_set_sha256": "dc2e8f2e20f972d679e7e15119518ff769362351230851956a540233ccede77f",
+  "validator_source_set_sha256": "e2296d1a5d82f295ec5194ed969ef6317b11e4fa2401579e36ddc524b3b689fa",
   "pdfjs_version": "5.4.624",
   "generation_contract": {
     "source_path": "source.pdf",

--- a/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
+++ b/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
@@ -61,8 +61,8 @@
     {
       "role": "markdown_conversion_module",
       "path": "server/markdown-conversion.js",
-      "bytes": 40599,
-      "sha256": "8433d6678483ae4db678f40b4a422e1c7886e3a5ddab6a975e9ff6c25cee2909"
+      "bytes": 40911,
+      "sha256": "8b08f1ed68983061c8b57a33d7828e1eed5b72052913eefbaaf0ca8d46d7db3d"
     },
     {
       "role": "output_schemas_module",
@@ -95,7 +95,7 @@
       "sha256": "6e4429db62fcbe1dd73141d8c20a48b564d41f8bf8920d88775846995e1daf94"
     }
   ],
-  "validator_source_set_sha256": "ff707efddba4f6ad3a6d4dc9049d3b9dc66cbbe2e02ca1b257db1da363f4376b",
+  "validator_source_set_sha256": "dc2e8f2e20f972d679e7e15119518ff769362351230851956a540233ccede77f",
   "pdfjs_version": "5.4.624",
   "generation_contract": {
     "source_path": "source.pdf",

--- a/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
+++ b/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
@@ -61,14 +61,14 @@
     {
       "role": "markdown_conversion_module",
       "path": "server/markdown-conversion.js",
-      "bytes": 40266,
-      "sha256": "41d813e3004dd7f8ced1b51ea1ce63cdb3e58934d98b6c28121a8aa783fe8265"
+      "bytes": 40599,
+      "sha256": "8433d6678483ae4db678f40b4a422e1c7886e3a5ddab6a975e9ff6c25cee2909"
     },
     {
       "role": "output_schemas_module",
       "path": "server/output-schemas.js",
       "bytes": 29954,
-      "sha256": "698c45842fa6b3b6f93259a96ff0c82c111631f5ddfc226027540f50ce78473f"
+      "sha256": "6e0d1ef863db1eb31a992c331dbb47b5eb3778ca1018f005de343603b4d30040"
     },
     {
       "role": "package_json",
@@ -95,7 +95,7 @@
       "sha256": "6e4429db62fcbe1dd73141d8c20a48b564d41f8bf8920d88775846995e1daf94"
     }
   ],
-  "validator_source_set_sha256": "46c4f1a7a584640e6dff05d51557f5dffec6f81f932a1512836332f8ed15fbc8",
+  "validator_source_set_sha256": "ff707efddba4f6ad3a6d4dc9049d3b9dc66cbbe2e02ca1b257db1da363f4376b",
   "pdfjs_version": "5.4.624",
   "generation_contract": {
     "source_path": "source.pdf",

--- a/test/fixtures/eval/shannon/manifest.v1.json
+++ b/test/fixtures/eval/shannon/manifest.v1.json
@@ -22,7 +22,7 @@
     "pdf_tools": {
       "slot": "control.current_product.v0",
       "renderer_name": "pdf-tools.layout-markdown-renderer",
-      "renderer_version": "1.4.0",
+      "renderer_version": "1.5.0",
       "parser_name": "pdfjs-dist",
       "parser_version": "5.4.624"
     },

--- a/test/markdown-conversion.test.js
+++ b/test/markdown-conversion.test.js
@@ -239,7 +239,7 @@ describe("layout Markdown renderer", () => {
     expect(result.markdown).not.toMatch(/^#{1,6}\s+(?:INTRODUCTION|APPENDIX 1|PART I: REPEATED PAGE LABEL)$/gmu);
   });
 
-  it("joins a geometrically supported drop cap and line-end word break without joining ambiguous structure", async () => {
+  it("joins a geometrically supported drop cap without deleting ambiguous line-end hyphens", async () => {
     const layout = await validatedSyntheticLayout([{
       items: [
         textItem("T", { top: 50, left: 40, fontSize: 30 }),
@@ -248,13 +248,20 @@ describe("layout Markdown renderer", () => {
         centeredTextItem("PART I: BODY", { top: 140 }),
         textItem("state-", { top: 180 }),
         textItem("2) of the art", { top: 210 }),
+        textItem("three-", { top: 250 }),
+        textItem("dimensional sound", { top: 280 }),
+        textItem("Ordinary context", { top: 320 }),
+        textItem("A", { top: 360, left: 40, fontSize: 30 }),
+        textItem("BC Corporation provides ordinary business services", { top: 372, left: 67 }),
       ],
     }]);
     const result = renderPdfLayoutToMarkdown(layout, { includePageBoundaries: false });
 
-    expect(result.markdown).toContain("THE recent development was rapid and approximately correct.");
+    expect(result.markdown).toContain("THE recent development was rapid and ap-\nproximately correct.");
     expect(result.markdown).toContain("## PART I: BODY");
     expect(result.markdown).toContain("state-\n2) of the art");
+    expect(result.markdown).toContain("three-\ndimensional sound");
+    expect(result.markdown).toContain("Ordinary context\nA\nBC Corporation provides ordinary business services");
   });
 
   it("neutralizes hostile Markdown, HTML, table, autolink, and control syntax", async () => {

--- a/test/markdown-conversion.test.js
+++ b/test/markdown-conversion.test.js
@@ -239,6 +239,24 @@ describe("layout Markdown renderer", () => {
     expect(result.markdown).not.toMatch(/^#{1,6}\s+(?:INTRODUCTION|APPENDIX 1|PART I: REPEATED PAGE LABEL)$/gmu);
   });
 
+  it("joins a geometrically supported drop cap and line-end word break without joining ambiguous structure", async () => {
+    const layout = await validatedSyntheticLayout([{
+      items: [
+        textItem("T", { top: 50, left: 40, fontSize: 30 }),
+        textItem("HE recent development was rapid and ap-", { top: 62, left: 67 }),
+        textItem("proximately correct.", { top: 90, left: 67 }),
+        centeredTextItem("PART I: BODY", { top: 140 }),
+        textItem("state-", { top: 180 }),
+        textItem("2) of the art", { top: 210 }),
+      ],
+    }]);
+    const result = renderPdfLayoutToMarkdown(layout, { includePageBoundaries: false });
+
+    expect(result.markdown).toContain("THE recent development was rapid and approximately correct.");
+    expect(result.markdown).toContain("## PART I: BODY");
+    expect(result.markdown).toContain("state-\n2) of the art");
+  });
+
   it("neutralizes hostile Markdown, HTML, table, autolink, and control syntax", async () => {
     const layout = await validatedSyntheticLayout([{
       items: [

--- a/test/mcp-contract.test.js
+++ b/test/mcp-contract.test.js
@@ -44,7 +44,10 @@ const EXAMPLE_PDF = path.join(REPO_ROOT, "example-fw9.pdf");
 // 2026-08-03: convert_pdf_to_markdown renderer 1.4.0 adds conservative
 // source-backed title, introduction, part, and appendix structure. Previously
 // a7619f2d4b07b855e8625578be66f5c61c54af2a2881a33545deed7e7b008de0.
-const TOOL_CONTRACT_SHA256 = "fc757dc89b8aaf25b22f05b07863a4b8be1e09b6a544764a1b4afc8cdca3d6dd";
+// 2026-08-03: convert_pdf_to_markdown renderer 1.5.0 adds bounded drop-cap
+// continuation and same-flow lowercase line-end dehyphenation. Previously
+// fc757dc89b8aaf25b22f05b07863a4b8be1e09b6a544764a1b4afc8cdca3d6dd.
+const TOOL_CONTRACT_SHA256 = "e80436c2e09aefc4a8ecb7bbc989a9c133fa3a1a2b84e4b07747a784c3e16d6b";
 
 const CLOSED_READ = Object.freeze({
   readOnlyHint: true,


### PR DESCRIPTION
## Summary

- Join a geometrically supported oversized opening capital to a sufficiently long left-to-right paragraph after a structural boundary.
- Preserve every ordinary printed line-end hyphen because geometry cannot reliably distinguish a split word from an intentional compound.
- Keep headings, lists, links, tables, different columns, and ambiguous cases separate.
- Advance the deterministic Markdown renderer contract to 1.5.0.

## Reviewed result

- Paragraph continuity improves from 1/4 to 2/4.
- Ordered anchors improve from 22/24 to 23/24.
- Complete ordered groups improve from 4/6 to 5/6.
- Heading recovery remains 14/14 at the expected levels.
- Sampled malformed, fragmentary, and equation-like false headings remain 0.
- Footnotes remain 4/4 and page-local equations remain 2/4.
- A prior version reached 3/4 by deleting printed hyphens, but independent review found that it damaged words such as three-dimensional, four-letter, and non-negative. That behavior was removed.
- The real 55-page before/after now changes only the supported opening capital; no printed hyphen is deleted.
- Remaining paragraph misses are the deliberately preserved ambiguous hyphen and the stacked printed fraction 3 1/3.

## Evidence and verification

- Clean evidence SHA-256: 0dcc8284d18b960b1a63bdeba6f91f4cf28ae7ab5aad0b20f9b623f34961fc06
- Focused and dependent checks: 115 passed, 6 skipped.
- Full Vitest: 1,864 passed, 79 skipped, with one unrelated pre-existing macOS permission assertion.
- Node-native: 62 passed, 9 intentional skips.
- Bead: pdf-toolkit-mcp-1b0, closed.

No model, dependency, OCR, document-specific replacement, interface, bundle, or release change.