### PR TITLE
Restore proven mathematical operator spacing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,7 @@ that maps to exactly one contiguous run of text on one line. Ruling lines,
 merged or spanning cells, internal destinations, actions, other URL schemes,
 and ambiguous labels stay escaped text. It may restore a missing space after a
 separate `log` source item only in a short, tightly bounded math run with
-same-baseline variable evidence. It does not reconstruct general equations,
+same-baseline variable evidence plus an independent local math-layout clue. It does not reconstruct general equations,
 scripts, or fraction bars. It does not run OCR or use an external model.
 Unsupported visual or structural content is reported as typed partial coverage
 rather than silently represented as complete Markdown.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,9 +136,12 @@ every detected column and the first row carries real header evidence, and emits
 a link only for a source-validated external http or https annotation target
 that maps to exactly one contiguous run of text on one line. Ruling lines,
 merged or spanning cells, internal destinations, actions, other URL schemes,
-and ambiguous labels stay escaped text. It does not run OCR or use an external
-model. Unsupported visual or structural content is reported as
-typed partial coverage rather than silently represented as complete Markdown.
+and ambiguous labels stay escaped text. It may restore a missing space after a
+separate `log` source item only in a short, tightly bounded math run with
+same-baseline variable evidence. It does not reconstruct general equations,
+scripts, or fraction bars. It does not run OCR or use an external model.
+Unsupported visual or structural content is reported as typed partial coverage
+rather than silently represented as complete Markdown.
 
 PDF Tools performs filesystem operations and rasterization locally and does not
 upload files to a separate PDF service. Content returned through MCP can be

--- a/docs/SHANNON_MARKDOWN_EVALUATION.md
+++ b/docs/SHANNON_MARKDOWN_EVALUATION.md
@@ -37,6 +37,10 @@ files are revalidated after every repetition.
 
 The sampled oracle is deliberately narrow. A missing anchor can identify a
 regression, but a passing anchor set cannot prove complete 55-page fidelity.
+The current PDF Tools result finds all four sampled page-local equation anchors,
+but that token result does not prove faithful equation topology. Damaged arrows,
+minus signs, scripts, summation limits, and fraction bars remain separate known
+gaps; see `docs/evidence/shannon-math-operator-spacing-2026-08.md`.
 
 ## Reproduction
 

--- a/docs/evidence/shannon-math-operator-spacing-2026-08.md
+++ b/docs/evidence/shannon-math-operator-spacing-2026-08.md
@@ -4,15 +4,16 @@
 
 PDF Tools now restores a missing visible space after a separate source text
 item that is exactly the mathematical operator `log`, but only in a short,
-compact left-to-right math run. The following item must be a differently styled
-single-letter variable on the same baseline, separated by a small positive gap.
+compact left-to-right math run. The following item must be a single-letter
+variable from a different embedded-font resource on the same baseline,
+separated by a small positive gap, with independent local math-layout evidence.
 The original Extraction IR remains unchanged. The Markdown renderer identity is
 now `pdf-tools.layout-markdown-renderer` version `1.6.0`.
 
 On the hash-bound 55-page Shannon document, the sampled page-local equation
 anchors improved from 2 of 4 to 4 of 4. All three PDF Tools repetitions were
-byte-identical. The source-text diff contained 35 restored `log` operator
-boundaries and no other source-text changes; the new limitation also appears in
+byte-identical. The source-text diff contained 37 restored `log` operator
+boundaries across 35 changed lines and no other source-text changes; the new limitation also appears in
 each bounded output chunk. Sampled headings, reading order, paragraph
 continuity, footnotes, table topology, omission/duplication, and evidence did
 not regress.

--- a/docs/evidence/shannon-math-operator-spacing-2026-08.md
+++ b/docs/evidence/shannon-math-operator-spacing-2026-08.md
@@ -12,8 +12,8 @@ now `pdf-tools.layout-markdown-renderer` version `1.6.0`.
 
 On the hash-bound 55-page Shannon document, the sampled page-local equation
 anchors improved from 2 of 4 to 4 of 4. All three PDF Tools repetitions were
-byte-identical. The source-text diff contained 19 restored `log` operator
-boundaries across 18 changed lines and no other source-text changes; the new
+byte-identical. The source-text diff contained 18 restored `log` operator
+boundaries across 17 changed lines and no other source-text changes; the new
 limitation also appears in each bounded output chunk. Sampled headings, reading
 order, paragraph continuity, footnotes, table topology, omission/duplication,
 and evidence did not regress.
@@ -28,19 +28,19 @@ table cells.
 
 ## Clean run
 
-- Evaluated commit: `b8b301ce6c2eb87d1a55aeafffff9323e25d3eba`
+- Evaluated commit: `0e323e782039bff86da6647822061ef06ec07605`
 - Source PDF SHA-256:
   `6e4e3411984f3edf99dbfe8b941cb5e8a321379ff0cae6ae5c1f592ad8882ca8`
 - Previous paragraph-continuity report SHA-256:
   `0dcc8284d18b960b1a63bdeba6f91f4cf28ae7ab5aad0b20f9b623f34961fc06`
 - Math-spacing report SHA-256:
-  `6e81ae082de64650595c70b659bb82b79e04400ecc9506352d92766ae46ddb39`
+  `2074f1b1a0d0856c523d827b9fb27e387623713db0273f1c37d30fab24c1cf3e`
 - Private report directory:
-  `/Users/silverbook/Sites/pdf-tools-extraction-sidecars/shannon-math-spacing-final-review-20260803-clean-b8b301c`
+  `/Users/silverbook/Sites/pdf-tools-extraction-sidecars/shannon-math-spacing-final-review-20260803-clean-0e323e7`
 - Repetitions: three fresh processes per candidate
 - PDF Tools Markdown deterministic across repetitions: `true`
-- Median PDF Tools elapsed time: 3533.064 ms
-- Median PDF Tools maximum RSS: 312,033,280 bytes
+- Median PDF Tools elapsed time: 3534.91 ms
+- Median PDF Tools maximum RSS: 287,244,288 bytes
 
 ## Metric comparison
 

--- a/docs/evidence/shannon-math-operator-spacing-2026-08.md
+++ b/docs/evidence/shannon-math-operator-spacing-2026-08.md
@@ -1,0 +1,60 @@
+# Shannon math-operator spacing — 2026-08
+
+## Outcome
+
+PDF Tools now restores a missing visible space after a separate source text
+item that is exactly the mathematical operator `log`, but only in a short,
+compact left-to-right math run. The following item must be a differently styled
+single-letter variable on the same baseline, separated by a small positive gap.
+The original Extraction IR remains unchanged. The Markdown renderer identity is
+now `pdf-tools.layout-markdown-renderer` version `1.6.0`.
+
+On the hash-bound 55-page Shannon document, the sampled page-local equation
+anchors improved from 2 of 4 to 4 of 4. All three PDF Tools repetitions were
+byte-identical. The source-text diff contained 35 restored `log` operator
+boundaries and no other source-text changes; the new limitation also appears in
+each bounded output chunk. Sampled headings, reading order, paragraph
+continuity, footnotes, table topology, omission/duplication, and evidence did
+not regress.
+
+The 4-of-4 sample result does **not** mean equation extraction is solved. The
+paper still contains damaged or flattened arrows, minus signs, subscripts,
+summation limits, and fractions. The renderer does not guess replacements for
+those structures. In particular, it does not turn vertically stacked digits
+into a fraction because the current IR does not locate the printed fraction bar
+and cannot reliably distinguish that stack from scripts, footnotes, charts, or
+table cells.
+
+## Clean run
+
+- Evaluated commit: `befbb553eeb73a6e6144312809df4acf15cc4827`
+- Source PDF SHA-256:
+  `6e4e3411984f3edf99dbfe8b941cb5e8a321379ff0cae6ae5c1f592ad8882ca8`
+- Previous paragraph-continuity report SHA-256:
+  `0dcc8284d18b960b1a63bdeba6f91f4cf28ae7ab5aad0b20f9b623f34961fc06`
+- Math-spacing report SHA-256:
+  `51f8a3df6bf04538fcd5b2f7cb5be79f30bde231c8840c7a5a54b0b7fba4a787`
+- Private report directory:
+  `/Users/silverbook/Sites/pdf-tools-extraction-sidecars/shannon-math-spacing-20260803-clean-befbb55`
+- Repetitions: three fresh processes per candidate
+- PDF Tools Markdown deterministic across repetitions: `true`
+- Median PDF Tools elapsed time: 3465.051 ms
+- Median PDF Tools maximum RSS: 286,146,560 bytes
+
+## Metric comparison
+
+| Sampled PDF Tools metric | Before | After |
+| --- | ---: | ---: |
+| Page-local equation anchors | 2 / 4 | 4 / 4 |
+| Intended headings found | 14 / 14 | 14 / 14 |
+| Malformed or fragmentary false headings | 0 | 0 |
+| Equation-like false headings | 0 | 0 |
+| Ordered anchors retained | 23 / 24 | 23 / 24 |
+| Complete ordered-anchor groups | 5 / 6 | 5 / 6 |
+| Paragraph-continuity anchors | 2 / 4 | 2 / 4 |
+| Footnote anchors | 4 / 4 | 4 / 4 |
+| Sampled Table I topology | absent | absent |
+
+This is a sampled adversarial evaluation, not a complete transcript ground
+truth, public benchmark, release qualification, or claim that general
+mathematical notation is reconstructed faithfully.

