### PR TITLE
Recover the primary vetted Type-3 glyph batch

### DIFF
--- a/docs/evidence/shannon-primary-type3-glyph-batch-2026-08.md
+++ b/docs/evidence/shannon-primary-type3-glyph-batch-2026-08.md
@@ -109,13 +109,25 @@ because Silverbook's caller uses private mode-077 creation and one existing
 portable-symlink test explicitly expects the ordinary macOS mode. No machine
 setting was changed.
 
-The exact bundle has not yet been installed over Silverbook's currently enabled
-older PDF Toolkit build. A verified recovery backup was created at
-`/Users/silverbook/Library/Application Support/Claude/PDF Tools Host Validation Backups/20260804T141500Z-pre-pr62`,
-but Claude's app-control bridge failed to start twice before any installation
-action. Native Claude Desktop installation and chat-level use therefore remain
-an explicit human-assisted gate.
+On 2026-08-04, the exact MCPB above was installed in Claude Desktop. Claude's
+installation registry records the matching SHA-256, and its host log records a
+successful server start, initialization, and tool discovery. The legacy PDF
+Tools identity was removed, leaving exactly one enabled current installation.
+A verified recovery backup remains at
+`/Users/silverbook/Library/Application Support/Claude/PDF Tools Host Validation Backups/20260804T141500Z-pre-pr62`.
+
+The installed extension directory passed the synthetic installed-server smoke:
+40 unique tools, the exact reviewed tool-contract digest, text extraction,
+Markdown conversion, native raster rendering, one verified mutation, a fresh
+session, and denial outside the configured directory. The installed directory
+then converted all 55 Shannon pages in six bounded calls. It produced the exact
+reviewed Markdown SHA-256
+`8b1d2520e4fdbbb1ec3aa1b9fa3ee3604f72712c0b0a37b53a4e4c9d3962ca94`,
+177,761 bytes, 511 replacement characters, and 68 explicit gaps. This proves
+native installation, Claude host loading/tool discovery, and installed-bundle
+server behavior. A Shannon conversion initiated from a Claude chat remains a
+separate unrun UI-level check.
 
 This evidence does not prove general Type-3 decoding, formula reconstruction,
-OCR, full mathematical fidelity, native Claude Desktop behavior, Windows or
-Linux execution, release readiness, or that Kepano's complete issue is solved.
+OCR, full mathematical fidelity, Windows or Linux behavior, release readiness,
+or that Kepano's complete issue is solved.

--- a/docs/evidence/shannon-primary-type3-glyph-batch-2026-08.md
+++ b/docs/evidence/shannon-primary-type3-glyph-batch-2026-08.md
@@ -92,6 +92,8 @@ each target plus two witness digests.
   across 5/6 complete groups, paragraphs 2/4, equations 4/4, footnotes 4/4,
   and one qualifying Table I topology. `TABLE I` remains duplicated.
 - Full repository suite: 1,886 passed, 79 intentionally skipped, zero failed.
+- Separate native macOS/Node safety suite: 62 passed, 9 intentionally skipped,
+  zero failed.
 - Transactional share contract: 40 tools, 14 prompts, 112 SBOM components;
   SHA-256
   `957b534b598c87555790d835f8b69fb7d40f83259ceaf119c55add79b379d4ba`.
@@ -106,6 +108,13 @@ The full suite was run in a subshell with ordinary mode-022 file creation
 because Silverbook's caller uses private mode-077 creation and one existing
 portable-symlink test explicitly expects the ordinary macOS mode. No machine
 setting was changed.
+
+The exact bundle has not yet been installed over Silverbook's currently enabled
+older PDF Toolkit build. A verified recovery backup was created at
+`/Users/silverbook/Library/Application Support/Claude/PDF Tools Host Validation Backups/20260804T141500Z-pre-pr62`,
+but Claude's app-control bridge failed to start twice before any installation
+action. Native Claude Desktop installation and chat-level use therefore remain
+an explicit human-assisted gate.
 
 This evidence does not prove general Type-3 decoding, formula reconstruction,
 OCR, full mathematical fidelity, native Claude Desktop behavior, Windows or

--- a/docs/evidence/shannon-primary-type3-glyph-batch-2026-08.md
+++ b/docs/evidence/shannon-primary-type3-glyph-batch-2026-08.md
@@ -4,8 +4,9 @@
 
 PDF Tools now recovers 1,021 additional exact characters from nine repeatedly
 used legacy Computer Modern Type-3 glyph groups in Shannon's 55-page paper.
-Together with the preceding qualified batch, the production extractor recovers
-1,052 exact characters from 13 registered groups.
+Together with the preceding qualified batch, the tested draft production path
+recovers 1,052 exact characters from 13 registered groups. PR #62 remains an
+unmerged draft; this is verified implementation behavior, not a shipped claim.
 
 This remains a fail-closed character recovery. A replacement is accepted only
 when the raw PDF font link, official Computer Modern character position, target

--- a/docs/evidence/shannon-primary-type3-glyph-batch-2026-08.md
+++ b/docs/evidence/shannon-primary-type3-glyph-batch-2026-08.md
@@ -1,0 +1,111 @@
+# Shannon primary Type-3 glyph batch — 2026-08
+
+## Outcome
+
+PDF Tools now recovers 1,021 additional exact characters from nine repeatedly
+used legacy Computer Modern Type-3 glyph groups in Shannon's 55-page paper.
+Together with the preceding qualified batch, the production extractor recovers
+1,052 exact characters from 13 registered groups.
+
+This remains a fail-closed character recovery. A replacement is accepted only
+when the raw PDF font link, official Computer Modern character position, target
+glyph digest, two witness glyph digests, font metrics, and complete page token
+sequence agree. Missing, ambiguous, or altered evidence is left unchanged.
+
+## Exact new batch
+
+Ranges below are inclusive. The target digest identifies the reviewed custom-
+drawn glyph program; every group also has two independently matched witness
+digests in `server/layout-extraction.js`.
+
+| Character | Count | Target digest | Shannon pages |
+| --- | ---: | --- | --- |
+| period (`.`) | 345 | `2df559091df37cc5da5c1ce3e05eebc1075c4c041b83d96a1904d2c2f21edab0` | 1, 3-4, 6-14, 16-21, 24-32, 34-55 |
+| comma (`,`) | 315 | `42b5ebf435945b75e1dc1bc271bfbb4aa2dc02b8adc93cd26b4bb64dec9fde8a` | 1-6, 8-12, 14-15, 18-19, 21, 25-26, 28-29, 31-33, 35-44, 46, 48-52, 54-55 |
+| minus (`−`) | 216 | `fb1f6bf10138511bcefade47467b3e2f9ae691ab3dab097914be1f0f66305470` | 3-4, 9, 11-14, 16-31, 34-47, 49, 51, 53 |
+| pi (`π`) | 55 | `780b04fa47830ca782211b86dbedfe0adec0445bdf94d538bfe7adde08ed9445` | 18, 32-34, 36-40, 43-47, 51, 53 |
+| rho (`ρ`) | 27 | `1500df39391626d02f9e98132f991f71899612069298e52340e12fb65590836f` | 48-51, 54 |
+| square root (`√`) | 27 | `772f491fc17e6bb3bc37c17ace6be704244ab121c7180d59319726e0af4b0efc` | 24, 35-39, 45-47, 51 |
+| greater-or-equal (`≥`) | 22 | `05b4a9d88c1df64b3ac339ae6bb7ed82383b93bb08512842452db43453a28970` | 12-13, 15, 17, 21, 30, 36, 42, 44-46 |
+| slash (`/`) | 8 | `55447dde50a97970297d189788eb154c675c41e6d2eca2836949aefadd0b1780` | 1, 13-14, 16, 35, 40 |
+| omega (`ω`) | 6 | `81b41121b5e19a2aebd37331ab3584fe08221ca1afcda83f4ce8b76997177074` | 32, 40 |
+
+The four control-character groups account for the reduction from 831 to 511
+replacement characters in the deterministic Markdown. Punctuation and other
+printable source substitutions are exact improvements but do not change that
+replacement-character count.
+
+## Complete census and abstentions
+
+The maintenance census walks both the page operators and text tokens through
+the production PDF.js loader. It includes whitespace-like controls that the
+strict recovery path must normally discard. Three fresh census runs were byte-
+identical with SHA-256
+`2f46417aac09ff1241d03bdbcc844f9273f75bcae054175d0f9084f6fcb93ae6`.
+
+- Type-3 occurrences observed: 4,437.
+- Safely linked to raw fonts: 4,427.
+- Explicitly omitted: 10 on pages 33 and 52 because the raw font link was
+  ambiguous or unavailable.
+- Classified by an official Computer Modern family/position: 2,039.
+- Unclassified because the family was ambiguous or unavailable: 2,388.
+- Officially named characters: 1,240.
+- Strictly recovered: 1,052.
+- Officially named but not strictly recovered: 188.
+
+The 188 unresolved occurrences are visible future work, not silent misses.
+They include 60 alpha occurrences across three raster variants. Alpha arrives
+from PDF.js as the whitespace-like U+000B control; an experimental registration
+made an existing exact fixture recovery disappear, so it was completely
+reverted. A 64-occurrence minus variant has a target digest but lacks two
+qualified witness digests. Both remain unchanged rather than guessed.
+
+## Independent source and visual review
+
+The reference generator pins official CTAN Computer Modern metrics, Type-3
+programs, and Metafont source. The Metafont archive SHA-256 is
+`b22c69034d9f3f7a9bf22673544bdeaace5656973cf7fb1a395a857148943076`.
+Generation mechanically verifies the relevant definitions in `greekl.mf`,
+`romms.mf`, `symbol.mf`, and `sym.mf`. The generated runtime reference module
+is intentionally byte-identical to the preceding tranche; only its provenance
+gained the third independently pinned source.
+
+Rendered Shannon pages 3, 17, 37, 40, and 48 were visually reviewed against the
+period, comma, minus, pi, rho, square-root, greater-or-equal, slash, and omega
+claims. An independent reviewer also re-counted all nine groups and confirmed
+each target plus two witness digests.
+
+## Clean verification and package impact
+
+- Evaluated commit: `578f517c90f21c073673e6668421368374f7cf55`.
+- Source PDF SHA-256:
+  `6e4e3411984f3edf99dbfe8b941cb5e8a321379ff0cae6ae5c1f592ad8882ca8`.
+- Three-process report SHA-256:
+  `a785b07f9638be5419319330bb9102fe53b40259e3432f528aec83d6cf95d502`.
+- Private report directory:
+  `/Users/silverbook/Sites/pdf-tools-extraction-sidecars/shannon-primary-type3-final-20260803-clean-578f517`.
+- PDF Tools Markdown SHA-256 in all three repetitions:
+  `8b1d2520e4fdbbb1ec3aa1b9fa3ee3604f72712c0b0a37b53a4e4c9d3962ca94`.
+- Median elapsed time: 3,690.169 ms; median maximum RSS: 356,188,160 bytes.
+- Sampled structure remained unchanged: headings 14/14, reading anchors 23/24
+  across 5/6 complete groups, paragraphs 2/4, equations 4/4, footnotes 4/4,
+  and one qualifying Table I topology. `TABLE I` remains duplicated.
+- Full repository suite: 1,886 passed, 79 intentionally skipped, zero failed.
+- Transactional share contract: 40 tools, 14 prompts, 112 SBOM components;
+  SHA-256
+  `957b534b598c87555790d835f8b69fb7d40f83259ceaf119c55add79b379d4ba`.
+- Reproducible MCPB: two clean isolated builds were byte-identical; 3,000
+  files, 73,642,876 bytes; SHA-256
+  `713a31bfa8b2386dbbf66c76dad3488cc7be00ff0ee52d40bb4bbac5e4d64f90`.
+- MCPB growth over PR #61: 2,075 bytes, or approximately 0.0028%.
+- Packed MCPB smoke passed on macOS arm64 with all 40 tools, 14 prompts,
+  canonical resources, a verified mutation, and a native raster image.
+
+The full suite was run in a subshell with ordinary mode-022 file creation
+because Silverbook's caller uses private mode-077 creation and one existing
+portable-symlink test explicitly expects the ordinary macOS mode. No machine
+setting was changed.
+
+This evidence does not prove general Type-3 decoding, formula reconstruction,
+OCR, full mathematical fidelity, native Claude Desktop behavior, Windows or
+Linux execution, release readiness, or that Kepano's complete issue is solved.

