### PR TITLE
Recover bounded ruled table topology

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,12 +131,13 @@ they do not produce recognized text. Mixed text/raster documents and raster
 pages after page 1 can therefore remain unrecognized by a broad text read.
 
 `convert_pdf_to_markdown` consumes the bounded source-validated layout IR. It
-reconstructs a table only from recurring column geometry when every row fills
-every detected column and the first row carries real header evidence, and emits
-a link only for a source-validated external http or https annotation target
-that maps to exactly one contiguous run of text on one line. Ruling lines,
-merged or spanning cells, internal destinations, actions, other URL schemes,
-and ambiguous labels stay escaped text. It may restore a missing space after a
+reconstructs a table only from either a complete recurring text grid or a
+complete closed grid of bounded solid-mask rectangles. Every text item must fit
+exactly one cell, and the first row must carry independent header evidence.
+Stroked or incomplete grids, merged or spanning cells, cell artwork, internal
+destinations, actions, other URL schemes, and ambiguous labels stay escaped
+text. External links still require one source-validated contiguous text run.
+The renderer may restore a missing space after a
 separate `log` source item only in a short, tightly bounded math run with
 same-baseline variable evidence plus an independent local math-layout clue. It does not reconstruct general equations,
 scripts, or fraction bars. It does not run OCR or use an external model.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,9 +134,11 @@ pages after page 1 can therefore remain unrecognized by a broad text read.
 reconstructs a table only from either a complete recurring text grid or a
 complete closed grid of bounded solid-mask rectangles. Every text item must fit
 exactly one cell, and the first row must carry independent header evidence.
-Stroked or incomplete grids, merged or spanning cells, cell artwork, internal
-destinations, actions, other URL schemes, and ambiguous labels stay escaped
-text. External links still require one source-validated contiguous text run.
+Unsupported text from stroked, incomplete, or ambiguous grids, aligned partial
+dividers, internal destinations, actions, other URL schemes, and ambiguous
+labels stays escaped and is reported as a typed gap. Cell artwork is omitted
+and reported as a vector-content gap. External links still require one
+source-validated contiguous text run.
 The renderer may restore a missing space after a
 separate `log` source item only in a short, tightly bounded math run with
 same-baseline variable evidence plus an independent local math-layout clue. It does not reconstruct general equations,

--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -101,11 +101,14 @@ therefore remain unrecognized by a broad text read.
 layout IR. It preserves supported text and conservative order, returns typed
 gaps for incomplete coverage, and optionally commits a verified UTF-8 `.md`
 file. It reconstructs evidence-complete recurring-column tables that carry real
-header evidence, and emits source-validated external http or https link
-annotations that map to exactly one contiguous run of text. Unsupported table
-structures and link targets, including ruling lines, merged or spanning cells,
-internal destinations, actions, other URL schemes, and ambiguous labels, stay
-escaped text reported as a typed gap. It does not run OCR or use Docling,
+header evidence. It can also reconstruct one unambiguous complete closed grid
+from bounded solid-mask rectangle evidence when every retained text item fits
+exactly one cell and the first row has real header evidence. It emits
+source-validated external http or https link annotations that map to exactly
+one contiguous run of text. Unsupported table structures and link targets,
+including stroked, incomplete, or ambiguous grids, merged or spanning cells,
+cell artwork, internal destinations, actions, other URL schemes, and ambiguous
+labels, stay escaped text reported as a typed gap. It does not run OCR or use Docling,
 Python, a model, or the network. A complete status means the requested
 text-layer slice was converted under this bounded contract, not that
 the original PDF's visual or semantic structure was fully recovered.

--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -105,10 +105,11 @@ header evidence. It can also reconstruct one unambiguous complete closed grid
 from bounded solid-mask rectangle evidence when every retained text item fits
 exactly one cell and the first row has real header evidence. It emits
 source-validated external http or https link annotations that map to exactly
-one contiguous run of text. Unsupported table structures and link targets,
-including stroked, incomplete, or ambiguous grids, merged or spanning cells,
-cell artwork, internal destinations, actions, other URL schemes, and ambiguous
-labels, stay escaped text reported as a typed gap. It does not run OCR or use Docling,
+one contiguous run of text. Unsupported text from table structures and link
+targets, including stroked, incomplete, or ambiguous grids, aligned partial
+dividers, internal destinations, actions, other URL schemes, and ambiguous
+labels, stays escaped and is reported as a typed gap. Cell artwork is omitted
+and reported as a vector-content gap. It does not run OCR or use Docling,
 Python, a model, or the network. A complete status means the requested
 text-layer slice was converted under this bounded contract, not that
 the original PDF's visual or semantic structure was fully recovered.

--- a/docs/MCP_CONTRACT.md
+++ b/docs/MCP_CONTRACT.md
@@ -113,9 +113,12 @@ points are ordered anchor-top, terminal-top, anchor-bottom, terminal-bottom;
 they are not polygon winding order. `line_height` is the modeled TextLayer
 font-height vector, not a font-size or ink-height measurement.
 Stable item, line, and nonsemantic flow-block references support conservative
-reading order without claiming paragraphs or document structure. Raster-only,
-mixed, hidden, clipped, duplicate, and OCR-overlay gaps remain explicit. The
-tool does not render, OCR, infer tables, or claim arbitrary schema extraction,
+reading order without claiming paragraphs or document structure. Version 1.2
+also retains bounded, axis-aligned solid-mask rectangle evidence with exact
+source-operation and transform provenance. Those rectangles are neutral paint
+evidence, not inferred rules or cells. Raster-only, mixed, hidden, clipped,
+duplicate, and OCR-overlay gaps remain explicit. The tool does not render, OCR,
+infer tables, or claim arbitrary schema extraction,
 and every item, character, or output limit is fail-closed with truncation
 metadata. Its coordinates must not be passed to `render_pdf_region` or signing
 tools.
@@ -124,10 +127,13 @@ tools.
 deterministic UTF-8 Markdown. It preserves supported text and conservative
 reading order, escapes Markdown and HTML control syntax, and promotes headings
 or list markers only when the retained text and geometry support them. It
-reconstructs a table only when every row fills every recurring detected column
-and the first row carries real header evidence, and it emits a link only for a
-source-validated external http or https annotation target that maps to exactly
-one contiguous run of text on one line. Ruling lines, merged or spanning cells,
+reconstructs a table only when every row fills every recurring detected
+column, or when one unambiguous complete closed grid can be established from
+the bounded solid-mask rectangle evidence. Every retained grid item must fit
+exactly one cell, and either route requires real first-row header evidence. It
+emits a link only for a source-validated external http or https annotation
+target that maps to exactly one contiguous run of text on one line. Stroked,
+incomplete, or ambiguous grids, merged or spanning cells, cell artwork,
 internal destinations, actions, other URL schemes, and ambiguous or partially
 covered labels stay escaped text and are reported as typed gaps. It does not
 run OCR, render image content, or use an external model. Raster, mixed,

--- a/docs/MCP_CONTRACT.md
+++ b/docs/MCP_CONTRACT.md
@@ -132,10 +132,11 @@ column, or when one unambiguous complete closed grid can be established from
 the bounded solid-mask rectangle evidence. Every retained grid item must fit
 exactly one cell, and either route requires real first-row header evidence. It
 emits a link only for a source-validated external http or https annotation
-target that maps to exactly one contiguous run of text on one line. Stroked,
-incomplete, or ambiguous grids, merged or spanning cells, cell artwork,
+target that maps to exactly one contiguous run of text on one line. Unsupported
+text from stroked, incomplete, or ambiguous grids, aligned partial dividers,
 internal destinations, actions, other URL schemes, and ambiguous or partially
-covered labels stay escaped text and are reported as typed gaps. It does not
+covered labels stays escaped and is reported as a typed gap. Cell artwork is
+omitted and reported as a vector-content gap. It does not
 run OCR, render image content, or use an external model. Raster, mixed,
 vector, failed, caller-limit-truncated, invalid-geometry, and output-omission
 cases are represented as typed gaps and

--- a/docs/SHANNON_MARKDOWN_EVALUATION.md
+++ b/docs/SHANNON_MARKDOWN_EVALUATION.md
@@ -40,7 +40,11 @@ regression, but a passing anchor set cannot prove complete 55-page fidelity.
 The current PDF Tools result finds all four sampled page-local equation anchors,
 but that token result does not prove faithful equation topology. Damaged arrows,
 minus signs, scripts, summation limits, and fraction bars remain separate known
-gaps; see `docs/evidence/shannon-math-operator-spacing-2026-08.md`.
+gaps; see `docs/evidence/shannon-math-operator-spacing-2026-08.md`. The sampled
+Table I now has one qualifying four-column, five-data-row Markdown table. That
+result establishes the bounded ruled grid and text-to-cell assignment, not
+faithful formulas or mini-graphs inside those cells; see
+`docs/evidence/shannon-ruled-table-topology-2026-08.md`.
 
 ## Reproduction
 

--- a/docs/evidence/shannon-ruled-table-topology-2026-08.md
+++ b/docs/evidence/shannon-ruled-table-topology-2026-08.md
@@ -11,9 +11,11 @@ every retained text item fits exactly one cell, an isolated `TABLE I` caption
 is directly above it, and the shallow first row supplies independent uppercase
 header evidence.
 
-The renderer fails closed for missing rules, crossing text, multiple candidate
-grids, absent captions, weak headers, tiny bands, and merged or spanning cells.
-It does not interpret stroked paths, cell artwork, formulas, or mini-graphs.
+The renderer fails closed when the observed rules do not form one unambiguous
+complete grid, when aligned partial dividers evidence merged or spanning cells,
+or when text crosses the inferred cells. It also refuses multiple candidate
+grids, absent captions, weak headers, tiny bands, and overlarge grids. It does
+not interpret stroked paths, cell artwork, formulas, or mini-graphs.
 Several mathematical symbols within the Shannon table therefore remain
 damaged even though their row and column membership is now useful. The
 Markdown renderer identity is `pdf-tools.layout-markdown-renderer` version

--- a/docs/evidence/shannon-ruled-table-topology-2026-08.md
+++ b/docs/evidence/shannon-ruled-table-topology-2026-08.md
@@ -24,21 +24,21 @@ Markdown renderer identity is `pdf-tools.layout-markdown-renderer` version
 
 ## Clean run
 
-- Evaluated commit: `0511ab213137a669248ec611d4a4a4bb256717b5`
+- Evaluated commit: `0274bd84ca950f83d7fbd7b620527b7d4345b39d`
 - Source PDF SHA-256:
   `6e4e3411984f3edf99dbfe8b941cb5e8a321379ff0cae6ae5c1f592ad8882ca8`
 - Previous math-spacing report SHA-256:
   `2074f1b1a0d0856c523d827b9fb27e387623713db0273f1c37d30fab24c1cf3e`
 - Ruled-table report SHA-256:
-  `d9aaf1e482d3fdf81b4486797875e2397ce5e9e99e4b464d9c938a1b6cfd6a56`
+  `ed5a8d7c2ad7bdde748ae15fb755056bae14bd9ab27c048fd912de637566e8e6`
 - Private report directory:
-  `/Users/silverbook/Sites/pdf-tools-extraction-sidecars/shannon-table-topology-final-review-20260803-clean-0511ab2`
+  `/Users/silverbook/Sites/pdf-tools-extraction-sidecars/shannon-table-topology-hardened-final-20260803-clean-0274bd8`
 - Repetitions: three fresh processes per candidate
 - PDF Tools Markdown deterministic across repetitions: `true`
 - PDF Tools output SHA-256 for all three repetitions:
-  `3237ca7d3734b84ec42dc2e237a2d2e03d28715eeef7814747fd653996ba843d`
-- Median PDF Tools elapsed time: 3441.557 ms
-- Median PDF Tools maximum RSS: 316,440,576 bytes
+  `7405d8516b47ed0ec4bef4b63aabc58e973b2d1b475e4dff542d2d06d57d497f`
+- Median PDF Tools elapsed time: 3465.582 ms
+- Median PDF Tools maximum RSS: 310,116,352 bytes
 
 ## Metric comparison
 
@@ -60,6 +60,16 @@ The run emitted no other Markdown tables in the 55-page paper. The automatic
 judge was corrected to use the source-faithful four header phrases and to
 treat safe `<br>` line breaks as spaces while scoring the header. The original
 PDF page, not the candidate output, determined those phrases.
+
+Independent review found and the final commit closes three pre-publication
+issues: aligned partial dividers can no longer flatten a merged or spanning
+table into a coarser ordinary table; painted transforms retain their full
+finite precision before large `UserUnit` scaling; and ruled-table work is
+bounded before cell allocation and uses one indexed pass over retained lines.
+Adversarial tests also cover multiple grids and interleaved source item order.
+The final focused run passed 162 tests, the native platform run passed 62 with
+9 intentional skips, the phase-one layout oracle regenerated exactly, and the
+reproducible share-package contract passed.
 
 This is a sampled adversarial evaluation, not complete transcript ground truth,
 public benchmark, packed-MCPB qualification, or a claim that mathematical

--- a/docs/evidence/shannon-ruled-table-topology-2026-08.md
+++ b/docs/evidence/shannon-ruled-table-topology-2026-08.md
@@ -1,0 +1,64 @@
+# Shannon ruled-table topology — 2026-08
+
+## Outcome
+
+PDF Tools now reconstructs Shannon's Table I as one four-column Markdown table
+with its header and five data rows. The Extraction IR retains a bounded set of
+axis-aligned solid-mask rectangles with their exact source operation,
+transformation, and page geometry. The Markdown renderer accepts those neutral
+paint observations only when they form one unambiguous complete closed grid,
+every retained text item fits exactly one cell, an isolated `TABLE I` caption
+is directly above it, and the shallow first row supplies independent uppercase
+header evidence.
+
+The renderer fails closed for missing rules, crossing text, multiple candidate
+grids, absent captions, weak headers, tiny bands, and merged or spanning cells.
+It does not interpret stroked paths, cell artwork, formulas, or mini-graphs.
+Several mathematical symbols within the Shannon table therefore remain
+damaged even though their row and column membership is now useful. The
+Markdown renderer identity is `pdf-tools.layout-markdown-renderer` version
+`1.7.0`; the Extraction IR identity is `pdf-tools.extraction-ir` version
+`1.2.0`.
+
+## Clean run
+
+- Evaluated commit: `0511ab213137a669248ec611d4a4a4bb256717b5`
+- Source PDF SHA-256:
+  `6e4e3411984f3edf99dbfe8b941cb5e8a321379ff0cae6ae5c1f592ad8882ca8`
+- Previous math-spacing report SHA-256:
+  `2074f1b1a0d0856c523d827b9fb27e387623713db0273f1c37d30fab24c1cf3e`
+- Ruled-table report SHA-256:
+  `d9aaf1e482d3fdf81b4486797875e2397ce5e9e99e4b464d9c938a1b6cfd6a56`
+- Private report directory:
+  `/Users/silverbook/Sites/pdf-tools-extraction-sidecars/shannon-table-topology-final-review-20260803-clean-0511ab2`
+- Repetitions: three fresh processes per candidate
+- PDF Tools Markdown deterministic across repetitions: `true`
+- PDF Tools output SHA-256 for all three repetitions:
+  `3237ca7d3734b84ec42dc2e237a2d2e03d28715eeef7814747fd653996ba843d`
+- Median PDF Tools elapsed time: 3441.557 ms
+- Median PDF Tools maximum RSS: 316,440,576 bytes
+
+## Metric comparison
+
+| Sampled PDF Tools metric | Before | After |
+| --- | ---: | ---: |
+| Qualifying Table I topology | 0 | 1 |
+| Markdown tables | 0 | 1 |
+| Table I data rows | 0 | 5 |
+| Intended headings found | 14 / 14 | 14 / 14 |
+| Malformed or fragmentary false headings | 0 | 0 |
+| Equation-like false headings | 0 | 0 |
+| Ordered anchors retained | 23 / 24 | 23 / 24 |
+| Complete ordered-anchor groups | 5 / 6 | 5 / 6 |
+| Paragraph-continuity anchors | 2 / 4 | 2 / 4 |
+| Page-local equation anchors | 4 / 4 | 4 / 4 |
+| Footnote anchors | 4 / 4 | 4 / 4 |
+
+The run emitted no other Markdown tables in the 55-page paper. The automatic
+judge was corrected to use the source-faithful four header phrases and to
+treat safe `<br>` line breaks as spaces while scoring the header. The original
+PDF page, not the candidate output, determined those phrases.
+
+This is a sampled adversarial evaluation, not complete transcript ground truth,
+public benchmark, packed-MCPB qualification, or a claim that mathematical
+notation inside ruled cells is reconstructed faithfully.