--- a/docs/evidence/shannon-math-operator-spacing-2026-08.md
+++ b/docs/evidence/shannon-math-operator-spacing-2026-08.md
@@ -12,11 +12,11 @@ now `pdf-tools.layout-markdown-renderer` version `1.6.0`.
 
 On the hash-bound 55-page Shannon document, the sampled page-local equation
 anchors improved from 2 of 4 to 4 of 4. All three PDF Tools repetitions were
-byte-identical. The source-text diff contained 37 restored `log` operator
-boundaries across 35 changed lines and no other source-text changes; the new limitation also appears in
-each bounded output chunk. Sampled headings, reading order, paragraph
-continuity, footnotes, table topology, omission/duplication, and evidence did
-not regress.
+byte-identical. The source-text diff contained 19 restored `log` operator
+boundaries across 18 changed lines and no other source-text changes; the new
+limitation also appears in each bounded output chunk. Sampled headings, reading
+order, paragraph continuity, footnotes, table topology, omission/duplication,
+and evidence did not regress.
 
 The 4-of-4 sample result does **not** mean equation extraction is solved. The
 paper still contains damaged or flattened arrows, minus signs, subscripts,
@@ -28,19 +28,19 @@ table cells.
 
 ## Clean run
 
-- Evaluated commit: `befbb553eeb73a6e6144312809df4acf15cc4827`
+- Evaluated commit: `b8b301ce6c2eb87d1a55aeafffff9323e25d3eba`
 - Source PDF SHA-256:
   `6e4e3411984f3edf99dbfe8b941cb5e8a321379ff0cae6ae5c1f592ad8882ca8`
 - Previous paragraph-continuity report SHA-256:
   `0dcc8284d18b960b1a63bdeba6f91f4cf28ae7ab5aad0b20f9b623f34961fc06`
 - Math-spacing report SHA-256:
-  `51f8a3df6bf04538fcd5b2f7cb5be79f30bde231c8840c7a5a54b0b7fba4a787`
+  `6e81ae082de64650595c70b659bb82b79e04400ecc9506352d92766ae46ddb39`
 - Private report directory:
-  `/Users/silverbook/Sites/pdf-tools-extraction-sidecars/shannon-math-spacing-20260803-clean-befbb55`
+  `/Users/silverbook/Sites/pdf-tools-extraction-sidecars/shannon-math-spacing-final-review-20260803-clean-b8b301c`
 - Repetitions: three fresh processes per candidate
 - PDF Tools Markdown deterministic across repetitions: `true`
-- Median PDF Tools elapsed time: 3465.051 ms
-- Median PDF Tools maximum RSS: 286,146,560 bytes
+- Median PDF Tools elapsed time: 3533.064 ms
+- Median PDF Tools maximum RSS: 312,033,280 bytes
 
 ## Metric comparison
 