--- a/docs/handoffs/KEPANO_SHANNON.md
+++ b/docs/handoffs/KEPANO_SHANNON.md
@@ -26,8 +26,10 @@ to replace it with a newly invented benchmark.
 - Active worktree:
   `/Users/silverbook/Sites/pdf-tools-worktrees/codex-shannon-type3-next`
 - Active branch: `codex/shannon-type3-next`
-- Clean implementation checkpoint:
+- Exact runtime implementation and evaluation checkpoint:
   `578f517c90f21c073673e6668421368374f7cf55`
+- Later commits on the branch update evidence and this handoff only; use
+  `git rev-parse HEAD` for the current published branch tip.
 - Publication status: draft PR #62, stacked directly on PR #61.
 - Current draft stack, reviewed from bottom to top:
   - PR #59, `Restore proven mathematical operator spacing`
@@ -52,9 +54,9 @@ remain unchanged.
 The active next tranche adds 1,021 exact recoveries from nine primary glyph
 groups: 345 periods, 315 commas, 216 minuses, 55 pi characters, 27 rho
 characters, 27 square roots, 22 greater-or-equal characters, 8 slashes, and 6
-omega characters. Production recovery now totals 1,052 exact characters from
-13 registered groups. Replacement characters fall from 831 to 511 while all
-sampled structural scores remain unchanged.
+omega characters. The tested draft implementation totals 1,052 exact
+characters from 13 registered groups. Replacement characters fall from 831 to
+511 while all sampled structural scores remain unchanged.
 
 The complete two-lane census observes all 4,437 Type-3 occurrences. It safely
 links 4,427 and explicitly abstains on 10 ambiguous raw-font links. Of 1,240

--- a/docs/handoffs/KEPANO_SHANNON.md
+++ b/docs/handoffs/KEPANO_SHANNON.md
@@ -133,7 +133,8 @@ retarget PR #56 to `master`, verify its diff, and continue one PR at a time
 through #62. Never merge a higher draft while its direct base is still an
 unmerged feature branch. Re-run the cumulative tests and package proof after
 the final landing; any repack has a new artifact identity. Installed Claude
-Desktop proof remains a separate gate even after the code lands.
+Desktop proof must be repeated for that new artifact identity after the code
+lands.
 
 ## Fast recovery commands
 

--- a/docs/handoffs/KEPANO_SHANNON.md
+++ b/docs/handoffs/KEPANO_SHANNON.md
@@ -67,8 +67,9 @@ recovery during an experiment, and a 64-occurrence minus variant lacks two
 qualified witness glyphs. Do not register either by guess.
 
 The active clean full repository run passed 1,886 tests with 79 intentional
-skips and zero failures. The clean Shannon evaluation ran three fresh
-repetitions with byte-identical Markdown. Its report SHA-256 is
+skips and zero failures. The separate native Mac safety suite passed 62 with 9
+intentional skips and zero failures. The clean Shannon evaluation ran three
+fresh repetitions with byte-identical Markdown. Its report SHA-256 is
 `a785b07f9638be5419319330bb9102fe53b40259e3432f528aec83d6cf95d502`,
 stored outside the repository at:
 
@@ -78,6 +79,12 @@ The active MCPB passed its packed smoke test and grew by only 2,075 bytes
 (approximately 0.0028%) over PR #61. First-party documentation, tests, and
 maintainer scripts, plus private evaluation outputs, are excluded from the
 distributable package.
+
+Native Claude Desktop installation remains outstanding. The currently enabled
+PDF Toolkit is an older build. A verified pre-install backup exists at
+`/Users/silverbook/Library/Application Support/Claude/PDF Tools Host Validation Backups/20260804T141500Z-pre-pr62`;
+Claude's app-control bridge failed twice before any install action, so do not
+claim installed-host proof.
 
 As of this handoff, PR #62 is an open draft stacked on PR #61. Local
 verification is the available evidence; do not silently upgrade that into

--- a/docs/handoffs/KEPANO_SHANNON.md
+++ b/docs/handoffs/KEPANO_SHANNON.md
@@ -23,11 +23,13 @@ to replace it with a newly invented benchmark.
 
 ## Verified current state
 
-- Worktree:
-  `/Users/silverbook/Sites/pdf-tools-worktrees/codex-shannon-type3-glyphs`
-- Branch: `codex/shannon-type3-glyphs`
-- Published tip before this handoff:
-  `8490db5e51a6c52babacad2a89d79a1cb9ad97cb`
+- Active worktree:
+  `/Users/silverbook/Sites/pdf-tools-worktrees/codex-shannon-type3-next`
+- Active branch: `codex/shannon-type3-next`
+- Clean implementation checkpoint:
+  `578f517c90f21c073673e6668421368374f7cf55`
+- Publication status: local only; the next stacked draft PR has not yet been
+  opened.
 - Current draft stack, reviewed from bottom to top:
   - PR #59, `Restore proven mathematical operator spacing`
   - PR #60, `Recover bounded ruled table topology`
@@ -47,17 +49,33 @@ Examples now include `−8.69`, `0.411`, `t/2`, and `ω`. All sampled heading,
 reading-order, paragraph, equation-anchor, footnote, and table-topology metrics
 remain unchanged.
 
-The clean full repository run passed 1,883 tests with 79 intentional skips and
-zero failures. The clean Shannon evaluation ran three fresh repetitions with
-byte-identical Markdown. Its report SHA-256 is
-`f6502c3312b69cf0eb997817da59a536fe56a0189f9a5d5f54453dc653bc6b69`,
+The active next tranche adds 1,021 exact recoveries from nine primary glyph
+groups: 345 periods, 315 commas, 216 minuses, 55 pi characters, 27 rho
+characters, 27 square roots, 22 greater-or-equal characters, 8 slashes, and 6
+omega characters. Production recovery now totals 1,052 exact characters from
+13 registered groups. Replacement characters fall from 831 to 511 while all
+sampled structural scores remain unchanged.
+
+The complete two-lane census observes all 4,437 Type-3 occurrences. It safely
+links 4,427 and explicitly abstains on 10 ambiguous raw-font links. Of 1,240
+officially named occurrences, 1,052 are strictly recovered and 188 remain
+visible and unchanged. In particular, 60 alpha occurrences remain unresolved
+because the source control character interfered with an existing exact
+recovery during an experiment, and a 64-occurrence minus variant lacks two
+qualified witness glyphs. Do not register either by guess.
+
+The active clean full repository run passed 1,886 tests with 79 intentional
+skips and zero failures. The clean Shannon evaluation ran three fresh
+repetitions with byte-identical Markdown. Its report SHA-256 is
+`a785b07f9638be5419319330bb9102fe53b40259e3432f528aec83d6cf95d502`,
 stored outside the repository at:
 
-`/Users/silverbook/Sites/pdf-tools-extraction-sidecars/shannon-type3-final-20260803-clean-7851bb4`
+`/Users/silverbook/Sites/pdf-tools-extraction-sidecars/shannon-primary-type3-final-20260803-clean-578f517`
 
-The final MCPB passed its packed smoke test and grew by only 23,395 bytes
-(0.032%) over PR #60. Documentation, tests, scripts, and private evaluation
-outputs are excluded from the distributable package.
+The active MCPB passed its packed smoke test and grew by only 2,075 bytes
+(approximately 0.0028%) over PR #61. First-party documentation, tests, and
+maintainer scripts, plus private evaluation outputs, are excluded from the
+distributable package.
 
 As of this handoff, PRs #60 and #61 are open, mergeable drafts with no reviewer
 comments and no GitHub checks reported. Local verification is the available
@@ -66,14 +84,15 @@ proof.
 
 ## Current decision boundary
 
-PR #61 is the current review target. Do not wander off to locate a different
-Kepano PDF. First recover the exact state above from Git and the evidence
-record, inspect the draft, and preserve its narrow safety claim.
+The active branch is the next review target and should become a draft PR stacked
+on PR #61 only after its final independent review. Do not wander off to locate
+a different Kepano PDF. First recover the exact state above from Git and the
+evidence record, inspect the draft, and preserve its narrow safety claim.
 
-The feature honestly proves four exact recoveries from a narrowly qualified
-class of legacy Computer Modern Type-3 fonts. It does not prove general Type-3
-decoding, formula reconstruction, OCR, or faithful mathematical notation
-throughout the paper.
+The stack honestly proves bounded exact recoveries from qualified legacy
+Computer Modern Type-3 glyph groups. It does not prove general Type-3 decoding,
+formula reconstruction, OCR, or faithful mathematical notation throughout the
+paper.
 
 Do not merge, release, or reply publicly to Kepano without Mat's explicit
 authorization. No Kepano reply has been sent. A reply is worthwhile only if
@@ -93,7 +112,7 @@ shasum -a 256 /Users/silverbook/Sites/pdf-tools-extraction-sidecars/shannon-entr
 The focused feature checks are:
 
 ```sh
-npm test -- --run test/convert-pdf-to-markdown.test.js test/markdown-conversion.test.js test/mcp-contract.test.js test/pdfjs-worker-contract.test.js test/read-pdf-layout.test.js test/eval/markdown-bakeoff.test.js test/eval/extraction-phase1-layout-evidence.test.js
+PDF_TOOLS_SHANNON_SOURCE=/Users/silverbook/Sites/pdf-tools-extraction-sidecars/shannon-entropy.pdf npm test -- --run test/shannon-type3-live.test.js test/type3-glyph-inventory.test.js test/pdfjs-worker-contract.test.js test/read-pdf-layout.test.js test/eval/extraction-phase1-layout-evidence.test.js
 ```
 
 The clean Shannon runner command is:
@@ -102,8 +121,9 @@ The clean Shannon runner command is:
 node scripts/eval-run-shannon-markdown-bakeoff.mjs --source /Users/silverbook/Sites/pdf-tools-extraction-sidecars/shannon-entropy.pdf --pdf-inspector-root /Users/silverbook/Sites/pdf-tools-extraction-sidecars/pdf-inspector-1c32e4bd691b --output-dir /absolute/new/output-directory-outside-the-repository
 ```
 
-Use a new output directory for every run. The detailed evidence record is
-`docs/evidence/shannon-qualified-type3-glyphs-2026-08.md`.
+Use a new output directory for every run. The active detailed evidence record
+is `docs/evidence/shannon-primary-type3-glyph-batch-2026-08.md`; the preceding
+record is `docs/evidence/shannon-qualified-type3-glyphs-2026-08.md`.
 
 ## Working with Mat
 

--- a/docs/handoffs/KEPANO_SHANNON.md
+++ b/docs/handoffs/KEPANO_SHANNON.md
@@ -1,6 +1,6 @@
 # Kepano / Shannon current handoff
 
-Updated 2026-08-03 (America/Los_Angeles).
+Updated 2026-08-04 (America/Los_Angeles).
 
 ## Read this first
 
@@ -30,6 +30,9 @@ to replace it with a newly invented benchmark.
   `578f517c90f21c073673e6668421368374f7cf55`
 - Later commits on the branch update evidence and this handoff only; use
   `git rev-parse HEAD` for the current published branch tip.
+- The documentation tip is intentionally resolved live rather than written
+  into this file, because committing a self-referenced hash would immediately
+  create a different tip. The tested runtime checkpoint above is immutable.
 - Publication status: draft PR #62, stacked directly on PR #61.
 - Current draft stack, reviewed from bottom to top:
 

--- a/docs/handoffs/KEPANO_SHANNON.md
+++ b/docs/handoffs/KEPANO_SHANNON.md
@@ -32,10 +32,22 @@ to replace it with a newly invented benchmark.
   `git rev-parse HEAD` for the current published branch tip.
 - Publication status: draft PR #62, stacked directly on PR #61.
 - Current draft stack, reviewed from bottom to top:
-  - PR #59, `Restore proven mathematical operator spacing`
-  - PR #60, `Recover bounded ruled table topology`
-  - PR #61, `Recover qualified legacy Type-3 glyphs`
-  - PR #62, `Recover the primary vetted Type-3 glyph batch`
+
+| PR | Draft outcome | Direct base |
+| ---: | --- | --- |
+| #55 | Evaluate Shannon Markdown candidates and fix invalid line grouping | `master` |
+| #56 | Reject malformed heading candidates | PR #55 |
+| #57 | Recover strongly supported document headings | PR #56 |
+| #58 | Improve narrowly supported paragraph continuity | PR #57 |
+| #59 | Restore proven mathematical operator spacing | PR #58 |
+| #60 | Recover bounded ruled table topology | PR #59 |
+| #61 | Recover the first qualified legacy Type-3 glyph batch | PR #60 |
+| #62 | Recover the primary vetted Type-3 glyph batch | PR #61 |
+
+All eight local branch tips matched their live GitHub PR heads during the
+2026-08-04 review. Each draft was open and mergeable with no comments, reviews,
+or reported checks. The cumulative top branch passed the complete verification
+described below.
 
 PR #61 is stacked directly on PR #60. On the verified Shannon PDF it changes
 exactly 31 intended codepoint positions without changing output length:
@@ -104,6 +116,13 @@ paper.
 Do not merge, release, or reply publicly to Kepano without Mat's explicit
 authorization. No Kepano reply has been sent. A reply is worthwhile only if
 his actual issue is honestly solved; otherwise do not ping him.
+
+If Mat later authorizes landing, preserve the order above. Merge PR #55 first,
+retarget PR #56 to `master`, verify its diff, and continue one PR at a time
+through #62. Never merge a higher draft while its direct base is still an
+unmerged feature branch. Re-run the cumulative tests and package proof after
+the final landing; any repack has a new artifact identity. Installed Claude
+Desktop proof remains a separate gate even after the code lands.
 
 ## Fast recovery commands
 

--- a/docs/handoffs/KEPANO_SHANNON.md
+++ b/docs/handoffs/KEPANO_SHANNON.md
@@ -28,12 +28,12 @@ to replace it with a newly invented benchmark.
 - Active branch: `codex/shannon-type3-next`
 - Clean implementation checkpoint:
   `578f517c90f21c073673e6668421368374f7cf55`
-- Publication status: local only; the next stacked draft PR has not yet been
-  opened.
+- Publication status: draft PR #62, stacked directly on PR #61.
 - Current draft stack, reviewed from bottom to top:
   - PR #59, `Restore proven mathematical operator spacing`
   - PR #60, `Recover bounded ruled table topology`
   - PR #61, `Recover qualified legacy Type-3 glyphs`
+  - PR #62, `Recover the primary vetted Type-3 glyph batch`
 
 PR #61 is stacked directly on PR #60. On the verified Shannon PDF it changes
 exactly 31 intended codepoint positions without changing output length:
@@ -77,17 +77,15 @@ The active MCPB passed its packed smoke test and grew by only 2,075 bytes
 maintainer scripts, plus private evaluation outputs, are excluded from the
 distributable package.
 
-As of this handoff, PRs #60 and #61 are open, mergeable drafts with no reviewer
-comments and no GitHub checks reported. Local verification is the available
-evidence; do not silently upgrade that into host, release, or cross-platform
-proof.
+As of this handoff, PR #62 is an open draft stacked on PR #61. Local
+verification is the available evidence; do not silently upgrade that into
+host, release, or cross-platform proof.
 
 ## Current decision boundary
 
-The active branch is the next review target and should become a draft PR stacked
-on PR #61 only after its final independent review. Do not wander off to locate
-a different Kepano PDF. First recover the exact state above from Git and the
-evidence record, inspect the draft, and preserve its narrow safety claim.
+PR #62 is the active review target. Do not wander off to locate a different
+Kepano PDF. First recover the exact state above from Git and the evidence
+record, inspect the draft, and preserve its narrow safety claim.
 
 The stack honestly proves bounded exact recoveries from qualified legacy
 Computer Modern Type-3 glyph groups. It does not prove general Type-3 decoding,

--- a/docs/handoffs/KEPANO_SHANNON.md
+++ b/docs/handoffs/KEPANO_SHANNON.md
@@ -95,15 +95,23 @@ The active MCPB passed its packed smoke test and grew by only 2,075 bytes
 maintainer scripts, plus private evaluation outputs, are excluded from the
 distributable package.
 
-Native Claude Desktop installation remains outstanding. The currently enabled
-PDF Toolkit is an older build. A verified pre-install backup exists at
-`/Users/silverbook/Library/Application Support/Claude/PDF Tools Host Validation Backups/20260804T141500Z-pre-pr62`;
-Claude's app-control bridge failed twice before any install action, so do not
-claim installed-host proof.
+On 2026-08-04, the exact MCPB was installed in Claude Desktop. The installation
+registry SHA-256 matches the artifact, the Claude host log records successful
+startup and tool discovery, and the older PDF Tools identity was removed. One
+enabled current installation remains. Its installed directory passed the
+synthetic installed-server smoke and converted all 55 Shannon pages to the
+exact reviewed Markdown SHA-256
+`8b1d2520e4fdbbb1ec3aa1b9fa3ee3604f72712c0b0a37b53a4e4c9d3962ca94`,
+with 511 replacement characters and 68 explicit gaps. A verified pre-install
+backup remains at
+`/Users/silverbook/Library/Application Support/Claude/PDF Tools Host Validation Backups/20260804T141500Z-pre-pr62`.
+A Shannon conversion initiated inside a Claude chat remains an unrun UI-level
+check; do not silently claim that narrower proof.
 
-As of this handoff, PR #62 is an open draft stacked on PR #61. Local
-verification is the available evidence; do not silently upgrade that into
-host, release, or cross-platform proof.
+As of this handoff, PR #62 is an open draft stacked on PR #61. Local, native
+installation, Claude host-loading, and installed-bundle server verification are
+available; do not silently upgrade them into release, cross-platform, or
+Claude-chat proof.
 
 ## Current decision boundary
 

--- a/pdf-toolkit-mcp-share/server/layout-extraction.js
+++ b/pdf-toolkit-mcp-share/server/layout-extraction.js
@@ -48,6 +48,123 @@ const MAX_TYPE3_GLYPH_CANONICAL_BYTES = 250000;
 
 const TYPE3_RECOVERY_REGISTRY = Object.freeze([
   Object.freeze({
+    id: "cmmi-pk-raster-period-2df559-v1",
+    qualification: "ctan-cm-encoding-plus-reviewed-pk-raster-v1",
+    family: "computer-modern-math-italic",
+    original_char_code: 58,
+    source_unicode: ":",
+    target_unicode: ".",
+    charproc_sha256: "2df559091df37cc5da5c1ce3e05eebc1075c4c041b83d96a1904d2c2f21edab0",
+    witnesses: Object.freeze([
+      Object.freeze({ original_char_code: 59, charproc_sha256: "42b5ebf435945b75e1dc1bc271bfbb4aa2dc02b8adc93cd26b4bb64dec9fde8a" }),
+      Object.freeze({ original_char_code: 61, charproc_sha256: "55447dde50a97970297d189788eb154c675c41e6d2eca2836949aefadd0b1780" }),
+    ]),
+  }),
+  Object.freeze({
+    id: "cmmi-pk-raster-comma-42b5eb-v1",
+    qualification: "ctan-cm-encoding-plus-reviewed-pk-raster-v1",
+    family: "computer-modern-math-italic",
+    original_char_code: 59,
+    source_unicode: ";",
+    target_unicode: ",",
+    charproc_sha256: "42b5ebf435945b75e1dc1bc271bfbb4aa2dc02b8adc93cd26b4bb64dec9fde8a",
+    witnesses: Object.freeze([
+      Object.freeze({ original_char_code: 58, charproc_sha256: "2df559091df37cc5da5c1ce3e05eebc1075c4c041b83d96a1904d2c2f21edab0" }),
+      Object.freeze({ original_char_code: 61, charproc_sha256: "55447dde50a97970297d189788eb154c675c41e6d2eca2836949aefadd0b1780" }),
+    ]),
+  }),
+  Object.freeze({
+    id: "cmmi-pk-raster-pi-780b04-v1",
+    qualification: "ctan-cm-encoding-plus-reviewed-pk-raster-v1",
+    family: "computer-modern-math-italic",
+    original_char_code: 25,
+    source_unicode: "\u0019",
+    target_unicode: "π",
+    charproc_sha256: "780b04fa47830ca782211b86dbedfe0adec0445bdf94d538bfe7adde08ed9445",
+    witnesses: Object.freeze([
+      Object.freeze({ original_char_code: 11, charproc_sha256: "e688a83f98433c841694f990aabafe5245cfc9320f584d7f70da706f0eeba259" }),
+      Object.freeze({ original_char_code: 26, charproc_sha256: "1500df39391626d02f9e98132f991f71899612069298e52340e12fb65590836f" }),
+    ]),
+  }),
+  Object.freeze({
+    id: "cmmi-pk-raster-rho-1500df-v1",
+    qualification: "ctan-cm-encoding-plus-reviewed-pk-raster-v1",
+    family: "computer-modern-math-italic",
+    original_char_code: 26,
+    source_unicode: "\u001a",
+    target_unicode: "ρ",
+    charproc_sha256: "1500df39391626d02f9e98132f991f71899612069298e52340e12fb65590836f",
+    witnesses: Object.freeze([
+      Object.freeze({ original_char_code: 11, charproc_sha256: "e688a83f98433c841694f990aabafe5245cfc9320f584d7f70da706f0eeba259" }),
+      Object.freeze({ original_char_code: 25, charproc_sha256: "780b04fa47830ca782211b86dbedfe0adec0445bdf94d538bfe7adde08ed9445" }),
+    ]),
+  }),
+  Object.freeze({
+    id: "cmmi-pk-raster-omega-81b411-v1",
+    qualification: "ctan-cm-encoding-plus-reviewed-pk-raster-v1",
+    family: "computer-modern-math-italic",
+    original_char_code: 33,
+    source_unicode: "!",
+    target_unicode: "ω",
+    charproc_sha256: "81b41121b5e19a2aebd37331ab3584fe08221ca1afcda83f4ce8b76997177074",
+    witnesses: Object.freeze([
+      Object.freeze({ original_char_code: 11, charproc_sha256: "e688a83f98433c841694f990aabafe5245cfc9320f584d7f70da706f0eeba259" }),
+      Object.freeze({ original_char_code: 25, charproc_sha256: "780b04fa47830ca782211b86dbedfe0adec0445bdf94d538bfe7adde08ed9445" }),
+    ]),
+  }),
+  Object.freeze({
+    id: "cmmi-pk-raster-slash-55447d-v1",
+    qualification: "ctan-cm-encoding-plus-reviewed-pk-raster-v1",
+    family: "computer-modern-math-italic",
+    original_char_code: 61,
+    source_unicode: "=",
+    target_unicode: "/",
+    charproc_sha256: "55447dde50a97970297d189788eb154c675c41e6d2eca2836949aefadd0b1780",
+    witnesses: Object.freeze([
+      Object.freeze({ original_char_code: 58, charproc_sha256: "2df559091df37cc5da5c1ce3e05eebc1075c4c041b83d96a1904d2c2f21edab0" }),
+      Object.freeze({ original_char_code: 59, charproc_sha256: "42b5ebf435945b75e1dc1bc271bfbb4aa2dc02b8adc93cd26b4bb64dec9fde8a" }),
+    ]),
+  }),
+  Object.freeze({
+    id: "cmsy-pk-raster-minus-fb1f6b-v1",
+    qualification: "ctan-cm-encoding-plus-reviewed-pk-raster-v1",
+    family: "computer-modern-math-symbol",
+    original_char_code: 0,
+    source_unicode: "\u0000",
+    target_unicode: "−",
+    charproc_sha256: "fb1f6bf10138511bcefade47467b3e2f9ae691ab3dab097914be1f0f66305470",
+    witnesses: Object.freeze([
+      Object.freeze({ original_char_code: 21, charproc_sha256: "05b4a9d88c1df64b3ac339ae6bb7ed82383b93bb08512842452db43453a28970" }),
+      Object.freeze({ original_char_code: 112, charproc_sha256: "772f491fc17e6bb3bc37c17ace6be704244ab121c7180d59319726e0af4b0efc" }),
+    ]),
+  }),
+  Object.freeze({
+    id: "cmsy-pk-raster-greater-equal-05b4a9-v1",
+    qualification: "ctan-cm-encoding-plus-reviewed-pk-raster-v1",
+    family: "computer-modern-math-symbol",
+    original_char_code: 21,
+    source_unicode: "\u0015",
+    target_unicode: "≥",
+    charproc_sha256: "05b4a9d88c1df64b3ac339ae6bb7ed82383b93bb08512842452db43453a28970",
+    witnesses: Object.freeze([
+      Object.freeze({ original_char_code: 0, charproc_sha256: "fb1f6bf10138511bcefade47467b3e2f9ae691ab3dab097914be1f0f66305470" }),
+      Object.freeze({ original_char_code: 112, charproc_sha256: "772f491fc17e6bb3bc37c17ace6be704244ab121c7180d59319726e0af4b0efc" }),
+    ]),
+  }),
+  Object.freeze({
+    id: "cmsy-pk-raster-square-root-772f49-v1",
+    qualification: "ctan-cm-encoding-plus-reviewed-pk-raster-v1",
+    family: "computer-modern-math-symbol",
+    original_char_code: 112,
+    source_unicode: "p",
+    target_unicode: "√",
+    charproc_sha256: "772f491fc17e6bb3bc37c17ace6be704244ab121c7180d59319726e0af4b0efc",
+    witnesses: Object.freeze([
+      Object.freeze({ original_char_code: 0, charproc_sha256: "fb1f6bf10138511bcefade47467b3e2f9ae691ab3dab097914be1f0f66305470" }),
+      Object.freeze({ original_char_code: 21, charproc_sha256: "05b4a9d88c1df64b3ac339ae6bb7ed82383b93bb08512842452db43453a28970" }),
+    ]),
+  }),
+  Object.freeze({
     id: "cmmi-pk-raster-omega-v1",
     qualification: "ctan-cm-encoding-plus-reviewed-pk-raster-v1",
     family: "computer-modern-math-italic",
@@ -410,6 +527,135 @@ function collectType3GlyphRecoveries({ textContent, operators, pdfjsPage, pdfLib
     recoveries.set(sourceIndex, deduplicated);
   }
   return recoveries;
+}
+
+/**
+ * Read-only maintainer census for every understood legacy Type-3 showText
+ * glyph. Unlike recovery's strict text-binding lane, this keeps control and
+ * whitespace-like Unicode values so old encodings cannot disappear from the
+ * report. Missing links/classification/digests remain explicit omissions.
+ */
+export function inspectType3GlyphEvidenceForPage({ textContent, operators, pdfjsPage, pdfLibPage, pdfjsLib }) {
+  const ops = pdfjsLib?.OPS ?? {};
+  const omissions = [];
+  if (!operators || !Array.isArray(operators.fnArray) || !Array.isArray(operators.argsArray)) {
+    return { occurrences: [], omissions: [{ reason: "operator_evidence_unavailable", count: 1 }] };
+  }
+  let currentFont = null;
+  const fontStack = [];
+  const byFont = new Map();
+  const fonts = new Map();
+  const unsupportedTextOps = new Set([
+    ops.showSpacedText,
+    ops.nextLineShowText,
+    ops.nextLineSetSpacingShowText,
+  ].filter(Number.isFinite));
+  for (let operatorIndex = 0; operatorIndex < operators.fnArray.length; operatorIndex += 1) {
+    const operation = operators.fnArray[operatorIndex];
+    const args = operators.argsArray[operatorIndex];
+    if (operation === ops.save) fontStack.push(currentFont);
+    else if (operation === ops.restore) {
+      if (fontStack.length === 0) omissions.push({ reason: "font_stack_restore_underflow", count: 1 });
+      else currentFont = fontStack.pop();
+    } else if (operation === ops.setFont) {
+      currentFont = typeof args?.[0] === "string" ? args[0] : null;
+    } else if (unsupportedTextOps.has(operation)) {
+      omissions.push({ reason: "unsupported_text_operator", count: 1 });
+    } else if (operation === ops.showText && currentFont !== null && Array.isArray(args?.[0])) {
+      let font = fonts.get(currentFont);
+      if (font === undefined) {
+        try {
+          font = pdfjsPage.commonObjs.get(currentFont);
+        } catch {
+          font = null;
+          omissions.push({ font_id: currentFont, reason: "font_object_unavailable", scope: "potential_font_glyph", count: args[0].length });
+        }
+        if (font?.isType3Font !== true) font = null;
+        fonts.set(currentFont, font);
+      }
+      if (!font) continue;
+      if (!byFont.has(currentFont)) byFont.set(currentFont, []);
+      for (let glyphIndex = 0; glyphIndex < args[0].length; glyphIndex += 1) {
+        const glyph = args[0][glyphIndex];
+        // PDF.js interleaves numeric text-position adjustments with glyphs.
+        if (typeof glyph === "number" && Number.isFinite(glyph)) continue;
+        if (!glyph || typeof glyph !== "object") {
+          omissions.push({ font_id: currentFont, reason: "malformed_type3_glyph", scope: "type3_glyph", count: 1 });
+          continue;
+        }
+        byFont.get(currentFont).push({ glyph, operator_index: operatorIndex, glyph_index: glyphIndex });
+      }
+    } else if (operation === ops.showText && currentFont === null) {
+      omissions.push({ reason: "show_text_without_current_font", scope: "potential_font_glyph", count: Array.isArray(args?.[0]) ? args[0].length : 1 });
+    } else if (operation === ops.showText) {
+      omissions.push({ reason: "malformed_show_text_arguments", scope: "potential_font_glyph", count: 1 });
+    }
+  }
+  if (fontStack.length !== 0) omissions.push({ reason: "font_stack_unbalanced_at_end", count: fontStack.length });
+
+  const rawFonts = rawType3Fonts(pdfLibPage);
+  const occurrences = [];
+  for (const [fontId, fontTokens] of byFont) {
+    const font = fonts.get(fontId);
+    const rawFont = linkedRawType3Font(fontId, fontTokens, rawFonts);
+    if (!rawFont) {
+      omissions.push({ font_id: fontId, reason: "raw_type3_font_link_ambiguous_or_unavailable", scope: "type3_glyph", count: fontTokens.length });
+      continue;
+    }
+    const family = uniqueComputerModernFamily(rawFont.widths);
+    const official = family ? CM_CODEPOINTS[family] : null;
+    const mappedCodeCharprocSha256 = official ? Object.fromEntries(Object.keys(official)
+      .map(Number)
+      .sort((left, right) => left - right)
+      .map(code => [code, charProcDigestForCode(font, rawFont, code)])) : {};
+    for (const token of fontTokens) {
+      const code = token.glyph.originalCharCode;
+      if (!Number.isSafeInteger(code)) {
+        omissions.push({ font_id: fontId, reason: "original_char_code_unavailable", scope: "type3_glyph", count: 1 });
+        continue;
+      }
+      const digest = charProcDigestForCode(font, rawFont, code);
+      if (!digest) omissions.push({ font_id: fontId, reason: "charproc_digest_unavailable", scope: "glyph_evidence", count: 1 });
+      const registryEvidenceMatchIds = TYPE3_RECOVERY_REGISTRY.filter(entry => entry.family === family
+        && entry.original_char_code === code
+        && entry.source_unicode === token.glyph.unicode
+        && entry.target_unicode === official?.[code]
+        && entry.charproc_sha256 === digest
+        && entry.witnesses.every(witness => mappedCodeCharprocSha256[witness.original_char_code] === witness.charproc_sha256))
+        .map(entry => entry.id)
+        .sort();
+      occurrences.push({
+        family,
+        family_status: !family
+          ? "ambiguous_or_unavailable"
+          : official
+            ? "identified_reviewed_mapping"
+            : "identified_not_unicode_mapped",
+        original_char_code: code,
+        source_unicode: typeof token.glyph.unicode === "string" ? token.glyph.unicode : "",
+        intended_unicode: official?.[code] ?? null,
+        charproc_sha256: digest,
+        mapped_code_charproc_sha256: mappedCodeCharprocSha256,
+        registry_evidence_match_ids: registryEvidenceMatchIds,
+        operator_index: token.operator_index,
+        glyph_index: token.glyph_index,
+        tfm_reference_version: CM_TFM_REFERENCE_VERSION,
+        canonicalizer_version: TYPE3_GLYPH_CANONICALIZER_VERSION,
+      });
+    }
+  }
+  const strictRecoveries = textContent ? [...collectType3GlyphRecoveries({
+    textContent,
+    operators,
+    pdfjsPage,
+    pdfLibPage,
+    pdfjsLib,
+  }).entries()].flatMap(([sourceIndex, recoveries]) => recoveries.map(recovery => ({
+    source_index: sourceIndex,
+    ...recovery,
+  }))) : [];
+  if (!textContent) omissions.push({ reason: "strict_text_binding_unavailable", scope: "strict_recovery", count: 1 });
+  return { occurrences, omissions, strict_recoveries: strictRecoveries };
 }
 
 function applyType3GlyphRecoveries(sourceText, recoveries) {

--- a/pdf-toolkit-mcp-share/server/pdfjs-worker.js
+++ b/pdf-toolkit-mcp-share/server/pdfjs-worker.js
@@ -478,6 +478,12 @@ async function loadPdfjs() {
   return pdfjsLib;
 }
 
+// Maintenance scripts use the production loader so glyph-program evidence is
+// never computed under a different DOM/canvas implementation than the worker.
+export async function loadPdfjsForMaintenance() {
+  return await loadPdfjs();
+}
+
 function nativeCanvasBindingCandidate() {
   const packageByPlatform = {
     "darwin-arm64": "@napi-rs/canvas-darwin-arm64",

--- a/scripts/generate-type3-cm-reference.mjs
+++ b/scripts/generate-type3-cm-reference.mjs
@@ -10,8 +10,10 @@ import { fileURLToPath } from "node:url";
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const TFM_ARCHIVE_URL = "https://mirrors.ctan.org/fonts/cm/tfm.zip";
 const TYPE3_ARCHIVE_URL = "https://mirrors.ctan.org/fonts/cm/ps-type3.zip";
+const MF_ARCHIVE_URL = "https://mirrors.ctan.org/fonts/cm/mf.zip";
 const TFM_ARCHIVE_SHA256 = "9c0f99fa34c7d801c40f6b5ff60bc28f200e8ef6ffb2fe75e54ca835c67fc04c";
 const TYPE3_ARCHIVE_SHA256 = "ef38efbd58774b454b190e17c8b5ca0fde13dd5d5ff2282bf0dc0313197f1033";
+const MF_ARCHIVE_SHA256 = "b22c69034d9f3f7a9bf22673544bdeaace5656973cf7fb1a395a857148943076";
 const OUTPUT_MODULE = path.join(REPO_ROOT, "server/type3-cm-reference.js");
 const OUTPUT_SHARE_MODULE = path.join(REPO_ROOT, "pdf-toolkit-mcp-share/server/type3-cm-reference.js");
 const OUTPUT_FIXTURE = path.join(REPO_ROOT, "test/fixtures/eval/extraction/type3-cm-reference.pdf");
@@ -60,6 +62,28 @@ function encodingFamily(filename) {
   if (/^(?:cmmi|cmmib)/u.test(filename)) return "computer-modern-math-italic";
   if (/^(?:cmsy|cmbsy)/u.test(filename)) return "computer-modern-math-symbol";
   return `unsupported:${filename.replace(/\.tfm$/u, "")}`;
+}
+
+function requireSourceDefinitions(mfRoot) {
+  const checks = [
+    ["greekl.mf", /cmchar "Lowercase Greek alpha";\s*beginchar\(oct"013"/u],
+    ["greekl.mf", /cmchar "Lowercase Greek pi";\s*beginchar\(oct"031"/u],
+    ["greekl.mf", /cmchar "Lowercase Greek rho";\s*beginchar\(oct"032"/u],
+    ["greekl.mf", /cmchar "Lowercase Greek omega";\s*beginchar\(oct"041"/u],
+    ["romms.mf", /cmchar "Period";[\s\S]*?beginchar\(oct"072"/u],
+    ["romms.mf", /cmchar "Comma";[\s\S]*?beginchar\(oct"073"/u],
+    ["romms.mf", /cmchar "Virgule \(slash\)";\s*beginchar\(oct"075"/u],
+    ["symbol.mf", /minus=oct"000"/u],
+    ["sym.mf", /iff known minus: cmchar "Minus sign";\s*beginarithchar\(minus\)/u],
+    ["symbol.mf", /geq=oct"025"/u],
+    ["sym.mf", /iff known geq: cmchar "Greater than or equal to sign";[\s\S]*?beginchar\(geq,/u],
+    ["symbol.mf", /cmchar "Radical sign";\s*beginchar\(oct"160"/u],
+  ];
+  const sources = new Map();
+  for (const [filename, pattern] of checks) {
+    if (!sources.has(filename)) sources.set(filename, fs.readFileSync(path.join(mfRoot, filename), "utf8"));
+    if (!pattern.test(sources.get(filename))) throw new Error(`Official Computer Modern definition check failed: ${filename}`);
+  }
 }
 
 function generateMetricModule(tfmRoot, archiveSha256) {
@@ -116,15 +140,21 @@ const temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pdf-tools-type3-cm-
 try {
   const tfmArchive = path.join(temporaryRoot, "cm-tfm.zip");
   const type3Archive = path.join(temporaryRoot, "cm-type3.zip");
+  const mfArchive = path.join(temporaryRoot, "cm-mf.zip");
   download(TFM_ARCHIVE_URL, tfmArchive);
   download(TYPE3_ARCHIVE_URL, type3Archive);
+  download(MF_ARCHIVE_URL, mfArchive);
   requireDigest(tfmArchive, TFM_ARCHIVE_SHA256);
   requireDigest(type3Archive, TYPE3_ARCHIVE_SHA256);
+  requireDigest(mfArchive, MF_ARCHIVE_SHA256);
 
   const tfmExtracted = path.join(temporaryRoot, "tfm");
   const type3Extracted = path.join(temporaryRoot, "type3");
+  const mfExtracted = path.join(temporaryRoot, "mf");
   unzip(tfmArchive, tfmExtracted);
   unzip(type3Archive, type3Extracted);
+  unzip(mfArchive, mfExtracted);
+  requireSourceDefinitions(path.join(mfExtracted, "mf"));
   const metricModule = generateMetricModule(path.join(tfmExtracted, "tfm"), TFM_ARCHIVE_SHA256);
   fs.writeFileSync(OUTPUT_MODULE, metricModule);
   fs.writeFileSync(OUTPUT_SHARE_MODULE, metricModule);
@@ -136,6 +166,7 @@ try {
     sources: [
       { url: TFM_ARCHIVE_URL, sha256: TFM_ARCHIVE_SHA256 },
       { url: TYPE3_ARCHIVE_URL, sha256: TYPE3_ARCHIVE_SHA256 },
+      { url: MF_ARCHIVE_URL, sha256: MF_ARCHIVE_SHA256 },
     ],
     generator: {
       ghostscript: execFileSync("gs", ["--version"], { encoding: "utf8" }).trim(),

--- a/scripts/inventory-type3-glyphs.mjs
+++ b/scripts/inventory-type3-glyphs.mjs
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { createRequire } from "node:module";
+import { PDFDocument } from "pdf-lib";
+import {
+  inspectType3GlyphEvidenceForPage,
+  pdfjsFactoryDirectory,
+} from "../server/layout-extraction.js";
+import { loadPdfjsForMaintenance } from "../server/pdfjs-worker.js";
+
+const require = createRequire(import.meta.url);
+
+function exactSourceArgument(argv) {
+  if (argv.length !== 2 || argv[0] !== "--source" || !path.isAbsolute(argv[1])) {
+    throw new Error("Usage: node scripts/inventory-type3-glyphs.mjs --source /absolute/path/to/source.pdf");
+  }
+  return path.normalize(argv[1]);
+}
+
+function scalarLabel(value) {
+  if (value === null) return null;
+  return [...value].map(character => `U+${character.codePointAt(0).toString(16).toUpperCase().padStart(4, "0")}`).join(" ");
+}
+
+function canonicalJson(value) {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value).sort().map(key => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+async function loadPdfjs() {
+  const pdfjs = await loadPdfjsForMaintenance();
+  const packageDirectory = path.dirname(require.resolve("pdfjs-dist/package.json"));
+  return { pdfjs, packageDirectory };
+}
+
+async function main() {
+  const sourcePath = exactSourceArgument(process.argv.slice(2));
+  if (await fs.realpath(sourcePath) !== sourcePath) throw new Error("Source path must be canonical");
+  const bytes = await fs.readFile(sourcePath);
+  const [{ pdfjs, packageDirectory }, pdfLibDocument] = await Promise.all([
+    loadPdfjs(),
+    PDFDocument.load(bytes, { ignoreEncryption: true, updateMetadata: false }),
+  ]);
+  const loadingTask = pdfjs.getDocument({
+    data: new Uint8Array(bytes),
+    useWorkerFetch: false,
+    isEvalSupported: false,
+    cMapUrl: pdfjsFactoryDirectory(path.join(packageDirectory, "cmaps")),
+    cMapPacked: true,
+    standardFontDataUrl: pdfjsFactoryDirectory(path.join(packageDirectory, "standard_fonts")),
+  });
+  let document;
+  try {
+    document = await loadingTask.promise;
+    if (document.numPages !== pdfLibDocument.getPageCount()) throw new Error("Parser page counts disagree");
+    const occurrences = [];
+    const abstentions = [];
+    const strictRecoveries = [];
+    for (let pageNumber = 1; pageNumber <= document.numPages; pageNumber += 1) {
+      const page = await document.getPage(pageNumber);
+      try {
+        const [textContent, operators] = await Promise.all([
+          page.getTextContent({ includeMarkedContent: false, disableNormalization: false }),
+          page.getOperatorList(),
+        ]);
+        const pageInventory = inspectType3GlyphEvidenceForPage({
+          textContent,
+          operators,
+          pdfjsPage: page,
+          pdfLibPage: pdfLibDocument.getPage(pageNumber - 1),
+          pdfjsLib: pdfjs,
+        });
+        for (const occurrence of pageInventory.occurrences) occurrences.push({ page: pageNumber, ...occurrence });
+        for (const omission of pageInventory.omissions) abstentions.push({ page: pageNumber, ...omission });
+        for (const recovery of pageInventory.strict_recoveries) strictRecoveries.push({ page: pageNumber, ...recovery });
+      } finally {
+        page.cleanup();
+      }
+    }
+
+    const groups = new Map();
+    for (const occurrence of occurrences) {
+      const key = canonicalJson([
+        occurrence.family,
+        occurrence.original_char_code,
+        occurrence.source_unicode,
+        occurrence.intended_unicode,
+        occurrence.charproc_sha256,
+        occurrence.mapped_code_charproc_sha256,
+        occurrence.registry_evidence_match_ids,
+      ]);
+      if (!groups.has(key)) groups.set(key, { ...occurrence, count: 0, pages: new Set(), locations_by_page: {} });
+      const group = groups.get(key);
+      group.count += 1;
+      group.pages.add(occurrence.page);
+      group.locations_by_page[occurrence.page] ??= [];
+      group.locations_by_page[occurrence.page].push([occurrence.operator_index, occurrence.glyph_index]);
+    }
+    const inventory = [...groups.values()].map(group => ({
+      family: group.family,
+      family_status: group.family_status,
+      original_char_code: group.original_char_code,
+      source_unicode: group.source_unicode,
+      source_unicode_codepoints: scalarLabel(group.source_unicode),
+      intended_unicode: group.intended_unicode,
+      intended_unicode_codepoints: scalarLabel(group.intended_unicode),
+      charproc_sha256: group.charproc_sha256,
+      mapped_code_charproc_sha256: group.mapped_code_charproc_sha256,
+      registry_evidence_match_ids: group.registry_evidence_match_ids,
+      count: group.count,
+      pages: [...group.pages].sort((left, right) => left - right),
+      locations_by_page: group.locations_by_page,
+      tfm_reference_version: group.tfm_reference_version,
+      canonicalizer_version: group.canonicalizer_version,
+    })).sort((left, right) => right.count - left.count
+      || String(left.family).localeCompare(String(right.family))
+      || left.original_char_code - right.original_char_code
+      || String(left.charproc_sha256).localeCompare(String(right.charproc_sha256)));
+    const abstentionGroups = new Map();
+    for (const abstention of abstentions) {
+      const key = canonicalJson([abstention.reason, abstention.family ?? null]);
+      if (!abstentionGroups.has(key)) abstentionGroups.set(key, {
+        reason: abstention.reason,
+        scope: abstention.scope ?? "operator_evidence",
+        ...(abstention.family ? { family: abstention.family } : {}),
+        count: 0,
+        pages: new Set(),
+      });
+      const group = abstentionGroups.get(key);
+      group.count += abstention.count ?? 1;
+      group.pages.add(abstention.page);
+    }
+    const strictRecoveryCountsByRegistry = Object.fromEntries([...strictRecoveries.reduce((counts, recovery) => {
+      counts.set(recovery.registry_id, (counts.get(recovery.registry_id) ?? 0) + 1);
+      return counts;
+    }, new Map())].sort());
+    const type3OmittedOccurrenceCount = abstentions
+      .filter(item => item.scope === "type3_glyph")
+      .reduce((sum, item) => sum + (item.count ?? 1), 0);
+    const classifiedOccurrenceCount = occurrences.filter(item => item.family !== null).length;
+    const officiallyNamedOccurrenceCount = occurrences.filter(item => item.intended_unicode !== null).length;
+    const registryEvidenceOccurrenceCount = occurrences.filter(item => item.registry_evidence_match_ids.length > 0).length;
+    process.stdout.write(`${canonicalJson({
+      schema: "pdf-tools.type3-glyph-inventory.v1",
+      source: {
+        filename: path.basename(sourcePath),
+        page_count: document.numPages,
+        sha256: createHash("sha256").update(bytes).digest("hex"),
+        size_bytes: bytes.length,
+      },
+      occurrence_count: occurrences.length,
+      coverage: {
+        observed_type3_occurrence_count: occurrences.length + type3OmittedOccurrenceCount,
+        linked_type3_occurrence_count: occurrences.length,
+        omitted_type3_occurrence_count: type3OmittedOccurrenceCount,
+        classified_occurrence_count: classifiedOccurrenceCount,
+        unclassified_occurrence_count: occurrences.length - classifiedOccurrenceCount,
+        officially_named_occurrence_count: officiallyNamedOccurrenceCount,
+        officially_unnamed_occurrence_count: occurrences.length - officiallyNamedOccurrenceCount,
+        registry_evidence_occurrence_count: registryEvidenceOccurrenceCount,
+        strict_recovery_count: strictRecoveries.length,
+        officially_named_not_strictly_recovered_count: officiallyNamedOccurrenceCount - strictRecoveries.length,
+      },
+      strict_recovery_counts_by_registry: strictRecoveryCountsByRegistry,
+      abstentions: [...abstentionGroups.values()].map(group => ({
+        ...group,
+        pages: [...group.pages].sort((left, right) => left - right),
+      })).sort((left, right) => right.count - left.count || left.reason.localeCompare(right.reason)),
+      groups: inventory,
+    })}\n`);
+  } finally {
+    await document?.destroy();
+    await loadingTask.destroy();
+  }
+}
+
+await main();

--- a/scripts/macos-claude-installed-shannon.mjs
+++ b/scripts/macos-claude-installed-shannon.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { readFile, realpath } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const extensionDirectory = path.resolve(process.argv[2] || "");
+const sourceArgument = path.resolve(process.argv[3] || "");
+if (!process.argv[2] || !process.argv[3]) {
+  throw new Error("Usage: macos-claude-installed-shannon.mjs <installed-extension-dir> <shannon-pdf>");
+}
+
+const EXPECTED_SOURCE_SHA256 = "6e4e3411984f3edf99dbfe8b941cb5e8a321379ff0cae6ae5c1f592ad8882ca8";
+const EXPECTED_MARKDOWN_SHA256 = "8b1d2520e4fdbbb1ec3aa1b9fa3ee3604f72712c0b0a37b53a4e4c9d3962ca94";
+const EXPECTED_TOOL_CONTRACT_SHA256 = "223c8ec6b37d600e2918b5b4b124af80845a51cb9530819024b2426a9c101c06";
+const EXPECTED_PAGE_COUNT = 55;
+const PAGE_SPAN = 10;
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+const sourcePath = await realpath(sourceArgument);
+assert(sourcePath === sourceArgument, "Shannon PDF path must be canonical");
+const sourceBytes = await readFile(sourcePath);
+const sourceSha256 = sha256(sourceBytes);
+assert(sourceSha256 === EXPECTED_SOURCE_SHA256, "Shannon PDF bytes differ from the reviewed source");
+
+const sdkDirectory = path.join(extensionDirectory, "node_modules", "@modelcontextprotocol", "sdk", "dist", "esm");
+const { Client } = await import(pathToFileURL(path.join(sdkDirectory, "client", "index.js")));
+const { StdioClientTransport } = await import(pathToFileURL(path.join(sdkDirectory, "client", "stdio.js")));
+const serverPath = path.join(extensionDirectory, "server", "index.js");
+const sourceDirectory = path.dirname(sourcePath);
+const client = new Client({ name: "installed-claude-shannon-proof", version: "1.0.0" });
+const transport = new StdioClientTransport({
+  command: process.execPath,
+  args: [serverPath, "--allowed-directories", sourceDirectory],
+  cwd: extensionDirectory,
+  env: {
+    ...process.env,
+    ALLOWED_DIRECTORIES: JSON.stringify([sourceDirectory]),
+    DEFAULT_PDF_DIR: sourceDirectory,
+    DEFAULT_DOWNLOAD_DIR: sourceDirectory,
+  },
+  stderr: "pipe",
+});
+
+const started = process.hrtime.bigint();
+const chunks = [];
+try {
+  await client.connect(transport);
+  const tools = await client.listTools();
+  assert(tools.tools.length === 40, `Expected 40 installed tools, received ${tools.tools.length}`);
+  assert(
+    sha256(Buffer.from(JSON.stringify(tools.tools))) === EXPECTED_TOOL_CONTRACT_SHA256,
+    "Installed tool contract differs from the reviewed build",
+  );
+
+  for (let startPage = 1; startPage <= EXPECTED_PAGE_COUNT; startPage += PAGE_SPAN) {
+    const endPage = Math.min(EXPECTED_PAGE_COUNT, startPage + PAGE_SPAN - 1);
+    const result = await client.callTool({
+      name: "convert_pdf_to_markdown",
+      arguments: {
+        pdf_path: sourcePath,
+        start_page: startPage,
+        end_page: endPage,
+        max_items: 5000,
+        max_characters: 100000,
+        max_markdown_bytes: 200000,
+        include_page_boundaries: true,
+      },
+    });
+    const value = result.structuredContent;
+    assert(!result.isError && value, `Installed conversion failed for pages ${startPage}-${endPage}`);
+    assert(value.renderer?.version === "1.8.0", "Installed Markdown renderer version differs");
+    assert(value.provenance?.layout?.parser_version === "5.4.624", "Installed PDF parser version differs");
+    assert(value.provenance?.source?.sha256 === sourceSha256, "Installed conversion source identity differs");
+    assert(value.provenance?.layout?.page_range?.start_page === startPage, "Installed conversion start page differs");
+    assert(value.provenance?.layout?.page_range?.end_page === endPage, "Installed conversion end page differs");
+    assert(value.provenance?.layout?.page_range?.total_pages === EXPECTED_PAGE_COUNT, "Installed page count differs");
+    assert(value.markdown_sha256 === sha256(Buffer.from(value.markdown, "utf8")), "Installed chunk digest differs");
+    chunks.push(value);
+  }
+} finally {
+  await transport.close();
+}
+
+const markdown = chunks.map(chunk => chunk.markdown).join("\n\n");
+const markdownSha256 = sha256(Buffer.from(markdown, "utf8"));
+assert(markdownSha256 === EXPECTED_MARKDOWN_SHA256, "Installed Shannon Markdown differs from the reviewed output");
+
+process.stdout.write(`${JSON.stringify({
+  installed_extension: extensionDirectory,
+  source_sha256: sourceSha256,
+  page_count: EXPECTED_PAGE_COUNT,
+  page_calls: chunks.map(chunk => chunk.provenance.layout.page_range),
+  conversion_statuses: [...new Set(chunks.map(chunk => chunk.conversion_status))].sort(),
+  total_gap_count: chunks.reduce((total, chunk) => total + chunk.gaps.length, 0),
+  replacement_character_count: [...markdown].filter(character => character === "\uFFFD").length,
+  markdown_bytes: Buffer.byteLength(markdown, "utf8"),
+  markdown_sha256: markdownSha256,
+  elapsed_ms: Number(process.hrtime.bigint() - started) / 1e6,
+}, null, 2)}\n`);

--- a/scripts/macos-claude-installed-smoke.mjs
+++ b/scripts/macos-claude-installed-smoke.mjs
@@ -29,7 +29,7 @@ const textFixture = path.join(fixtureDirectory, "synthetic-text-two-page.pdf");
 const rasterFixture = path.join(fixtureDirectory, "synthetic-raster-only.pdf");
 const mutationDirectory = path.join(fixtureDirectory, "mutation-output");
 const toolNames = [];
-const EXPECTED_TOOL_CONTRACT_SHA256 = "4f5c1299b4fab3b415fa6eb7cff4c802b832a4d0d6bbe9fbbc8db1bd109bccdc";
+const EXPECTED_TOOL_CONTRACT_SHA256 = "223c8ec6b37d600e2918b5b4b124af80845a51cb9530819024b2426a9c101c06";
 let toolContractSha256;
 let structuredToolCount;
 let markdownHash;

--- a/server/layout-extraction.js
+++ b/server/layout-extraction.js
@@ -48,6 +48,123 @@ const MAX_TYPE3_GLYPH_CANONICAL_BYTES = 250000;
 
 const TYPE3_RECOVERY_REGISTRY = Object.freeze([
   Object.freeze({
+    id: "cmmi-pk-raster-period-2df559-v1",
+    qualification: "ctan-cm-encoding-plus-reviewed-pk-raster-v1",
+    family: "computer-modern-math-italic",
+    original_char_code: 58,
+    source_unicode: ":",
+    target_unicode: ".",
+    charproc_sha256: "2df559091df37cc5da5c1ce3e05eebc1075c4c041b83d96a1904d2c2f21edab0",
+    witnesses: Object.freeze([
+      Object.freeze({ original_char_code: 59, charproc_sha256: "42b5ebf435945b75e1dc1bc271bfbb4aa2dc02b8adc93cd26b4bb64dec9fde8a" }),
+      Object.freeze({ original_char_code: 61, charproc_sha256: "55447dde50a97970297d189788eb154c675c41e6d2eca2836949aefadd0b1780" }),
+    ]),
+  }),
+  Object.freeze({
+    id: "cmmi-pk-raster-comma-42b5eb-v1",
+    qualification: "ctan-cm-encoding-plus-reviewed-pk-raster-v1",
+    family: "computer-modern-math-italic",
+    original_char_code: 59,
+    source_unicode: ";",
+    target_unicode: ",",
+    charproc_sha256: "42b5ebf435945b75e1dc1bc271bfbb4aa2dc02b8adc93cd26b4bb64dec9fde8a",
+    witnesses: Object.freeze([
+      Object.freeze({ original_char_code: 58, charproc_sha256: "2df559091df37cc5da5c1ce3e05eebc1075c4c041b83d96a1904d2c2f21edab0" }),
+      Object.freeze({ original_char_code: 61, charproc_sha256: "55447dde50a97970297d189788eb154c675c41e6d2eca2836949aefadd0b1780" }),
+    ]),
+  }),
+  Object.freeze({
+    id: "cmmi-pk-raster-pi-780b04-v1",
+    qualification: "ctan-cm-encoding-plus-reviewed-pk-raster-v1",
+    family: "computer-modern-math-italic",
+    original_char_code: 25,
+    source_unicode: "\u0019",
+    target_unicode: "π",
+    charproc_sha256: "780b04fa47830ca782211b86dbedfe0adec0445bdf94d538bfe7adde08ed9445",
+    witnesses: Object.freeze([
+      Object.freeze({ original_char_code: 11, charproc_sha256: "e688a83f98433c841694f990aabafe5245cfc9320f584d7f70da706f0eeba259" }),
+      Object.freeze({ original_char_code: 26, charproc_sha256: "1500df39391626d02f9e98132f991f71899612069298e52340e12fb65590836f" }),
+    ]),
+  }),
+  Object.freeze({
+    id: "cmmi-pk-raster-rho-1500df-v1",
+    qualification: "ctan-cm-encoding-plus-reviewed-pk-raster-v1",
+    family: "computer-modern-math-italic",
+    original_char_code: 26,
+    source_unicode: "\u001a",
+    target_unicode: "ρ",
+    charproc_sha256: "1500df39391626d02f9e98132f991f71899612069298e52340e12fb65590836f",
+    witnesses: Object.freeze([
+      Object.freeze({ original_char_code: 11, charproc_sha256: "e688a83f98433c841694f990aabafe5245cfc9320f584d7f70da706f0eeba259" }),
+      Object.freeze({ original_char_code: 25, charproc_sha256: "780b04fa47830ca782211b86dbedfe0adec0445bdf94d538bfe7adde08ed9445" }),
+    ]),
+  }),
+  Object.freeze({
+    id: "cmmi-pk-raster-omega-81b411-v1",
+    qualification: "ctan-cm-encoding-plus-reviewed-pk-raster-v1",
+    family: "computer-modern-math-italic",
+    original_char_code: 33,
+    source_unicode: "!",
+    target_unicode: "ω",
+    charproc_sha256: "81b41121b5e19a2aebd37331ab3584fe08221ca1afcda83f4ce8b76997177074",
+    witnesses: Object.freeze([
+      Object.freeze({ original_char_code: 11, charproc_sha256: "e688a83f98433c841694f990aabafe5245cfc9320f584d7f70da706f0eeba259" }),
+      Object.freeze({ original_char_code: 25, charproc_sha256: "780b04fa47830ca782211b86dbedfe0adec0445bdf94d538bfe7adde08ed9445" }),
+    ]),
+  }),
+  Object.freeze({
+    id: "cmmi-pk-raster-slash-55447d-v1",
+    qualification: "ctan-cm-encoding-plus-reviewed-pk-raster-v1",
+    family: "computer-modern-math-italic",
+    original_char_code: 61,
+    source_unicode: "=",
+    target_unicode: "/",
+    charproc_sha256: "55447dde50a97970297d189788eb154c675c41e6d2eca2836949aefadd0b1780",
+    witnesses: Object.freeze([
+      Object.freeze({ original_char_code: 58, charproc_sha256: "2df559091df37cc5da5c1ce3e05eebc1075c4c041b83d96a1904d2c2f21edab0" }),
+      Object.freeze({ original_char_code: 59, charproc_sha256: "42b5ebf435945b75e1dc1bc271bfbb4aa2dc02b8adc93cd26b4bb64dec9fde8a" }),
+    ]),
+  }),
+  Object.freeze({
+    id: "cmsy-pk-raster-minus-fb1f6b-v1",
+    qualification: "ctan-cm-encoding-plus-reviewed-pk-raster-v1",
+    family: "computer-modern-math-symbol",
+    original_char_code: 0,
+    source_unicode: "\u0000",
+    target_unicode: "−",
+    charproc_sha256: "fb1f6bf10138511bcefade47467b3e2f9ae691ab3dab097914be1f0f66305470",
+    witnesses: Object.freeze([
+      Object.freeze({ original_char_code: 21, charproc_sha256: "05b4a9d88c1df64b3ac339ae6bb7ed82383b93bb08512842452db43453a28970" }),
+      Object.freeze({ original_char_code: 112, charproc_sha256: "772f491fc17e6bb3bc37c17ace6be704244ab121c7180d59319726e0af4b0efc" }),
+    ]),
+  }),
+  Object.freeze({
+    id: "cmsy-pk-raster-greater-equal-05b4a9-v1",
+    qualification: "ctan-cm-encoding-plus-reviewed-pk-raster-v1",
+    family: "computer-modern-math-symbol",
+    original_char_code: 21,
+    source_unicode: "\u0015",
+    target_unicode: "≥",
+    charproc_sha256: "05b4a9d88c1df64b3ac339ae6bb7ed82383b93bb08512842452db43453a28970",
+    witnesses: Object.freeze([
+      Object.freeze({ original_char_code: 0, charproc_sha256: "fb1f6bf10138511bcefade47467b3e2f9ae691ab3dab097914be1f0f66305470" }),
+      Object.freeze({ original_char_code: 112, charproc_sha256: "772f491fc17e6bb3bc37c17ace6be704244ab121c7180d59319726e0af4b0efc" }),
+    ]),
+  }),
+  Object.freeze({
+    id: "cmsy-pk-raster-square-root-772f49-v1",
+    qualification: "ctan-cm-encoding-plus-reviewed-pk-raster-v1",
+    family: "computer-modern-math-symbol",
+    original_char_code: 112,
+    source_unicode: "p",
+    target_unicode: "√",
+    charproc_sha256: "772f491fc17e6bb3bc37c17ace6be704244ab121c7180d59319726e0af4b0efc",
+    witnesses: Object.freeze([
+      Object.freeze({ original_char_code: 0, charproc_sha256: "fb1f6bf10138511bcefade47467b3e2f9ae691ab3dab097914be1f0f66305470" }),
+      Object.freeze({ original_char_code: 21, charproc_sha256: "05b4a9d88c1df64b3ac339ae6bb7ed82383b93bb08512842452db43453a28970" }),
+    ]),
+  }),
+  Object.freeze({
     id: "cmmi-pk-raster-omega-v1",
     qualification: "ctan-cm-encoding-plus-reviewed-pk-raster-v1",
     family: "computer-modern-math-italic",
@@ -410,6 +527,135 @@ function collectType3GlyphRecoveries({ textContent, operators, pdfjsPage, pdfLib
     recoveries.set(sourceIndex, deduplicated);
   }
   return recoveries;
+}
+
+/**
+ * Read-only maintainer census for every understood legacy Type-3 showText
+ * glyph. Unlike recovery's strict text-binding lane, this keeps control and
+ * whitespace-like Unicode values so old encodings cannot disappear from the
+ * report. Missing links/classification/digests remain explicit omissions.
+ */
+export function inspectType3GlyphEvidenceForPage({ textContent, operators, pdfjsPage, pdfLibPage, pdfjsLib }) {
+  const ops = pdfjsLib?.OPS ?? {};
+  const omissions = [];
+  if (!operators || !Array.isArray(operators.fnArray) || !Array.isArray(operators.argsArray)) {
+    return { occurrences: [], omissions: [{ reason: "operator_evidence_unavailable", count: 1 }] };
+  }
+  let currentFont = null;
+  const fontStack = [];
+  const byFont = new Map();
+  const fonts = new Map();
+  const unsupportedTextOps = new Set([
+    ops.showSpacedText,
+    ops.nextLineShowText,
+    ops.nextLineSetSpacingShowText,
+  ].filter(Number.isFinite));
+  for (let operatorIndex = 0; operatorIndex < operators.fnArray.length; operatorIndex += 1) {
+    const operation = operators.fnArray[operatorIndex];
+    const args = operators.argsArray[operatorIndex];
+    if (operation === ops.save) fontStack.push(currentFont);
+    else if (operation === ops.restore) {
+      if (fontStack.length === 0) omissions.push({ reason: "font_stack_restore_underflow", count: 1 });
+      else currentFont = fontStack.pop();
+    } else if (operation === ops.setFont) {
+      currentFont = typeof args?.[0] === "string" ? args[0] : null;
+    } else if (unsupportedTextOps.has(operation)) {
+      omissions.push({ reason: "unsupported_text_operator", count: 1 });
+    } else if (operation === ops.showText && currentFont !== null && Array.isArray(args?.[0])) {
+      let font = fonts.get(currentFont);
+      if (font === undefined) {
+        try {
+          font = pdfjsPage.commonObjs.get(currentFont);
+        } catch {
+          font = null;
+          omissions.push({ font_id: currentFont, reason: "font_object_unavailable", scope: "potential_font_glyph", count: args[0].length });
+        }
+        if (font?.isType3Font !== true) font = null;
+        fonts.set(currentFont, font);
+      }
+      if (!font) continue;
+      if (!byFont.has(currentFont)) byFont.set(currentFont, []);
+      for (let glyphIndex = 0; glyphIndex < args[0].length; glyphIndex += 1) {
+        const glyph = args[0][glyphIndex];
+        // PDF.js interleaves numeric text-position adjustments with glyphs.
+        if (typeof glyph === "number" && Number.isFinite(glyph)) continue;
+        if (!glyph || typeof glyph !== "object") {
+          omissions.push({ font_id: currentFont, reason: "malformed_type3_glyph", scope: "type3_glyph", count: 1 });
+          continue;
+        }
+        byFont.get(currentFont).push({ glyph, operator_index: operatorIndex, glyph_index: glyphIndex });
+      }
+    } else if (operation === ops.showText && currentFont === null) {
+      omissions.push({ reason: "show_text_without_current_font", scope: "potential_font_glyph", count: Array.isArray(args?.[0]) ? args[0].length : 1 });
+    } else if (operation === ops.showText) {
+      omissions.push({ reason: "malformed_show_text_arguments", scope: "potential_font_glyph", count: 1 });
+    }
+  }
+  if (fontStack.length !== 0) omissions.push({ reason: "font_stack_unbalanced_at_end", count: fontStack.length });
+
+  const rawFonts = rawType3Fonts(pdfLibPage);
+  const occurrences = [];
+  for (const [fontId, fontTokens] of byFont) {
+    const font = fonts.get(fontId);
+    const rawFont = linkedRawType3Font(fontId, fontTokens, rawFonts);
+    if (!rawFont) {
+      omissions.push({ font_id: fontId, reason: "raw_type3_font_link_ambiguous_or_unavailable", scope: "type3_glyph", count: fontTokens.length });
+      continue;
+    }
+    const family = uniqueComputerModernFamily(rawFont.widths);
+    const official = family ? CM_CODEPOINTS[family] : null;
+    const mappedCodeCharprocSha256 = official ? Object.fromEntries(Object.keys(official)
+      .map(Number)
+      .sort((left, right) => left - right)
+      .map(code => [code, charProcDigestForCode(font, rawFont, code)])) : {};
+    for (const token of fontTokens) {
+      const code = token.glyph.originalCharCode;
+      if (!Number.isSafeInteger(code)) {
+        omissions.push({ font_id: fontId, reason: "original_char_code_unavailable", scope: "type3_glyph", count: 1 });
+        continue;
+      }
+      const digest = charProcDigestForCode(font, rawFont, code);
+      if (!digest) omissions.push({ font_id: fontId, reason: "charproc_digest_unavailable", scope: "glyph_evidence", count: 1 });
+      const registryEvidenceMatchIds = TYPE3_RECOVERY_REGISTRY.filter(entry => entry.family === family
+        && entry.original_char_code === code
+        && entry.source_unicode === token.glyph.unicode
+        && entry.target_unicode === official?.[code]
+        && entry.charproc_sha256 === digest
+        && entry.witnesses.every(witness => mappedCodeCharprocSha256[witness.original_char_code] === witness.charproc_sha256))
+        .map(entry => entry.id)
+        .sort();
+      occurrences.push({
+        family,
+        family_status: !family
+          ? "ambiguous_or_unavailable"
+          : official
+            ? "identified_reviewed_mapping"
+            : "identified_not_unicode_mapped",
+        original_char_code: code,
+        source_unicode: typeof token.glyph.unicode === "string" ? token.glyph.unicode : "",
+        intended_unicode: official?.[code] ?? null,
+        charproc_sha256: digest,
+        mapped_code_charproc_sha256: mappedCodeCharprocSha256,
+        registry_evidence_match_ids: registryEvidenceMatchIds,
+        operator_index: token.operator_index,
+        glyph_index: token.glyph_index,
+        tfm_reference_version: CM_TFM_REFERENCE_VERSION,
+        canonicalizer_version: TYPE3_GLYPH_CANONICALIZER_VERSION,
+      });
+    }
+  }
+  const strictRecoveries = textContent ? [...collectType3GlyphRecoveries({
+    textContent,
+    operators,
+    pdfjsPage,
+    pdfLibPage,
+    pdfjsLib,
+  }).entries()].flatMap(([sourceIndex, recoveries]) => recoveries.map(recovery => ({
+    source_index: sourceIndex,
+    ...recovery,
+  }))) : [];
+  if (!textContent) omissions.push({ reason: "strict_text_binding_unavailable", scope: "strict_recovery", count: 1 });
+  return { occurrences, omissions, strict_recoveries: strictRecoveries };
 }
 
 function applyType3GlyphRecoveries(sourceText, recoveries) {

--- a/server/pdfjs-worker.js
+++ b/server/pdfjs-worker.js
@@ -478,6 +478,12 @@ async function loadPdfjs() {
   return pdfjsLib;
 }
 
+// Maintenance scripts use the production loader so glyph-program evidence is
+// never computed under a different DOM/canvas implementation than the worker.
+export async function loadPdfjsForMaintenance() {
+  return await loadPdfjs();
+}
+
 function nativeCanvasBindingCandidate() {
   const packageByPlatform = {
     "darwin-arm64": "@napi-rs/canvas-darwin-arm64",

--- a/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
+++ b/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
@@ -49,8 +49,8 @@
     {
       "role": "layout_extraction_module",
       "path": "server/layout-extraction.js",
-      "bytes": 134141,
-      "sha256": "c9fc2017740c2b8e6f25024ed73c2d8ec29c82f9b27fa6d3e2d0ce480a1047b9"
+      "bytes": 146356,
+      "sha256": "fa536075a7053785e829fbc824d81b62954a3e96f5b8da351e4ca5d4621c951c"
     },
     {
       "role": "type3_cm_reference_module",
@@ -101,7 +101,7 @@
       "sha256": "6e4429db62fcbe1dd73141d8c20a48b564d41f8bf8920d88775846995e1daf94"
     }
   ],
-  "validator_source_set_sha256": "d970739046d7dceab3dd72f53b3571c80f52a0a1a61bb4a3313ae87d49be2744",
+  "validator_source_set_sha256": "74e695ed2bc79e45f3d51f0ffd57f64f083f30396f9e2439e445e186f5005603",
   "pdfjs_version": "5.4.624",
   "generation_contract": {
     "source_path": "source.pdf",

--- a/test/fixtures/eval/extraction/type3-cm-reference.provenance.json
+++ b/test/fixtures/eval/extraction/type3-cm-reference.provenance.json
@@ -9,6 +9,10 @@
     {
       "url": "https://mirrors.ctan.org/fonts/cm/ps-type3.zip",
       "sha256": "ef38efbd58774b454b190e17c8b5ca0fde13dd5d5ff2282bf0dc0313197f1033"
+    },
+    {
+      "url": "https://mirrors.ctan.org/fonts/cm/mf.zip",
+      "sha256": "b22c69034d9f3f7a9bf22673544bdeaace5656973cf7fb1a395a857148943076"
     }
   ],
   "generator": {

--- a/test/shannon-type3-live.test.js
+++ b/test/shannon-type3-live.test.js
@@ -1,0 +1,66 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { hashBoundedPdfFileSafely } from "../server/bounded-pdf-file.js";
+import {
+  createPdfjsSubprocessRequest,
+  runPdfjsSubprocess,
+} from "../server/pdfjs-subprocess.js";
+
+const SOURCE = process.env.PDF_TOOLS_SHANNON_SOURCE;
+const SOURCE_SHA256 = "6e4e3411984f3edf99dbfe8b941cb5e8a321379ff0cae6ae5c1f592ad8882ca8";
+
+describe("external Shannon Type-3 recovery", () => {
+  it.runIf(Boolean(SOURCE))("recovers only the exact registered glyph groups through the isolated worker", async () => {
+    const sourceFile = await hashBoundedPdfFileSafely(SOURCE, 250 * 1024 * 1024, {
+      assertPathAllowed: candidate => candidate,
+    });
+    expect(sourceFile.sha256).toBe(SOURCE_SHA256);
+    const source = {
+      canonical_path: sourceFile.canonicalPath,
+      file_identity: sourceFile.fileIdentity,
+      sha256: sourceFile.sha256,
+      size_bytes: sourceFile.sizeBytes,
+    };
+    const counts = new Map();
+    for (let startPage = 1; startPage <= 55; startPage += 10) {
+      const endPage = Math.min(55, startPage + 9);
+      const response = await runPdfjsSubprocess(createPdfjsSubprocessRequest({
+        operation: "extract_layout_for_markdown",
+        source,
+        password: null,
+        allowedDirectories: [path.dirname(SOURCE)],
+        options: {
+          source_path: SOURCE,
+          source_file_name: path.basename(SOURCE),
+          start_page: startPage,
+          end_page: endPage,
+          max_items: 5000,
+          max_characters: 100_000,
+          max_output_characters: 200_000,
+        },
+      }), { timeoutMs: 30_000 });
+      for (const page of response.layout.pages) {
+        for (const item of page.raw_items) {
+          for (const recovery of item.glyph_recoveries ?? []) {
+            counts.set(recovery.registry_id, (counts.get(recovery.registry_id) ?? 0) + 1);
+          }
+        }
+      }
+    }
+    expect(Object.fromEntries([...counts].sort())).toEqual({
+      "cmmi-pk-raster-comma-42b5eb-v1": 315,
+      "cmmi-pk-raster-omega-81b411-v1": 6,
+      "cmmi-pk-raster-omega-v1": 9,
+      "cmmi-pk-raster-period-2df559-v1": 345,
+      "cmmi-pk-raster-period-v1": 6,
+      "cmmi-pk-raster-pi-780b04-v1": 55,
+      "cmmi-pk-raster-rho-1500df-v1": 27,
+      "cmmi-pk-raster-slash-55447d-v1": 8,
+      "cmmi-pk-raster-slash-v1": 2,
+      "cmsy-pk-raster-greater-equal-05b4a9-v1": 22,
+      "cmsy-pk-raster-minus-fb1f6b-v1": 216,
+      "cmsy-pk-raster-minus-v1": 14,
+      "cmsy-pk-raster-square-root-772f49-v1": 27,
+    });
+  }, 60_000);
+});

--- a/test/type3-glyph-inventory.test.js
+++ b/test/type3-glyph-inventory.test.js
@@ -1,0 +1,44 @@
+import { execFile } from "node:child_process";
+import path from "node:path";
+import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const SCRIPT = path.join(REPO_ROOT, "scripts", "inventory-type3-glyphs.mjs");
+const FIXTURE = path.join(REPO_ROOT, "test", "fixtures", "eval", "extraction", "type3-cm-reference.pdf");
+
+describe("Type-3 maintainer inventory", () => {
+  it("keeps whitespace-like legacy glyph controls and reports explicit omissions", async () => {
+    const { stdout } = await execFileAsync(process.execPath, [SCRIPT, "--source", FIXTURE], {
+      cwd: REPO_ROOT,
+      maxBuffer: 1_000_000,
+    });
+    const report = JSON.parse(stdout);
+    expect(report).toMatchObject({
+      schema: "pdf-tools.type3-glyph-inventory.v1",
+      occurrence_count: 10,
+      abstentions: [],
+      source: { page_count: 1 },
+    });
+    expect(report.groups).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        original_char_code: 11,
+        source_unicode_codepoints: "U+000B",
+        count: 1,
+      }),
+      expect.objectContaining({
+        family: "computer-modern-math-symbol",
+        original_char_code: 0,
+        intended_unicode: "−",
+        count: 1,
+      }),
+    ]));
+  });
+
+  it("rejects ambiguous command-line input", async () => {
+    await expect(execFileAsync(process.execPath, [SCRIPT, FIXTURE], { cwd: REPO_ROOT }))
+      .rejects.toMatchObject({ code: 1 });
+  });
+});


### PR DESCRIPTION
## What changed

This stacked draft extends the fail-closed legacy Computer Modern Type-3
recovery from PR #61 with nine independently qualified glyph groups: period,
comma, minus, pi, rho, square root, greater-or-equal, slash, and omega.

It also adds a complete operator/text census using the production PDF.js
loader, a hash-bound live Shannon regression, an inventory completeness
fixture, and pinned official CTAN Metafont-source verification.

## Why

Shannon's 55-page paper repeatedly uses custom-drawn legacy glyphs whose
encoded text is wrong or discarded. We can safely recover 1,021 additional
exact characters when the target glyph, two witness glyphs, metrics, page
sequence, and raw font binding all agree. Unsupported variants remain
unchanged.

This is bounded character recovery, not general formula reconstruction, OCR,
Type-3 decoding, or full mathematical fidelity.

## Verified impact

- 1,021 new exact recoveries; 1,052 total across the stack
- replacement characters reduced from 831 to 511
- sampled headings, reading order, paragraphs, equations, footnotes, and table
  topology unchanged
- three fresh Shannon runs produced byte-identical Markdown
- full suite: 1,886 passed, 79 intentionally skipped, 0 failed
- separate native Mac safety suite: 62 passed, 9 intentionally skipped, 0
  failed
- reproducible MCPB grew by 2,075 bytes (approximately 0.0028%) over PR #61
- packed macOS arm64 smoke passed
- exact MCPB installed in Claude Desktop; registry hash matched and Claude's
  host loaded and discovered the tools successfully
- installed extension passed the synthetic smoke and reproduced the reviewed
  55-page Shannon Markdown hash with 511 replacement characters

Detailed evidence:
`docs/evidence/shannon-primary-type3-glyph-batch-2026-08.md`

Remaining limitations are explicit: 188 officially named occurrences are not
recovered, including 60 alpha controls, and 10 Type-3 occurrences abstain
because their raw font link is ambiguous or unavailable.

The older PDF Tools identity was removed, leaving one enabled current
installation. Native installation, Claude host loading/tool discovery, and
installed-bundle server behavior passed. A Shannon conversion initiated from
inside a Claude chat remains an unrun UI-level check; no chat-level pass is
claimed.