--- a/pdf-toolkit-mcp-share/server/index.js
+++ b/pdf-toolkit-mcp-share/server/index.js
@@ -2673,7 +2673,7 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
       },
       {
         name: "convert_pdf_to_markdown",
-        description: "Convert a bounded page range of a local PDF into deterministic Markdown from the source-validated PDF Tools Extraction IR. Headings and lists require geometry or literal marker evidence. A table is reconstructed only when every row fills every recurring detected column and the first row carries real header evidence. A link is emitted only for a source-validated external http or https annotation target covering one contiguous run of text on one line. Unsupported table structures and link targets, including merged cells, internal destinations, actions, and other schemes, stay escaped text reported as typed coverage gaps. No OCR and no external model. Optionally saves UTF-8 Markdown through the transactional output path. Use absolute or ~/ paths on the user's local machine, NOT Claude container paths (/mnt/...).",
+        description: "Convert a bounded page range of a local PDF into deterministic Markdown from the source-validated PDF Tools Extraction IR. Headings and lists require geometry or literal marker evidence. A table requires either a complete recurring text grid or a complete closed painted grid, with every item in one cell and real header evidence. A link requires a source-validated external http or https annotation target covering one contiguous text run. Unsupported tables and link targets, including merged cells, internal destinations, actions, and other schemes, stay escaped text with typed gaps. No OCR or external model. Optionally saves transactional UTF-8 Markdown. Use absolute or ~/ local paths, not Claude container paths (/mnt/...).",
         inputSchema: {
           type: "object",
           additionalProperties: false,
@@ -4515,7 +4515,7 @@ async function handleToolCall(request) {
             `Source SHA-256: ${sourceSha256}.`,
             ...(savedOutput ? [`Saved and reopened exact UTF-8 output: ${savedOutput.path}`] : []),
             ...(rendered.gaps.length > 0 ? [`Coverage gaps: ${rendered.gaps.map(gap => `page ${gap.page}: ${gap.code}`).join(", ")}.`] : []),
-            "No OCR, external model, hidden link-target recovery, or table-topology inference was performed.",
+            "No OCR, external model, hidden link-target recovery, or table inference beyond complete source-bound text or painted grids was performed.",
             rendered.markdown,
           ].join("\n\n");
           return {

--- a/pdf-toolkit-mcp-share/server/layout-extraction.js
+++ b/pdf-toolkit-mcp-share/server/layout-extraction.js
@@ -3,7 +3,7 @@ import { createHash } from "node:crypto";
 import { fileURLToPath } from "node:url";
 
 const IR_NAME = "pdf-tools.extraction-ir";
-const IR_VERSION = "1.1.0";
+const IR_VERSION = "1.2.0";
 const INTERNAL_SOURCE_REPLAY = Symbol("pdf-layout-internal-source-replay");
 const INTERNAL_MARKDOWN_PROJECTION = Symbol("pdf-layout-internal-markdown-projection");
 
@@ -35,6 +35,7 @@ const RAW_PAGE_SPACE = Object.freeze({
   unit: "pdf_user_unit",
   stage: "before_user_unit_and_page_rotation",
 });
+const MAX_PAINTED_RECTANGLES = 500;
 
 function round(value) {
   return Number(Number(value).toFixed(3));
@@ -545,6 +546,96 @@ function vectorOperationSet(pdfjsLib) {
   ].filter(Number.isInteger));
 }
 
+function unavailablePaintedRectangles() {
+  return {
+    status: "unavailable",
+    truncated: false,
+    observed_count: 0,
+    returned_count: 0,
+    items: [],
+  };
+}
+
+function unitRectangleGeometry(viewportTransform, graphicsTransform) {
+  if (![...viewportTransform, ...graphicsTransform].every(Number.isFinite)) return null;
+  const transformed = multiplyTransforms(viewportTransform, graphicsTransform);
+  if (!transformed.every(Number.isFinite)) return null;
+  const axisAligned = (Math.abs(transformed[1]) <= 0.002 && Math.abs(transformed[2]) <= 0.002)
+    || (Math.abs(transformed[0]) <= 0.002 && Math.abs(transformed[3]) <= 0.002);
+  if (!axisAligned) return null;
+  const points = [[0, 0], [1, 0], [1, 1], [0, 1]].map(([x, y]) => ({
+    x: round(transformed[0] * x + transformed[2] * y + transformed[4]),
+    y: round(transformed[1] * x + transformed[3] * y + transformed[5]),
+  }));
+  const xs = points.map(point => point.x);
+  const ys = points.map(point => point.y);
+  const x = Math.min(...xs);
+  const y = Math.min(...ys);
+  const width = round(Math.max(...xs) - x);
+  const height = round(Math.max(...ys) - y);
+  if (!(width > 0 && height > 0)) return null;
+  return {
+    quad: points,
+    bbox: { x: round(x), y: round(y), width, height },
+  };
+}
+
+/**
+ * Preserve a bounded neutral projection of PDF.js solid-color image-mask
+ * rectangles. These marks include rules but can also include fraction bars or
+ * other artwork; table semantics are deliberately left to the renderer, which
+ * must require a complete closed grid rather than trusting any one rectangle.
+ */
+function collectPaintedRectangles(operators, pdfjsLib, viewportTransform, pageNumber) {
+  const save = pdfjsLib.OPS?.save;
+  const restore = pdfjsLib.OPS?.restore;
+  const transform = pdfjsLib.OPS?.transform;
+  const paint = pdfjsLib.OPS?.paintSolidColorImageMask;
+  if (![save, restore, transform, paint].every(Number.isInteger)
+    || !Array.isArray(operators?.fnArray)
+    || !Array.isArray(operators?.argsArray)) return unavailablePaintedRectangles();
+  let current = [1, 0, 0, 1, 0, 0];
+  const stack = [];
+  const items = [];
+  let observedCount = 0;
+  for (let operationIndex = 0; operationIndex < operators.fnArray.length; operationIndex += 1) {
+    const operation = operators.fnArray[operationIndex];
+    if (operation === save) {
+      stack.push([...current]);
+    } else if (operation === restore) {
+      if (stack.length === 0) return unavailablePaintedRectangles();
+      current = stack.pop();
+    } else if (operation === transform) {
+      const values = operators.argsArray[operationIndex];
+      if (!Array.isArray(values) || values.length !== 6 || !values.every(Number.isFinite)) {
+        return unavailablePaintedRectangles();
+      }
+      current = multiplyTransforms(current, values);
+      if (!current.every(Number.isFinite)) return unavailablePaintedRectangles();
+    } else if (operation === paint) {
+      const geometry = unitRectangleGeometry(viewportTransform, current);
+      if (!geometry) continue;
+      observedCount += 1;
+      if (items.length >= MAX_PAINTED_RECTANGLES) continue;
+      items.push({
+        id: `p${String(pageNumber).padStart(4, "0")}-r${String(operationIndex + 1).padStart(6, "0")}`,
+        source_operation_index: operationIndex,
+        source_kind: "solid_color_image_mask",
+        graphics_transform: current.map(round),
+        quad: geometry.quad,
+        bbox: geometry.bbox,
+      });
+    }
+  }
+  return {
+    status: "available",
+    truncated: observedCount > items.length,
+    observed_count: observedCount,
+    returned_count: items.length,
+    items,
+  };
+}
+
 function errorRecord(stage, error) {
   return {
     stage,
@@ -599,6 +690,26 @@ function recomputeDocumentTruncation(payload) {
 
 function markOutputBudget(payload, maxOutputCharacters) {
   if (JSON.stringify(payload).length <= maxOutputCharacters) return payload;
+  for (let index = payload.pages.length - 1; index >= 0 && JSON.stringify(payload).length > maxOutputCharacters; index -= 1) {
+    const page = payload.pages[index];
+    if (page.painted_rectangles.items.length === 0) continue;
+    page.painted_rectangles = {
+      status: "unavailable",
+      truncated: true,
+      observed_count: page.painted_rectangles.observed_count,
+      returned_count: 0,
+      items: [],
+    };
+    page.extraction_status = page.extraction_status === "failed" ? "failed" : "partial";
+    page.needs_visual_inspection = true;
+    if (!page.limitations.includes("Painted rectangle detail was omitted to satisfy max_output_characters.")) {
+      page.limitations.push("Painted rectangle detail was omitted to satisfy max_output_characters.");
+    }
+  }
+  if (JSON.stringify(payload).length <= maxOutputCharacters) {
+    payload.extraction_status = payload.pages.every(page => page.extraction_status === "complete") ? "complete" : "partial";
+    return payload;
+  }
   if (!payload.truncation.reasons.includes("max_output_characters")) payload.truncation.reasons.push("max_output_characters");
   for (let index = payload.pages.length - 1; index >= 0 && JSON.stringify(payload).length > maxOutputCharacters; index -= 1) {
     const page = payload.pages[index];
@@ -618,6 +729,13 @@ function markOutputBudget(payload, maxOutputCharacters) {
     // Link items are page detail too. Leaving them would keep a link-heavy
     // page over budget and turn a bounded partial into a whole-call error.
     page.link_annotations = { status: "unavailable", truncated: true, items: [] };
+    page.painted_rectangles = {
+      status: "unavailable",
+      truncated: true,
+      observed_count: page.painted_rectangles.observed_count,
+      returned_count: 0,
+      items: [],
+    };
     page.flow_text = "";
     page.spatial_text = "";
     page.reading_order = {
@@ -848,6 +966,48 @@ export function validatePdfLayoutSemantics(payload, {
     semanticAssertion(!documentIds.has(page.id), `duplicate ID ${page.id}`);
     documentIds.add(page.id);
 
+    const painted = page.painted_rectangles;
+    semanticAssertion(painted && ["available", "unavailable"].includes(painted.status),
+      `page ${page.page} painted rectangle status is invalid`);
+    semanticAssertion(typeof painted.truncated === "boolean"
+      && Number.isSafeInteger(painted.observed_count) && painted.observed_count >= 0
+      && Number.isSafeInteger(painted.returned_count) && painted.returned_count >= 0
+      && painted.returned_count === painted.items.length
+      && painted.returned_count <= painted.observed_count
+      && painted.returned_count <= MAX_PAINTED_RECTANGLES,
+    `page ${page.page} painted rectangle counts are invalid`);
+    if (painted.status === "available") {
+      semanticAssertion(painted.returned_count === Math.min(painted.observed_count, MAX_PAINTED_RECTANGLES)
+        && painted.truncated === (painted.observed_count > painted.returned_count),
+      `page ${page.page} painted rectangle availability is inconsistent`);
+    } else {
+      semanticAssertion(painted.returned_count === 0 && painted.items.length === 0,
+        `page ${page.page} unavailable painted rectangles leaked items`);
+    }
+    let priorPaintOperation = -1;
+    for (const item of painted.items) {
+      semanticAssertion(Number.isSafeInteger(item.source_operation_index)
+        && item.source_operation_index > priorPaintOperation,
+      `page ${page.page} painted rectangle operation order is invalid`);
+      priorPaintOperation = item.source_operation_index;
+      semanticAssertion(item.id === `${pagePrefix}-r${String(item.source_operation_index + 1).padStart(6, "0")}`
+        && item.source_kind === "solid_color_image_mask"
+        && Array.isArray(item.graphics_transform)
+        && item.graphics_transform.length === 6
+        && item.graphics_transform.every(Number.isFinite),
+      `painted rectangle ${item.id} source identity is invalid`);
+      semanticAssertion(!documentIds.has(item.id), `duplicate ID ${item.id}`);
+      documentIds.add(item.id);
+      const expected = unitRectangleGeometry(
+        page.geometry.viewport_transform,
+        item.graphics_transform,
+      );
+      semanticAssertion(expected !== null
+        && sameJson(item.quad, expected.quad)
+        && sameJson(item.bbox, expected.bbox),
+      `painted rectangle ${item.id} geometry mismatch`);
+    }
+
     const itemById = new Map();
     let returnedCharacters = 0;
     for (let index = 0; index < page.raw_items.length; index += 1) {
@@ -1033,9 +1193,11 @@ export function validatePdfLayoutSemantics(payload, {
     // Degraded link evidence, including a hit 200-link cap, is partial evidence.
     const hasDegradedLinks = page.link_annotations.status !== "available"
       || page.link_annotations.truncated === true;
+    const hasDegradedPaintedRectangles = page.painted_rectangles.status !== "available"
+      || page.painted_rectangles.truncated === true;
     const expectedExtraction = expectedTextLayerStatus === "failed"
       ? "failed"
-      : page.truncation.truncated || hasInvalidGeometry || hasRawGeometryGap || expectedImageStatus === "failed" || expectedModality !== "text-layer-candidate" || hasAnnotationError || hasDegradedLinks
+      : page.truncation.truncated || hasInvalidGeometry || hasRawGeometryGap || expectedImageStatus === "failed" || expectedModality !== "text-layer-candidate" || hasAnnotationError || hasDegradedLinks || hasDegradedPaintedRectangles
         ? "partial" : "complete";
     semanticAssertion(page.extraction_status === expectedExtraction, `page ${page.page} extraction status mismatch`);
     semanticAssertion(page.needs_visual_inspection === (expectedExtraction !== "complete" || expectedModality !== "text-layer-candidate"), `page ${page.page} visual-inspection status mismatch`);
@@ -1048,6 +1210,8 @@ export function validatePdfLayoutSemantics(payload, {
         && page.errors.length === 0
         && page.link_annotations.status === "available"
         && page.link_annotations.truncated === false
+        && page.painted_rectangles.status === "available"
+        && page.painted_rectangles.truncated === false
         && page.raw_items.every(item => item.geometry_valid), `page ${page.page} complete status overclaims evidence`);
     }
     if (page.text_layer_status === "failed") semanticAssertion(page.extraction_status === "failed", `page ${page.page} failed text status mismatch`);
@@ -1087,6 +1251,26 @@ function replayOutputBudgetIndependently(seedPayload, maxOutputCharacters) {
   replay.id_scope.max_output_characters = maxOutputCharacters;
   replay.limits.max_output_characters = maxOutputCharacters;
   if (JSON.stringify(replay).length <= maxOutputCharacters) return replay;
+  for (let index = replay.pages.length - 1; index >= 0 && JSON.stringify(replay).length > maxOutputCharacters; index -= 1) {
+    const page = replay.pages[index];
+    if (page.painted_rectangles.items.length === 0) continue;
+    page.painted_rectangles = {
+      status: "unavailable",
+      truncated: true,
+      observed_count: page.painted_rectangles.observed_count,
+      returned_count: 0,
+      items: [],
+    };
+    page.extraction_status = page.extraction_status === "failed" ? "failed" : "partial";
+    page.needs_visual_inspection = true;
+    if (!page.limitations.includes("Painted rectangle detail was omitted to satisfy max_output_characters.")) {
+      page.limitations.push("Painted rectangle detail was omitted to satisfy max_output_characters.");
+    }
+  }
+  if (JSON.stringify(replay).length <= maxOutputCharacters) {
+    replay.extraction_status = replay.pages.every(page => page.extraction_status === "complete") ? "complete" : "partial";
+    return replay;
+  }
   if (!replay.truncation.reasons.includes("max_output_characters")) replay.truncation.reasons.push("max_output_characters");
   for (let index = replay.pages.length - 1; index >= 0 && JSON.stringify(replay).length > maxOutputCharacters; index -= 1) {
     const page = replay.pages[index];
@@ -1104,6 +1288,13 @@ function replayOutputBudgetIndependently(seedPayload, maxOutputCharacters) {
     page.lines = [];
     page.blocks = [];
     page.link_annotations = { status: "unavailable", truncated: true, items: [] };
+    page.painted_rectangles = {
+      status: "unavailable",
+      truncated: true,
+      observed_count: page.painted_rectangles.observed_count,
+      returned_count: 0,
+      items: [],
+    };
     page.flow_text = "";
     page.spatial_text = "";
     page.reading_order = {
@@ -1304,7 +1495,8 @@ export async function validatePdfLayoutSourceEvidence(payload, {
                 ],
               })
               && outputPage.has_image_operations === null
-              && outputPage.has_vector_paint_operations === null,
+              && outputPage.has_vector_paint_operations === null
+              && sameJson(outputPage.painted_rectangles, unavailablePaintedRectangles()),
             `page ${outputPage.page} ordinary page failure differs from reparsed source`,
           );
           continue;
@@ -1447,9 +1639,28 @@ export async function validatePdfLayoutSourceEvidence(payload, {
         if (sourceOperatorError === null) {
           const sourceHasImageOperations = sourceOperators.fnArray.some(operation => sourceImageOps.has(operation));
           const sourceHasVectorOperations = sourceOperators.fnArray.some(operation => sourceVectorOps.has(operation));
+          const sourcePaintedRectangles = collectPaintedRectangles(
+            sourceOperators,
+            pdfjsLib,
+            sourceViewport?.transform ?? [],
+            outputPage.page,
+          );
+          const paintedOutputOmitted = outputPage.painted_rectangles.status === "unavailable"
+            && outputPage.painted_rectangles.truncated === true
+            && !outputPage.errors.some(error => error.stage === "operators" || error.stage === "page");
+          const expectedPaintedRectangles = (outputOmitted || paintedOutputOmitted)
+            ? {
+              status: "unavailable",
+              truncated: true,
+              observed_count: sourcePaintedRectangles.observed_count,
+              returned_count: 0,
+              items: [],
+            }
+            : sourcePaintedRectangles;
           sourceEvidenceAssertion(
             outputPage.has_image_operations === sourceHasImageOperations
               && outputPage.has_vector_paint_operations === sourceHasVectorOperations
+              && sameJson(outputPage.painted_rectangles, expectedPaintedRectangles)
               && !outputPage.errors.some(error => error.stage === "operators"),
             `page ${outputPage.page} operator evidence differs from reparsed source`,
           );
@@ -1458,6 +1669,7 @@ export async function validatePdfLayoutSourceEvidence(payload, {
           sourceEvidenceAssertion(
             outputPage.has_image_operations === null
               && outputPage.has_vector_paint_operations === null
+              && sameJson(outputPage.painted_rectangles, unavailablePaintedRectangles())
               && outputPage.errors.some(outputError => sameJson(outputError, expectedError)),
             `page ${outputPage.page} source operator parse failed but output claims operator evidence`,
           );
@@ -1481,10 +1693,12 @@ export async function validatePdfLayoutSourceEvidence(payload, {
     sourceEvidenceAssertion(payload.extraction_status === sourceDocumentStatus, "document status differs from source-verified page records");
     if (!enforceOutputBudget) {
       sourceEvidenceAssertion(
-        payload.pages.every(page => !page.truncation.reasons.includes("max_output_characters")),
+        payload.pages.every(page => !page.truncation.reasons.includes("max_output_characters")
+          && !(page.painted_rectangles.status === "unavailable" && page.painted_rectangles.truncated)),
         "internal Markdown evidence contains a public output-budget omission",
       );
-    } else if (payload.pages.some(page => page.truncation.reasons.includes("max_output_characters"))) {
+    } else if (payload.pages.some(page => page.truncation.reasons.includes("max_output_characters")
+      || (page.painted_rectangles.status === "unavailable" && page.painted_rectangles.truncated))) {
       const replaySeed = await extractPdfLayout({
         pdfjsLib,
         pdfBytes: sourceBytes,
@@ -1592,6 +1806,7 @@ export async function extractPdfLayout({
       let textContent = null;
       let hasImageOperations = null;
       let hasVectorPaintOperations = null;
+      let paintedRectangles = unavailablePaintedRectangles();
       let pdfjsPage = null;
       let viewport = null;
       let linkAnnotations = UNAVAILABLE_LINK_ANNOTATIONS;
@@ -1625,6 +1840,12 @@ export async function extractPdfLayout({
           const operators = await withDeadline(pdfjsPage.getOperatorList(), deadlineAt);
           hasImageOperations = operators.fnArray.some(operation => imageOps.has(operation));
           hasVectorPaintOperations = operators.fnArray.some(operation => vectorOps.has(operation));
+          paintedRectangles = collectPaintedRectangles(
+            operators,
+            pdfjsLib,
+            viewport?.transform ?? [],
+            pageNumber,
+          );
         } catch (error) {
           if (isFatalParserResourceError(error)) throw error;
           errors.push(errorRecord("operators", error));
@@ -1774,7 +1995,7 @@ export async function extractPdfLayout({
       const pageTruncated = firstOmittedSourceIndex !== null;
       let extractionStatus = "complete";
       if (textLayerStatus === "failed") extractionStatus = "failed";
-      else if (pageTruncated || invalidGeometry || !pdfLibPages || imageDetectionStatus === "failed" || modalityHint !== "text-layer-candidate" || errors.some(error => error.stage === "annotations") || linkAnnotations.truncated === true) extractionStatus = "partial";
+      else if (pageTruncated || invalidGeometry || !pdfLibPages || imageDetectionStatus === "failed" || modalityHint !== "text-layer-candidate" || errors.some(error => error.stage === "annotations") || linkAnnotations.truncated === true || paintedRectangles.status !== "available" || paintedRectangles.truncated === true) extractionStatus = "partial";
       const needsVisualInspection = extractionStatus !== "complete" || modalityHint !== "text-layer-candidate";
       if (hasImageOperations) limitations.push("Image paint operations were detected, but no image was rendered or OCRed; this is not raster-content proof.");
       if (hasVectorPaintOperations) limitations.push("Vector paint operations were detected but not interpreted.");
@@ -1795,6 +2016,7 @@ export async function extractPdfLayout({
         geometry,
         has_image_operations: hasImageOperations,
         has_vector_paint_operations: hasVectorPaintOperations,
+        painted_rectangles: paintedRectangles,
         link_annotations: linkAnnotations,
         raw_items: rawItems,
         lines: ordered.lines,

--- a/pdf-toolkit-mcp-share/server/layout-extraction.js
+++ b/pdf-toolkit-mcp-share/server/layout-extraction.js
@@ -621,7 +621,7 @@ function collectPaintedRectangles(operators, pdfjsLib, viewportTransform, pageNu
         id: `p${String(pageNumber).padStart(4, "0")}-r${String(operationIndex + 1).padStart(6, "0")}`,
         source_operation_index: operationIndex,
         source_kind: "solid_color_image_mask",
-        graphics_transform: current.map(round),
+        graphics_transform: [...current],
         quad: geometry.quad,
         bbox: geometry.bbox,
       });

--- a/pdf-toolkit-mcp-share/server/markdown-conversion.js
+++ b/pdf-toolkit-mcp-share/server/markdown-conversion.js
@@ -26,6 +26,9 @@ const RULE_MAX_THICKNESS = 1.5;
 const RULE_AXIS_TOLERANCE = 1;
 const RULE_JOIN_TOLERANCE = 1;
 const RULE_EDGE_TOLERANCE = 1.5;
+const RULED_TABLE_MAX_ROWS = 100;
+const RULED_TABLE_MAX_COLUMNS = 50;
+const RULED_TABLE_MAX_CELLS = 1_000;
 
 const MAX_MARKDOWN_BYTES_LIMIT = 200_000;
 const GAP_CODES = new Set([
@@ -52,7 +55,7 @@ const LIMITATIONS = Object.freeze([
   "A missing space after a separate source text item that is exactly the mathematical operator log is restored only in a short, compact left-to-right math run when a single-letter variable from a different embedded-font resource follows on the same baseline with a small positive geometric gap and independent local math-layout evidence. General equations, scripts, fraction bars, and damaged mathematical glyphs remain source reading-order text rather than being guessed.",
   "Lists are emitted only for literal bullet glyphs or decimal markers present in the source text.",
   "Links are emitted only for source-validated http or https annotation targets that map to exactly one contiguous run of text on one line. Internal destinations, actions, other schemes, ambiguous or partially covered labels, and links inside reconstructed tables remain escaped text reported as a conversion gap, and URL-looking source text is escaped to resist host autolinking.",
-  "Tables are reconstructed only from either complete text-item column geometry or a complete closed grid of bounded axis-aligned solid-mask rectangles. Ruled grids require every text item to fit exactly one cell, no merged or spanning topology, and independent caption and header evidence because Markdown imposes header semantics. Stroked paths, incomplete grids, cell artwork, and damaged mathematical glyphs are not interpreted; ambiguous content remains escaped reading-order text with a conversion gap.",
+  "Tables are reconstructed only from either complete text-item column geometry or one unambiguous complete closed grid of bounded axis-aligned solid-mask rectangles. Ruled grids require every text item to fit exactly one cell, reject aligned partial dividers that evidence merged or spanning topology, and require independent caption and header evidence because Markdown imposes header semantics. Unsupported text remains escaped reading-order text with a conversion gap. Stroked paths are omitted and reported as vector-content gaps. Cell artwork is omitted and reported as a vector-content gap; damaged mathematical glyphs are not repaired.",
   "OCR is not performed. Image-only text and text that exists only inside page images are omitted and reported as conversion gaps.",
   "Unsafe control characters and malformed UTF-16 surrogates are replaced with the Unicode replacement character and reported as conversion gaps.",
 ]);
@@ -763,10 +766,36 @@ function uniqueCoordinates(values) {
   return unique;
 }
 
+function alignedCoordinateIndex(values, candidate) {
+  return values.findIndex(value => Math.abs(value - candidate) <= RULE_EDGE_TOLERANCE);
+}
+
+function hasAlignedPartialRule(horizontal, vertical, xs, ys) {
+  const lastX = xs.length - 1;
+  const lastY = ys.length - 1;
+  for (const rule of vertical) {
+    if (rule.axis < xs[0] - RULE_EDGE_TOLERANCE || rule.axis > xs[lastX] + RULE_EDGE_TOLERANCE) continue;
+    const xIndex = alignedCoordinateIndex(xs, rule.axis);
+    const startIndex = alignedCoordinateIndex(ys, rule.start);
+    const endIndex = alignedCoordinateIndex(ys, rule.end);
+    if (startIndex < 0 || endIndex <= startIndex) continue;
+    if (!(xIndex >= 0 && startIndex === 0 && endIndex === lastY)) return true;
+  }
+  for (const rule of horizontal) {
+    if (rule.axis < ys[0] - RULE_EDGE_TOLERANCE || rule.axis > ys[lastY] + RULE_EDGE_TOLERANCE) continue;
+    const yIndex = alignedCoordinateIndex(ys, rule.axis);
+    const startIndex = alignedCoordinateIndex(xs, rule.start);
+    const endIndex = alignedCoordinateIndex(xs, rule.end);
+    if (startIndex < 0 || endIndex <= startIndex) continue;
+    if (!(yIndex >= 0 && startIndex === 0 && endIndex === lastX)) return true;
+  }
+  return false;
+}
+
 function closedRuleGrid(page) {
   const evidence = page.painted_rectangles;
   if (!evidence || evidence.status !== "available" || evidence.truncated || evidence.items.length === 0) {
-    return null;
+    return { boundaries: null, tableReason: null };
   }
   const horizontal = mergeRuleSegments(evidence.items, "horizontal")
     .filter(rule => rule.end - rule.start >= 100);
@@ -788,7 +817,11 @@ function closedRuleGrid(page) {
       || Math.abs(xs[0] - seed.start) > RULE_EDGE_TOLERANCE
       || Math.abs(xs[xs.length - 1] - seed.end) > RULE_EDGE_TOLERANCE
       || xs.some((value, index) => index > 0 && value - xs[index - 1] < 12)) continue;
-    candidates.push({ xs, ys });
+    candidates.push({
+      xs,
+      ys,
+      hasPartialRule: hasAlignedPartialRule(horizontal, vertical, xs, ys),
+    });
   }
   const distinct = [];
   for (const candidate of candidates) {
@@ -798,7 +831,11 @@ function closedRuleGrid(page) {
     });
     if (!distinct.some(value => value.key === key)) distinct.push({ key, ...candidate });
   }
-  return distinct.length === 1 ? distinct[0] : null;
+  if (distinct.length === 1 && !distinct[0].hasPartialRule) {
+    return { boundaries: distinct[0], tableReason: null };
+  }
+  const gridLikeEvidence = horizontal.length >= 3 && vertical.length >= 2;
+  return { boundaries: null, tableReason: distinct.length > 0 || gridLikeEvidence ? "topology" : null };
 }
 
 function itemCell(item, xs, ys) {
@@ -816,39 +853,18 @@ function itemCell(item, xs, ys) {
   return { row, column };
 }
 
-function fragmentsForCell(page, itemIds) {
-  const wanted = new Set(itemIds);
-  return page.lines
-    .map(line => ({
-      line,
-      allItems: line.item_ids
-        .map(id => page.raw_items.find(item => item.id === id))
-        .filter(Boolean),
-    }))
-    .map(value => ({
-      ...value,
-      indexes: value.line.item_ids
-        .map((id, index) => (wanted.has(id) ? index : -1))
-        .filter(index => index !== -1),
-    }))
-    .filter(value => value.indexes.length > 0)
-    .sort((left, right) => left.line.y - right.line.y || left.line.x - right.line.x)
-    .map(({ line, allItems, indexes }) => {
-      const offsets = itemOffsets(line, allItems);
-      if (offsets === null) return indexes.map(index => allItems[index].text).join(" ").trim();
-      const start = offsets[Math.min(...indexes)].start;
-      const end = offsets[Math.max(...indexes)].end;
-      return line.text.slice(start, end).trim();
-    })
-    .filter(Boolean);
-}
-
 function ruledGridSegment(page) {
-  const boundaries = closedRuleGrid(page);
-  if (!boundaries) return { segment: null, tableReason: null };
+  const detected = closedRuleGrid(page);
+  const boundaries = detected.boundaries;
+  if (!boundaries) return { segment: null, tableReason: detected.tableReason };
   const { xs, ys } = boundaries;
   const rowCount = ys.length - 1;
   const columnCount = xs.length - 1;
+  if (rowCount > RULED_TABLE_MAX_ROWS
+    || columnCount > RULED_TABLE_MAX_COLUMNS
+    || rowCount * columnCount > RULED_TABLE_MAX_CELLS) {
+    return { segment: null, tableReason: "topology" };
+  }
   const rowHeights = ys.slice(1).map((value, index) => value - ys[index]);
   const bodyMedian = median(rowHeights.slice(1));
   if (rowCount < 3 || columnCount < 2 || !(rowHeights[0] <= bodyMedian * 0.6)) {
@@ -870,6 +886,8 @@ function ruledGridSegment(page) {
     Array.from({ length: columnCount }, () => [])
   ));
   const covered = new Set();
+  const itemLocations = new Map();
+  const itemById = new Map(page.raw_items.map(item => [item.id, item]));
   const gridBox = { left: xs[0], right: xs[xs.length - 1], top: ys[0], bottom: ys[ys.length - 1] };
   for (const item of page.raw_items) {
     if (!item.geometry_valid || !item.bbox || item.text_kind !== "non_whitespace") continue;
@@ -880,24 +898,60 @@ function ruledGridSegment(page) {
     if (!location) return { segment: null, tableReason: "topology" };
     cells[location.row][location.column].push(item.id);
     covered.add(item.id);
+    itemLocations.set(item.id, location);
   }
   if (cells.some(row => row.some(cell => cell.length === 0))) {
     return { segment: null, tableReason: "topology" };
   }
-  const rows = page.lines
-    .map((line, index) => ({
-      index,
-      line,
-      cells: line.item_ids.map(id => page.raw_items.find(item => item.id === id)).filter(Boolean),
-      covered: line.item_ids.filter(id => covered.has(id)).length,
-    }));
-  if (rows.some(row => row.covered > 0 && row.covered !== row.line.item_ids.length)) {
+  const grid = Array.from({ length: rowCount }, () => (
+    Array.from({ length: columnCount }, () => [])
+  ));
+  const coveredRows = [];
+  for (let lineIndex = 0; lineIndex < page.lines.length; lineIndex += 1) {
+    const line = page.lines[lineIndex];
+    const allItems = line.item_ids.map(id => itemById.get(id)).filter(Boolean);
+    const coveredCount = line.item_ids.filter(id => covered.has(id)).length;
+    if (coveredCount === 0) continue;
+    if (coveredCount !== line.item_ids.length || allItems.length !== line.item_ids.length) {
+      return { segment: null, tableReason: "topology" };
+    }
+    const locations = line.item_ids.map(id => itemLocations.get(id));
+    const tableRow = locations[0]?.row;
+    if (!Number.isInteger(tableRow) || locations.some(location => location?.row !== tableRow)) {
+      return { segment: null, tableReason: "topology" };
+    }
+    const groups = [];
+    let previousColumn = -1;
+    for (let itemIndex = 0; itemIndex < locations.length; itemIndex += 1) {
+      const column = locations[itemIndex].column;
+      if (column < previousColumn) return { segment: null, tableReason: "topology" };
+      if (column !== previousColumn) groups.push({ column, start: itemIndex, end: itemIndex });
+      else groups.at(-1).end = itemIndex;
+      previousColumn = column;
+    }
+    const offsets = itemOffsets(line, allItems);
+    for (const group of groups) {
+      const fragment = offsets === null
+        ? allItems.slice(group.start, group.end + 1).map(item => item.text).join(" ").trim()
+        : line.text.slice(offsets[group.start].start, offsets[group.end].end).trim();
+      if (!fragment) return { segment: null, tableReason: "topology" };
+      grid[tableRow][group.column].push({
+        text: fragment,
+        y: line.y,
+        x: line.x,
+        lineIndex,
+      });
+    }
+    coveredRows.push({ index: lineIndex, line, cells: allItems });
+  }
+  if (coveredRows.length === 0) return { segment: null, tableReason: "topology" };
+  if (grid.some(row => row.some(fragments => fragments.length === 0))) {
     return { segment: null, tableReason: "topology" };
   }
-  const coveredRows = rows.filter(row => row.covered > 0);
-  if (coveredRows.length === 0) return { segment: null, tableReason: "topology" };
-  const grid = cells.map(row => row.map(itemIds => fragmentsForCell(page, itemIds)));
-  const header = grid[0];
+  const orderedGrid = grid.map(row => row.map(fragments => fragments
+    .sort((left, right) => left.y - right.y || left.x - right.x || left.lineIndex - right.lineIndex)
+    .map(fragment => fragment.text)));
+  const header = orderedGrid[0];
   if (header.some(fragments => {
     const text = fragments.join(" ").trim();
     const letters = text.match(/\p{L}/gu)?.length ?? 0;
@@ -909,7 +963,7 @@ function ruledGridSegment(page) {
     segment: {
       kind: "table",
       rows: coveredRows.map(({ line, cells: rowCells }) => ({ line, cells: rowCells })),
-      grid,
+      grid: orderedGrid,
       coveredLineIds: new Set(coveredRows.map(row => row.line.id)),
       insertionIndex: page.lines.findIndex(line => line.id === captionCandidates[0].id) + 1,
     },

--- a/pdf-toolkit-mcp-share/server/markdown-conversion.js
+++ b/pdf-toolkit-mcp-share/server/markdown-conversion.js
@@ -6,7 +6,7 @@ import {
 
 const RENDERER = Object.freeze({
   name: "pdf-tools.layout-markdown-renderer",
-  version: "1.6.0",
+  version: "1.7.0",
 });
 
 // Bounded geometric table inference. A run of adjacent lines is treated as a
@@ -22,6 +22,10 @@ const TABLE_MIN_COLUMN_ROWS = 2;
 const TABLE_COLUMNAR_COVERAGE = 0.8;
 // How much taller the first row must be to evidence a header row.
 const HEADER_HEIGHT_RATIO = 1.15;
+const RULE_MAX_THICKNESS = 1.5;
+const RULE_AXIS_TOLERANCE = 1;
+const RULE_JOIN_TOLERANCE = 1;
+const RULE_EDGE_TOLERANCE = 1.5;
 
 const MAX_MARKDOWN_BYTES_LIMIT = 200_000;
 const GAP_CODES = new Set([
@@ -48,7 +52,7 @@ const LIMITATIONS = Object.freeze([
   "A missing space after a separate source text item that is exactly the mathematical operator log is restored only in a short, compact left-to-right math run when a single-letter variable from a different embedded-font resource follows on the same baseline with a small positive geometric gap and independent local math-layout evidence. General equations, scripts, fraction bars, and damaged mathematical glyphs remain source reading-order text rather than being guessed.",
   "Lists are emitted only for literal bullet glyphs or decimal markers present in the source text.",
   "Links are emitted only for source-validated http or https annotation targets that map to exactly one contiguous run of text on one line. Internal destinations, actions, other schemes, ambiguous or partially covered labels, and links inside reconstructed tables remain escaped text reported as a conversion gap, and URL-looking source text is escaped to resist host autolinking.",
-  "Tables are reconstructed only from text-item column geometry, and only when every row fills every detected column and the first row is typographically distinct enough to evidence a header, because a Markdown table imposes header semantics. Ruling lines and merged or spanning cells are not interpreted, and table-like content that fails either test remains escaped reading-order text reported as a conversion gap.",
+  "Tables are reconstructed only from either complete text-item column geometry or a complete closed grid of bounded axis-aligned solid-mask rectangles. Ruled grids require every text item to fit exactly one cell, no merged or spanning topology, and independent caption and header evidence because Markdown imposes header semantics. Stroked paths, incomplete grids, cell artwork, and damaged mathematical glyphs are not interpreted; ambiguous content remains escaped reading-order text with a conversion gap.",
   "OCR is not performed. Image-only text and text that exists only inside page images are omitted and reported as conversion gaps.",
   "Unsafe control characters and malformed UTF-16 surrogates are replaced with the Unicode replacement character and reported as conversion gaps.",
 ]);
@@ -708,15 +712,212 @@ function assignRowToColumns(row, anchors) {
   return anchors.map((_anchor, index) => assigned.get(index));
 }
 
-/**
- * Partition a page's lines into reading-order segments. Each segment is either
- * a confidently reconstructed table or a run of ordinary lines. Table-like runs
- * that cannot be reconstructed are returned as text with tableReason set, so
- * the caller can report typed partial coverage instead of silently flattening.
- */
-function segmentPageLines(page) {
-  const itemById = new Map(page.raw_items.map(item => [item.id, item]));
-  const rows = page.lines.map(line => ({ line, cells: lineCells(line, itemById) }));
+function mergeRuleSegments(rectangles, orientation) {
+  const horizontal = orientation === "horizontal";
+  const candidates = rectangles
+    .map(item => item.bbox)
+    .filter(rect => horizontal
+      ? rect.height <= RULE_MAX_THICKNESS && rect.width >= 20
+      : rect.width <= RULE_MAX_THICKNESS && rect.height >= 8)
+    .map(rect => ({
+      axis: horizontal ? rect.y + rect.height / 2 : rect.x + rect.width / 2,
+      start: horizontal ? rect.x : rect.y,
+      end: horizontal ? rect.x + rect.width : rect.y + rect.height,
+    }))
+    .sort((left, right) => left.axis - right.axis || left.start - right.start);
+  const axisGroups = [];
+  for (const candidate of candidates) {
+    const group = axisGroups.find(value => Math.abs(value.axis - candidate.axis) <= RULE_AXIS_TOLERANCE);
+    if (group) {
+      group.values.push(candidate);
+      group.axis = median(group.values.map(value => value.axis));
+    } else {
+      axisGroups.push({ axis: candidate.axis, values: [candidate] });
+    }
+  }
+  const merged = [];
+  for (const group of axisGroups) {
+    const spans = group.values.sort((left, right) => left.start - right.start);
+    for (const span of spans) {
+      const prior = merged[merged.length - 1];
+      if (prior && Math.abs(prior.axis - group.axis) <= RULE_AXIS_TOLERANCE
+        && span.start <= prior.end + RULE_JOIN_TOLERANCE) {
+        prior.end = Math.max(prior.end, span.end);
+      } else {
+        merged.push({ axis: group.axis, start: span.start, end: span.end });
+      }
+    }
+  }
+  return merged;
+}
+
+function uniqueCoordinates(values) {
+  const unique = [];
+  for (const value of [...values].sort((left, right) => left - right)) {
+    if (unique.length === 0 || Math.abs(unique[unique.length - 1] - value) > RULE_AXIS_TOLERANCE) {
+      unique.push(value);
+    } else {
+      unique[unique.length - 1] = (unique[unique.length - 1] + value) / 2;
+    }
+  }
+  return unique;
+}
+
+function closedRuleGrid(page) {
+  const evidence = page.painted_rectangles;
+  if (!evidence || evidence.status !== "available" || evidence.truncated || evidence.items.length === 0) {
+    return null;
+  }
+  const horizontal = mergeRuleSegments(evidence.items, "horizontal")
+    .filter(rule => rule.end - rule.start >= 100);
+  const vertical = mergeRuleSegments(evidence.items, "vertical");
+  const candidates = [];
+  for (const seed of horizontal) {
+    const peers = horizontal.filter(rule => Math.abs(rule.start - seed.start) <= RULE_EDGE_TOLERANCE
+      && Math.abs(rule.end - seed.end) <= RULE_EDGE_TOLERANCE);
+    const ys = uniqueCoordinates(peers.map(rule => rule.axis));
+    if (ys.length < 3 || ys.some((value, index) => index > 0 && value - ys[index - 1] < 8)) continue;
+    const top = ys[0];
+    const bottom = ys[ys.length - 1];
+    const spanning = vertical.filter(rule => rule.start <= top + RULE_EDGE_TOLERANCE
+      && rule.end >= bottom - RULE_EDGE_TOLERANCE
+      && rule.axis >= seed.start - RULE_EDGE_TOLERANCE
+      && rule.axis <= seed.end + RULE_EDGE_TOLERANCE);
+    const xs = uniqueCoordinates(spanning.map(rule => rule.axis));
+    if (xs.length < 3
+      || Math.abs(xs[0] - seed.start) > RULE_EDGE_TOLERANCE
+      || Math.abs(xs[xs.length - 1] - seed.end) > RULE_EDGE_TOLERANCE
+      || xs.some((value, index) => index > 0 && value - xs[index - 1] < 12)) continue;
+    candidates.push({ xs, ys });
+  }
+  const distinct = [];
+  for (const candidate of candidates) {
+    const key = JSON.stringify({
+      xs: candidate.xs.map(value => Number(value.toFixed(1))),
+      ys: candidate.ys.map(value => Number(value.toFixed(1))),
+    });
+    if (!distinct.some(value => value.key === key)) distinct.push({ key, ...candidate });
+  }
+  return distinct.length === 1 ? distinct[0] : null;
+}
+
+function itemCell(item, xs, ys) {
+  if (!item.geometry_valid || !item.bbox || item.text_kind !== "non_whitespace") return null;
+  const centerX = item.bbox.x + item.bbox.width / 2;
+  const centerY = item.bbox.y + item.bbox.height / 2;
+  const column = xs.findIndex((right, index) => index > 0 && centerX < right) - 1;
+  const row = ys.findIndex((bottom, index) => index > 0 && centerY < bottom) - 1;
+  if (column < 0 || row < 0) return null;
+  const tolerance = 0.75;
+  if (item.bbox.x < xs[column] - tolerance
+    || item.bbox.x + item.bbox.width > xs[column + 1] + tolerance
+    || item.bbox.y < ys[row] - tolerance
+    || item.bbox.y + item.bbox.height > ys[row + 1] + tolerance) return null;
+  return { row, column };
+}
+
+function fragmentsForCell(page, itemIds) {
+  const wanted = new Set(itemIds);
+  return page.lines
+    .map(line => ({
+      line,
+      allItems: line.item_ids
+        .map(id => page.raw_items.find(item => item.id === id))
+        .filter(Boolean),
+    }))
+    .map(value => ({
+      ...value,
+      indexes: value.line.item_ids
+        .map((id, index) => (wanted.has(id) ? index : -1))
+        .filter(index => index !== -1),
+    }))
+    .filter(value => value.indexes.length > 0)
+    .sort((left, right) => left.line.y - right.line.y || left.line.x - right.line.x)
+    .map(({ line, allItems, indexes }) => {
+      const offsets = itemOffsets(line, allItems);
+      if (offsets === null) return indexes.map(index => allItems[index].text).join(" ").trim();
+      const start = offsets[Math.min(...indexes)].start;
+      const end = offsets[Math.max(...indexes)].end;
+      return line.text.slice(start, end).trim();
+    })
+    .filter(Boolean);
+}
+
+function ruledGridSegment(page) {
+  const boundaries = closedRuleGrid(page);
+  if (!boundaries) return { segment: null, tableReason: null };
+  const { xs, ys } = boundaries;
+  const rowCount = ys.length - 1;
+  const columnCount = xs.length - 1;
+  const rowHeights = ys.slice(1).map((value, index) => value - ys[index]);
+  const bodyMedian = median(rowHeights.slice(1));
+  if (rowCount < 3 || columnCount < 2 || !(rowHeights[0] <= bodyMedian * 0.6)) {
+    return { segment: null, tableReason: "topology" };
+  }
+  const captionCandidates = page.lines.filter(line => {
+    const text = line.text.trim();
+    const bottom = line.y + line.height;
+    const center = line.x + line.width / 2;
+    return /^TABLE\s+(?:\d+|[IVXLCDM]+)$/iu.test(text)
+      && bottom <= ys[0]
+      && ys[0] - bottom <= 30
+      && center >= xs[0]
+      && center <= xs[xs.length - 1];
+  });
+  if (captionCandidates.length !== 1) return { segment: null, tableReason: "header" };
+
+  const cells = Array.from({ length: rowCount }, () => (
+    Array.from({ length: columnCount }, () => [])
+  ));
+  const covered = new Set();
+  const gridBox = { left: xs[0], right: xs[xs.length - 1], top: ys[0], bottom: ys[ys.length - 1] };
+  for (const item of page.raw_items) {
+    if (!item.geometry_valid || !item.bbox || item.text_kind !== "non_whitespace") continue;
+    const overlaps = item.bbox.x < gridBox.right && item.bbox.x + item.bbox.width > gridBox.left
+      && item.bbox.y < gridBox.bottom && item.bbox.y + item.bbox.height > gridBox.top;
+    if (!overlaps) continue;
+    const location = itemCell(item, xs, ys);
+    if (!location) return { segment: null, tableReason: "topology" };
+    cells[location.row][location.column].push(item.id);
+    covered.add(item.id);
+  }
+  if (cells.some(row => row.some(cell => cell.length === 0))) {
+    return { segment: null, tableReason: "topology" };
+  }
+  const rows = page.lines
+    .map((line, index) => ({
+      index,
+      line,
+      cells: line.item_ids.map(id => page.raw_items.find(item => item.id === id)).filter(Boolean),
+      covered: line.item_ids.filter(id => covered.has(id)).length,
+    }));
+  if (rows.some(row => row.covered > 0 && row.covered !== row.line.item_ids.length)) {
+    return { segment: null, tableReason: "topology" };
+  }
+  const coveredRows = rows.filter(row => row.covered > 0);
+  if (coveredRows.length === 0) return { segment: null, tableReason: "topology" };
+  const grid = cells.map(row => row.map(itemIds => fragmentsForCell(page, itemIds)));
+  const header = grid[0];
+  if (header.some(fragments => {
+    const text = fragments.join(" ").trim();
+    const letters = text.match(/\p{L}/gu)?.length ?? 0;
+    const visible = text.match(/[\p{L}\p{N}]/gu)?.length ?? 0;
+    return text.length === 0 || text.length > 80 || visible === 0
+      || letters / visible < 0.8 || text !== text.toLocaleUpperCase("en-US");
+  })) return { segment: null, tableReason: "header" };
+  return {
+    segment: {
+      kind: "table",
+      rows: coveredRows.map(({ line, cells: rowCells }) => ({ line, cells: rowCells })),
+      grid,
+      coveredLineIds: new Set(coveredRows.map(row => row.line.id)),
+      insertionIndex: page.lines.findIndex(line => line.id === captionCandidates[0].id) + 1,
+    },
+    tableReason: null,
+  };
+}
+
+function segmentTextRows(rows) {
   const segments = [];
   let tableReason = null;
   let index = 0;
@@ -734,12 +935,7 @@ function segmentPageLines(page) {
     if (grid && grid.every(Boolean) && hasHeaderEvidence(run)) {
       segments.push({ kind: "table", rows: run, grid });
     } else {
-      // Only report a topology gap for runs that actually look columnar.
-      // Ordinary prose that happens to share a left margin must not be
-      // reported as an unreconstructed table.
-      if (tableLike) {
-        tableReason = grid && grid.every(Boolean) ? "header" : "topology";
-      }
+      if (tableLike) tableReason = grid && grid.every(Boolean) ? "header" : "topology";
       segments.push({ kind: "text", rows: run });
     }
     index = end;
@@ -747,11 +943,37 @@ function segmentPageLines(page) {
   return { segments, tableReason };
 }
 
+/**
+ * Partition a page's lines into reading-order segments. Each segment is either
+ * a confidently reconstructed table or a run of ordinary lines. Table-like runs
+ * that cannot be reconstructed are returned as text with tableReason set, so
+ * the caller can report typed partial coverage instead of silently flattening.
+ */
+function segmentPageLines(page) {
+  const itemById = new Map(page.raw_items.map(item => [item.id, item]));
+  const rows = page.lines.map(line => ({ line, cells: lineCells(line, itemById) }));
+  const ruled = ruledGridSegment(page);
+  if (!ruled.segment) {
+    const text = segmentTextRows(rows);
+    return { segments: text.segments, tableReason: ruled.tableReason ?? text.tableReason };
+  }
+  const remaining = rows.map((row, index) => ({ ...row, sourceIndex: index }))
+    .filter(row => !ruled.segment.coveredLineIds.has(row.line.id));
+  const before = segmentTextRows(remaining.filter(row => row.sourceIndex < ruled.segment.insertionIndex));
+  const after = segmentTextRows(remaining.filter(row => row.sourceIndex >= ruled.segment.insertionIndex));
+  return {
+    segments: [...before.segments, ruled.segment, ...after.segments],
+    tableReason: before.tableReason ?? after.tableReason,
+  };
+}
+
 // escapePlainMarkdown already escapes "|" (and backslashes before it), so a
 // second pass here would emit "\\|", which is an escaped backslash followed by
 // a live cell delimiter. Reuse the single existing escape.
 function escapeTableCell(value) {
-  return escapePlainMarkdown(value);
+  return Array.isArray(value)
+    ? value.map(fragment => escapePlainMarkdown(fragment)).join("<br>")
+    : escapePlainMarkdown(value);
 }
 
 function renderTable(grid) {
@@ -840,7 +1062,7 @@ function pageGaps(page, analysis, linkState) {
     add("IMAGE_CONTENT_NOT_RENDERED", "Image content was not rendered into Markdown.");
   }
   if (page.has_vector_paint_operations) {
-    add("VECTOR_CONTENT_NOT_INTERPRETED", "Vector-painted content was not interpreted as text or table structure.");
+    add("VECTOR_CONTENT_NOT_INTERPRETED", "Vector-painted content beyond bounded solid-mask grid evidence was not interpreted as text or table structure.");
   }
   if (page.errors.some(error => error.code === "RAW_PAGE_GEOMETRY_UNAVAILABLE")) {
     add("RAW_PAGE_GEOMETRY_UNAVAILABLE", "Raw MediaBox, CropBox, or rotation evidence was unavailable.");
@@ -1080,8 +1302,8 @@ export function validateMarkdownConversionSemantics(result, { layout = null } = 
  * Render an already source-validated PDF Tools layout IR to deterministic
  * Markdown. This function rechecks IR semantics but deliberately performs no
  * I/O, PDF parsing, rendering, OCR, or annotation lookup. Table reconstruction
- * is bounded to the layout IR's own text-item column geometry; it reads no
- * ruling lines and infers no merged or spanning cells.
+ * is bounded to the layout IR's text geometry and complete axis-aligned
+ * solid-mask grids; it interprets no stroked paths, merged cells, or cell art.
  */
 export function renderPdfLayoutToMarkdown(layout, {
   includePageBoundaries = true,

--- a/pdf-toolkit-mcp-share/server/output-schemas.js
+++ b/pdf-toolkit-mcp-share/server/output-schemas.js
@@ -317,6 +317,20 @@ const layoutError = object({
   message: string,
 });
 const layoutPoint = object({ x: number, y: number });
+const layoutPaintedRectangles = object({
+  status: enumString(["available", "unavailable"]),
+  truncated: boolean,
+  observed_count: integer,
+  returned_count: integer,
+  items: arrayOf(object({
+    id: string,
+    source_operation_index: integer,
+    source_kind: { const: "solid_color_image_mask" },
+    graphics_transform: { type: "array", minItems: 6, maxItems: 6, items: number },
+    quad: { type: "array", minItems: 4, maxItems: 4, items: layoutPoint },
+    bbox: layoutBox,
+  })),
+});
 const layoutRawItem = object({
   id: string,
   source_index: integer,
@@ -425,6 +439,7 @@ const layoutPage = object({
   geometry: layoutGeometry,
   has_image_operations: nullable(boolean),
   has_vector_paint_operations: nullable(boolean),
+  painted_rectangles: layoutPaintedRectangles,
   link_annotations: object({
     status: enumString(["available", "unavailable"]),
     truncated: boolean,
@@ -512,7 +527,7 @@ export const TOOL_SUCCESS_OUTPUT_SCHEMAS = Object.freeze({
     truncated: boolean,
   }),
   read_pdf_layout: object({
-    ir: object({ name: { const: "pdf-tools.extraction-ir" }, version: { const: "1.1.0" } }),
+    ir: object({ name: { const: "pdf-tools.extraction-ir" }, version: { const: "1.2.0" } }),
     parser: object({ name: { const: "pdfjs-dist" }, version: { const: "5.4.624" } }),
     source: object({
       pdf_path: string,
@@ -524,7 +539,7 @@ export const TOOL_SUCCESS_OUTPUT_SCHEMAS = Object.freeze({
       kind: { const: "source_parser_ir_options" },
       source_sha256: { type: "string", pattern: "^[a-f0-9]{64}$" },
       parser_version: { const: "5.4.624" },
-      ir_version: { const: "1.1.0" },
+      ir_version: { const: "1.2.0" },
       requested_start_page: integer,
       requested_end_page: integer,
       max_items: integer,
@@ -552,7 +567,7 @@ export const TOOL_SUCCESS_OUTPUT_SCHEMAS = Object.freeze({
   convert_pdf_to_markdown: object({
     renderer: object({
       name: { const: "pdf-tools.layout-markdown-renderer" },
-      version: { const: "1.6.0" },
+      version: { const: "1.7.0" },
     }),
     conversion_status: enumString(["complete", "partial", "failed"]),
     markdown: string,
@@ -571,7 +586,7 @@ export const TOOL_SUCCESS_OUTPUT_SCHEMAS = Object.freeze({
       }),
       layout: object({
         name: { const: "pdf-tools.extraction-ir" },
-        version: { const: "1.1.0" },
+        version: { const: "1.2.0" },
         parser_name: { const: "pdfjs-dist" },
         parser_version: { const: "5.4.624" },
         page_range: object({

--- a/scripts/eval-run-markdown-bakeoff.mjs
+++ b/scripts/eval-run-markdown-bakeoff.mjs
@@ -190,7 +190,7 @@ export function validateMarkdownResult(result, binding) {
     throw new Error(`Markdown conversion failed for ${binding.fixture.id}`);
   }
   const value = result.structuredContent;
-  if (value.renderer?.name !== "pdf-tools.layout-markdown-renderer" || value.renderer?.version !== "1.6.0"
+  if (value.renderer?.name !== "pdf-tools.layout-markdown-renderer" || value.renderer?.version !== "1.7.0"
     || value.options?.include_page_boundaries !== true || value.limits?.max_markdown_bytes !== 200000
     || value.provenance?.source?.file_name !== binding.retained.filename
     || value.provenance?.source?.sha256 !== binding.retained.sha256

--- a/scripts/smoke-mcpb.mjs
+++ b/scripts/smoke-mcpb.mjs
@@ -137,7 +137,7 @@ async function main() {
       arguments: { pdf_path: fixturePath, max_output_characters: 200000 },
     });
     if (layout.isError
-      || layout.structuredContent?.ir?.version !== "1.1.0"
+      || layout.structuredContent?.ir?.version !== "1.2.0"
       || layout.structuredContent?.source?.size_bytes !== statSync(fixturePath).size) {
       throw new Error("Packed read_pdf_layout contract smoke failed");
     }
@@ -146,7 +146,7 @@ async function main() {
       arguments: { pdf_path: fixturePath, max_markdown_bytes: 200000 },
     });
     if (markdown.isError
-      || markdown.structuredContent?.renderer?.version !== "1.6.0"
+      || markdown.structuredContent?.renderer?.version !== "1.7.0"
       || markdown.structuredContent?.markdown_bytes !== Buffer.byteLength(markdown.structuredContent?.markdown || "", "utf8")
       || markdown.structuredContent?.markdown_sha256 !== sha256(Buffer.from(markdown.structuredContent?.markdown || "", "utf8"))) {
       throw new Error("Packed convert_pdf_to_markdown contract smoke failed");

--- a/scripts/test-share-contract.mjs
+++ b/scripts/test-share-contract.mjs
@@ -828,7 +828,7 @@ async function main() {
       arguments: { pdf_path: fixturePath, max_output_characters: 200000 },
     });
     if (layout.isError
-      || layout.structuredContent?.ir?.version !== "1.1.0"
+      || layout.structuredContent?.ir?.version !== "1.2.0"
       || layout.structuredContent?.source?.size_bytes !== statSync(fixturePath).size) {
       throw new Error("Share read_pdf_layout contract smoke failed");
     }
@@ -837,7 +837,7 @@ async function main() {
       arguments: { pdf_path: fixturePath, max_markdown_bytes: 200000 },
     });
     if (markdown.isError
-      || markdown.structuredContent?.renderer?.version !== "1.6.0"
+      || markdown.structuredContent?.renderer?.version !== "1.7.0"
       || markdown.structuredContent?.markdown_bytes !== Buffer.byteLength(markdown.structuredContent?.markdown || "", "utf8")
       || markdown.structuredContent?.markdown_sha256 !== sha256(Buffer.from(markdown.structuredContent?.markdown || "", "utf8"))) {
       throw new Error("Share convert_pdf_to_markdown contract smoke failed");

--- a/server/index.js
+++ b/server/index.js
@@ -2673,7 +2673,7 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
       },
       {
         name: "convert_pdf_to_markdown",
-        description: "Convert a bounded page range of a local PDF into deterministic Markdown from the source-validated PDF Tools Extraction IR. Headings and lists require geometry or literal marker evidence. A table is reconstructed only when every row fills every recurring detected column and the first row carries real header evidence. A link is emitted only for a source-validated external http or https annotation target covering one contiguous run of text on one line. Unsupported table structures and link targets, including merged cells, internal destinations, actions, and other schemes, stay escaped text reported as typed coverage gaps. No OCR and no external model. Optionally saves UTF-8 Markdown through the transactional output path. Use absolute or ~/ paths on the user's local machine, NOT Claude container paths (/mnt/...).",
+        description: "Convert a bounded page range of a local PDF into deterministic Markdown from the source-validated PDF Tools Extraction IR. Headings and lists require geometry or literal marker evidence. A table requires either a complete recurring text grid or a complete closed painted grid, with every item in one cell and real header evidence. A link requires a source-validated external http or https annotation target covering one contiguous text run. Unsupported tables and link targets, including merged cells, internal destinations, actions, and other schemes, stay escaped text with typed gaps. No OCR or external model. Optionally saves transactional UTF-8 Markdown. Use absolute or ~/ local paths, not Claude container paths (/mnt/...).",
         inputSchema: {
           type: "object",
           additionalProperties: false,
@@ -4515,7 +4515,7 @@ async function handleToolCall(request) {
             `Source SHA-256: ${sourceSha256}.`,
             ...(savedOutput ? [`Saved and reopened exact UTF-8 output: ${savedOutput.path}`] : []),
             ...(rendered.gaps.length > 0 ? [`Coverage gaps: ${rendered.gaps.map(gap => `page ${gap.page}: ${gap.code}`).join(", ")}.`] : []),
-            "No OCR, external model, hidden link-target recovery, or table-topology inference was performed.",
+            "No OCR, external model, hidden link-target recovery, or table inference beyond complete source-bound text or painted grids was performed.",
             rendered.markdown,
           ].join("\n\n");
           return {

--- a/server/layout-extraction.js
+++ b/server/layout-extraction.js
@@ -3,7 +3,7 @@ import { createHash } from "node:crypto";
 import { fileURLToPath } from "node:url";
 
 const IR_NAME = "pdf-tools.extraction-ir";
-const IR_VERSION = "1.1.0";
+const IR_VERSION = "1.2.0";
 const INTERNAL_SOURCE_REPLAY = Symbol("pdf-layout-internal-source-replay");
 const INTERNAL_MARKDOWN_PROJECTION = Symbol("pdf-layout-internal-markdown-projection");
 
@@ -35,6 +35,7 @@ const RAW_PAGE_SPACE = Object.freeze({
   unit: "pdf_user_unit",
   stage: "before_user_unit_and_page_rotation",
 });
+const MAX_PAINTED_RECTANGLES = 500;
 
 function round(value) {
   return Number(Number(value).toFixed(3));
@@ -545,6 +546,96 @@ function vectorOperationSet(pdfjsLib) {
   ].filter(Number.isInteger));
 }
 
+function unavailablePaintedRectangles() {
+  return {
+    status: "unavailable",
+    truncated: false,
+    observed_count: 0,
+    returned_count: 0,
+    items: [],
+  };
+}
+
+function unitRectangleGeometry(viewportTransform, graphicsTransform) {
+  if (![...viewportTransform, ...graphicsTransform].every(Number.isFinite)) return null;
+  const transformed = multiplyTransforms(viewportTransform, graphicsTransform);
+  if (!transformed.every(Number.isFinite)) return null;
+  const axisAligned = (Math.abs(transformed[1]) <= 0.002 && Math.abs(transformed[2]) <= 0.002)
+    || (Math.abs(transformed[0]) <= 0.002 && Math.abs(transformed[3]) <= 0.002);
+  if (!axisAligned) return null;
+  const points = [[0, 0], [1, 0], [1, 1], [0, 1]].map(([x, y]) => ({
+    x: round(transformed[0] * x + transformed[2] * y + transformed[4]),
+    y: round(transformed[1] * x + transformed[3] * y + transformed[5]),
+  }));
+  const xs = points.map(point => point.x);
+  const ys = points.map(point => point.y);
+  const x = Math.min(...xs);
+  const y = Math.min(...ys);
+  const width = round(Math.max(...xs) - x);
+  const height = round(Math.max(...ys) - y);
+  if (!(width > 0 && height > 0)) return null;
+  return {
+    quad: points,
+    bbox: { x: round(x), y: round(y), width, height },
+  };
+}
+
+/**
+ * Preserve a bounded neutral projection of PDF.js solid-color image-mask
+ * rectangles. These marks include rules but can also include fraction bars or
+ * other artwork; table semantics are deliberately left to the renderer, which
+ * must require a complete closed grid rather than trusting any one rectangle.
+ */
+function collectPaintedRectangles(operators, pdfjsLib, viewportTransform, pageNumber) {
+  const save = pdfjsLib.OPS?.save;
+  const restore = pdfjsLib.OPS?.restore;
+  const transform = pdfjsLib.OPS?.transform;
+  const paint = pdfjsLib.OPS?.paintSolidColorImageMask;
+  if (![save, restore, transform, paint].every(Number.isInteger)
+    || !Array.isArray(operators?.fnArray)
+    || !Array.isArray(operators?.argsArray)) return unavailablePaintedRectangles();
+  let current = [1, 0, 0, 1, 0, 0];
+  const stack = [];
+  const items = [];
+  let observedCount = 0;
+  for (let operationIndex = 0; operationIndex < operators.fnArray.length; operationIndex += 1) {
+    const operation = operators.fnArray[operationIndex];
+    if (operation === save) {
+      stack.push([...current]);
+    } else if (operation === restore) {
+      if (stack.length === 0) return unavailablePaintedRectangles();
+      current = stack.pop();
+    } else if (operation === transform) {
+      const values = operators.argsArray[operationIndex];
+      if (!Array.isArray(values) || values.length !== 6 || !values.every(Number.isFinite)) {
+        return unavailablePaintedRectangles();
+      }
+      current = multiplyTransforms(current, values);
+      if (!current.every(Number.isFinite)) return unavailablePaintedRectangles();
+    } else if (operation === paint) {
+      const geometry = unitRectangleGeometry(viewportTransform, current);
+      if (!geometry) continue;
+      observedCount += 1;
+      if (items.length >= MAX_PAINTED_RECTANGLES) continue;
+      items.push({
+        id: `p${String(pageNumber).padStart(4, "0")}-r${String(operationIndex + 1).padStart(6, "0")}`,
+        source_operation_index: operationIndex,
+        source_kind: "solid_color_image_mask",
+        graphics_transform: current.map(round),
+        quad: geometry.quad,
+        bbox: geometry.bbox,
+      });
+    }
+  }
+  return {
+    status: "available",
+    truncated: observedCount > items.length,
+    observed_count: observedCount,
+    returned_count: items.length,
+    items,
+  };
+}
+
 function errorRecord(stage, error) {
   return {
     stage,
@@ -599,6 +690,26 @@ function recomputeDocumentTruncation(payload) {
 
 function markOutputBudget(payload, maxOutputCharacters) {
   if (JSON.stringify(payload).length <= maxOutputCharacters) return payload;
+  for (let index = payload.pages.length - 1; index >= 0 && JSON.stringify(payload).length > maxOutputCharacters; index -= 1) {
+    const page = payload.pages[index];
+    if (page.painted_rectangles.items.length === 0) continue;
+    page.painted_rectangles = {
+      status: "unavailable",
+      truncated: true,
+      observed_count: page.painted_rectangles.observed_count,
+      returned_count: 0,
+      items: [],
+    };
+    page.extraction_status = page.extraction_status === "failed" ? "failed" : "partial";
+    page.needs_visual_inspection = true;
+    if (!page.limitations.includes("Painted rectangle detail was omitted to satisfy max_output_characters.")) {
+      page.limitations.push("Painted rectangle detail was omitted to satisfy max_output_characters.");
+    }
+  }
+  if (JSON.stringify(payload).length <= maxOutputCharacters) {
+    payload.extraction_status = payload.pages.every(page => page.extraction_status === "complete") ? "complete" : "partial";
+    return payload;
+  }
   if (!payload.truncation.reasons.includes("max_output_characters")) payload.truncation.reasons.push("max_output_characters");
   for (let index = payload.pages.length - 1; index >= 0 && JSON.stringify(payload).length > maxOutputCharacters; index -= 1) {
     const page = payload.pages[index];
@@ -618,6 +729,13 @@ function markOutputBudget(payload, maxOutputCharacters) {
     // Link items are page detail too. Leaving them would keep a link-heavy
     // page over budget and turn a bounded partial into a whole-call error.
     page.link_annotations = { status: "unavailable", truncated: true, items: [] };
+    page.painted_rectangles = {
+      status: "unavailable",
+      truncated: true,
+      observed_count: page.painted_rectangles.observed_count,
+      returned_count: 0,
+      items: [],
+    };
     page.flow_text = "";
     page.spatial_text = "";
     page.reading_order = {
@@ -848,6 +966,48 @@ export function validatePdfLayoutSemantics(payload, {
     semanticAssertion(!documentIds.has(page.id), `duplicate ID ${page.id}`);
     documentIds.add(page.id);
 
+    const painted = page.painted_rectangles;
+    semanticAssertion(painted && ["available", "unavailable"].includes(painted.status),
+      `page ${page.page} painted rectangle status is invalid`);
+    semanticAssertion(typeof painted.truncated === "boolean"
+      && Number.isSafeInteger(painted.observed_count) && painted.observed_count >= 0
+      && Number.isSafeInteger(painted.returned_count) && painted.returned_count >= 0
+      && painted.returned_count === painted.items.length
+      && painted.returned_count <= painted.observed_count
+      && painted.returned_count <= MAX_PAINTED_RECTANGLES,
+    `page ${page.page} painted rectangle counts are invalid`);
+    if (painted.status === "available") {
+      semanticAssertion(painted.returned_count === Math.min(painted.observed_count, MAX_PAINTED_RECTANGLES)
+        && painted.truncated === (painted.observed_count > painted.returned_count),
+      `page ${page.page} painted rectangle availability is inconsistent`);
+    } else {
+      semanticAssertion(painted.returned_count === 0 && painted.items.length === 0,
+        `page ${page.page} unavailable painted rectangles leaked items`);
+    }
+    let priorPaintOperation = -1;
+    for (const item of painted.items) {
+      semanticAssertion(Number.isSafeInteger(item.source_operation_index)
+        && item.source_operation_index > priorPaintOperation,
+      `page ${page.page} painted rectangle operation order is invalid`);
+      priorPaintOperation = item.source_operation_index;
+      semanticAssertion(item.id === `${pagePrefix}-r${String(item.source_operation_index + 1).padStart(6, "0")}`
+        && item.source_kind === "solid_color_image_mask"
+        && Array.isArray(item.graphics_transform)
+        && item.graphics_transform.length === 6
+        && item.graphics_transform.every(Number.isFinite),
+      `painted rectangle ${item.id} source identity is invalid`);
+      semanticAssertion(!documentIds.has(item.id), `duplicate ID ${item.id}`);
+      documentIds.add(item.id);
+      const expected = unitRectangleGeometry(
+        page.geometry.viewport_transform,
+        item.graphics_transform,
+      );
+      semanticAssertion(expected !== null
+        && sameJson(item.quad, expected.quad)
+        && sameJson(item.bbox, expected.bbox),
+      `painted rectangle ${item.id} geometry mismatch`);
+    }
+
     const itemById = new Map();
     let returnedCharacters = 0;
     for (let index = 0; index < page.raw_items.length; index += 1) {
@@ -1033,9 +1193,11 @@ export function validatePdfLayoutSemantics(payload, {
     // Degraded link evidence, including a hit 200-link cap, is partial evidence.
     const hasDegradedLinks = page.link_annotations.status !== "available"
       || page.link_annotations.truncated === true;
+    const hasDegradedPaintedRectangles = page.painted_rectangles.status !== "available"
+      || page.painted_rectangles.truncated === true;
     const expectedExtraction = expectedTextLayerStatus === "failed"
       ? "failed"
-      : page.truncation.truncated || hasInvalidGeometry || hasRawGeometryGap || expectedImageStatus === "failed" || expectedModality !== "text-layer-candidate" || hasAnnotationError || hasDegradedLinks
+      : page.truncation.truncated || hasInvalidGeometry || hasRawGeometryGap || expectedImageStatus === "failed" || expectedModality !== "text-layer-candidate" || hasAnnotationError || hasDegradedLinks || hasDegradedPaintedRectangles
         ? "partial" : "complete";
     semanticAssertion(page.extraction_status === expectedExtraction, `page ${page.page} extraction status mismatch`);
     semanticAssertion(page.needs_visual_inspection === (expectedExtraction !== "complete" || expectedModality !== "text-layer-candidate"), `page ${page.page} visual-inspection status mismatch`);
@@ -1048,6 +1210,8 @@ export function validatePdfLayoutSemantics(payload, {
         && page.errors.length === 0
         && page.link_annotations.status === "available"
         && page.link_annotations.truncated === false
+        && page.painted_rectangles.status === "available"
+        && page.painted_rectangles.truncated === false
         && page.raw_items.every(item => item.geometry_valid), `page ${page.page} complete status overclaims evidence`);
     }
     if (page.text_layer_status === "failed") semanticAssertion(page.extraction_status === "failed", `page ${page.page} failed text status mismatch`);
@@ -1087,6 +1251,26 @@ function replayOutputBudgetIndependently(seedPayload, maxOutputCharacters) {
   replay.id_scope.max_output_characters = maxOutputCharacters;
   replay.limits.max_output_characters = maxOutputCharacters;
   if (JSON.stringify(replay).length <= maxOutputCharacters) return replay;
+  for (let index = replay.pages.length - 1; index >= 0 && JSON.stringify(replay).length > maxOutputCharacters; index -= 1) {
+    const page = replay.pages[index];
+    if (page.painted_rectangles.items.length === 0) continue;
+    page.painted_rectangles = {
+      status: "unavailable",
+      truncated: true,
+      observed_count: page.painted_rectangles.observed_count,
+      returned_count: 0,
+      items: [],
+    };
+    page.extraction_status = page.extraction_status === "failed" ? "failed" : "partial";
+    page.needs_visual_inspection = true;
+    if (!page.limitations.includes("Painted rectangle detail was omitted to satisfy max_output_characters.")) {
+      page.limitations.push("Painted rectangle detail was omitted to satisfy max_output_characters.");
+    }
+  }
+  if (JSON.stringify(replay).length <= maxOutputCharacters) {
+    replay.extraction_status = replay.pages.every(page => page.extraction_status === "complete") ? "complete" : "partial";
+    return replay;
+  }
   if (!replay.truncation.reasons.includes("max_output_characters")) replay.truncation.reasons.push("max_output_characters");
   for (let index = replay.pages.length - 1; index >= 0 && JSON.stringify(replay).length > maxOutputCharacters; index -= 1) {
     const page = replay.pages[index];
@@ -1104,6 +1288,13 @@ function replayOutputBudgetIndependently(seedPayload, maxOutputCharacters) {
     page.lines = [];
     page.blocks = [];
     page.link_annotations = { status: "unavailable", truncated: true, items: [] };
+    page.painted_rectangles = {
+      status: "unavailable",
+      truncated: true,
+      observed_count: page.painted_rectangles.observed_count,
+      returned_count: 0,
+      items: [],
+    };
     page.flow_text = "";
     page.spatial_text = "";
     page.reading_order = {
@@ -1304,7 +1495,8 @@ export async function validatePdfLayoutSourceEvidence(payload, {
                 ],
               })
               && outputPage.has_image_operations === null
-              && outputPage.has_vector_paint_operations === null,
+              && outputPage.has_vector_paint_operations === null
+              && sameJson(outputPage.painted_rectangles, unavailablePaintedRectangles()),
             `page ${outputPage.page} ordinary page failure differs from reparsed source`,
           );
           continue;
@@ -1447,9 +1639,28 @@ export async function validatePdfLayoutSourceEvidence(payload, {
         if (sourceOperatorError === null) {
           const sourceHasImageOperations = sourceOperators.fnArray.some(operation => sourceImageOps.has(operation));
           const sourceHasVectorOperations = sourceOperators.fnArray.some(operation => sourceVectorOps.has(operation));
+          const sourcePaintedRectangles = collectPaintedRectangles(
+            sourceOperators,
+            pdfjsLib,
+            sourceViewport?.transform ?? [],
+            outputPage.page,
+          );
+          const paintedOutputOmitted = outputPage.painted_rectangles.status === "unavailable"
+            && outputPage.painted_rectangles.truncated === true
+            && !outputPage.errors.some(error => error.stage === "operators" || error.stage === "page");
+          const expectedPaintedRectangles = (outputOmitted || paintedOutputOmitted)
+            ? {
+              status: "unavailable",
+              truncated: true,
+              observed_count: sourcePaintedRectangles.observed_count,
+              returned_count: 0,
+              items: [],
+            }
+            : sourcePaintedRectangles;
           sourceEvidenceAssertion(
             outputPage.has_image_operations === sourceHasImageOperations
               && outputPage.has_vector_paint_operations === sourceHasVectorOperations
+              && sameJson(outputPage.painted_rectangles, expectedPaintedRectangles)
               && !outputPage.errors.some(error => error.stage === "operators"),
             `page ${outputPage.page} operator evidence differs from reparsed source`,
           );
@@ -1458,6 +1669,7 @@ export async function validatePdfLayoutSourceEvidence(payload, {
           sourceEvidenceAssertion(
             outputPage.has_image_operations === null
               && outputPage.has_vector_paint_operations === null
+              && sameJson(outputPage.painted_rectangles, unavailablePaintedRectangles())
               && outputPage.errors.some(outputError => sameJson(outputError, expectedError)),
             `page ${outputPage.page} source operator parse failed but output claims operator evidence`,
           );
@@ -1481,10 +1693,12 @@ export async function validatePdfLayoutSourceEvidence(payload, {
     sourceEvidenceAssertion(payload.extraction_status === sourceDocumentStatus, "document status differs from source-verified page records");
     if (!enforceOutputBudget) {
       sourceEvidenceAssertion(
-        payload.pages.every(page => !page.truncation.reasons.includes("max_output_characters")),
+        payload.pages.every(page => !page.truncation.reasons.includes("max_output_characters")
+          && !(page.painted_rectangles.status === "unavailable" && page.painted_rectangles.truncated)),
         "internal Markdown evidence contains a public output-budget omission",
       );
-    } else if (payload.pages.some(page => page.truncation.reasons.includes("max_output_characters"))) {
+    } else if (payload.pages.some(page => page.truncation.reasons.includes("max_output_characters")
+      || (page.painted_rectangles.status === "unavailable" && page.painted_rectangles.truncated))) {
       const replaySeed = await extractPdfLayout({
         pdfjsLib,
         pdfBytes: sourceBytes,
@@ -1592,6 +1806,7 @@ export async function extractPdfLayout({
       let textContent = null;
       let hasImageOperations = null;
       let hasVectorPaintOperations = null;
+      let paintedRectangles = unavailablePaintedRectangles();
       let pdfjsPage = null;
       let viewport = null;
       let linkAnnotations = UNAVAILABLE_LINK_ANNOTATIONS;
@@ -1625,6 +1840,12 @@ export async function extractPdfLayout({
           const operators = await withDeadline(pdfjsPage.getOperatorList(), deadlineAt);
           hasImageOperations = operators.fnArray.some(operation => imageOps.has(operation));
           hasVectorPaintOperations = operators.fnArray.some(operation => vectorOps.has(operation));
+          paintedRectangles = collectPaintedRectangles(
+            operators,
+            pdfjsLib,
+            viewport?.transform ?? [],
+            pageNumber,
+          );
         } catch (error) {
           if (isFatalParserResourceError(error)) throw error;
           errors.push(errorRecord("operators", error));
@@ -1774,7 +1995,7 @@ export async function extractPdfLayout({
       const pageTruncated = firstOmittedSourceIndex !== null;
       let extractionStatus = "complete";
       if (textLayerStatus === "failed") extractionStatus = "failed";
-      else if (pageTruncated || invalidGeometry || !pdfLibPages || imageDetectionStatus === "failed" || modalityHint !== "text-layer-candidate" || errors.some(error => error.stage === "annotations") || linkAnnotations.truncated === true) extractionStatus = "partial";
+      else if (pageTruncated || invalidGeometry || !pdfLibPages || imageDetectionStatus === "failed" || modalityHint !== "text-layer-candidate" || errors.some(error => error.stage === "annotations") || linkAnnotations.truncated === true || paintedRectangles.status !== "available" || paintedRectangles.truncated === true) extractionStatus = "partial";
       const needsVisualInspection = extractionStatus !== "complete" || modalityHint !== "text-layer-candidate";
       if (hasImageOperations) limitations.push("Image paint operations were detected, but no image was rendered or OCRed; this is not raster-content proof.");
       if (hasVectorPaintOperations) limitations.push("Vector paint operations were detected but not interpreted.");
@@ -1795,6 +2016,7 @@ export async function extractPdfLayout({
         geometry,
         has_image_operations: hasImageOperations,
         has_vector_paint_operations: hasVectorPaintOperations,
+        painted_rectangles: paintedRectangles,
         link_annotations: linkAnnotations,
         raw_items: rawItems,
         lines: ordered.lines,

--- a/server/layout-extraction.js
+++ b/server/layout-extraction.js
@@ -621,7 +621,7 @@ function collectPaintedRectangles(operators, pdfjsLib, viewportTransform, pageNu
         id: `p${String(pageNumber).padStart(4, "0")}-r${String(operationIndex + 1).padStart(6, "0")}`,
         source_operation_index: operationIndex,
         source_kind: "solid_color_image_mask",
-        graphics_transform: current.map(round),
+        graphics_transform: [...current],
         quad: geometry.quad,
         bbox: geometry.bbox,
       });

--- a/server/markdown-conversion.js
+++ b/server/markdown-conversion.js
@@ -26,6 +26,9 @@ const RULE_MAX_THICKNESS = 1.5;
 const RULE_AXIS_TOLERANCE = 1;
 const RULE_JOIN_TOLERANCE = 1;
 const RULE_EDGE_TOLERANCE = 1.5;
+const RULED_TABLE_MAX_ROWS = 100;
+const RULED_TABLE_MAX_COLUMNS = 50;
+const RULED_TABLE_MAX_CELLS = 1_000;
 
 const MAX_MARKDOWN_BYTES_LIMIT = 200_000;
 const GAP_CODES = new Set([
@@ -52,7 +55,7 @@ const LIMITATIONS = Object.freeze([
   "A missing space after a separate source text item that is exactly the mathematical operator log is restored only in a short, compact left-to-right math run when a single-letter variable from a different embedded-font resource follows on the same baseline with a small positive geometric gap and independent local math-layout evidence. General equations, scripts, fraction bars, and damaged mathematical glyphs remain source reading-order text rather than being guessed.",
   "Lists are emitted only for literal bullet glyphs or decimal markers present in the source text.",
   "Links are emitted only for source-validated http or https annotation targets that map to exactly one contiguous run of text on one line. Internal destinations, actions, other schemes, ambiguous or partially covered labels, and links inside reconstructed tables remain escaped text reported as a conversion gap, and URL-looking source text is escaped to resist host autolinking.",
-  "Tables are reconstructed only from either complete text-item column geometry or a complete closed grid of bounded axis-aligned solid-mask rectangles. Ruled grids require every text item to fit exactly one cell, no merged or spanning topology, and independent caption and header evidence because Markdown imposes header semantics. Stroked paths, incomplete grids, cell artwork, and damaged mathematical glyphs are not interpreted; ambiguous content remains escaped reading-order text with a conversion gap.",
+  "Tables are reconstructed only from either complete text-item column geometry or one unambiguous complete closed grid of bounded axis-aligned solid-mask rectangles. Ruled grids require every text item to fit exactly one cell, reject aligned partial dividers that evidence merged or spanning topology, and require independent caption and header evidence because Markdown imposes header semantics. Unsupported text remains escaped reading-order text with a conversion gap. Stroked paths are omitted and reported as vector-content gaps. Cell artwork is omitted and reported as a vector-content gap; damaged mathematical glyphs are not repaired.",
   "OCR is not performed. Image-only text and text that exists only inside page images are omitted and reported as conversion gaps.",
   "Unsafe control characters and malformed UTF-16 surrogates are replaced with the Unicode replacement character and reported as conversion gaps.",
 ]);
@@ -763,10 +766,36 @@ function uniqueCoordinates(values) {
   return unique;
 }
 
+function alignedCoordinateIndex(values, candidate) {
+  return values.findIndex(value => Math.abs(value - candidate) <= RULE_EDGE_TOLERANCE);
+}
+
+function hasAlignedPartialRule(horizontal, vertical, xs, ys) {
+  const lastX = xs.length - 1;
+  const lastY = ys.length - 1;
+  for (const rule of vertical) {
+    if (rule.axis < xs[0] - RULE_EDGE_TOLERANCE || rule.axis > xs[lastX] + RULE_EDGE_TOLERANCE) continue;
+    const xIndex = alignedCoordinateIndex(xs, rule.axis);
+    const startIndex = alignedCoordinateIndex(ys, rule.start);
+    const endIndex = alignedCoordinateIndex(ys, rule.end);
+    if (startIndex < 0 || endIndex <= startIndex) continue;
+    if (!(xIndex >= 0 && startIndex === 0 && endIndex === lastY)) return true;
+  }
+  for (const rule of horizontal) {
+    if (rule.axis < ys[0] - RULE_EDGE_TOLERANCE || rule.axis > ys[lastY] + RULE_EDGE_TOLERANCE) continue;
+    const yIndex = alignedCoordinateIndex(ys, rule.axis);
+    const startIndex = alignedCoordinateIndex(xs, rule.start);
+    const endIndex = alignedCoordinateIndex(xs, rule.end);
+    if (startIndex < 0 || endIndex <= startIndex) continue;
+    if (!(yIndex >= 0 && startIndex === 0 && endIndex === lastX)) return true;
+  }
+  return false;
+}
+
 function closedRuleGrid(page) {
   const evidence = page.painted_rectangles;
   if (!evidence || evidence.status !== "available" || evidence.truncated || evidence.items.length === 0) {
-    return null;
+    return { boundaries: null, tableReason: null };
   }
   const horizontal = mergeRuleSegments(evidence.items, "horizontal")
     .filter(rule => rule.end - rule.start >= 100);
@@ -788,7 +817,11 @@ function closedRuleGrid(page) {
       || Math.abs(xs[0] - seed.start) > RULE_EDGE_TOLERANCE
       || Math.abs(xs[xs.length - 1] - seed.end) > RULE_EDGE_TOLERANCE
       || xs.some((value, index) => index > 0 && value - xs[index - 1] < 12)) continue;
-    candidates.push({ xs, ys });
+    candidates.push({
+      xs,
+      ys,
+      hasPartialRule: hasAlignedPartialRule(horizontal, vertical, xs, ys),
+    });
   }
   const distinct = [];
   for (const candidate of candidates) {
@@ -798,7 +831,11 @@ function closedRuleGrid(page) {
     });
     if (!distinct.some(value => value.key === key)) distinct.push({ key, ...candidate });
   }
-  return distinct.length === 1 ? distinct[0] : null;
+  if (distinct.length === 1 && !distinct[0].hasPartialRule) {
+    return { boundaries: distinct[0], tableReason: null };
+  }
+  const gridLikeEvidence = horizontal.length >= 3 && vertical.length >= 2;
+  return { boundaries: null, tableReason: distinct.length > 0 || gridLikeEvidence ? "topology" : null };
 }
 
 function itemCell(item, xs, ys) {
@@ -816,39 +853,18 @@ function itemCell(item, xs, ys) {
   return { row, column };
 }
 
-function fragmentsForCell(page, itemIds) {
-  const wanted = new Set(itemIds);
-  return page.lines
-    .map(line => ({
-      line,
-      allItems: line.item_ids
-        .map(id => page.raw_items.find(item => item.id === id))
-        .filter(Boolean),
-    }))
-    .map(value => ({
-      ...value,
-      indexes: value.line.item_ids
-        .map((id, index) => (wanted.has(id) ? index : -1))
-        .filter(index => index !== -1),
-    }))
-    .filter(value => value.indexes.length > 0)
-    .sort((left, right) => left.line.y - right.line.y || left.line.x - right.line.x)
-    .map(({ line, allItems, indexes }) => {
-      const offsets = itemOffsets(line, allItems);
-      if (offsets === null) return indexes.map(index => allItems[index].text).join(" ").trim();
-      const start = offsets[Math.min(...indexes)].start;
-      const end = offsets[Math.max(...indexes)].end;
-      return line.text.slice(start, end).trim();
-    })
-    .filter(Boolean);
-}
-
 function ruledGridSegment(page) {
-  const boundaries = closedRuleGrid(page);
-  if (!boundaries) return { segment: null, tableReason: null };
+  const detected = closedRuleGrid(page);
+  const boundaries = detected.boundaries;
+  if (!boundaries) return { segment: null, tableReason: detected.tableReason };
   const { xs, ys } = boundaries;
   const rowCount = ys.length - 1;
   const columnCount = xs.length - 1;
+  if (rowCount > RULED_TABLE_MAX_ROWS
+    || columnCount > RULED_TABLE_MAX_COLUMNS
+    || rowCount * columnCount > RULED_TABLE_MAX_CELLS) {
+    return { segment: null, tableReason: "topology" };
+  }
   const rowHeights = ys.slice(1).map((value, index) => value - ys[index]);
   const bodyMedian = median(rowHeights.slice(1));
   if (rowCount < 3 || columnCount < 2 || !(rowHeights[0] <= bodyMedian * 0.6)) {
@@ -870,6 +886,8 @@ function ruledGridSegment(page) {
     Array.from({ length: columnCount }, () => [])
   ));
   const covered = new Set();
+  const itemLocations = new Map();
+  const itemById = new Map(page.raw_items.map(item => [item.id, item]));
   const gridBox = { left: xs[0], right: xs[xs.length - 1], top: ys[0], bottom: ys[ys.length - 1] };
   for (const item of page.raw_items) {
     if (!item.geometry_valid || !item.bbox || item.text_kind !== "non_whitespace") continue;
@@ -880,24 +898,60 @@ function ruledGridSegment(page) {
     if (!location) return { segment: null, tableReason: "topology" };
     cells[location.row][location.column].push(item.id);
     covered.add(item.id);
+    itemLocations.set(item.id, location);
   }
   if (cells.some(row => row.some(cell => cell.length === 0))) {
     return { segment: null, tableReason: "topology" };
   }
-  const rows = page.lines
-    .map((line, index) => ({
-      index,
-      line,
-      cells: line.item_ids.map(id => page.raw_items.find(item => item.id === id)).filter(Boolean),
-      covered: line.item_ids.filter(id => covered.has(id)).length,
-    }));
-  if (rows.some(row => row.covered > 0 && row.covered !== row.line.item_ids.length)) {
+  const grid = Array.from({ length: rowCount }, () => (
+    Array.from({ length: columnCount }, () => [])
+  ));
+  const coveredRows = [];
+  for (let lineIndex = 0; lineIndex < page.lines.length; lineIndex += 1) {
+    const line = page.lines[lineIndex];
+    const allItems = line.item_ids.map(id => itemById.get(id)).filter(Boolean);
+    const coveredCount = line.item_ids.filter(id => covered.has(id)).length;
+    if (coveredCount === 0) continue;
+    if (coveredCount !== line.item_ids.length || allItems.length !== line.item_ids.length) {
+      return { segment: null, tableReason: "topology" };
+    }
+    const locations = line.item_ids.map(id => itemLocations.get(id));
+    const tableRow = locations[0]?.row;
+    if (!Number.isInteger(tableRow) || locations.some(location => location?.row !== tableRow)) {
+      return { segment: null, tableReason: "topology" };
+    }
+    const groups = [];
+    let previousColumn = -1;
+    for (let itemIndex = 0; itemIndex < locations.length; itemIndex += 1) {
+      const column = locations[itemIndex].column;
+      if (column < previousColumn) return { segment: null, tableReason: "topology" };
+      if (column !== previousColumn) groups.push({ column, start: itemIndex, end: itemIndex });
+      else groups.at(-1).end = itemIndex;
+      previousColumn = column;
+    }
+    const offsets = itemOffsets(line, allItems);
+    for (const group of groups) {
+      const fragment = offsets === null
+        ? allItems.slice(group.start, group.end + 1).map(item => item.text).join(" ").trim()
+        : line.text.slice(offsets[group.start].start, offsets[group.end].end).trim();
+      if (!fragment) return { segment: null, tableReason: "topology" };
+      grid[tableRow][group.column].push({
+        text: fragment,
+        y: line.y,
+        x: line.x,
+        lineIndex,
+      });
+    }
+    coveredRows.push({ index: lineIndex, line, cells: allItems });
+  }
+  if (coveredRows.length === 0) return { segment: null, tableReason: "topology" };
+  if (grid.some(row => row.some(fragments => fragments.length === 0))) {
     return { segment: null, tableReason: "topology" };
   }
-  const coveredRows = rows.filter(row => row.covered > 0);
-  if (coveredRows.length === 0) return { segment: null, tableReason: "topology" };
-  const grid = cells.map(row => row.map(itemIds => fragmentsForCell(page, itemIds)));
-  const header = grid[0];
+  const orderedGrid = grid.map(row => row.map(fragments => fragments
+    .sort((left, right) => left.y - right.y || left.x - right.x || left.lineIndex - right.lineIndex)
+    .map(fragment => fragment.text)));
+  const header = orderedGrid[0];
   if (header.some(fragments => {
     const text = fragments.join(" ").trim();
     const letters = text.match(/\p{L}/gu)?.length ?? 0;
@@ -909,7 +963,7 @@ function ruledGridSegment(page) {
     segment: {
       kind: "table",
       rows: coveredRows.map(({ line, cells: rowCells }) => ({ line, cells: rowCells })),
-      grid,
+      grid: orderedGrid,
       coveredLineIds: new Set(coveredRows.map(row => row.line.id)),
       insertionIndex: page.lines.findIndex(line => line.id === captionCandidates[0].id) + 1,
     },

--- a/server/markdown-conversion.js
+++ b/server/markdown-conversion.js
@@ -6,7 +6,7 @@ import {
 
 const RENDERER = Object.freeze({
   name: "pdf-tools.layout-markdown-renderer",
-  version: "1.6.0",
+  version: "1.7.0",
 });
 
 // Bounded geometric table inference. A run of adjacent lines is treated as a
@@ -22,6 +22,10 @@ const TABLE_MIN_COLUMN_ROWS = 2;
 const TABLE_COLUMNAR_COVERAGE = 0.8;
 // How much taller the first row must be to evidence a header row.
 const HEADER_HEIGHT_RATIO = 1.15;
+const RULE_MAX_THICKNESS = 1.5;
+const RULE_AXIS_TOLERANCE = 1;
+const RULE_JOIN_TOLERANCE = 1;
+const RULE_EDGE_TOLERANCE = 1.5;
 
 const MAX_MARKDOWN_BYTES_LIMIT = 200_000;
 const GAP_CODES = new Set([
@@ -48,7 +52,7 @@ const LIMITATIONS = Object.freeze([
   "A missing space after a separate source text item that is exactly the mathematical operator log is restored only in a short, compact left-to-right math run when a single-letter variable from a different embedded-font resource follows on the same baseline with a small positive geometric gap and independent local math-layout evidence. General equations, scripts, fraction bars, and damaged mathematical glyphs remain source reading-order text rather than being guessed.",
   "Lists are emitted only for literal bullet glyphs or decimal markers present in the source text.",
   "Links are emitted only for source-validated http or https annotation targets that map to exactly one contiguous run of text on one line. Internal destinations, actions, other schemes, ambiguous or partially covered labels, and links inside reconstructed tables remain escaped text reported as a conversion gap, and URL-looking source text is escaped to resist host autolinking.",
-  "Tables are reconstructed only from text-item column geometry, and only when every row fills every detected column and the first row is typographically distinct enough to evidence a header, because a Markdown table imposes header semantics. Ruling lines and merged or spanning cells are not interpreted, and table-like content that fails either test remains escaped reading-order text reported as a conversion gap.",
+  "Tables are reconstructed only from either complete text-item column geometry or a complete closed grid of bounded axis-aligned solid-mask rectangles. Ruled grids require every text item to fit exactly one cell, no merged or spanning topology, and independent caption and header evidence because Markdown imposes header semantics. Stroked paths, incomplete grids, cell artwork, and damaged mathematical glyphs are not interpreted; ambiguous content remains escaped reading-order text with a conversion gap.",
   "OCR is not performed. Image-only text and text that exists only inside page images are omitted and reported as conversion gaps.",
   "Unsafe control characters and malformed UTF-16 surrogates are replaced with the Unicode replacement character and reported as conversion gaps.",
 ]);
@@ -708,15 +712,212 @@ function assignRowToColumns(row, anchors) {
   return anchors.map((_anchor, index) => assigned.get(index));
 }
 
-/**
- * Partition a page's lines into reading-order segments. Each segment is either
- * a confidently reconstructed table or a run of ordinary lines. Table-like runs
- * that cannot be reconstructed are returned as text with tableReason set, so
- * the caller can report typed partial coverage instead of silently flattening.
- */
-function segmentPageLines(page) {
-  const itemById = new Map(page.raw_items.map(item => [item.id, item]));
-  const rows = page.lines.map(line => ({ line, cells: lineCells(line, itemById) }));
+function mergeRuleSegments(rectangles, orientation) {
+  const horizontal = orientation === "horizontal";
+  const candidates = rectangles
+    .map(item => item.bbox)
+    .filter(rect => horizontal
+      ? rect.height <= RULE_MAX_THICKNESS && rect.width >= 20
+      : rect.width <= RULE_MAX_THICKNESS && rect.height >= 8)
+    .map(rect => ({
+      axis: horizontal ? rect.y + rect.height / 2 : rect.x + rect.width / 2,
+      start: horizontal ? rect.x : rect.y,
+      end: horizontal ? rect.x + rect.width : rect.y + rect.height,
+    }))
+    .sort((left, right) => left.axis - right.axis || left.start - right.start);
+  const axisGroups = [];
+  for (const candidate of candidates) {
+    const group = axisGroups.find(value => Math.abs(value.axis - candidate.axis) <= RULE_AXIS_TOLERANCE);
+    if (group) {
+      group.values.push(candidate);
+      group.axis = median(group.values.map(value => value.axis));
+    } else {
+      axisGroups.push({ axis: candidate.axis, values: [candidate] });
+    }
+  }
+  const merged = [];
+  for (const group of axisGroups) {
+    const spans = group.values.sort((left, right) => left.start - right.start);
+    for (const span of spans) {
+      const prior = merged[merged.length - 1];
+      if (prior && Math.abs(prior.axis - group.axis) <= RULE_AXIS_TOLERANCE
+        && span.start <= prior.end + RULE_JOIN_TOLERANCE) {
+        prior.end = Math.max(prior.end, span.end);
+      } else {
+        merged.push({ axis: group.axis, start: span.start, end: span.end });
+      }
+    }
+  }
+  return merged;
+}
+
+function uniqueCoordinates(values) {
+  const unique = [];
+  for (const value of [...values].sort((left, right) => left - right)) {
+    if (unique.length === 0 || Math.abs(unique[unique.length - 1] - value) > RULE_AXIS_TOLERANCE) {
+      unique.push(value);
+    } else {
+      unique[unique.length - 1] = (unique[unique.length - 1] + value) / 2;
+    }
+  }
+  return unique;
+}
+
+function closedRuleGrid(page) {
+  const evidence = page.painted_rectangles;
+  if (!evidence || evidence.status !== "available" || evidence.truncated || evidence.items.length === 0) {
+    return null;
+  }
+  const horizontal = mergeRuleSegments(evidence.items, "horizontal")
+    .filter(rule => rule.end - rule.start >= 100);
+  const vertical = mergeRuleSegments(evidence.items, "vertical");
+  const candidates = [];
+  for (const seed of horizontal) {
+    const peers = horizontal.filter(rule => Math.abs(rule.start - seed.start) <= RULE_EDGE_TOLERANCE
+      && Math.abs(rule.end - seed.end) <= RULE_EDGE_TOLERANCE);
+    const ys = uniqueCoordinates(peers.map(rule => rule.axis));
+    if (ys.length < 3 || ys.some((value, index) => index > 0 && value - ys[index - 1] < 8)) continue;
+    const top = ys[0];
+    const bottom = ys[ys.length - 1];
+    const spanning = vertical.filter(rule => rule.start <= top + RULE_EDGE_TOLERANCE
+      && rule.end >= bottom - RULE_EDGE_TOLERANCE
+      && rule.axis >= seed.start - RULE_EDGE_TOLERANCE
+      && rule.axis <= seed.end + RULE_EDGE_TOLERANCE);
+    const xs = uniqueCoordinates(spanning.map(rule => rule.axis));
+    if (xs.length < 3
+      || Math.abs(xs[0] - seed.start) > RULE_EDGE_TOLERANCE
+      || Math.abs(xs[xs.length - 1] - seed.end) > RULE_EDGE_TOLERANCE
+      || xs.some((value, index) => index > 0 && value - xs[index - 1] < 12)) continue;
+    candidates.push({ xs, ys });
+  }
+  const distinct = [];
+  for (const candidate of candidates) {
+    const key = JSON.stringify({
+      xs: candidate.xs.map(value => Number(value.toFixed(1))),
+      ys: candidate.ys.map(value => Number(value.toFixed(1))),
+    });
+    if (!distinct.some(value => value.key === key)) distinct.push({ key, ...candidate });
+  }
+  return distinct.length === 1 ? distinct[0] : null;
+}
+
+function itemCell(item, xs, ys) {
+  if (!item.geometry_valid || !item.bbox || item.text_kind !== "non_whitespace") return null;
+  const centerX = item.bbox.x + item.bbox.width / 2;
+  const centerY = item.bbox.y + item.bbox.height / 2;
+  const column = xs.findIndex((right, index) => index > 0 && centerX < right) - 1;
+  const row = ys.findIndex((bottom, index) => index > 0 && centerY < bottom) - 1;
+  if (column < 0 || row < 0) return null;
+  const tolerance = 0.75;
+  if (item.bbox.x < xs[column] - tolerance
+    || item.bbox.x + item.bbox.width > xs[column + 1] + tolerance
+    || item.bbox.y < ys[row] - tolerance
+    || item.bbox.y + item.bbox.height > ys[row + 1] + tolerance) return null;
+  return { row, column };
+}
+
+function fragmentsForCell(page, itemIds) {
+  const wanted = new Set(itemIds);
+  return page.lines
+    .map(line => ({
+      line,
+      allItems: line.item_ids
+        .map(id => page.raw_items.find(item => item.id === id))
+        .filter(Boolean),
+    }))
+    .map(value => ({
+      ...value,
+      indexes: value.line.item_ids
+        .map((id, index) => (wanted.has(id) ? index : -1))
+        .filter(index => index !== -1),
+    }))
+    .filter(value => value.indexes.length > 0)
+    .sort((left, right) => left.line.y - right.line.y || left.line.x - right.line.x)
+    .map(({ line, allItems, indexes }) => {
+      const offsets = itemOffsets(line, allItems);
+      if (offsets === null) return indexes.map(index => allItems[index].text).join(" ").trim();
+      const start = offsets[Math.min(...indexes)].start;
+      const end = offsets[Math.max(...indexes)].end;
+      return line.text.slice(start, end).trim();
+    })
+    .filter(Boolean);
+}
+
+function ruledGridSegment(page) {
+  const boundaries = closedRuleGrid(page);
+  if (!boundaries) return { segment: null, tableReason: null };
+  const { xs, ys } = boundaries;
+  const rowCount = ys.length - 1;
+  const columnCount = xs.length - 1;
+  const rowHeights = ys.slice(1).map((value, index) => value - ys[index]);
+  const bodyMedian = median(rowHeights.slice(1));
+  if (rowCount < 3 || columnCount < 2 || !(rowHeights[0] <= bodyMedian * 0.6)) {
+    return { segment: null, tableReason: "topology" };
+  }
+  const captionCandidates = page.lines.filter(line => {
+    const text = line.text.trim();
+    const bottom = line.y + line.height;
+    const center = line.x + line.width / 2;
+    return /^TABLE\s+(?:\d+|[IVXLCDM]+)$/iu.test(text)
+      && bottom <= ys[0]
+      && ys[0] - bottom <= 30
+      && center >= xs[0]
+      && center <= xs[xs.length - 1];
+  });
+  if (captionCandidates.length !== 1) return { segment: null, tableReason: "header" };
+
+  const cells = Array.from({ length: rowCount }, () => (
+    Array.from({ length: columnCount }, () => [])
+  ));
+  const covered = new Set();
+  const gridBox = { left: xs[0], right: xs[xs.length - 1], top: ys[0], bottom: ys[ys.length - 1] };
+  for (const item of page.raw_items) {
+    if (!item.geometry_valid || !item.bbox || item.text_kind !== "non_whitespace") continue;
+    const overlaps = item.bbox.x < gridBox.right && item.bbox.x + item.bbox.width > gridBox.left
+      && item.bbox.y < gridBox.bottom && item.bbox.y + item.bbox.height > gridBox.top;
+    if (!overlaps) continue;
+    const location = itemCell(item, xs, ys);
+    if (!location) return { segment: null, tableReason: "topology" };
+    cells[location.row][location.column].push(item.id);
+    covered.add(item.id);
+  }
+  if (cells.some(row => row.some(cell => cell.length === 0))) {
+    return { segment: null, tableReason: "topology" };
+  }
+  const rows = page.lines
+    .map((line, index) => ({
+      index,
+      line,
+      cells: line.item_ids.map(id => page.raw_items.find(item => item.id === id)).filter(Boolean),
+      covered: line.item_ids.filter(id => covered.has(id)).length,
+    }));
+  if (rows.some(row => row.covered > 0 && row.covered !== row.line.item_ids.length)) {
+    return { segment: null, tableReason: "topology" };
+  }
+  const coveredRows = rows.filter(row => row.covered > 0);
+  if (coveredRows.length === 0) return { segment: null, tableReason: "topology" };
+  const grid = cells.map(row => row.map(itemIds => fragmentsForCell(page, itemIds)));
+  const header = grid[0];
+  if (header.some(fragments => {
+    const text = fragments.join(" ").trim();
+    const letters = text.match(/\p{L}/gu)?.length ?? 0;
+    const visible = text.match(/[\p{L}\p{N}]/gu)?.length ?? 0;
+    return text.length === 0 || text.length > 80 || visible === 0
+      || letters / visible < 0.8 || text !== text.toLocaleUpperCase("en-US");
+  })) return { segment: null, tableReason: "header" };
+  return {
+    segment: {
+      kind: "table",
+      rows: coveredRows.map(({ line, cells: rowCells }) => ({ line, cells: rowCells })),
+      grid,
+      coveredLineIds: new Set(coveredRows.map(row => row.line.id)),
+      insertionIndex: page.lines.findIndex(line => line.id === captionCandidates[0].id) + 1,
+    },
+    tableReason: null,
+  };
+}
+
+function segmentTextRows(rows) {
   const segments = [];
   let tableReason = null;
   let index = 0;
@@ -734,12 +935,7 @@ function segmentPageLines(page) {
     if (grid && grid.every(Boolean) && hasHeaderEvidence(run)) {
       segments.push({ kind: "table", rows: run, grid });
     } else {
-      // Only report a topology gap for runs that actually look columnar.
-      // Ordinary prose that happens to share a left margin must not be
-      // reported as an unreconstructed table.
-      if (tableLike) {
-        tableReason = grid && grid.every(Boolean) ? "header" : "topology";
-      }
+      if (tableLike) tableReason = grid && grid.every(Boolean) ? "header" : "topology";
       segments.push({ kind: "text", rows: run });
     }
     index = end;
@@ -747,11 +943,37 @@ function segmentPageLines(page) {
   return { segments, tableReason };
 }
 
+/**
+ * Partition a page's lines into reading-order segments. Each segment is either
+ * a confidently reconstructed table or a run of ordinary lines. Table-like runs
+ * that cannot be reconstructed are returned as text with tableReason set, so
+ * the caller can report typed partial coverage instead of silently flattening.
+ */
+function segmentPageLines(page) {
+  const itemById = new Map(page.raw_items.map(item => [item.id, item]));
+  const rows = page.lines.map(line => ({ line, cells: lineCells(line, itemById) }));
+  const ruled = ruledGridSegment(page);
+  if (!ruled.segment) {
+    const text = segmentTextRows(rows);
+    return { segments: text.segments, tableReason: ruled.tableReason ?? text.tableReason };
+  }
+  const remaining = rows.map((row, index) => ({ ...row, sourceIndex: index }))
+    .filter(row => !ruled.segment.coveredLineIds.has(row.line.id));
+  const before = segmentTextRows(remaining.filter(row => row.sourceIndex < ruled.segment.insertionIndex));
+  const after = segmentTextRows(remaining.filter(row => row.sourceIndex >= ruled.segment.insertionIndex));
+  return {
+    segments: [...before.segments, ruled.segment, ...after.segments],
+    tableReason: before.tableReason ?? after.tableReason,
+  };
+}
+
 // escapePlainMarkdown already escapes "|" (and backslashes before it), so a
 // second pass here would emit "\\|", which is an escaped backslash followed by
 // a live cell delimiter. Reuse the single existing escape.
 function escapeTableCell(value) {
-  return escapePlainMarkdown(value);
+  return Array.isArray(value)
+    ? value.map(fragment => escapePlainMarkdown(fragment)).join("<br>")
+    : escapePlainMarkdown(value);
 }
 
 function renderTable(grid) {
@@ -840,7 +1062,7 @@ function pageGaps(page, analysis, linkState) {
     add("IMAGE_CONTENT_NOT_RENDERED", "Image content was not rendered into Markdown.");
   }
   if (page.has_vector_paint_operations) {
-    add("VECTOR_CONTENT_NOT_INTERPRETED", "Vector-painted content was not interpreted as text or table structure.");
+    add("VECTOR_CONTENT_NOT_INTERPRETED", "Vector-painted content beyond bounded solid-mask grid evidence was not interpreted as text or table structure.");
   }
   if (page.errors.some(error => error.code === "RAW_PAGE_GEOMETRY_UNAVAILABLE")) {
     add("RAW_PAGE_GEOMETRY_UNAVAILABLE", "Raw MediaBox, CropBox, or rotation evidence was unavailable.");
@@ -1080,8 +1302,8 @@ export function validateMarkdownConversionSemantics(result, { layout = null } = 
  * Render an already source-validated PDF Tools layout IR to deterministic
  * Markdown. This function rechecks IR semantics but deliberately performs no
  * I/O, PDF parsing, rendering, OCR, or annotation lookup. Table reconstruction
- * is bounded to the layout IR's own text-item column geometry; it reads no
- * ruling lines and infers no merged or spanning cells.
+ * is bounded to the layout IR's text geometry and complete axis-aligned
+ * solid-mask grids; it interprets no stroked paths, merged cells, or cell art.
  */
 export function renderPdfLayoutToMarkdown(layout, {
   includePageBoundaries = true,

--- a/server/output-schemas.js
+++ b/server/output-schemas.js
@@ -317,6 +317,20 @@ const layoutError = object({
   message: string,
 });
 const layoutPoint = object({ x: number, y: number });
+const layoutPaintedRectangles = object({
+  status: enumString(["available", "unavailable"]),
+  truncated: boolean,
+  observed_count: integer,
+  returned_count: integer,
+  items: arrayOf(object({
+    id: string,
+    source_operation_index: integer,
+    source_kind: { const: "solid_color_image_mask" },
+    graphics_transform: { type: "array", minItems: 6, maxItems: 6, items: number },
+    quad: { type: "array", minItems: 4, maxItems: 4, items: layoutPoint },
+    bbox: layoutBox,
+  })),
+});
 const layoutRawItem = object({
   id: string,
   source_index: integer,
@@ -425,6 +439,7 @@ const layoutPage = object({
   geometry: layoutGeometry,
   has_image_operations: nullable(boolean),
   has_vector_paint_operations: nullable(boolean),
+  painted_rectangles: layoutPaintedRectangles,
   link_annotations: object({
     status: enumString(["available", "unavailable"]),
     truncated: boolean,
@@ -512,7 +527,7 @@ export const TOOL_SUCCESS_OUTPUT_SCHEMAS = Object.freeze({
     truncated: boolean,
   }),
   read_pdf_layout: object({
-    ir: object({ name: { const: "pdf-tools.extraction-ir" }, version: { const: "1.1.0" } }),
+    ir: object({ name: { const: "pdf-tools.extraction-ir" }, version: { const: "1.2.0" } }),
     parser: object({ name: { const: "pdfjs-dist" }, version: { const: "5.4.624" } }),
     source: object({
       pdf_path: string,
@@ -524,7 +539,7 @@ export const TOOL_SUCCESS_OUTPUT_SCHEMAS = Object.freeze({
       kind: { const: "source_parser_ir_options" },
       source_sha256: { type: "string", pattern: "^[a-f0-9]{64}$" },
       parser_version: { const: "5.4.624" },
-      ir_version: { const: "1.1.0" },
+      ir_version: { const: "1.2.0" },
       requested_start_page: integer,
       requested_end_page: integer,
       max_items: integer,
@@ -552,7 +567,7 @@ export const TOOL_SUCCESS_OUTPUT_SCHEMAS = Object.freeze({
   convert_pdf_to_markdown: object({
     renderer: object({
       name: { const: "pdf-tools.layout-markdown-renderer" },
-      version: { const: "1.6.0" },
+      version: { const: "1.7.0" },
     }),
     conversion_status: enumString(["complete", "partial", "failed"]),
     markdown: string,
@@ -571,7 +586,7 @@ export const TOOL_SUCCESS_OUTPUT_SCHEMAS = Object.freeze({
       }),
       layout: object({
         name: { const: "pdf-tools.extraction-ir" },
-        version: { const: "1.1.0" },
+        version: { const: "1.2.0" },
         parser_name: { const: "pdfjs-dist" },
         parser_version: { const: "5.4.624" },
         page_range: object({

--- a/test/convert-pdf-to-markdown.test.js
+++ b/test/convert-pdf-to-markdown.test.js
@@ -305,11 +305,11 @@ describe("convert_pdf_to_markdown MCP tool", () => {
     expect(first.isError).not.toBe(true);
     expect(second.structuredContent).toEqual(first.structuredContent);
     expect(first.structuredContent).toMatchObject({
-      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.6.0" },
+      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.7.0" },
       conversion_status: "complete",
       saved_output: null,
       provenance: {
-        layout: { name: "pdf-tools.extraction-ir", version: "1.1.0", parser_version: "5.4.624" },
+        layout: { name: "pdf-tools.extraction-ir", version: "1.2.0", parser_version: "5.4.624" },
       },
     });
     const { markdown } = first.structuredContent;
@@ -542,7 +542,7 @@ describe("convert_pdf_to_markdown MCP tool", () => {
       const codes = result.structuredContent.gaps.map(gap => gap.code);
       expect(codes, pdfPath).toEqual(expect.arrayContaining(expectedCodes));
       expect(result.structuredContent.limitations.join("\n")).toMatch(/OCR is not performed/);
-      expect(result.structuredContent.limitations.join("\n")).toMatch(/Ruling lines and merged or spanning cells are not interpreted/);
+      expect(result.structuredContent.limitations.join("\n")).toMatch(/Stroked paths, incomplete grids, cell artwork/);
     }
 
     const table = await client.callTool({
@@ -550,7 +550,7 @@ describe("convert_pdf_to_markdown MCP tool", () => {
       arguments: { pdf_path: TABLE, max_markdown_bytes: 100000 },
     });
     expect(table.isError).not.toBe(true);
-    expect(table.structuredContent.limitations.join("\n")).toMatch(/Ruling lines and merged or spanning cells are not interpreted/);
+    expect(table.structuredContent.limitations.join("\n")).toMatch(/Stroked paths, incomplete grids, cell artwork/);
     // This fixture has a merged/blank cell, so no row fills every detected
     // column. It must degrade to reading-order text and report typed partial
     // coverage rather than inventing a topology.

--- a/test/convert-pdf-to-markdown.test.js
+++ b/test/convert-pdf-to-markdown.test.js
@@ -542,7 +542,7 @@ describe("convert_pdf_to_markdown MCP tool", () => {
       const codes = result.structuredContent.gaps.map(gap => gap.code);
       expect(codes, pdfPath).toEqual(expect.arrayContaining(expectedCodes));
       expect(result.structuredContent.limitations.join("\n")).toMatch(/OCR is not performed/);
-      expect(result.structuredContent.limitations.join("\n")).toMatch(/Stroked paths, incomplete grids, cell artwork/);
+      expect(result.structuredContent.limitations.join("\n")).toMatch(/Cell artwork is omitted and reported as a vector-content gap/);
     }
 
     const table = await client.callTool({
@@ -550,7 +550,7 @@ describe("convert_pdf_to_markdown MCP tool", () => {
       arguments: { pdf_path: TABLE, max_markdown_bytes: 100000 },
     });
     expect(table.isError).not.toBe(true);
-    expect(table.structuredContent.limitations.join("\n")).toMatch(/Stroked paths, incomplete grids, cell artwork/);
+    expect(table.structuredContent.limitations.join("\n")).toMatch(/Cell artwork is omitted and reported as a vector-content gap/);
     // This fixture has a merged/blank cell, so no row fills every detected
     // column. It must degrade to reading-order text and report typed partial
     // coverage rather than inventing a topology.

--- a/test/eval/markdown-bakeoff.test.js
+++ b/test/eval/markdown-bakeoff.test.js
@@ -64,7 +64,7 @@ async function handle(message) {
     const pageBoundaries = Array.from({ length: pageCount }, (_, index) => "<!-- PDF page " + (index + 1) + " -->");
     const markdown = pageBoundaries.join("\n\n") + "\n\nINV-1001 fixture evidence\n";
     const value = {
-      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.6.0" },
+      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.7.0" },
       conversion_status: "complete",
       markdown,
       markdown_sha256: digest(Buffer.from(markdown)),
@@ -143,7 +143,7 @@ function resultFor(binding) {
   const markdown = "<!-- PDF page 1 -->\n\nFixture text\n";
   return {
     structuredContent: {
-      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.6.0" },
+      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.7.0" },
       conversion_status: "complete",
       markdown,
       markdown_sha256: sha256(Buffer.from(markdown)),
@@ -231,8 +231,8 @@ describe("Markdown bakeoff renderer version binding", () => {
   });
 
   it("accepts the current renderer version and rejects the superseded one", () => {
-    expect(validateMarkdownResult(resultFor("1.6.0"), binding).renderer.version).toBe("1.6.0");
-    for (const stale of ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0"]) {
+    expect(validateMarkdownResult(resultFor("1.7.0"), binding).renderer.version).toBe("1.7.0");
+    for (const stale of ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.6.0"]) {
       expect(() => validateMarkdownResult(resultFor(stale), binding), stale)
         .toThrow(/Markdown result evidence is invalid/u);
     }

--- a/test/eval/shannon-markdown-scorer.js
+++ b/test/eval/shannon-markdown-scorer.js
@@ -1,6 +1,7 @@
 function stripMarkdown(value) {
   return value
     .replace(/<!--[^]*?-->/gu, " ")
+    .replace(/<br\s*\/?\s*>/giu, " ")
     .replace(/!\[([^\]]*)\]\([^)]*\)/gu, "$1")
     .replace(/\[([^\]]+)\]\([^)]*\)/gu, "$1")
     .replace(/[*_`~]/gu, "");

--- a/test/eval/shannon-markdown-scorer.test.js
+++ b/test/eval/shannon-markdown-scorer.test.js
@@ -14,6 +14,7 @@ async function oracle() {
 describe("Shannon Markdown adversarial scorer", () => {
   it("normalizes presentation punctuation without repairing displaced text", () => {
     expect(normalizeShannonText("A—B  *C*\nD")).toBe("a-b c d");
+    expect(normalizeShannonText("ENTROPY<br>POWER GAIN<br />IN DECIBELS")).toBe("entropy power gain in decibels");
     expect(normalizeShannonText("HE recent T bandwidth")).not.toContain("the recent");
   });
 

--- a/test/eval/shannon-markdown-scorer.test.js
+++ b/test/eval/shannon-markdown-scorer.test.js
@@ -52,7 +52,7 @@ describe("Shannon Markdown adversarial scorer", () => {
         "Representation of a noisy discrete channel",
         "PART II: THE DISCRETE CHANNEL WITH NOISE",
         "TABLE I",
-        "entropy gain in decibels impulse response gain factor entropy power factor",
+        "entropy power gain in decibels impulse response gain entropy power factor",
         "| value | value |",
         "|---|---|",
         "| 1 | 2 |",
@@ -74,8 +74,8 @@ describe("Shannon Markdown adversarial scorer", () => {
         "W log P N appear much later.",
         "| junk | header |",
         "|---|---|",
-        "| impulse response | gain factor |",
-        "| entropy power factor | entropy gain in decibels |",
+        "| impulse response | gain |",
+        "| entropy power factor | entropy power gain in decibels |",
         "| value | value |",
         "| value | value |",
         "| value | value |",
@@ -86,6 +86,25 @@ describe("Shannon Markdown adversarial scorer", () => {
     expect(result.equations.found).toBe(0);
     expect(result.table_topology.qualifying_table_count).toBe(0);
     expect(result.table_topology.topology_present).toBe(false);
+  });
+
+  it("awards topology credit to the source-faithful four-column Table I header and five data rows", async () => {
+    const result = scoreShannonMarkdown({
+      markdown: [
+        "TABLE I",
+        "| GAIN | ENTROPY POWER FACTOR | ENTROPY POWER GAIN IN DECIBELS | IMPULSE RESPONSE |",
+        "|---|---|---|---|",
+        "| 1 | a | b | c |",
+        "| 2 | a | b | c |",
+        "| 3 | a | b | c |",
+        "| 4 | a | b | c |",
+        "| 5 | a | b | c |",
+      ].join("\n"),
+      oracle: await oracle(),
+      evidence: {},
+    });
+    expect(result.table_topology.qualifying_table_count).toBe(1);
+    expect(result.table_topology.topology_present).toBe(true);
   });
 
   it("reports omissions and duplications independently", async () => {

--- a/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
+++ b/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
@@ -30,7 +30,7 @@
     }
   },
   "layout_contract_bindings": {
-    "layout_output_schema_sha256": "f283d01a0feea9333d9ded8e39757d4e2aeeb36da88b7f5a4e17b48c7bdd454d",
+    "layout_output_schema_sha256": "fe7cf371f9f7b8402da6588a152dcdc43283faf1715def238533524a1cfb366a",
     "layout_evidence_contract_sha256": "39cb7e89cd65558bb661ebc0edab517dabc9398908750de6c3b56d511b887bef"
   },
   "validator_sources": [
@@ -49,8 +49,8 @@
     {
       "role": "layout_extraction_module",
       "path": "server/layout-extraction.js",
-      "bytes": 100717,
-      "sha256": "3112e46b04373eed55abaed630da3adca7a74612f9dc503701422f84d6e5f0f9"
+      "bytes": 110996,
+      "sha256": "7b0093035f33a74c8f131c7d1b40fc30bc9f8ce98a2d32c2d36df9384f8ea544"
     },
     {
       "role": "layout_oracle_schema",
@@ -61,14 +61,14 @@
     {
       "role": "markdown_conversion_module",
       "path": "server/markdown-conversion.js",
-      "bytes": 48387,
-      "sha256": "e4b7212d06e9f3052929706aeb6412275f26988ae578d95df6eeb9eb8d4b6cd4"
+      "bytes": 57951,
+      "sha256": "7bc23ba268709d6d3be59e3d3609646b147860c5070a8f0867b9b78dfdafe00a"
     },
     {
       "role": "output_schemas_module",
       "path": "server/output-schemas.js",
-      "bytes": 29954,
-      "sha256": "b8aabcb644f037fba9edabca849039b5648845964e52678f968c3ccaeccb45d0"
+      "bytes": 30494,
+      "sha256": "af6281c668b090e220bdac23054ea5fce35d405a77b8c04850cb1549e9439b0b"
     },
     {
       "role": "package_json",
@@ -95,7 +95,7 @@
       "sha256": "6e4429db62fcbe1dd73141d8c20a48b564d41f8bf8920d88775846995e1daf94"
     }
   ],
-  "validator_source_set_sha256": "41a2e8232fb5c0cecfe534ae60aabd1a94fef2c355fb47caeb9dc3bfacb67b14",
+  "validator_source_set_sha256": "3c248a9c7fbf755d87b02033c92d0f987e9e969aa5063e23074939c4606fdb05",
   "pdfjs_version": "5.4.624",
   "generation_contract": {
     "source_path": "source.pdf",
@@ -116,8 +116,8 @@
       "source_sha256": "706dcc669a763bc88852eff3bfdf3ee428d3ff1dac01b85e2b60942e907d5403",
       "source_bytes": 2325,
       "page_count": 1,
-      "layout_ir_sha256": "fab8de053bfad95010a0ae8450c57f6f68194d2303b9c33527fdb4c7515ff16b",
-      "layout_id_scope_sha256": "be483b7e0165d5d3d3c962d9e655a498bbadf6588d15b9e9e4e1df214709fd3c",
+      "layout_ir_sha256": "d2add90d4a3f914eaec28e065fc8eec6410e18eff2fbd4cddf01939b5c1a6c2a",
+      "layout_id_scope_sha256": "e53651589799928a9354da099a143642c74fe5a5fdf2eb9a9d83bd01a296ee7b",
       "layout_extraction_status": "complete",
       "facts": [
         {
@@ -130,11 +130,11 @@
           "geometry_status": "eligible",
           "geometry_reason": null,
           "observed_occurrence_sha256": [
-            "90487fb6fa10a185507e1382dc0447200d723568ac0324186cc70348cfd1e7ea"
+            "3de7c04ec0b32a17439c073d272a904e780bf1452eaaf56073d83be58a23afda"
           ],
           "approved_occurrence": {
             "source_sha256": "706dcc669a763bc88852eff3bfdf3ee428d3ff1dac01b85e2b60942e907d5403",
-            "layout_ir_sha256": "fab8de053bfad95010a0ae8450c57f6f68194d2303b9c33527fdb4c7515ff16b",
+            "layout_ir_sha256": "d2add90d4a3f914eaec28e065fc8eec6410e18eff2fbd4cddf01939b5c1a6c2a",
             "page": 1,
             "line_id": "p0001-l000003",
             "line_start_code_point": 12,
@@ -156,7 +156,7 @@
               "width": 129.164,
               "height": 14
             },
-            "occurrence_sha256": "90487fb6fa10a185507e1382dc0447200d723568ac0324186cc70348cfd1e7ea"
+            "occurrence_sha256": "3de7c04ec0b32a17439c073d272a904e780bf1452eaaf56073d83be58a23afda"
           }
         },
         {
@@ -169,11 +169,11 @@
           "geometry_status": "eligible",
           "geometry_reason": null,
           "observed_occurrence_sha256": [
-            "55478b4f229e3908f29a196abd2d06c50f16906f0209778625a1394663435a41"
+            "bcc0249cbd34721e5921a2c843872dc0d72101caaf84c7aff9cfc69c35a1239a"
           ],
           "approved_occurrence": {
             "source_sha256": "706dcc669a763bc88852eff3bfdf3ee428d3ff1dac01b85e2b60942e907d5403",
-            "layout_ir_sha256": "fab8de053bfad95010a0ae8450c57f6f68194d2303b9c33527fdb4c7515ff16b",
+            "layout_ir_sha256": "d2add90d4a3f914eaec28e065fc8eec6410e18eff2fbd4cddf01939b5c1a6c2a",
             "page": 1,
             "line_id": "p0001-l000009",
             "line_start_code_point": 7,
@@ -195,7 +195,7 @@
               "width": 107.38,
               "height": 14
             },
-            "occurrence_sha256": "55478b4f229e3908f29a196abd2d06c50f16906f0209778625a1394663435a41"
+            "occurrence_sha256": "bcc0249cbd34721e5921a2c843872dc0d72101caaf84c7aff9cfc69c35a1239a"
           }
         }
       ]
@@ -206,8 +206,8 @@
       "source_sha256": "c9baaed165000f0e7112e2bfc89e070e0bda26c7ce3f1f16b0dbeebb67e9f11f",
       "source_bytes": 2571,
       "page_count": 1,
-      "layout_ir_sha256": "4ba6103a0122c7441a82fe543416bd5811b1440d9cf3a1817012034f890ed639",
-      "layout_id_scope_sha256": "04e1c5333048a779ba20bd1456ce38db7af14dd19a9ccafbb960e6d25660d0e2",
+      "layout_ir_sha256": "075abfe8e29e7649fc5e2390c67b8e8158cc7767d8c6f81f0b66206ba4c1e226",
+      "layout_id_scope_sha256": "3d790490565f2ee7e4039a3d8ac60488f9a031d442344edc8c2c322e61645b5a",
       "layout_extraction_status": "complete",
       "facts": [
         {
@@ -220,11 +220,11 @@
           "geometry_status": "eligible",
           "geometry_reason": null,
           "observed_occurrence_sha256": [
-            "771fc65ac809fa273a04f907dfeffdb5e71333ace9d683251ab4c2f2be44e944"
+            "451596946b6ae830d49811e0cbfc623d594c3c09bfd8ea3616044bc9e6379f62"
           ],
           "approved_occurrence": {
             "source_sha256": "c9baaed165000f0e7112e2bfc89e070e0bda26c7ce3f1f16b0dbeebb67e9f11f",
-            "layout_ir_sha256": "4ba6103a0122c7441a82fe543416bd5811b1440d9cf3a1817012034f890ed639",
+            "layout_ir_sha256": "075abfe8e29e7649fc5e2390c67b8e8158cc7767d8c6f81f0b66206ba4c1e226",
             "page": 1,
             "line_id": "p0001-l000003",
             "line_start_code_point": 13,
@@ -246,7 +246,7 @@
               "width": 124.474,
               "height": 14
             },
-            "occurrence_sha256": "771fc65ac809fa273a04f907dfeffdb5e71333ace9d683251ab4c2f2be44e944"
+            "occurrence_sha256": "451596946b6ae830d49811e0cbfc623d594c3c09bfd8ea3616044bc9e6379f62"
           }
         },
         {
@@ -259,11 +259,11 @@
           "geometry_status": "eligible",
           "geometry_reason": null,
           "observed_occurrence_sha256": [
-            "8a79596c2dc5159c9f38fc257b250cc515a1c511bfcf0e4f9091ef7a9c5b27d3"
+            "049b69bdd2615d074c176461827be89012c7acf3942296179ce03b23dcdd8a45"
           ],
           "approved_occurrence": {
             "source_sha256": "c9baaed165000f0e7112e2bfc89e070e0bda26c7ce3f1f16b0dbeebb67e9f11f",
-            "layout_ir_sha256": "4ba6103a0122c7441a82fe543416bd5811b1440d9cf3a1817012034f890ed639",
+            "layout_ir_sha256": "075abfe8e29e7649fc5e2390c67b8e8158cc7767d8c6f81f0b66206ba4c1e226",
             "page": 1,
             "line_id": "p0001-l000013",
             "line_start_code_point": 13,
@@ -285,7 +285,7 @@
               "width": 119.854,
               "height": 14
             },
-            "occurrence_sha256": "8a79596c2dc5159c9f38fc257b250cc515a1c511bfcf0e4f9091ef7a9c5b27d3"
+            "occurrence_sha256": "049b69bdd2615d074c176461827be89012c7acf3942296179ce03b23dcdd8a45"
           }
         }
       ]
@@ -296,8 +296,8 @@
       "source_sha256": "aaaae6795676db9e33f79e75f4662808ee9646f8f2bb12a319f74e3edb11c101",
       "source_bytes": 2427,
       "page_count": 1,
-      "layout_ir_sha256": "962c4143047b2f63accf3d04ceff1a2ff31c91c8f891642d8b753bfeaa1a4ffb",
-      "layout_id_scope_sha256": "4e224e935c72da7c6ea7de8747712b258207fbd7cd59096e4a684fbd72896240",
+      "layout_ir_sha256": "0dfcddb8b7d663a3cccc2ae96046b531eccaaf0298e8bebeba740e53a0640695",
+      "layout_id_scope_sha256": "4e6ed88590d719cce1f5a55fe2fd621c6e0c1855e7fee0d431618ef1168480d7",
       "layout_extraction_status": "partial",
       "facts": [
         {
@@ -310,11 +310,11 @@
           "geometry_status": "eligible",
           "geometry_reason": null,
           "observed_occurrence_sha256": [
-            "3e1a365a3abce1e04b3570bc44f5b1d6b1bfa96864d7e006b388cea015879bb5"
+            "4103358ecd197ad2b0d6a9b39e034126a08510a1953f1020a5032edbfd004852"
           ],
           "approved_occurrence": {
             "source_sha256": "aaaae6795676db9e33f79e75f4662808ee9646f8f2bb12a319f74e3edb11c101",
-            "layout_ir_sha256": "962c4143047b2f63accf3d04ceff1a2ff31c91c8f891642d8b753bfeaa1a4ffb",
+            "layout_ir_sha256": "0dfcddb8b7d663a3cccc2ae96046b531eccaaf0298e8bebeba740e53a0640695",
             "page": 1,
             "line_id": "p0001-l000007",
             "line_start_code_point": 8,
@@ -336,7 +336,7 @@
               "width": 192.166,
               "height": 13
             },
-            "occurrence_sha256": "3e1a365a3abce1e04b3570bc44f5b1d6b1bfa96864d7e006b388cea015879bb5"
+            "occurrence_sha256": "4103358ecd197ad2b0d6a9b39e034126a08510a1953f1020a5032edbfd004852"
           }
         }
       ]
@@ -347,8 +347,8 @@
       "source_sha256": "370dc0ac71939cba9db8584327c87899716dc770ac9ee8cad33fc27b5e73b73c",
       "source_bytes": 2622,
       "page_count": 1,
-      "layout_ir_sha256": "c715da54a50a8b1f92f1f32f61e5366fb89f55221e5abb82aefce599cd40adef",
-      "layout_id_scope_sha256": "5b36a98a2e67a243b6975a7b8822fcb96c6bde43b01687629f54d60682b379e4",
+      "layout_ir_sha256": "6aa831d2e328073abe76ef907caabbeeab5e8af1fe6e32293d817694d41b8568",
+      "layout_id_scope_sha256": "77adcffa6fd20c22f1c67a9c26705a28030f9bce55a8052f9d133c8da2e94bdf",
       "layout_extraction_status": "partial",
       "facts": [
         {
@@ -361,11 +361,11 @@
           "geometry_status": "eligible",
           "geometry_reason": null,
           "observed_occurrence_sha256": [
-            "25391b05b5241f61ea4cefdb673689103776db82dfa34e5de223e954b77b7218"
+            "17577aceb87a2b15975a3ab65128ea250c4a1871baf50539a18a7300b0cd0e18"
           ],
           "approved_occurrence": {
             "source_sha256": "370dc0ac71939cba9db8584327c87899716dc770ac9ee8cad33fc27b5e73b73c",
-            "layout_ir_sha256": "c715da54a50a8b1f92f1f32f61e5366fb89f55221e5abb82aefce599cd40adef",
+            "layout_ir_sha256": "6aa831d2e328073abe76ef907caabbeeab5e8af1fe6e32293d817694d41b8568",
             "page": 1,
             "line_id": "p0001-l000015",
             "line_start_code_point": 9,
@@ -387,7 +387,7 @@
               "width": 52.02,
               "height": 12
             },
-            "occurrence_sha256": "25391b05b5241f61ea4cefdb673689103776db82dfa34e5de223e954b77b7218"
+            "occurrence_sha256": "17577aceb87a2b15975a3ab65128ea250c4a1871baf50539a18a7300b0cd0e18"
           }
         }
       ]
@@ -398,8 +398,8 @@
       "source_sha256": "8287bc8965aef64fe33ae81b0abc2f2c3a9df4dc86c2335982f0747e0ae851e9",
       "source_bytes": 25293,
       "page_count": 1,
-      "layout_ir_sha256": "b84528953f3a06ff0b51c06293f12f957820bba806603752e60fa595546fa4dc",
-      "layout_id_scope_sha256": "ec899425667731cbac70a3655ee93d79f59feeb90fc1619c5b57199490c85f74",
+      "layout_ir_sha256": "733a959b53228dbe6e1aa3a6f86fd32735a3c520fa78bfcd6c7050a8d8426967",
+      "layout_id_scope_sha256": "18e71648896eb4e8c126dbd180b6fa0e9bf5c4fb51621d6f393853dd1e9ef5da",
       "layout_extraction_status": "partial",
       "facts": [
         {
@@ -422,8 +422,8 @@
       "source_sha256": "570b9f004596d5f8c0fc1f52c2ea3d1d0e88f987f287aa7692be2a5b3a6fc042",
       "source_bytes": 8183,
       "page_count": 1,
-      "layout_ir_sha256": "53353593fe3597a0420e30f0c76b0bc78768a568935a200af037be1cca665391",
-      "layout_id_scope_sha256": "1afeb089811c661965d27f046f9822e79eb989916f6e342159f8fb4dcff857ef",
+      "layout_ir_sha256": "e71340d05888abc986e2185b03733e1d20753c705afe2f0f2ae269eb78490b30",
+      "layout_id_scope_sha256": "581968e4e7099b85cbc1f2eb731277aaee0b30d63e161a8f6fc11f9e0a723fa4",
       "layout_extraction_status": "partial",
       "facts": [
         {
@@ -446,8 +446,8 @@
       "source_sha256": "b5374f2e96b6205a6cf824ba90b55ffa23612658eca169270682c9445daa476f",
       "source_bytes": 25899,
       "page_count": 2,
-      "layout_ir_sha256": "5bb007e3f6fa46f139687702d1e6e4a6e03387dce6d5349f4719b3fe8d74c61e",
-      "layout_id_scope_sha256": "510a55a2e97bd0818bab513c55cda3763ccda8167e10b5fbb8a693e018e2c3e6",
+      "layout_ir_sha256": "b57e0756c36401c6af2eaeb4a9b1e9f487062390dbe8894564c300b1b41fcf13",
+      "layout_id_scope_sha256": "f5c35463f3161b8a4d21ad821f34b677bf7c0625600beec7410d0d0989bc469f",
       "layout_extraction_status": "partial",
       "facts": [
         {
@@ -460,11 +460,11 @@
           "geometry_status": "eligible",
           "geometry_reason": null,
           "observed_occurrence_sha256": [
-            "4e8b6a36d13bd7498c38ce7342d347cc563878f0120d180825d889f987cbf787"
+            "94eb97c9d2fe2eb9998712997ba44b483e96cb43250dba4f19bbbd9e23413cbb"
           ],
           "approved_occurrence": {
             "source_sha256": "b5374f2e96b6205a6cf824ba90b55ffa23612658eca169270682c9445daa476f",
-            "layout_ir_sha256": "5bb007e3f6fa46f139687702d1e6e4a6e03387dce6d5349f4719b3fe8d74c61e",
+            "layout_ir_sha256": "b57e0756c36401c6af2eaeb4a9b1e9f487062390dbe8894564c300b1b41fcf13",
             "page": 1,
             "line_id": "p0001-l000003",
             "line_start_code_point": 11,
@@ -486,7 +486,7 @@
               "width": 113.596,
               "height": 14
             },
-            "occurrence_sha256": "4e8b6a36d13bd7498c38ce7342d347cc563878f0120d180825d889f987cbf787"
+            "occurrence_sha256": "94eb97c9d2fe2eb9998712997ba44b483e96cb43250dba4f19bbbd9e23413cbb"
           }
         },
         {
@@ -509,8 +509,8 @@
       "source_sha256": "2938fbd44c847b950a87a691fa1d1a956e5c12e1ea17482e30d8e255e6876dde",
       "source_bytes": 2411,
       "page_count": 1,
-      "layout_ir_sha256": "6156deadaf8cc474ae4f955c41f2c7659a6f19c1a3027b17785859a098c57937",
-      "layout_id_scope_sha256": "bc5fd76edb7205fd784f451cbacf61f92db1ccb97b908acaf7d641dcafe42111",
+      "layout_ir_sha256": "efd816519b2b2beee7ecaa1fbdfae1c0ec6f908784925c74f1a6efdcea225a3a",
+      "layout_id_scope_sha256": "e0a8e132d37f67471ae081a853edb7bdf1edc0b5960141a46660ae035f43cbcf",
       "layout_extraction_status": "complete",
       "facts": [
         {
@@ -523,11 +523,11 @@
           "geometry_status": "eligible",
           "geometry_reason": null,
           "observed_occurrence_sha256": [
-            "d8d4357ede409f457a2d558c1bbe36163369400da06e586722cc25fc859578dc"
+            "c5be9c0de66c9d581e44b6eaf8c798afa0f8909b87966e4efe564ecc8c29c514"
           ],
           "approved_occurrence": {
             "source_sha256": "2938fbd44c847b950a87a691fa1d1a956e5c12e1ea17482e30d8e255e6876dde",
-            "layout_ir_sha256": "6156deadaf8cc474ae4f955c41f2c7659a6f19c1a3027b17785859a098c57937",
+            "layout_ir_sha256": "efd816519b2b2beee7ecaa1fbdfae1c0ec6f908784925c74f1a6efdcea225a3a",
             "page": 1,
             "line_id": "p0001-l000003",
             "line_start_code_point": 19,
@@ -549,7 +549,7 @@
               "width": 198.394,
               "height": 14
             },
-            "occurrence_sha256": "d8d4357ede409f457a2d558c1bbe36163369400da06e586722cc25fc859578dc"
+            "occurrence_sha256": "c5be9c0de66c9d581e44b6eaf8c798afa0f8909b87966e4efe564ecc8c29c514"
           }
         },
         {
@@ -562,11 +562,11 @@
           "geometry_status": "eligible",
           "geometry_reason": null,
           "observed_occurrence_sha256": [
-            "4f2ecf0bfab60c609f056e2b99ca123cb8ecd77247c4548d8d4b49380cbda3b9"
+            "7ff7b58ae6186a34c10650ae16720c167b8825441246a2cb530b1b3f42320196"
           ],
           "approved_occurrence": {
             "source_sha256": "2938fbd44c847b950a87a691fa1d1a956e5c12e1ea17482e30d8e255e6876dde",
-            "layout_ir_sha256": "6156deadaf8cc474ae4f955c41f2c7659a6f19c1a3027b17785859a098c57937",
+            "layout_ir_sha256": "efd816519b2b2beee7ecaa1fbdfae1c0ec6f908784925c74f1a6efdcea225a3a",
             "page": 1,
             "line_id": "p0001-l000005",
             "line_start_code_point": 19,
@@ -588,7 +588,7 @@
               "width": 194.488,
               "height": 14
             },
-            "occurrence_sha256": "4f2ecf0bfab60c609f056e2b99ca123cb8ecd77247c4548d8d4b49380cbda3b9"
+            "occurrence_sha256": "7ff7b58ae6186a34c10650ae16720c167b8825441246a2cb530b1b3f42320196"
           }
         },
         {
@@ -601,11 +601,11 @@
           "geometry_status": "eligible",
           "geometry_reason": null,
           "observed_occurrence_sha256": [
-            "5148a689ca79776d05bc65f25ec7773d26069a2d62bdfe93870022dd4fa29835"
+            "175fc54996fbe93396538e5d0542bc939862b4e998baf8406aa787c1457ec2d2"
           ],
           "approved_occurrence": {
             "source_sha256": "2938fbd44c847b950a87a691fa1d1a956e5c12e1ea17482e30d8e255e6876dde",
-            "layout_ir_sha256": "6156deadaf8cc474ae4f955c41f2c7659a6f19c1a3027b17785859a098c57937",
+            "layout_ir_sha256": "efd816519b2b2beee7ecaa1fbdfae1c0ec6f908784925c74f1a6efdcea225a3a",
             "page": 1,
             "line_id": "p0001-l000009",
             "line_start_code_point": 25,
@@ -627,7 +627,7 @@
               "width": 234.22,
               "height": 14
             },
-            "occurrence_sha256": "5148a689ca79776d05bc65f25ec7773d26069a2d62bdfe93870022dd4fa29835"
+            "occurrence_sha256": "175fc54996fbe93396538e5d0542bc939862b4e998baf8406aa787c1457ec2d2"
           }
         }
       ]

--- a/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
+++ b/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
@@ -49,8 +49,8 @@
     {
       "role": "layout_extraction_module",
       "path": "server/layout-extraction.js",
-      "bytes": 110996,
-      "sha256": "7b0093035f33a74c8f131c7d1b40fc30bc9f8ce98a2d32c2d36df9384f8ea544"
+      "bytes": 110990,
+      "sha256": "313eb55b4fe0ced72cb92aa75b50f33e149abd3a9619b8009c0553aa9e265692"
     },
     {
       "role": "layout_oracle_schema",
@@ -61,8 +61,8 @@
     {
       "role": "markdown_conversion_module",
       "path": "server/markdown-conversion.js",
-      "bytes": 57951,
-      "sha256": "7bc23ba268709d6d3be59e3d3609646b147860c5070a8f0867b9b78dfdafe00a"
+      "bytes": 60952,
+      "sha256": "6797ab7f8e3232559e654d9831a238b28cde67415e3452cfecc22ab9babff099"
     },
     {
       "role": "output_schemas_module",
@@ -95,7 +95,7 @@
       "sha256": "6e4429db62fcbe1dd73141d8c20a48b564d41f8bf8920d88775846995e1daf94"
     }
   ],
-  "validator_source_set_sha256": "3c248a9c7fbf755d87b02033c92d0f987e9e969aa5063e23074939c4606fdb05",
+  "validator_source_set_sha256": "37e9a6d7d26bd7aae5ecd31dfcba9e9fb546b681a91e488396703739247d7110",
   "pdfjs_version": "5.4.624",
   "generation_contract": {
     "source_path": "source.pdf",

--- a/test/fixtures/eval/shannon/manifest.v1.json
+++ b/test/fixtures/eval/shannon/manifest.v1.json
@@ -120,9 +120,9 @@
       "label": "TABLE I",
       "required_header_terms": [
         "impulse response",
-        "gain factor",
+        "gain",
         "entropy power factor",
-        "entropy gain in decibels"
+        "entropy power gain in decibels"
       ],
       "minimum_data_rows": 5
     },

--- a/test/fixtures/eval/shannon/manifest.v1.json
+++ b/test/fixtures/eval/shannon/manifest.v1.json
@@ -22,7 +22,7 @@
     "pdf_tools": {
       "slot": "control.current_product.v0",
       "renderer_name": "pdf-tools.layout-markdown-renderer",
-      "renderer_version": "1.6.0",
+      "renderer_version": "1.7.0",
       "parser_name": "pdfjs-dist",
       "parser_version": "5.4.624"
     },

--- a/test/markdown-conversion.test.js
+++ b/test/markdown-conversion.test.js
@@ -127,7 +127,7 @@ async function validatedSyntheticLayout(pageConfigs) {
   });
 }
 
-function paintedGridOperations({ xs, ys, missingVertical = null }) {
+function paintedGridOperations({ xs, ys, missingVertical = null, extraRectangles = [] }) {
   const rectangles = [
     ...ys.map(y => ({ x: xs[0], y, width: xs[xs.length - 1] - xs[0], height: 0.5 })),
     ...xs.filter(x => x !== missingVertical).map(x => ({
@@ -136,6 +136,7 @@ function paintedGridOperations({ xs, ys, missingVertical = null }) {
       width: 0.5,
       height: ys[ys.length - 1] - ys[0],
     })),
+    ...extraRectangles,
   ];
   const operations = [];
   const operatorArgs = [];
@@ -149,6 +150,13 @@ function paintedGridOperations({ xs, ys, missingVertical = null }) {
     );
   }
   return { operations, operatorArgs };
+}
+
+function combinePaintedOperations(...groups) {
+  return {
+    operations: groups.flatMap(group => group.operations),
+    operatorArgs: groups.flatMap(group => group.operatorArgs),
+  };
 }
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -248,6 +256,100 @@ describe("layout Markdown renderer", () => {
       expect.objectContaining({ code: "TABLE_TOPOLOGY_UNKNOWN", page: 3 }),
     ]));
     expect(result.markdown.match(/\| --- \| --- \|/gu)).toBeNull();
+  });
+
+  it("refuses partial dividers that evidence merged columns or rows", async () => {
+    const mergedHeader = paintedGridOperations({
+      xs: [100, 300, 400],
+      ys: [100, 130, 200, 270],
+      extraRectangles: [{ x: 200, y: 130, width: 0.5, height: 140 }],
+    });
+    const rowSpan = paintedGridOperations({
+      xs: [100, 250, 400],
+      ys: [100, 130, 270, 340],
+      extraRectangles: [{ x: 250, y: 200, width: 150, height: 0.5 }],
+    });
+    const mergedItems = [
+      centeredTextItem("TABLE 1", { top: 70, fontSize: 10 }),
+      positionedTextItem("FIRST", { top: 105, left: 120, width: 30 }),
+      positionedTextItem("SECOND", { top: 105, left: 210, width: 40 }),
+      positionedTextItem("THIRD", { top: 105, left: 320, width: 30, eol: true }),
+      positionedTextItem("a", { top: 150, left: 120, width: 8 }),
+      positionedTextItem("b", { top: 150, left: 220, width: 8 }),
+      positionedTextItem("1", { top: 150, left: 320, width: 8, eol: true }),
+      positionedTextItem("c", { top: 220, left: 120, width: 8 }),
+      positionedTextItem("d", { top: 220, left: 220, width: 8 }),
+      positionedTextItem("2", { top: 220, left: 320, width: 8, eol: true }),
+    ];
+    const rowSpanItems = [
+      centeredTextItem("TABLE 2", { top: 70, fontSize: 10 }),
+      positionedTextItem("FIRST", { top: 105, left: 120, width: 30 }),
+      positionedTextItem("SECOND", { top: 105, left: 270, width: 40, eol: true }),
+      positionedTextItem("span", { top: 155, left: 120, width: 25 }),
+      positionedTextItem("upper", { top: 155, left: 270, width: 30, eol: true }),
+      positionedTextItem("lower", { top: 220, left: 270, width: 30, eol: true }),
+      positionedTextItem("left", { top: 290, left: 120, width: 20 }),
+      positionedTextItem("right", { top: 290, left: 270, width: 25, eol: true }),
+    ];
+    const layout = await validatedSyntheticLayout([
+      { ...mergedHeader, items: mergedItems },
+      { ...rowSpan, items: rowSpanItems },
+    ]);
+    const result = renderPdfLayoutToMarkdown(layout, { includePageBoundaries: false });
+    expect(result.gaps).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: "TABLE_TOPOLOGY_UNKNOWN", page: 1 }),
+      expect.objectContaining({ code: "TABLE_TOPOLOGY_UNKNOWN", page: 2 }),
+    ]));
+    expect(result.markdown).not.toContain("| --- |");
+  });
+
+  it("refuses ambiguous multiple grids and source-order cell interleaving", async () => {
+    const firstGrid = paintedGridOperations({ xs: [40, 110, 180], ys: [100, 130, 200, 270] });
+    const secondGrid = paintedGridOperations({ xs: [300, 370, 440], ys: [100, 130, 200, 270] });
+    const closed = paintedGridOperations({ xs: [100, 150, 200], ys: [100, 130, 200, 270] });
+    const interleavedItems = [
+      positionedTextItem("TABLE 3", { top: 70, left: 130, width: 40, eol: true }),
+      positionedTextItem("FIRST", { top: 105, left: 105, width: 30 }),
+      positionedTextItem("SECOND", { top: 105, left: 155, width: 40, eol: true }),
+      positionedTextItem("a", { top: 150, left: 110, width: 8 }),
+      positionedTextItem("1", { top: 150, left: 160, width: 8 }),
+      positionedTextItem("b", { top: 150, left: 130, width: 8 }),
+      positionedTextItem("2", { top: 150, left: 180, width: 8, eol: true }),
+      positionedTextItem("c", { top: 220, left: 110, width: 8 }),
+      positionedTextItem("3", { top: 220, left: 160, width: 8, eol: true }),
+    ];
+    const layout = await validatedSyntheticLayout([
+      { ...combinePaintedOperations(firstGrid, secondGrid), items: [] },
+      { ...closed, items: interleavedItems },
+    ]);
+    const interleavedLine = layout.pages[1].lines.find(line => line.text.includes("a") && line.text.includes("1"));
+    expect(interleavedLine?.text).toMatch(/a.*1.*b.*2/u);
+    const result = renderPdfLayoutToMarkdown(layout, { includePageBoundaries: false });
+    expect(result.gaps).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: "TABLE_TOPOLOGY_UNKNOWN", page: 1 }),
+      expect.objectContaining({ code: "TABLE_TOPOLOGY_UNKNOWN", page: 2 }),
+    ]));
+    expect(result.markdown).not.toContain("| --- |");
+  });
+
+  it("bounds ruled-grid rows, columns, and cells before allocating cell content", async () => {
+    const tooManyColumns = paintedGridOperations({
+      xs: Array.from({ length: 52 }, (_value, index) => index * 12),
+      ys: [100, 110, 200, 300],
+    });
+    const tooManyCells = paintedGridOperations({
+      xs: Array.from({ length: 41 }, (_value, index) => 50 + index * 12),
+      ys: [100, 108, ...Array.from({ length: 29 }, (_value, index) => 116 + index * 8)],
+    });
+    const layout = await validatedSyntheticLayout([
+      { ...tooManyColumns, items: [] },
+      { ...tooManyCells, items: [] },
+    ]);
+    const result = renderPdfLayoutToMarkdown(layout, { includePageBoundaries: false });
+    expect(result.gaps).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: "TABLE_TOPOLOGY_UNKNOWN", page: 1 }),
+      expect.objectContaining({ code: "TABLE_TOPOLOGY_UNKNOWN", page: 2 }),
+    ]));
   });
 
   it("does not invent a heading without enough geometric evidence", async () => {
@@ -545,7 +647,7 @@ describe("layout Markdown renderer", () => {
     expect(result.pages[2].gaps.map(gap => gap.code)).toEqual(["VECTOR_CONTENT_NOT_INTERPRETED"]);
     expect(result.markdown).toContain("## Conversion gaps");
     expect(result.markdown).toContain("OCR is not performed");
-    expect(result.limitations.some(value => value.includes("Stroked paths, incomplete grids, cell artwork"))).toBe(true);
+    expect(result.limitations.some(value => value.includes("Cell artwork is omitted and reported as a vector-content gap"))).toBe(true);
     expect(result.limitations.some(value => value.includes("Links are emitted only for source-validated http or https annotation targets"))).toBe(true);
   });
 

--- a/test/markdown-conversion.test.js
+++ b/test/markdown-conversion.test.js
@@ -77,7 +77,10 @@ function fakePdfjs(pageConfigs) {
         },
       };
     },
-    getOperatorList: async () => ({ fnArray: config.operations ?? [] }),
+    getOperatorList: async () => ({
+      fnArray: config.operations ?? [],
+      argsArray: config.operatorArgs ?? (config.operations ?? []).map(() => null),
+    }),
     getAnnotations: async () => {
       if (config.annotationError) throw config.annotationError;
       return config.annotations ?? [];
@@ -86,7 +89,15 @@ function fakePdfjs(pageConfigs) {
   }));
   return {
     version: "5.4.624",
-    OPS: { paintImageXObject: 1, constructPath: 2, fill: 3 },
+    OPS: {
+      paintImageXObject: 1,
+      constructPath: 2,
+      fill: 3,
+      save: 4,
+      restore: 5,
+      transform: 6,
+      paintSolidColorImageMask: 7,
+    },
     Util: { transform: multiply },
     getDocument: () => ({
       promise: Promise.resolve({
@@ -114,6 +125,30 @@ async function validatedSyntheticLayout(pageConfigs) {
     requestedEndPage: pageConfigs.length,
     maxOutputCharacters: 200000,
   });
+}
+
+function paintedGridOperations({ xs, ys, missingVertical = null }) {
+  const rectangles = [
+    ...ys.map(y => ({ x: xs[0], y, width: xs[xs.length - 1] - xs[0], height: 0.5 })),
+    ...xs.filter(x => x !== missingVertical).map(x => ({
+      x,
+      y: ys[0],
+      width: 0.5,
+      height: ys[ys.length - 1] - ys[0],
+    })),
+  ];
+  const operations = [];
+  const operatorArgs = [];
+  for (const rectangle of rectangles) {
+    operations.push(4, 6, 7, 5);
+    operatorArgs.push(
+      null,
+      [rectangle.width, 0, 0, -rectangle.height, rectangle.x, 792 - rectangle.y],
+      [],
+      null,
+    );
+  }
+  return { operations, operatorArgs };
 }
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -151,6 +186,68 @@ describe("layout Markdown renderer", () => {
     expect(first.markdown_bytes).toBe(Buffer.byteLength(first.markdown, "utf8"));
     expect(first.markdown_sha256).toBe(createHash("sha256").update(first.markdown).digest("hex"));
     expect(validateMarkdownConversionSemantics(first, { layout })).toBe(first);
+  });
+
+  it("uses a complete painted grid to recover multi-line table cells", async () => {
+    const rules = paintedGridOperations({ xs: [100, 250, 400], ys: [100, 130, 200, 270] });
+    const layout = await validatedSyntheticLayout([{
+      ...rules,
+      items: [
+        centeredTextItem("TABLE 1", { top: 70, fontSize: 10 }),
+        positionedTextItem("FIRST", { top: 105, left: 120, width: 30 }),
+        positionedTextItem("SECOND", { top: 105, left: 270, width: 40, eol: true }),
+        positionedTextItem("alpha", { top: 145, left: 120, width: 30 }),
+        positionedTextItem("one", { top: 155, left: 120, width: 20, eol: true }),
+        positionedTextItem("10", { top: 150, left: 270, width: 12, eol: true }),
+        positionedTextItem("beta", { top: 215, left: 120, width: 25, eol: true }),
+        positionedTextItem("20", { top: 220, left: 270, width: 12, eol: true }),
+        textItem("Following prose remains outside the table.", { top: 300 }),
+      ],
+    }]);
+    expect(layout.pages[0].painted_rectangles).toMatchObject({
+      status: "available",
+      truncated: false,
+      observed_count: 7,
+      returned_count: 7,
+    });
+    const result = renderPdfLayoutToMarkdown(layout, { includePageBoundaries: false });
+    expect(result.markdown).toContain("| FIRST | SECOND |\n| --- | --- |\n| alpha<br>one | 10 |\n| beta | 20 |");
+    expect(result.markdown).toContain("Following prose remains outside the table.");
+    expect(result.gaps.map(gap => gap.code)).not.toContain("TABLE_TOPOLOGY_UNKNOWN");
+  });
+
+  it("refuses incomplete grids and closed grids without header evidence", async () => {
+    const incomplete = paintedGridOperations({
+      xs: [100, 250, 400],
+      ys: [100, 130, 200, 270],
+      missingVertical: 250,
+    });
+    const items = [
+      centeredTextItem("TABLE 1", { top: 70, fontSize: 10 }),
+      positionedTextItem("FIRST", { top: 105, left: 120, width: 30 }),
+      positionedTextItem("SECOND", { top: 105, left: 270, width: 40, eol: true }),
+      positionedTextItem("alpha", { top: 150, left: 120, width: 30 }),
+      positionedTextItem("10", { top: 150, left: 270, width: 12, eol: true }),
+      positionedTextItem("beta", { top: 220, left: 120, width: 25 }),
+      positionedTextItem("20", { top: 220, left: 270, width: 12, eol: true }),
+    ];
+    const closed = paintedGridOperations({ xs: [100, 250, 400], ys: [100, 130, 200, 270] });
+    const crossing = [
+      centeredTextItem("TABLE 2", { top: 70, fontSize: 10 }),
+      positionedTextItem("CROSSING HEADER", { top: 105, left: 225, width: 80, eol: true }),
+      ...items.slice(3),
+    ];
+    const layout = await validatedSyntheticLayout([
+      { ...incomplete, items },
+      { ...closed, items: items.slice(1) },
+      { ...closed, items: crossing },
+    ]);
+    const result = renderPdfLayoutToMarkdown(layout, { includePageBoundaries: false });
+    expect(result.gaps).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: "TABLE_TOPOLOGY_UNKNOWN", page: 2 }),
+      expect.objectContaining({ code: "TABLE_TOPOLOGY_UNKNOWN", page: 3 }),
+    ]));
+    expect(result.markdown.match(/\| --- \| --- \|/gu)).toBeNull();
   });
 
   it("does not invent a heading without enough geometric evidence", async () => {
@@ -448,7 +545,7 @@ describe("layout Markdown renderer", () => {
     expect(result.pages[2].gaps.map(gap => gap.code)).toEqual(["VECTOR_CONTENT_NOT_INTERPRETED"]);
     expect(result.markdown).toContain("## Conversion gaps");
     expect(result.markdown).toContain("OCR is not performed");
-    expect(result.limitations.some(value => value.includes("Ruling lines and merged or spanning cells are not interpreted"))).toBe(true);
+    expect(result.limitations.some(value => value.includes("Stroked paths, incomplete grids, cell artwork"))).toBe(true);
     expect(result.limitations.some(value => value.includes("Links are emitted only for source-validated http or https annotation targets"))).toBe(true);
   });
 

--- a/test/mcp-contract.test.js
+++ b/test/mcp-contract.test.js
@@ -50,7 +50,11 @@ const EXAMPLE_PDF = path.join(REPO_ROOT, "example-fw9.pdf");
 // 2026-08-03: convert_pdf_to_markdown renderer 1.6.0 adds bounded, local
 // math-operator spacing with explicit limitations. Previously
 // e80436c2e09aefc4a8ecb7bbc989a9c133fa3a1a2b84e4b07747a784c3e16d6b.
-const TOOL_CONTRACT_SHA256 = "4efcce458b5041a2d822bb921f46550cc15cdb9bcb2d54550f8eaa80c4f5a756";
+// 2026-08-03: extraction IR 1.2.0 preserves bounded solid-mask rectangle
+// evidence and Markdown renderer 1.7.0 uses only complete closed grids for
+// ruled tables. Previously
+// 4efcce458b5041a2d822bb921f46550cc15cdb9bcb2d54550f8eaa80c4f5a756.
+const TOOL_CONTRACT_SHA256 = "9947d16e32562981651216c95598786d9f3324d5f1fae3b53fa8d7f089d2ea05";
 
 const CLOSED_READ = Object.freeze({
   readOnlyHint: true,
@@ -395,7 +399,7 @@ describe.each(RUNTIMES)("$name runtime discovery", runtime => {
     });
     expect(result.isError).not.toBe(true);
     expect(result.structuredContent).toMatchObject({
-      ir: { name: "pdf-tools.extraction-ir", version: "1.1.0" },
+      ir: { name: "pdf-tools.extraction-ir", version: "1.2.0" },
       parser: { name: "pdfjs-dist", version: "5.4.624" },
       page_range: { start_page: 1, end_page: 1 },
     });

--- a/test/pdfjs-worker-contract.test.js
+++ b/test/pdfjs-worker-contract.test.js
@@ -151,7 +151,7 @@ describe.sequential("one-shot PDF.js worker contracts", () => {
     };
     const layout = await run("extract_layout", common);
     expect(layout.layout).toMatchObject({
-      ir: { name: "pdf-tools.extraction-ir", version: "1.1.0" },
+      ir: { name: "pdf-tools.extraction-ir", version: "1.2.0" },
       parser: { name: "pdfjs-dist", version: "5.4.624" },
       pages: expect.any(Array),
     });

--- a/test/read-pdf-layout.test.js
+++ b/test/read-pdf-layout.test.js
@@ -84,7 +84,10 @@ function fakePdfjs(pageConfigs, { requiredPassword = null, neverLoad = false } =
     },
     getOperatorList: async () => {
       if (config.operatorError) throw config.operatorError;
-      return { fnArray: config.operations ?? [] };
+      return {
+        fnArray: config.operations ?? [],
+        argsArray: config.operatorArgs ?? (config.operations ?? []).map(() => null),
+      };
     },
     getAnnotations: async () => {
       if (config.annotationError) throw config.annotationError;
@@ -95,7 +98,15 @@ function fakePdfjs(pageConfigs, { requiredPassword = null, neverLoad = false } =
   const pdfjs = {
     version: "5.4.624",
     PasswordResponses: { NEED_PASSWORD: 1, INCORRECT_PASSWORD: 2 },
-    OPS: { paintImageXObject: 1, constructPath: 2, fill: 3 },
+    OPS: {
+      paintImageXObject: 1,
+      constructPath: 2,
+      fill: 3,
+      save: 4,
+      restore: 5,
+      transform: 6,
+      paintSolidColorImageMask: 7,
+    },
     Util: { transform: multiply },
     getDocument: documentOptions => {
       state.document_options = documentOptions;
@@ -275,14 +286,14 @@ describe("read_pdf_layout MCP tool", () => {
     expect(first.isError).not.toBe(true);
     expect(JSON.stringify(first.structuredContent)).toBe(JSON.stringify(second.structuredContent));
     expect(first.structuredContent).toMatchObject({
-      ir: { name: "pdf-tools.extraction-ir", version: "1.1.0" },
+      ir: { name: "pdf-tools.extraction-ir", version: "1.2.0" },
       parser: { name: "pdfjs-dist", version: "5.4.624" },
       source: { sha256: expect.stringMatching(/^[a-f0-9]{64}$/) },
       id_scope: {
         kind: "source_parser_ir_options",
         source_sha256: expect.stringMatching(/^[a-f0-9]{64}$/),
         parser_version: "5.4.624",
-        ir_version: "1.1.0",
+        ir_version: "1.2.0",
         max_output_characters: 200000,
       },
       page_range: { requested_start_page: 1, requested_end_page: 1, start_page: 1, end_page: 1, total_pages: 1 },
@@ -648,6 +659,68 @@ describe("read_pdf_layout MCP tool", () => {
     expect(() => validatePdfLayoutSemantics(forgedImageEvidence, { sourceBytes: bytes })).not.toThrow();
     await expect(validatePdfLayoutSourceEvidence(forgedImageEvidence, { pdfjsLib: pdfjs, sourceBytes: bytes }))
       .rejects.toThrow(/operator evidence differs from reparsed source/);
+  });
+
+  it("captures bounded solid-mask rectangles and binds them to source operators", async () => {
+    const config = {
+      items: [textItem({ text: "Cell", x: 110, top: 100 })],
+      operations: [4, 6, 7, 5],
+      operatorArgs: [null, [40, 0, 0, -0.5, 100, 700], [], null],
+    };
+    const { result, bytes } = await runFake([config]);
+    expect(result.pages[0].painted_rectangles).toEqual({
+      status: "available",
+      truncated: false,
+      observed_count: 1,
+      returned_count: 1,
+      items: [{
+        id: "p0001-r000003",
+        source_operation_index: 2,
+        source_kind: "solid_color_image_mask",
+        graphics_transform: [40, 0, 0, -0.5, 100, 700],
+        quad: [
+          { x: 100, y: 92 },
+          { x: 140, y: 92 },
+          { x: 140, y: 92.5 },
+          { x: 100, y: 92.5 },
+        ],
+        bbox: { x: 100, y: 92, width: 40, height: 0.5 },
+      }],
+    });
+    const { pdfjs } = fakePdfjs([config]);
+    await expect(validatePdfLayoutSourceEvidence(result, { pdfjsLib: pdfjs, sourceBytes: bytes }))
+      .resolves.toBe(result);
+
+    const translated = structuredClone(result);
+    const painted = translated.pages[0].painted_rectangles.items[0];
+    painted.graphics_transform[4] += 5;
+    painted.quad = painted.quad.map(point => ({ ...point, x: point.x + 5 }));
+    painted.bbox.x += 5;
+    expect(() => validatePdfLayoutSemantics(translated, { sourceBytes: bytes })).not.toThrow();
+    await expect(validatePdfLayoutSourceEvidence(translated, { pdfjsLib: pdfjs, sourceBytes: bytes }))
+      .rejects.toThrow(/painted_rectangles|operator evidence differs/);
+  });
+
+  it("caps painted rectangle evidence without accepting it as complete", async () => {
+    const operations = [];
+    const operatorArgs = [];
+    for (let index = 0; index < 501; index += 1) {
+      operations.push(4, 6, 7, 5);
+      operatorArgs.push(null, [20, 0, 0, -0.5, 20, 700 - index * 0.01], [], null);
+    }
+    const { result } = await runFake([{
+      items: [textItem({ text: "Bounded", x: 50, top: 50 })],
+      operations,
+      operatorArgs,
+    }]);
+    expect(result.pages[0].painted_rectangles).toMatchObject({
+      status: "available",
+      truncated: true,
+      observed_count: 501,
+      returned_count: 500,
+    });
+    expect(result.pages[0].extraction_status).toBe("partial");
+    expect(result.pages[0].needs_visual_inspection).toBe(true);
   });
 
   it("fails closed on retention/output limits and keeps references non-dangling", async () => {

--- a/test/read-pdf-layout.test.js
+++ b/test/read-pdf-layout.test.js
@@ -701,6 +701,29 @@ describe("read_pdf_layout MCP tool", () => {
       .rejects.toThrow(/painted_rectangles|operator evidence differs/);
   });
 
+  it("retains the full painted-rectangle transform under large UserUnit scaling", async () => {
+    const graphicsTransform = [1.23456, 0, 0, -0.5, 100.12345, 700.67891];
+    const viewport = {
+      scale: 75,
+      width: 45_900,
+      height: 59_400,
+      transform: [75, 0, 0, -75, 0, 59_400],
+    };
+    const config = {
+      userUnit: 75,
+      viewport,
+      items: [textItem({ text: "Scaled", x: 110, top: 100 })],
+      operations: [4, 6, 7, 5],
+      operatorArgs: [null, graphicsTransform, [], null],
+    };
+    const { result, bytes } = await runFake([config]);
+    expect(result.pages[0].painted_rectangles.items[0].graphics_transform).toEqual(graphicsTransform);
+    expect(() => validatePdfLayoutSemantics(result, { sourceBytes: bytes })).not.toThrow();
+    const { pdfjs } = fakePdfjs([config]);
+    await expect(validatePdfLayoutSourceEvidence(result, { pdfjsLib: pdfjs, sourceBytes: bytes }))
+      .resolves.toBe(result);
+  });
+
   it("caps painted rectangle evidence without accepting it as complete", async () => {
     const operations = [];
     const operatorArgs = [];


### PR DESCRIPTION
## What changed

- Retain a bounded, source-verified record of axis-aligned solid-mask rectangles from PDF.js.
- Reconstruct a Markdown table only when those marks form one unambiguous complete closed grid, every retained word fits one cell, and the caption and header provide independent evidence.
- Refuse aligned partial dividers, multiple grids, interleaved source order, oversized grids, crossing text, weak headers, and other ambiguous cases with a typed conversion gap.
- Correct the Shannon Table I evaluation oracle to the source-faithful header wording and safe multiline-header scoring.
- Keep the source and share runtimes byte-identical and document the exact supported boundary.

## Why

Shannon's Table I had usable drawn borders, but PDF Tools previously flattened the page into reading-order text. That lost the four-column, five-data-row structure. This change recovers that bounded structure without introducing OCR, a model, or a general formula parser.

## User impact

On the pinned 55-page Shannon paper, PDF Tools now emits exactly one qualifying Markdown table: four columns and five data rows. Three fresh runs are byte-identical, and the existing heading, reading-order, paragraph, equation-token, and footnote samples do not regress.

This does not claim full cell fidelity. Several mathematical glyphs remain damaged, and mini-graphs inside cells are omitted with an explicit vector-content gap.

## Validation

- Clean Shannon report SHA-256: ed5a8d7c2ad7bdde748ae15fb755056bae14bd9ab27c048fd912de637566e8e6
- Focused suite: 162 passed
- Native platform suite: 62 passed, 9 intentional skips
- Share-package contract: passed; 40 tools, 14 prompts, 112 components
- Full serialized suite: 1,874 passed, 79 skipped; two known unrelated Mac harness failures reproduced:
  - managed Python symlink mode observed as 0700 instead of the test's 0755/0777 set
  - deadline process-group evidence race in the Phase 1 external-candidate harness
- Three independent read-only reviews of the hardened final tip: pass, no blockers

## Stack

Draft stacked on #59 (math spacing). Merge and release are not authorized by this draft.