--- a/pdf-toolkit-mcp-share/server/markdown-conversion.js
+++ b/pdf-toolkit-mcp-share/server/markdown-conversion.js
@@ -45,7 +45,7 @@ const GAP_CODES = new Set([
 const LIMITATIONS = Object.freeze([
   "Headings are emitted only from consistent enlarged font metrics or centered English-language source structure with section spacing for a first-page title, introduction, part, or appendix. Ambiguous, very short, or unsupported heading styles remain body text.",
   "A geometrically overlapping initial capital may be joined to its following uppercase word remainder. Line-end hyphens are preserved because source geometry cannot reliably distinguish a split word from an intentional compound. The source Extraction IR retains the original lines.",
-  "A missing space after a separate source text item that is exactly the mathematical operator log is restored only in a short, compact left-to-right math run when a differently styled single-letter variable follows on the same baseline with a small positive geometric gap. General equations, scripts, fraction bars, and damaged mathematical glyphs remain source reading-order text rather than being guessed.",
+  "A missing space after a separate source text item that is exactly the mathematical operator log is restored only in a short, compact left-to-right math run when a single-letter variable from a different embedded-font resource follows on the same baseline with a small positive geometric gap and independent local math-layout evidence. General equations, scripts, fraction bars, and damaged mathematical glyphs remain source reading-order text rather than being guessed.",
   "Lists are emitted only for literal bullet glyphs or decimal markers present in the source text.",
   "Links are emitted only for source-validated http or https annotation targets that map to exactly one contiguous run of text on one line. Internal destinations, actions, other schemes, ambiguous or partially covered labels, and links inside reconstructed tables remain escaped text reported as a conversion gap, and URL-looking source text is escaped to resist host autolinking.",
   "Tables are reconstructed only from text-item column geometry, and only when every row fills every detected column and the first row is typographically distinct enough to evidence a header, because a Markdown table imposes header semantics. Ruling lines and merged or spanning cells are not interpreted, and table-like content that fails either test remains escaped reading-order text reported as a conversion gap.",
@@ -513,6 +513,50 @@ function operatorVariableGap(left, right) {
   return rightX - (leftX + leftWidth);
 }
 
+function hasSmallerOffsetScript(cells) {
+  const heights = cells.map(item => item.line_height).filter(Number.isFinite);
+  const ys = cells.map(item => item.y).filter(Number.isFinite);
+  if (heights.length !== cells.length || ys.length !== cells.length) return false;
+  const baseHeight = Math.max(...heights);
+  const baselineY = Math.min(...ys.filter((_y, index) => heights[index] >= baseHeight * 0.9));
+  return cells.some(item => item.line_height <= baseHeight * 0.8
+    && Math.abs(item.y - baselineY) >= baseHeight * 0.2);
+}
+
+function rowHasExplicitEquationOperator(row) {
+  return row.cells.some(item => /^(?:=|[+\-−×÷∑∫∞])$/u.test(item.text.trim()));
+}
+
+function nearbyEquationEvidence(rows, rowIndex) {
+  const row = rows[rowIndex];
+  const start = Math.max(0, rowIndex - 4);
+  const end = Math.min(rows.length - 1, rowIndex + 4);
+  for (let index = start; index <= end; index += 1) {
+    if (index === rowIndex) continue;
+    const candidate = rows[index];
+    if (candidate.line.column_index !== row.line.column_index
+      || candidate.line.direction !== "ltr"
+      || candidate.line.text.length > 80
+      || !candidate.cells.some(item => /^(?:=|Lim|Max|Min|[∑∫∞])$/u.test(item.text.trim()))) continue;
+    const verticalDistance = Math.abs(candidate.line.y - row.line.y);
+    const height = Math.max(candidate.line.height, row.line.height);
+    const horizontalGap = Math.max(
+      candidate.line.x - (row.line.x + row.line.width),
+      row.line.x - (candidate.line.x + candidate.line.width),
+      0,
+    );
+    if (verticalDistance <= height * 2.5 && horizontalGap <= height * 2) return true;
+  }
+  return false;
+}
+
+function hasIndependentMathLayoutEvidence(row, rows, rowIndex) {
+  return hasSmallerOffsetScript(row.cells)
+    || rowHasExplicitEquationOperator(row)
+    || (row.cells.some(item => /^[()]$/u.test(item.text.trim()))
+      && nearbyEquationEvidence(rows, rowIndex));
+}
+
 /**
  * Restore one visible operator boundary that the layout IR can prove without
  * interpreting equation topology. PDF.js may expose roman "log" and its
@@ -520,12 +564,19 @@ function operatorVariableGap(left, right) {
  * gap is smaller than the general prose-spacing threshold. This projection is
  * intentionally much narrower than lowering that threshold for every line.
  */
-function mathOperatorSpacedText(row, { headingLevel, linked }) {
+function mathOperatorSpacedText(row, {
+  headingLevel,
+  linked,
+  rows,
+  rowIndex,
+  unsafePage,
+}) {
   const { line, cells } = row;
-  if (headingLevel || linked || rewritesLineStructure(line)
+  if (headingLevel || linked || unsafePage || rewritesLineStructure(line)
     || line.direction !== "ltr" || line.text.length > 80
     || cells.length < 2 || cells.length > 16
-    || cells.some(item => !compactMathItemText(item.text) || containsUnsafeText(item.text))) return null;
+    || cells.some(item => !compactMathItemText(item.text) || containsUnsafeText(item.text))
+    || !hasIndependentMathLayoutEvidence(row, rows, rowIndex)) return null;
   const offsets = itemOffsets(line, cells);
   if (offsets === null) return null;
   const insertions = [];
@@ -845,14 +896,13 @@ function joinParagraphContinuity(records) {
 }
 
 function renderPage(page) {
-  const itemById = new Map(page.raw_items.map(item => [item.id, item]));
   const headings = headingLevels(page);
   const analysis = segmentPageLines(page);
   const linkState = analyzePageLinks(page, analysis, headings);
   const records = analysis.segments.flatMap(segment => (
     segment.kind === "table"
       ? renderTable(segment.grid).map(text => ({ text, line: null, joinable: false }))
-      : segment.rows.map(({ line }) => {
+      : segment.rows.map(({ line, cells }, rowIndex, rows) => {
         const spans = linkState.spansByLine.get(line.id);
         const offsets = linkState.offsetsByLine.get(line.id);
         if (spans && spans.length > 0 && offsets && !headings.get(line.id)) {
@@ -860,8 +910,17 @@ function renderPage(page) {
           if (linked !== null) return { text: linked, line, joinable: false };
         }
         const mathText = mathOperatorSpacedText(
-          { line, cells: lineCells(line, itemById) },
-          { headingLevel: headings.get(line.id), linked: Boolean(spans?.length) },
+          { line, cells },
+          {
+            headingLevel: headings.get(line.id),
+            linked: Boolean(spans?.length),
+            rows,
+            rowIndex,
+            unsafePage: analysis.tableReason !== null
+              || linkState.unavailable
+              || linkState.ambiguous
+              || linkState.unsupportedTarget,
+          },
         );
         return {
           text: renderLine(line, headings.get(line.id), mathText ?? line.text),

--- a/pdf-toolkit-mcp-share/server/markdown-conversion.js
+++ b/pdf-toolkit-mcp-share/server/markdown-conversion.js
@@ -6,7 +6,7 @@ import {
 
 const RENDERER = Object.freeze({
   name: "pdf-tools.layout-markdown-renderer",
-  version: "1.5.0",
+  version: "1.6.0",
 });
 
 // Bounded geometric table inference. A run of adjacent lines is treated as a
@@ -45,6 +45,7 @@ const GAP_CODES = new Set([
 const LIMITATIONS = Object.freeze([
   "Headings are emitted only from consistent enlarged font metrics or centered English-language source structure with section spacing for a first-page title, introduction, part, or appendix. Ambiguous, very short, or unsupported heading styles remain body text.",
   "A geometrically overlapping initial capital may be joined to its following uppercase word remainder. Line-end hyphens are preserved because source geometry cannot reliably distinguish a split word from an intentional compound. The source Extraction IR retains the original lines.",
+  "A missing space after a separate source text item that is exactly the mathematical operator log is restored only in a short, compact left-to-right math run when a differently styled single-letter variable follows on the same baseline with a small positive geometric gap. General equations, scripts, fraction bars, and damaged mathematical glyphs remain source reading-order text rather than being guessed.",
   "Lists are emitted only for literal bullet glyphs or decimal markers present in the source text.",
   "Links are emitted only for source-validated http or https annotation targets that map to exactly one contiguous run of text on one line. Internal destinations, actions, other schemes, ambiguous or partially covered labels, and links inside reconstructed tables remain escaped text reported as a conversion gap, and URL-looking source text is escaped to resist host autolinking.",
   "Tables are reconstructed only from text-item column geometry, and only when every row fills every detected column and the first row is typographically distinct enough to evidence a header, because a Markdown table imposes header semantics. Ruling lines and merged or spanning cells are not interpreted, and table-like content that fails either test remains escaped reading-order text reported as a conversion gap.",
@@ -269,8 +270,8 @@ function rewritesLineStructure(line) {
     || /^(\d{1,3})([.)])\s+(.+)$/u.test(text);
 }
 
-function renderLine(line, headingLevel) {
-  const text = line.text.trim();
+function renderLine(line, headingLevel, sourceText = line.text) {
+  const text = sourceText.trim();
   if (headingLevel) return `${"#".repeat(headingLevel)} ${escapePlainMarkdown(text)}`;
   const bullet = text.match(/^[\u2022\u2023\u25e6\u2043\u2219]\s+(.+)$/u);
   if (bullet) return `- ${escapePlainMarkdown(bullet[1])}`;
@@ -480,6 +481,77 @@ function lineCells(line, itemById) {
       && typeof item.text === "string"
       && item.text.trim().length > 0
       && Number.isFinite(itemStartX(item)));
+}
+
+const COMPACT_MATH_PUNCTUATION = /^[()[\]{},.;:+\-*/=∞∑∫]+$/u;
+
+function compactMathItemText(value) {
+  const text = String(value).trim();
+  return text === "log"
+    || /^\p{L}$/u.test(text)
+    || /^\p{N}$/u.test(text)
+    || COMPACT_MATH_PUNCTUATION.test(text);
+}
+
+function sameMathBaseline(left, right) {
+  const leftHeight = left.line_height;
+  const rightHeight = right.line_height;
+  return Number.isFinite(left.y)
+    && Number.isFinite(right.y)
+    && Number.isFinite(leftHeight)
+    && Number.isFinite(rightHeight)
+    && leftHeight > 0
+    && rightHeight > 0
+    && Math.abs(left.y - right.y) <= Math.max(leftHeight, rightHeight) * 0.1;
+}
+
+function operatorVariableGap(left, right) {
+  const leftX = itemStartX(left);
+  const rightX = itemStartX(right);
+  const leftWidth = left.bbox && Number.isFinite(left.bbox.width) ? left.bbox.width : left.width;
+  if (!Number.isFinite(leftX) || !Number.isFinite(rightX) || !Number.isFinite(leftWidth)) return null;
+  return rightX - (leftX + leftWidth);
+}
+
+/**
+ * Restore one visible operator boundary that the layout IR can prove without
+ * interpreting equation topology. PDF.js may expose roman "log" and its
+ * following italic variable as separate same-baseline items whose positive
+ * gap is smaller than the general prose-spacing threshold. This projection is
+ * intentionally much narrower than lowering that threshold for every line.
+ */
+function mathOperatorSpacedText(row, { headingLevel, linked }) {
+  const { line, cells } = row;
+  if (headingLevel || linked || rewritesLineStructure(line)
+    || line.direction !== "ltr" || line.text.length > 80
+    || cells.length < 2 || cells.length > 16
+    || cells.some(item => !compactMathItemText(item.text) || containsUnsafeText(item.text))) return null;
+  const offsets = itemOffsets(line, cells);
+  if (offsets === null) return null;
+  const insertions = [];
+  for (let index = 0; index < cells.length - 1; index += 1) {
+    const operator = cells[index];
+    const variable = cells[index + 1];
+    if (operator.text.trim() !== "log"
+      || !/^\p{L}$/u.test(variable.text.trim())
+      || operator.font_name === null
+      || variable.font_name === null
+      || operator.font_name === variable.font_name
+      || !sameMathBaseline(operator, variable)) continue;
+    const gap = operatorVariableGap(operator, variable);
+    const height = Math.max(operator.line_height, variable.line_height);
+    if (!(gap > height * 0.05 && gap <= height * 0.25)) continue;
+    const from = offsets[index].end;
+    const to = offsets[index + 1].start;
+    if (from !== to || /\s/u.test(line.text.slice(from, to))) continue;
+    insertions.push(from);
+  }
+  if (insertions.length === 0) return null;
+  let text = line.text;
+  for (const offset of insertions.sort((left, right) => right - left)) {
+    text = `${text.slice(0, offset)} ${text.slice(offset)}`;
+  }
+  return text;
 }
 
 function columnAnchors(rows) {
@@ -773,6 +845,7 @@ function joinParagraphContinuity(records) {
 }
 
 function renderPage(page) {
+  const itemById = new Map(page.raw_items.map(item => [item.id, item]));
   const headings = headingLevels(page);
   const analysis = segmentPageLines(page);
   const linkState = analyzePageLinks(page, analysis, headings);
@@ -786,10 +859,14 @@ function renderPage(page) {
           const linked = renderLinkedLine(line, offsets, spans);
           if (linked !== null) return { text: linked, line, joinable: false };
         }
+        const mathText = mathOperatorSpacedText(
+          { line, cells: lineCells(line, itemById) },
+          { headingLevel: headings.get(line.id), linked: Boolean(spans?.length) },
+        );
         return {
-          text: renderLine(line, headings.get(line.id)),
+          text: renderLine(line, headings.get(line.id), mathText ?? line.text),
           line,
-          joinable: !headings.get(line.id) && !rewritesLineStructure(line),
+          joinable: mathText === null && !headings.get(line.id) && !rewritesLineStructure(line),
         };
       })
   ));

--- a/pdf-toolkit-mcp-share/server/markdown-conversion.js
+++ b/pdf-toolkit-mcp-share/server/markdown-conversion.js
@@ -513,18 +513,26 @@ function operatorVariableGap(left, right) {
   return rightX - (leftX + leftWidth);
 }
 
-function hasSmallerOffsetScript(cells) {
-  const heights = cells.map(item => item.line_height).filter(Number.isFinite);
-  const ys = cells.map(item => item.y).filter(Number.isFinite);
-  if (heights.length !== cells.length || ys.length !== cells.length) return false;
-  const baseHeight = Math.max(...heights);
-  const baselineY = Math.min(...ys.filter((_y, index) => heights[index] >= baseHeight * 0.9));
-  return cells.some(item => item.line_height <= baseHeight * 0.8
-    && Math.abs(item.y - baselineY) >= baseHeight * 0.2);
+function hasAttachedSmallerOffsetScript(cells, variableIndex) {
+  const variable = cells[variableIndex];
+  const script = cells[variableIndex + 1];
+  if (!variable || !script
+    || !/^\p{L}$/u.test(variable.text.trim())
+    || !/^[\p{L}\p{N}]+$/u.test(script.text.trim())
+    || !Number.isFinite(variable.line_height)
+    || !Number.isFinite(script.line_height)
+    || !Number.isFinite(variable.y)
+    || !Number.isFinite(script.y)) return false;
+  const gap = operatorVariableGap(variable, script);
+  return script.line_height <= variable.line_height * 0.8
+    && Math.abs(script.y - variable.y) >= variable.line_height * 0.2
+    && gap !== null
+    && gap >= -variable.line_height * 0.05
+    && gap <= variable.line_height * 0.25;
 }
 
-function rowHasExplicitEquationOperator(row) {
-  return row.cells.some(item => /^(?:=|[+\-−×÷∑∫∞])$/u.test(item.text.trim()));
+function rowHasSpecificMathOperator(row) {
+  return row.cells.some(item => /^(?:Lim|Max|Min|[∑∫∞])$/u.test(item.text.trim()));
 }
 
 function nearbyEquationEvidence(rows, rowIndex) {
@@ -537,7 +545,7 @@ function nearbyEquationEvidence(rows, rowIndex) {
     if (candidate.line.column_index !== row.line.column_index
       || candidate.line.direction !== "ltr"
       || candidate.line.text.length > 80
-      || !candidate.cells.some(item => /^(?:=|Lim|Max|Min|[∑∫∞])$/u.test(item.text.trim()))) continue;
+      || !rowHasSpecificMathOperator(candidate)) continue;
     const verticalDistance = Math.abs(candidate.line.y - row.line.y);
     const height = Math.max(candidate.line.height, row.line.height);
     const horizontalGap = Math.max(
@@ -550,9 +558,9 @@ function nearbyEquationEvidence(rows, rowIndex) {
   return false;
 }
 
-function hasIndependentMathLayoutEvidence(row, rows, rowIndex) {
-  return hasSmallerOffsetScript(row.cells)
-    || rowHasExplicitEquationOperator(row)
+function hasIndependentMathLayoutEvidence(row, operatorIndex, rows, rowIndex) {
+  return hasAttachedSmallerOffsetScript(row.cells, operatorIndex + 1)
+    || rowHasSpecificMathOperator(row)
     || (row.cells.some(item => /^[()]$/u.test(item.text.trim()))
       && nearbyEquationEvidence(rows, rowIndex));
 }
@@ -575,8 +583,7 @@ function mathOperatorSpacedText(row, {
   if (headingLevel || linked || unsafePage || rewritesLineStructure(line)
     || line.direction !== "ltr" || line.text.length > 80
     || cells.length < 2 || cells.length > 16
-    || cells.some(item => !compactMathItemText(item.text) || containsUnsafeText(item.text))
-    || !hasIndependentMathLayoutEvidence(row, rows, rowIndex)) return null;
+    || cells.some(item => !compactMathItemText(item.text) || containsUnsafeText(item.text))) return null;
   const offsets = itemOffsets(line, cells);
   if (offsets === null) return null;
   const insertions = [];
@@ -588,7 +595,8 @@ function mathOperatorSpacedText(row, {
       || operator.font_name === null
       || variable.font_name === null
       || operator.font_name === variable.font_name
-      || !sameMathBaseline(operator, variable)) continue;
+      || !sameMathBaseline(operator, variable)
+      || !hasIndependentMathLayoutEvidence(row, index, rows, rowIndex)) continue;
     const gap = operatorVariableGap(operator, variable);
     const height = Math.max(operator.line_height, variable.line_height);
     if (!(gap > height * 0.05 && gap <= height * 0.25)) continue;

--- a/pdf-toolkit-mcp-share/server/output-schemas.js
+++ b/pdf-toolkit-mcp-share/server/output-schemas.js
@@ -552,7 +552,7 @@ export const TOOL_SUCCESS_OUTPUT_SCHEMAS = Object.freeze({
   convert_pdf_to_markdown: object({
     renderer: object({
       name: { const: "pdf-tools.layout-markdown-renderer" },
-      version: { const: "1.5.0" },
+      version: { const: "1.6.0" },
     }),
     conversion_status: enumString(["complete", "partial", "failed"]),
     markdown: string,

--- a/scripts/eval-run-markdown-bakeoff.mjs
+++ b/scripts/eval-run-markdown-bakeoff.mjs
@@ -190,7 +190,7 @@ export function validateMarkdownResult(result, binding) {
     throw new Error(`Markdown conversion failed for ${binding.fixture.id}`);
   }
   const value = result.structuredContent;
-  if (value.renderer?.name !== "pdf-tools.layout-markdown-renderer" || value.renderer?.version !== "1.5.0"
+  if (value.renderer?.name !== "pdf-tools.layout-markdown-renderer" || value.renderer?.version !== "1.6.0"
     || value.options?.include_page_boundaries !== true || value.limits?.max_markdown_bytes !== 200000
     || value.provenance?.source?.file_name !== binding.retained.filename
     || value.provenance?.source?.sha256 !== binding.retained.sha256

--- a/scripts/smoke-mcpb.mjs
+++ b/scripts/smoke-mcpb.mjs
@@ -146,7 +146,7 @@ async function main() {
       arguments: { pdf_path: fixturePath, max_markdown_bytes: 200000 },
     });
     if (markdown.isError
-      || markdown.structuredContent?.renderer?.version !== "1.5.0"
+      || markdown.structuredContent?.renderer?.version !== "1.6.0"
       || markdown.structuredContent?.markdown_bytes !== Buffer.byteLength(markdown.structuredContent?.markdown || "", "utf8")
       || markdown.structuredContent?.markdown_sha256 !== sha256(Buffer.from(markdown.structuredContent?.markdown || "", "utf8"))) {
       throw new Error("Packed convert_pdf_to_markdown contract smoke failed");

--- a/scripts/test-share-contract.mjs
+++ b/scripts/test-share-contract.mjs
@@ -837,7 +837,7 @@ async function main() {
       arguments: { pdf_path: fixturePath, max_markdown_bytes: 200000 },
     });
     if (markdown.isError
-      || markdown.structuredContent?.renderer?.version !== "1.5.0"
+      || markdown.structuredContent?.renderer?.version !== "1.6.0"
       || markdown.structuredContent?.markdown_bytes !== Buffer.byteLength(markdown.structuredContent?.markdown || "", "utf8")
       || markdown.structuredContent?.markdown_sha256 !== sha256(Buffer.from(markdown.structuredContent?.markdown || "", "utf8"))) {
       throw new Error("Share convert_pdf_to_markdown contract smoke failed");

--- a/server/markdown-conversion.js
+++ b/server/markdown-conversion.js
@@ -45,7 +45,7 @@ const GAP_CODES = new Set([
 const LIMITATIONS = Object.freeze([
   "Headings are emitted only from consistent enlarged font metrics or centered English-language source structure with section spacing for a first-page title, introduction, part, or appendix. Ambiguous, very short, or unsupported heading styles remain body text.",
   "A geometrically overlapping initial capital may be joined to its following uppercase word remainder. Line-end hyphens are preserved because source geometry cannot reliably distinguish a split word from an intentional compound. The source Extraction IR retains the original lines.",
-  "A missing space after a separate source text item that is exactly the mathematical operator log is restored only in a short, compact left-to-right math run when a differently styled single-letter variable follows on the same baseline with a small positive geometric gap. General equations, scripts, fraction bars, and damaged mathematical glyphs remain source reading-order text rather than being guessed.",
+  "A missing space after a separate source text item that is exactly the mathematical operator log is restored only in a short, compact left-to-right math run when a single-letter variable from a different embedded-font resource follows on the same baseline with a small positive geometric gap and independent local math-layout evidence. General equations, scripts, fraction bars, and damaged mathematical glyphs remain source reading-order text rather than being guessed.",
   "Lists are emitted only for literal bullet glyphs or decimal markers present in the source text.",
   "Links are emitted only for source-validated http or https annotation targets that map to exactly one contiguous run of text on one line. Internal destinations, actions, other schemes, ambiguous or partially covered labels, and links inside reconstructed tables remain escaped text reported as a conversion gap, and URL-looking source text is escaped to resist host autolinking.",
   "Tables are reconstructed only from text-item column geometry, and only when every row fills every detected column and the first row is typographically distinct enough to evidence a header, because a Markdown table imposes header semantics. Ruling lines and merged or spanning cells are not interpreted, and table-like content that fails either test remains escaped reading-order text reported as a conversion gap.",
@@ -513,6 +513,50 @@ function operatorVariableGap(left, right) {
   return rightX - (leftX + leftWidth);
 }
 
+function hasSmallerOffsetScript(cells) {
+  const heights = cells.map(item => item.line_height).filter(Number.isFinite);
+  const ys = cells.map(item => item.y).filter(Number.isFinite);
+  if (heights.length !== cells.length || ys.length !== cells.length) return false;
+  const baseHeight = Math.max(...heights);
+  const baselineY = Math.min(...ys.filter((_y, index) => heights[index] >= baseHeight * 0.9));
+  return cells.some(item => item.line_height <= baseHeight * 0.8
+    && Math.abs(item.y - baselineY) >= baseHeight * 0.2);
+}
+
+function rowHasExplicitEquationOperator(row) {
+  return row.cells.some(item => /^(?:=|[+\-−×÷∑∫∞])$/u.test(item.text.trim()));
+}
+
+function nearbyEquationEvidence(rows, rowIndex) {
+  const row = rows[rowIndex];
+  const start = Math.max(0, rowIndex - 4);
+  const end = Math.min(rows.length - 1, rowIndex + 4);
+  for (let index = start; index <= end; index += 1) {
+    if (index === rowIndex) continue;
+    const candidate = rows[index];
+    if (candidate.line.column_index !== row.line.column_index
+      || candidate.line.direction !== "ltr"
+      || candidate.line.text.length > 80
+      || !candidate.cells.some(item => /^(?:=|Lim|Max|Min|[∑∫∞])$/u.test(item.text.trim()))) continue;
+    const verticalDistance = Math.abs(candidate.line.y - row.line.y);
+    const height = Math.max(candidate.line.height, row.line.height);
+    const horizontalGap = Math.max(
+      candidate.line.x - (row.line.x + row.line.width),
+      row.line.x - (candidate.line.x + candidate.line.width),
+      0,
+    );
+    if (verticalDistance <= height * 2.5 && horizontalGap <= height * 2) return true;
+  }
+  return false;
+}
+
+function hasIndependentMathLayoutEvidence(row, rows, rowIndex) {
+  return hasSmallerOffsetScript(row.cells)
+    || rowHasExplicitEquationOperator(row)
+    || (row.cells.some(item => /^[()]$/u.test(item.text.trim()))
+      && nearbyEquationEvidence(rows, rowIndex));
+}
+
 /**
  * Restore one visible operator boundary that the layout IR can prove without
  * interpreting equation topology. PDF.js may expose roman "log" and its
@@ -520,12 +564,19 @@ function operatorVariableGap(left, right) {
  * gap is smaller than the general prose-spacing threshold. This projection is
  * intentionally much narrower than lowering that threshold for every line.
  */
-function mathOperatorSpacedText(row, { headingLevel, linked }) {
+function mathOperatorSpacedText(row, {
+  headingLevel,
+  linked,
+  rows,
+  rowIndex,
+  unsafePage,
+}) {
   const { line, cells } = row;
-  if (headingLevel || linked || rewritesLineStructure(line)
+  if (headingLevel || linked || unsafePage || rewritesLineStructure(line)
     || line.direction !== "ltr" || line.text.length > 80
     || cells.length < 2 || cells.length > 16
-    || cells.some(item => !compactMathItemText(item.text) || containsUnsafeText(item.text))) return null;
+    || cells.some(item => !compactMathItemText(item.text) || containsUnsafeText(item.text))
+    || !hasIndependentMathLayoutEvidence(row, rows, rowIndex)) return null;
   const offsets = itemOffsets(line, cells);
   if (offsets === null) return null;
   const insertions = [];
@@ -845,14 +896,13 @@ function joinParagraphContinuity(records) {
 }
 
 function renderPage(page) {
-  const itemById = new Map(page.raw_items.map(item => [item.id, item]));
   const headings = headingLevels(page);
   const analysis = segmentPageLines(page);
   const linkState = analyzePageLinks(page, analysis, headings);
   const records = analysis.segments.flatMap(segment => (
     segment.kind === "table"
       ? renderTable(segment.grid).map(text => ({ text, line: null, joinable: false }))
-      : segment.rows.map(({ line }) => {
+      : segment.rows.map(({ line, cells }, rowIndex, rows) => {
         const spans = linkState.spansByLine.get(line.id);
         const offsets = linkState.offsetsByLine.get(line.id);
         if (spans && spans.length > 0 && offsets && !headings.get(line.id)) {
@@ -860,8 +910,17 @@ function renderPage(page) {
           if (linked !== null) return { text: linked, line, joinable: false };
         }
         const mathText = mathOperatorSpacedText(
-          { line, cells: lineCells(line, itemById) },
-          { headingLevel: headings.get(line.id), linked: Boolean(spans?.length) },
+          { line, cells },
+          {
+            headingLevel: headings.get(line.id),
+            linked: Boolean(spans?.length),
+            rows,
+            rowIndex,
+            unsafePage: analysis.tableReason !== null
+              || linkState.unavailable
+              || linkState.ambiguous
+              || linkState.unsupportedTarget,
+          },
         );
         return {
           text: renderLine(line, headings.get(line.id), mathText ?? line.text),

--- a/server/markdown-conversion.js
+++ b/server/markdown-conversion.js
@@ -6,7 +6,7 @@ import {
 
 const RENDERER = Object.freeze({
   name: "pdf-tools.layout-markdown-renderer",
-  version: "1.5.0",
+  version: "1.6.0",
 });
 
 // Bounded geometric table inference. A run of adjacent lines is treated as a
@@ -45,6 +45,7 @@ const GAP_CODES = new Set([
 const LIMITATIONS = Object.freeze([
   "Headings are emitted only from consistent enlarged font metrics or centered English-language source structure with section spacing for a first-page title, introduction, part, or appendix. Ambiguous, very short, or unsupported heading styles remain body text.",
   "A geometrically overlapping initial capital may be joined to its following uppercase word remainder. Line-end hyphens are preserved because source geometry cannot reliably distinguish a split word from an intentional compound. The source Extraction IR retains the original lines.",
+  "A missing space after a separate source text item that is exactly the mathematical operator log is restored only in a short, compact left-to-right math run when a differently styled single-letter variable follows on the same baseline with a small positive geometric gap. General equations, scripts, fraction bars, and damaged mathematical glyphs remain source reading-order text rather than being guessed.",
   "Lists are emitted only for literal bullet glyphs or decimal markers present in the source text.",
   "Links are emitted only for source-validated http or https annotation targets that map to exactly one contiguous run of text on one line. Internal destinations, actions, other schemes, ambiguous or partially covered labels, and links inside reconstructed tables remain escaped text reported as a conversion gap, and URL-looking source text is escaped to resist host autolinking.",
   "Tables are reconstructed only from text-item column geometry, and only when every row fills every detected column and the first row is typographically distinct enough to evidence a header, because a Markdown table imposes header semantics. Ruling lines and merged or spanning cells are not interpreted, and table-like content that fails either test remains escaped reading-order text reported as a conversion gap.",
@@ -269,8 +270,8 @@ function rewritesLineStructure(line) {
     || /^(\d{1,3})([.)])\s+(.+)$/u.test(text);
 }
 
-function renderLine(line, headingLevel) {
-  const text = line.text.trim();
+function renderLine(line, headingLevel, sourceText = line.text) {
+  const text = sourceText.trim();
   if (headingLevel) return `${"#".repeat(headingLevel)} ${escapePlainMarkdown(text)}`;
   const bullet = text.match(/^[\u2022\u2023\u25e6\u2043\u2219]\s+(.+)$/u);
   if (bullet) return `- ${escapePlainMarkdown(bullet[1])}`;
@@ -480,6 +481,77 @@ function lineCells(line, itemById) {
       && typeof item.text === "string"
       && item.text.trim().length > 0
       && Number.isFinite(itemStartX(item)));
+}
+
+const COMPACT_MATH_PUNCTUATION = /^[()[\]{},.;:+\-*/=∞∑∫]+$/u;
+
+function compactMathItemText(value) {
+  const text = String(value).trim();
+  return text === "log"
+    || /^\p{L}$/u.test(text)
+    || /^\p{N}$/u.test(text)
+    || COMPACT_MATH_PUNCTUATION.test(text);
+}
+
+function sameMathBaseline(left, right) {
+  const leftHeight = left.line_height;
+  const rightHeight = right.line_height;
+  return Number.isFinite(left.y)
+    && Number.isFinite(right.y)
+    && Number.isFinite(leftHeight)
+    && Number.isFinite(rightHeight)
+    && leftHeight > 0
+    && rightHeight > 0
+    && Math.abs(left.y - right.y) <= Math.max(leftHeight, rightHeight) * 0.1;
+}
+
+function operatorVariableGap(left, right) {
+  const leftX = itemStartX(left);
+  const rightX = itemStartX(right);
+  const leftWidth = left.bbox && Number.isFinite(left.bbox.width) ? left.bbox.width : left.width;
+  if (!Number.isFinite(leftX) || !Number.isFinite(rightX) || !Number.isFinite(leftWidth)) return null;
+  return rightX - (leftX + leftWidth);
+}
+
+/**
+ * Restore one visible operator boundary that the layout IR can prove without
+ * interpreting equation topology. PDF.js may expose roman "log" and its
+ * following italic variable as separate same-baseline items whose positive
+ * gap is smaller than the general prose-spacing threshold. This projection is
+ * intentionally much narrower than lowering that threshold for every line.
+ */
+function mathOperatorSpacedText(row, { headingLevel, linked }) {
+  const { line, cells } = row;
+  if (headingLevel || linked || rewritesLineStructure(line)
+    || line.direction !== "ltr" || line.text.length > 80
+    || cells.length < 2 || cells.length > 16
+    || cells.some(item => !compactMathItemText(item.text) || containsUnsafeText(item.text))) return null;
+  const offsets = itemOffsets(line, cells);
+  if (offsets === null) return null;
+  const insertions = [];
+  for (let index = 0; index < cells.length - 1; index += 1) {
+    const operator = cells[index];
+    const variable = cells[index + 1];
+    if (operator.text.trim() !== "log"
+      || !/^\p{L}$/u.test(variable.text.trim())
+      || operator.font_name === null
+      || variable.font_name === null
+      || operator.font_name === variable.font_name
+      || !sameMathBaseline(operator, variable)) continue;
+    const gap = operatorVariableGap(operator, variable);
+    const height = Math.max(operator.line_height, variable.line_height);
+    if (!(gap > height * 0.05 && gap <= height * 0.25)) continue;
+    const from = offsets[index].end;
+    const to = offsets[index + 1].start;
+    if (from !== to || /\s/u.test(line.text.slice(from, to))) continue;
+    insertions.push(from);
+  }
+  if (insertions.length === 0) return null;
+  let text = line.text;
+  for (const offset of insertions.sort((left, right) => right - left)) {
+    text = `${text.slice(0, offset)} ${text.slice(offset)}`;
+  }
+  return text;
 }
 
 function columnAnchors(rows) {
@@ -773,6 +845,7 @@ function joinParagraphContinuity(records) {
 }
 
 function renderPage(page) {
+  const itemById = new Map(page.raw_items.map(item => [item.id, item]));
   const headings = headingLevels(page);
   const analysis = segmentPageLines(page);
   const linkState = analyzePageLinks(page, analysis, headings);
@@ -786,10 +859,14 @@ function renderPage(page) {
           const linked = renderLinkedLine(line, offsets, spans);
           if (linked !== null) return { text: linked, line, joinable: false };
         }
+        const mathText = mathOperatorSpacedText(
+          { line, cells: lineCells(line, itemById) },
+          { headingLevel: headings.get(line.id), linked: Boolean(spans?.length) },
+        );
         return {
-          text: renderLine(line, headings.get(line.id)),
+          text: renderLine(line, headings.get(line.id), mathText ?? line.text),
           line,
-          joinable: !headings.get(line.id) && !rewritesLineStructure(line),
+          joinable: mathText === null && !headings.get(line.id) && !rewritesLineStructure(line),
         };
       })
   ));

--- a/server/markdown-conversion.js
+++ b/server/markdown-conversion.js
@@ -513,18 +513,26 @@ function operatorVariableGap(left, right) {
   return rightX - (leftX + leftWidth);
 }
 
-function hasSmallerOffsetScript(cells) {
-  const heights = cells.map(item => item.line_height).filter(Number.isFinite);
-  const ys = cells.map(item => item.y).filter(Number.isFinite);
-  if (heights.length !== cells.length || ys.length !== cells.length) return false;
-  const baseHeight = Math.max(...heights);
-  const baselineY = Math.min(...ys.filter((_y, index) => heights[index] >= baseHeight * 0.9));
-  return cells.some(item => item.line_height <= baseHeight * 0.8
-    && Math.abs(item.y - baselineY) >= baseHeight * 0.2);
+function hasAttachedSmallerOffsetScript(cells, variableIndex) {
+  const variable = cells[variableIndex];
+  const script = cells[variableIndex + 1];
+  if (!variable || !script
+    || !/^\p{L}$/u.test(variable.text.trim())
+    || !/^[\p{L}\p{N}]+$/u.test(script.text.trim())
+    || !Number.isFinite(variable.line_height)
+    || !Number.isFinite(script.line_height)
+    || !Number.isFinite(variable.y)
+    || !Number.isFinite(script.y)) return false;
+  const gap = operatorVariableGap(variable, script);
+  return script.line_height <= variable.line_height * 0.8
+    && Math.abs(script.y - variable.y) >= variable.line_height * 0.2
+    && gap !== null
+    && gap >= -variable.line_height * 0.05
+    && gap <= variable.line_height * 0.25;
 }
 
-function rowHasExplicitEquationOperator(row) {
-  return row.cells.some(item => /^(?:=|[+\-−×÷∑∫∞])$/u.test(item.text.trim()));
+function rowHasSpecificMathOperator(row) {
+  return row.cells.some(item => /^(?:Lim|Max|Min|[∑∫∞])$/u.test(item.text.trim()));
 }
 
 function nearbyEquationEvidence(rows, rowIndex) {
@@ -537,7 +545,7 @@ function nearbyEquationEvidence(rows, rowIndex) {
     if (candidate.line.column_index !== row.line.column_index
       || candidate.line.direction !== "ltr"
       || candidate.line.text.length > 80
-      || !candidate.cells.some(item => /^(?:=|Lim|Max|Min|[∑∫∞])$/u.test(item.text.trim()))) continue;
+      || !rowHasSpecificMathOperator(candidate)) continue;
     const verticalDistance = Math.abs(candidate.line.y - row.line.y);
     const height = Math.max(candidate.line.height, row.line.height);
     const horizontalGap = Math.max(
@@ -550,9 +558,9 @@ function nearbyEquationEvidence(rows, rowIndex) {
   return false;
 }
 
-function hasIndependentMathLayoutEvidence(row, rows, rowIndex) {
-  return hasSmallerOffsetScript(row.cells)
-    || rowHasExplicitEquationOperator(row)
+function hasIndependentMathLayoutEvidence(row, operatorIndex, rows, rowIndex) {
+  return hasAttachedSmallerOffsetScript(row.cells, operatorIndex + 1)
+    || rowHasSpecificMathOperator(row)
     || (row.cells.some(item => /^[()]$/u.test(item.text.trim()))
       && nearbyEquationEvidence(rows, rowIndex));
 }
@@ -575,8 +583,7 @@ function mathOperatorSpacedText(row, {
   if (headingLevel || linked || unsafePage || rewritesLineStructure(line)
     || line.direction !== "ltr" || line.text.length > 80
     || cells.length < 2 || cells.length > 16
-    || cells.some(item => !compactMathItemText(item.text) || containsUnsafeText(item.text))
-    || !hasIndependentMathLayoutEvidence(row, rows, rowIndex)) return null;
+    || cells.some(item => !compactMathItemText(item.text) || containsUnsafeText(item.text))) return null;
   const offsets = itemOffsets(line, cells);
   if (offsets === null) return null;
   const insertions = [];
@@ -588,7 +595,8 @@ function mathOperatorSpacedText(row, {
       || operator.font_name === null
       || variable.font_name === null
       || operator.font_name === variable.font_name
-      || !sameMathBaseline(operator, variable)) continue;
+      || !sameMathBaseline(operator, variable)
+      || !hasIndependentMathLayoutEvidence(row, index, rows, rowIndex)) continue;
     const gap = operatorVariableGap(operator, variable);
     const height = Math.max(operator.line_height, variable.line_height);
     if (!(gap > height * 0.05 && gap <= height * 0.25)) continue;

--- a/server/output-schemas.js
+++ b/server/output-schemas.js
@@ -552,7 +552,7 @@ export const TOOL_SUCCESS_OUTPUT_SCHEMAS = Object.freeze({
   convert_pdf_to_markdown: object({
     renderer: object({
       name: { const: "pdf-tools.layout-markdown-renderer" },
-      version: { const: "1.5.0" },
+      version: { const: "1.6.0" },
     }),
     conversion_status: enumString(["complete", "partial", "failed"]),
     markdown: string,

--- a/test/convert-pdf-to-markdown.test.js
+++ b/test/convert-pdf-to-markdown.test.js
@@ -305,7 +305,7 @@ describe("convert_pdf_to_markdown MCP tool", () => {
     expect(first.isError).not.toBe(true);
     expect(second.structuredContent).toEqual(first.structuredContent);
     expect(first.structuredContent).toMatchObject({
-      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.5.0" },
+      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.6.0" },
       conversion_status: "complete",
       saved_output: null,
       provenance: {

--- a/test/eval/markdown-bakeoff.test.js
+++ b/test/eval/markdown-bakeoff.test.js
@@ -232,7 +232,7 @@ describe("Markdown bakeoff renderer version binding", () => {
 
   it("accepts the current renderer version and rejects the superseded one", () => {
     expect(validateMarkdownResult(resultFor("1.6.0"), binding).renderer.version).toBe("1.6.0");
-    for (const stale of ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0"]) {
+    for (const stale of ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0"]) {
       expect(() => validateMarkdownResult(resultFor(stale), binding), stale)
         .toThrow(/Markdown result evidence is invalid/u);
     }

--- a/test/eval/markdown-bakeoff.test.js
+++ b/test/eval/markdown-bakeoff.test.js
@@ -64,7 +64,7 @@ async function handle(message) {
     const pageBoundaries = Array.from({ length: pageCount }, (_, index) => "<!-- PDF page " + (index + 1) + " -->");
     const markdown = pageBoundaries.join("\n\n") + "\n\nINV-1001 fixture evidence\n";
     const value = {
-      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.5.0" },
+      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.6.0" },
       conversion_status: "complete",
       markdown,
       markdown_sha256: digest(Buffer.from(markdown)),
@@ -143,7 +143,7 @@ function resultFor(binding) {
   const markdown = "<!-- PDF page 1 -->\n\nFixture text\n";
   return {
     structuredContent: {
-      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.5.0" },
+      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.6.0" },
       conversion_status: "complete",
       markdown,
       markdown_sha256: sha256(Buffer.from(markdown)),
@@ -231,7 +231,7 @@ describe("Markdown bakeoff renderer version binding", () => {
   });
 
   it("accepts the current renderer version and rejects the superseded one", () => {
-    expect(validateMarkdownResult(resultFor("1.5.0"), binding).renderer.version).toBe("1.5.0");
+    expect(validateMarkdownResult(resultFor("1.6.0"), binding).renderer.version).toBe("1.6.0");
     for (const stale of ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0"]) {
       expect(() => validateMarkdownResult(resultFor(stale), binding), stale)
         .toThrow(/Markdown result evidence is invalid/u);

--- a/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
+++ b/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
@@ -61,14 +61,14 @@
     {
       "role": "markdown_conversion_module",
       "path": "server/markdown-conversion.js",
-      "bytes": 42285,
-      "sha256": "39f17d0d6a1224a15ca344d5f10c2e880ec1fcef83b30de06a5aa87c0e34b822"
+      "bytes": 48188,
+      "sha256": "7d311ef7f13bfa0a860571b071cc5c6b9c9271542f6936fcef7bec4a12ec105f"
     },
     {
       "role": "output_schemas_module",
       "path": "server/output-schemas.js",
       "bytes": 29954,
-      "sha256": "6e0d1ef863db1eb31a992c331dbb47b5eb3778ca1018f005de343603b4d30040"
+      "sha256": "b8aabcb644f037fba9edabca849039b5648845964e52678f968c3ccaeccb45d0"
     },
     {
       "role": "package_json",
@@ -95,7 +95,7 @@
       "sha256": "6e4429db62fcbe1dd73141d8c20a48b564d41f8bf8920d88775846995e1daf94"
     }
   ],
-  "validator_source_set_sha256": "e2296d1a5d82f295ec5194ed969ef6317b11e4fa2401579e36ddc524b3b689fa",
+  "validator_source_set_sha256": "90317b8937ca8c29170dbb4e127254cb00a05085731c0470f633a798185013f2",
   "pdfjs_version": "5.4.624",
   "generation_contract": {
     "source_path": "source.pdf",

--- a/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
+++ b/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
@@ -61,8 +61,8 @@
     {
       "role": "markdown_conversion_module",
       "path": "server/markdown-conversion.js",
-      "bytes": 48188,
-      "sha256": "7d311ef7f13bfa0a860571b071cc5c6b9c9271542f6936fcef7bec4a12ec105f"
+      "bytes": 48387,
+      "sha256": "e4b7212d06e9f3052929706aeb6412275f26988ae578d95df6eeb9eb8d4b6cd4"
     },
     {
       "role": "output_schemas_module",
@@ -95,7 +95,7 @@
       "sha256": "6e4429db62fcbe1dd73141d8c20a48b564d41f8bf8920d88775846995e1daf94"
     }
   ],
-  "validator_source_set_sha256": "90317b8937ca8c29170dbb4e127254cb00a05085731c0470f633a798185013f2",
+  "validator_source_set_sha256": "41a2e8232fb5c0cecfe534ae60aabd1a94fef2c355fb47caeb9dc3bfacb67b14",
   "pdfjs_version": "5.4.624",
   "generation_contract": {
     "source_path": "source.pdf",

--- a/test/fixtures/eval/shannon/manifest.v1.json
+++ b/test/fixtures/eval/shannon/manifest.v1.json
@@ -22,7 +22,7 @@
     "pdf_tools": {
       "slot": "control.current_product.v0",
       "renderer_name": "pdf-tools.layout-markdown-renderer",
-      "renderer_version": "1.5.0",
+      "renderer_version": "1.6.0",
       "parser_name": "pdfjs-dist",
       "parser_version": "5.4.624"
     },

--- a/test/markdown-conversion.test.js
+++ b/test/markdown-conversion.test.js
@@ -37,6 +37,25 @@ function textItem(text, { top, fontSize = 12, left = 50, eol = true } = {}) {
   };
 }
 
+function positionedTextItem(text, {
+  top,
+  left,
+  width,
+  fontSize = 10,
+  fontName = "f1",
+  eol = false,
+} = {}) {
+  return {
+    str: text,
+    dir: "ltr",
+    width,
+    height: fontSize,
+    transform: [fontSize, 0, 0, fontSize, left, 792 - top - fontSize],
+    fontName,
+    hasEOL: eol,
+  };
+}
+
 function centeredTextItem(text, { top, fontSize = 12 } = {}) {
   const width = Math.max(20, text.length * fontSize * 0.5);
   return textItem(text, { top, fontSize, left: (612 - width) / 2 });
@@ -52,7 +71,10 @@ function fakePdfjs(pageConfigs) {
       if (config.textError) throw config.textError;
       return {
         items: config.items ?? [],
-        styles: { f1: { fontFamily: "Test Sans", ascent: 0.8, descent: -0.2, vertical: false } },
+        styles: {
+          f1: { fontFamily: "Test Sans", ascent: 0.8, descent: -0.2, vertical: false },
+          f2: { fontFamily: "Test Serif", ascent: 0.8, descent: -0.2, vertical: false },
+        },
       };
     },
     getOperatorList: async () => ({ fnArray: config.operations ?? [] }),
@@ -167,6 +189,53 @@ describe("layout Markdown renderer", () => {
     expect(result.markdown).toContain("T\n");
     expect(result.markdown).toContain("H = p log p\n");
     expect(result.markdown).not.toMatch(/^#{1,6}\s+(?:�|T|H = p log p)$/gmu);
+  });
+
+  it("restores only a geometrically proven space after a separate log operator", async () => {
+    const layout = await validatedSyntheticLayout([
+      { items: [
+        positionedTextItem("log", { top: 100, left: 100, width: 12.8 }),
+        positionedTextItem("N", { top: 100, left: 113.8, width: 6.67, fontName: "f2" }),
+        positionedTextItem("(", { top: 100, left: 120.9, width: 3.84 }),
+        positionedTextItem("T", { top: 100, left: 124.74, width: 5.56, fontName: "f2" }),
+        positionedTextItem(")", { top: 100, left: 131, width: 3.84, eol: true }),
+      ] },
+      { items: [
+        positionedTextItem("p", { top: 100, left: 100, width: 5, fontName: "f2" }),
+        positionedTextItem("i", { top: 103.52, left: 105.04, width: 2.057, fontSize: 7.4, fontName: "f2" }),
+        positionedTextItem(" ", { top: 100, left: 107.1, width: 1.7 }),
+        positionedTextItem("log", { top: 100, left: 108.8, width: 12.8 }),
+        positionedTextItem("p", { top: 100, left: 123.319, width: 5, fontName: "f2" }),
+        positionedTextItem("i", { top: 103.52, left: 128.36, width: 2.057, fontSize: 7.4, fontName: "f2", eol: true }),
+      ] },
+      { items: [
+        positionedTextItem("cata", { top: 100, left: 100, width: 16 }),
+        positionedTextItem("log", { top: 100, left: 116, width: 12.8 }),
+        positionedTextItem("N", { top: 100, left: 129.8, width: 6.67, fontName: "f2", eol: true }),
+      ] },
+      { items: [
+        positionedTextItem("log", { top: 100, left: 100, width: 12.8 }),
+        positionedTextItem("N", { top: 100, left: 113.8, width: 6.67, eol: true }),
+      ] },
+      { items: [
+        positionedTextItem("logN", { top: 100, left: 100, width: 20, fontName: "f2", eol: true }),
+      ] },
+      { items: [
+        positionedTextItem("log", { top: 100, left: 100, width: 12.8 }),
+        positionedTextItem("Noise", { top: 100, left: 113.8, width: 22, fontName: "f2", eol: true }),
+      ] },
+    ]);
+    const originalLines = layout.pages.map(page => page.lines.map(line => line.text));
+    const result = renderPdfLayoutToMarkdown(layout);
+
+    expect(result.markdown).toContain("log N(T)");
+    expect(result.markdown).toContain("pi log pi");
+    expect(result.markdown).toContain("catalogN");
+    expect(result.markdown).toContain("logN\n");
+    expect(result.markdown).toContain("logNoise");
+    expect(layout.pages.map(page => page.lines.map(line => line.text))).toEqual(originalLines);
+    expect(originalLines[0]).toContain("logN(T)");
+    expect(validateMarkdownConversionSemantics(result, { layout })).toBe(result);
   });
 
   it("recognizes conservative document structure without promoting lookalike equations", async () => {

--- a/test/markdown-conversion.test.js
+++ b/test/markdown-conversion.test.js
@@ -73,7 +73,7 @@ function fakePdfjs(pageConfigs) {
         items: config.items ?? [],
         styles: {
           f1: { fontFamily: "Test Sans", ascent: 0.8, descent: -0.2, vertical: false },
-          f2: { fontFamily: "Test Serif", ascent: 0.8, descent: -0.2, vertical: false },
+          f2: { fontFamily: "Test Sans", ascent: 0.8, descent: -0.2, vertical: false },
         },
       };
     },
@@ -194,6 +194,9 @@ describe("layout Markdown renderer", () => {
   it("restores only a geometrically proven space after a separate log operator", async () => {
     const layout = await validatedSyntheticLayout([
       { items: [
+        positionedTextItem("C", { top: 80, left: 60, width: 6.67, fontName: "f2" }),
+        positionedTextItem("=", { top: 80, left: 68.5, width: 7.8 }),
+        positionedTextItem("Lim", { top: 80, left: 78.5, width: 16.65, eol: true }),
         positionedTextItem("log", { top: 100, left: 100, width: 12.8 }),
         positionedTextItem("N", { top: 100, left: 113.8, width: 6.67, fontName: "f2" }),
         positionedTextItem("(", { top: 100, left: 120.9, width: 3.84 }),
@@ -218,6 +221,16 @@ describe("layout Markdown renderer", () => {
         positionedTextItem("N", { top: 100, left: 113.8, width: 6.67, eol: true }),
       ] },
       { items: [
+        positionedTextItem("log", { top: 100, left: 100, width: 12.8 }),
+        positionedTextItem("N", { top: 100, left: 113.8, width: 6.67, fontName: "f2", eol: true }),
+      ] },
+      { items: [
+        positionedTextItem("s", { top: 100, left: 100, width: 5 }),
+        positionedTextItem("log", { top: 100, left: 105, width: 12.8 }),
+        positionedTextItem("a", { top: 100, left: 118.8, width: 5, fontName: "f2" }),
+        positionedTextItem("n", { top: 100, left: 123.8, width: 5, fontName: "f2", eol: true }),
+      ] },
+      { items: [
         positionedTextItem("logN", { top: 100, left: 100, width: 20, fontName: "f2", eol: true }),
       ] },
       { items: [
@@ -232,10 +245,51 @@ describe("layout Markdown renderer", () => {
     expect(result.markdown).toContain("pi log pi");
     expect(result.markdown).toContain("catalogN");
     expect(result.markdown).toContain("logN\n");
+    expect(result.markdown.split("\n").filter(line => line === "logN")).toHaveLength(3);
+    expect(result.markdown).toContain("slogan");
     expect(result.markdown).toContain("logNoise");
     expect(layout.pages.map(page => page.lines.map(line => line.text))).toEqual(originalLines);
     expect(originalLines[0]).toContain("logN(T)");
     expect(validateMarkdownConversionSemantics(result, { layout })).toBe(result);
+  });
+
+  it("does not rewrite math-like lists, ambiguous tables, or unsupported link pages", async () => {
+    const compactScript = top => [
+      positionedTextItem("p", { top, left: 100, width: 5, fontName: "f2" }),
+      positionedTextItem("i", { top: top + 3.52, left: 105.04, width: 2.057, fontSize: 7.4, fontName: "f2" }),
+      positionedTextItem(" ", { top, left: 107.1, width: 1.7 }),
+      positionedTextItem("log", { top, left: 108.8, width: 12.8 }),
+      positionedTextItem("p", { top, left: 123.319, width: 5, fontName: "f2" }),
+      positionedTextItem("i", { top: top + 3.52, left: 128.36, width: 2.057, fontSize: 7.4, fontName: "f2", eol: true }),
+    ];
+    const layout = await validatedSyntheticLayout([
+      { items: [
+        positionedTextItem("• ", { top: 100, left: 90, width: 8 }),
+        positionedTextItem("log", { top: 100, left: 100, width: 12.8 }),
+        positionedTextItem("N", { top: 100, left: 113.8, width: 6.67, fontName: "f2" }),
+        positionedTextItem("(", { top: 100, left: 120.9, width: 3.84 }),
+        positionedTextItem("T", { top: 100, left: 124.74, width: 5.56, fontName: "f2" }),
+        positionedTextItem(")", { top: 100, left: 131, width: 3.84, eol: true }),
+      ] },
+      { items: [
+        positionedTextItem("A", { top: 60, left: 50, width: 5 }),
+        positionedTextItem("B", { top: 60, left: 80, width: 5, eol: true }),
+        positionedTextItem("1", { top: 80, left: 50, width: 5 }),
+        positionedTextItem("2", { top: 80, left: 80, width: 5, eol: true }),
+        textItem("separator", { top: 110, left: 50 }),
+        ...compactScript(140),
+      ] },
+      {
+        items: compactScript(100),
+        annotations: [{ subtype: "Link", rect: [99, 677, 150, 690], dest: ["XYZ"] }],
+      },
+    ]);
+    const result = renderPdfLayoutToMarkdown(layout);
+
+    expect(result.markdown).toMatch(/^- logN\(T\)$/mu);
+    expect(result.markdown.split("\n").filter(line => line === "pi logpi")).toHaveLength(2);
+    expect(result.gaps.map(gap => gap.code)).toContain("TABLE_TOPOLOGY_UNKNOWN");
+    expect(result.gaps.map(gap => gap.code)).toContain("UNSUPPORTED_LINK_TARGET");
   });
 
   it("recognizes conservative document structure without promoting lookalike equations", async () => {

--- a/test/markdown-conversion.test.js
+++ b/test/markdown-conversion.test.js
@@ -237,6 +237,21 @@ describe("layout Markdown renderer", () => {
         positionedTextItem("log", { top: 100, left: 100, width: 12.8 }),
         positionedTextItem("Noise", { top: 100, left: 113.8, width: 22, fontName: "f2", eol: true }),
       ] },
+      { items: [
+        positionedTextItem("log", { top: 100, left: 100, width: 12.8 }),
+        positionedTextItem("N", { top: 100, left: 113.8, width: 6.67, fontName: "f2" }),
+        positionedTextItem("=", { top: 100, left: 121, width: 7.8 }),
+        positionedTextItem("5", { top: 100, left: 130, width: 5, eol: true }),
+      ] },
+      { items: [
+        positionedTextItem("x", { top: 80, left: 100, width: 5, fontName: "f2" }),
+        positionedTextItem("=", { top: 80, left: 106, width: 7.8 }),
+        positionedTextItem("1", { top: 80, left: 115, width: 5, eol: true }),
+        positionedTextItem("log", { top: 100, left: 100, width: 12.8 }),
+        positionedTextItem("N", { top: 100, left: 113.8, width: 6.67, fontName: "f2" }),
+        positionedTextItem("(", { top: 100, left: 120.9, width: 3.84 }),
+        positionedTextItem(")", { top: 100, left: 124.74, width: 3.84, eol: true }),
+      ] },
     ]);
     const originalLines = layout.pages.map(page => page.lines.map(line => line.text));
     const result = renderPdfLayoutToMarkdown(layout);
@@ -248,6 +263,8 @@ describe("layout Markdown renderer", () => {
     expect(result.markdown.split("\n").filter(line => line === "logN")).toHaveLength(3);
     expect(result.markdown).toContain("slogan");
     expect(result.markdown).toContain("logNoise");
+    expect(result.markdown).toContain("logN=5");
+    expect(result.markdown).toContain("x=1\nlogN()");
     expect(layout.pages.map(page => page.lines.map(line => line.text))).toEqual(originalLines);
     expect(originalLines[0]).toContain("logN(T)");
     expect(validateMarkdownConversionSemantics(result, { layout })).toBe(result);

--- a/test/mcp-contract.test.js
+++ b/test/mcp-contract.test.js
@@ -45,9 +45,12 @@ const EXAMPLE_PDF = path.join(REPO_ROOT, "example-fw9.pdf");
 // source-backed title, introduction, part, and appendix structure. Previously
 // a7619f2d4b07b855e8625578be66f5c61c54af2a2881a33545deed7e7b008de0.
 // 2026-08-03: convert_pdf_to_markdown renderer 1.5.0 adds bounded drop-cap
-// continuation and same-flow lowercase line-end dehyphenation. Previously
+// continuation while preserving ordinary printed line-end hyphens. Previously
 // fc757dc89b8aaf25b22f05b07863a4b8be1e09b6a544764a1b4afc8cdca3d6dd.
-const TOOL_CONTRACT_SHA256 = "e80436c2e09aefc4a8ecb7bbc989a9c133fa3a1a2b84e4b07747a784c3e16d6b";
+// 2026-08-03: convert_pdf_to_markdown renderer 1.6.0 adds bounded, local
+// math-operator spacing with explicit limitations. Previously
+// e80436c2e09aefc4a8ecb7bbc989a9c133fa3a1a2b84e4b07747a784c3e16d6b.
+const TOOL_CONTRACT_SHA256 = "4efcce458b5041a2d822bb921f46550cc15cdb9bcb2d54550f8eaa80c4f5a756";
 
 const CLOSED_READ = Object.freeze({
   readOnlyHint: true,


### PR DESCRIPTION
## Summary

- Restores a missing visible space after a separate mathematical log operator, but only when the PDF supplies strong, independent layout evidence.
- Leaves ordinary words, identifiers, lists, uncertain tables, and problematic links untouched.
- Updates the renderer contract to 1.6 and records the evidence and remaining limitations.

## Why

The Shannon paper exposes log and its following variable as separate PDF items, but the general prose spacing rule was flattening them together. This repairs the two proven cases without guessing at general equation structure.

This is stacked on #58.

## Evidence

- Shannon equation anchors improve from 2/4 to 4/4.
- Three repeated conversions are byte-for-byte identical.
- The exact source-text change is only 18 inserted spaces across 17 lines.
- Headings, paragraph continuity, footnotes, ordered anchors, and omission checks do not regress.
- Three independent reviewers approved the final revision.

## Checks

- Focused suite: 180 passed, 6 skipped, 0 failed.
- Phase 1 evidence binding: 20 passed, 0 failed.
- Native compatibility suite: 62 passed, 9 intentionally skipped, 0 failed.
- Full serialized suite: 1,865 passed and 79 skipped. Two unrelated existing checks remain unreliable on this Mac: one file-permission expectation and one intermittent process-cleanup signal. The process-cleanup issue is being tracked separately.

## Honest boundary

This does not claim to reconstruct general equations. Fraction bars, damaged symbols, superscripts and subscripts, and full table structure remain future work. It also makes no release or packaged-extension claim.
