### PR TITLE
Restore narrowly supported prose/math spacing

### DIFF
--- a/docs/evidence/shannon-prose-math-spacing-2026-08.md
+++ b/docs/evidence/shannon-prose-math-spacing-2026-08.md
@@ -77,12 +77,18 @@ rule and appears once per ten-page conversion chunk.
   `63ca160a177f5f9b22db6f057714ed0f1a83968d26f41a05ac994e720d0ea80a`.
 - Complete repository suite from the committed clean draft snapshot: 1,888
   passed, 80 intentionally skipped, zero failed.
+- Reproducible MCPB: two isolated builds were byte-identical; 3,000 files,
+  73,643,660 bytes; SHA-256
+  `23ba42f4c9f9c2949021c5b098748cd54e0f46145b6346d6478c9fe0dd118f18`.
+- Packed MCPB smoke passed on macOS arm64 with all 40 tools, 14 prompts,
+  canonical resources, one verified PDF-lib mutation, and a native raster
+  image.
 
 ## Claim boundary
 
-This is a draft stacked above PR #62. It is not merged, released, repacked, or
-installed. The prior PR #62 installed-copy proof applies only to its exact
-artifact and must not be silently transferred to this draft.
+This is a draft stacked above PR #62. It is not merged, released, or installed.
+The prior PR #62 installed-copy proof applies only to its exact artifact and
+must not be silently transferred to the new packed PR #63 artifact.
 
 The result does not prove general formula reconstruction, mathematical layout
 fidelity, OCR, general prose spacing repair, cross-platform behavior, release

--- a/docs/evidence/shannon-prose-math-spacing-2026-08.md
+++ b/docs/evidence/shannon-prose-math-spacing-2026-08.md
@@ -1,0 +1,91 @@
+# Shannon prose/math boundary spacing — 2026-08
+
+## Outcome
+
+The stacked draft restores two source-supported spaces where Shannon's prose
+switches into a separately embedded single-letter mathematical variable:
+
+- `storeN bits` becomes `store N bits`.
+- `capacityC of a discrete channel` becomes `capacity C of a discrete channel`.
+
+This improves the sampled reading-order score from 23/24 anchors across 5/6
+complete groups to 24/24 across 6/6 complete groups. It does not reconstruct
+equations or repair general word spacing.
+
+The same draft also corrects the Shannon evaluator's `TABLE I` duplication
+check. The standalone table label is counted once; the legitimate prose
+reference `In Table I` is no longer misclassified as a second label. The
+sampled omission-and-duplication score therefore moves from 6/7 to 7/7 without
+changing the paper's table output.
+
+## Narrow acceptance rule
+
+A prose boundary is changed only when all of the following evidence agrees:
+
+- multiword prose, a separate uppercase letter, and continuing prose share one
+  left-to-right baseline;
+- the letter uses a different source font resource and the continuing prose
+  returns to the original prose resource;
+- both boundary gaps are small and positive, with the continuation gap larger;
+- the same letter and font resource occur in a nearby compact equation with a
+  separate equals sign on the same page and column; and
+- the line is outside links, headings, unsafe text, structural rewrites, and
+  ambiguous table regions.
+
+The nearby-equation search is limited to three rows and four line heights. Its
+cells must be compact mathematical items (apart from `Lim`, `Max`, or `Min`).
+An adversarial prose example using a different-font uppercase letter but no
+qualifying nearby equation remains unchanged.
+
+## Deterministic Shannon proof
+
+- Source PDF SHA-256:
+  `6e4e3411984f3edf99dbfe8b941cb5e8a321379ff0cae6ae5c1f592ad8882ca8`.
+- Fresh three-process report directory:
+  `/Users/silverbook/Sites/pdf-tools-extraction-sidecars/shannon-prose-math-spacing-final3-20260804-0845`.
+- Report SHA-256:
+  `6f9ec8aac28c9b25f181cbb91809e7ca300213be72fbb6fc16771ede94930572`.
+- PDF Tools Markdown SHA-256 in all three repetitions:
+  `5aefe08bd0228379f0dc8a23c57bbc906899a1995baadd92c67a5aae0065e602`.
+- Markdown size: 179,845 bytes.
+- Median elapsed time: 4,047.805 ms.
+- Median maximum RSS: 326,385,664 bytes.
+- Sampled scores: headings 14/14, reading order 24/24 across 6/6 groups,
+  paragraphs 2/4, equations 4/4, footnotes 4/4, table topology present, and
+  omissions/duplication 7/7.
+
+All three outputs are byte-identical. Compared with the preceding PR #62
+output, the paper content changes only at the two prose/math boundaries listed
+above. The renderer limitation text also changes to describe the new bounded
+rule and appears once per ten-page conversion chunk.
+
+## Verification state
+
+- Focused Markdown conversion tests: 45/45 passed.
+- Focused renderer, contract, output-schema, bakeoff, and conversion suites:
+  122 passed, 6 intentionally skipped, zero failed.
+- Extraction-oracle verification: 20/20 passed. Regeneration changed only the
+  expected renderer/schema source fingerprints, not occurrence truth data.
+- Source-identity classification check: 18/18 passed after registering the new
+  installed-Shannon checker's reviewed dynamic module loads.
+- Native macOS/Node safety suite: 62 passed, 9 intentionally skipped, zero
+  failed.
+- Transactional share contract: 40 tools, 14 prompts, 112 SBOM components,
+  native raster image; SHA-256
+  `63ca160a177f5f9b22db6f057714ed0f1a83968d26f41a05ac994e720d0ea80a`.
+
+The complete repository suite must be repeated from the committed clean draft
+snapshot because its source-identity cases intentionally reject a dirty
+worktree.
+
+## Claim boundary
+
+This is a draft stacked above PR #62. It is not merged, released, repacked, or
+installed. The prior PR #62 installed-copy proof applies only to its exact
+artifact and must not be silently transferred to this draft.
+
+The result does not prove general formula reconstruction, mathematical layout
+fidelity, OCR, general prose spacing repair, cross-platform behavior, release
+readiness, or that Kepano's complete issue is solved. Paragraph continuity
+remains 2/4, and the known replacement characters and explicit extraction gaps
+remain visible.

--- a/docs/evidence/shannon-prose-math-spacing-2026-08.md
+++ b/docs/evidence/shannon-prose-math-spacing-2026-08.md
@@ -61,6 +61,8 @@ rule and appears once per ten-page conversion chunk.
 
 ## Verification state
 
+- Evaluated implementation/evidence commit:
+  `7208abd739f394493278996f57d514fa6f4fda58`.
 - Focused Markdown conversion tests: 45/45 passed.
 - Focused renderer, contract, output-schema, bakeoff, and conversion suites:
   122 passed, 6 intentionally skipped, zero failed.
@@ -73,10 +75,8 @@ rule and appears once per ten-page conversion chunk.
 - Transactional share contract: 40 tools, 14 prompts, 112 SBOM components,
   native raster image; SHA-256
   `63ca160a177f5f9b22db6f057714ed0f1a83968d26f41a05ac994e720d0ea80a`.
-
-The complete repository suite must be repeated from the committed clean draft
-snapshot because its source-identity cases intentionally reject a dirty
-worktree.
+- Complete repository suite from the committed clean draft snapshot: 1,888
+  passed, 80 intentionally skipped, zero failed.
 
 ## Claim boundary
 

--- a/docs/handoffs/KEPANO_SHANNON.md
+++ b/docs/handoffs/KEPANO_SHANNON.md
@@ -121,10 +121,14 @@ check; do not silently claim that narrower proof.
 
 As of this handoff, PR #63 is an open draft stacked on PR #62. PR #63 has clean
 source-checkout, deterministic Shannon, native Mac safety, and transactional
-share-contract proof. It has not been repacked or installed. The native
-installation, Claude host-loading, and installed-bundle server proof belongs
-only to the exact PR #62 artifact; do not silently transfer it to PR #63 or
-upgrade either result into release, cross-platform, or Claude-chat proof.
+share-contract proof. Its two isolated MCPB builds were byte-identical: 3,000
+files, 73,643,660 bytes, SHA-256
+`23ba42f4c9f9c2949021c5b098748cd54e0f46145b6346d6478c9fe0dd118f18`.
+The packed copy passed its macOS arm64 smoke with all 40 tools, but has not been
+installed. The native installation, Claude host-loading, and installed-bundle
+server proof belongs only to the exact PR #62 artifact; do not silently
+transfer it to PR #63 or upgrade either result into release, cross-platform,
+or Claude-chat proof.
 
 ## Current decision boundary
 

--- a/docs/handoffs/KEPANO_SHANNON.md
+++ b/docs/handoffs/KEPANO_SHANNON.md
@@ -24,16 +24,16 @@ to replace it with a newly invented benchmark.
 ## Verified current state
 
 - Active worktree:
-  `/Users/silverbook/Sites/pdf-tools-worktrees/codex-shannon-type3-next`
-- Active branch: `codex/shannon-type3-next`
-- Exact runtime implementation and evaluation checkpoint:
-  `578f517c90f21c073673e6668421368374f7cf55`
+  `/Users/silverbook/Sites/pdf-tools-worktrees/codex-shannon-prose-math-spacing`
+- Active branch: `codex/shannon-prose-math-spacing`
+- Exact current implementation and clean-suite checkpoint:
+  `7208abd739f394493278996f57d514fa6f4fda58`
 - Later commits on the branch update evidence and this handoff only; use
   `git rev-parse HEAD` for the current published branch tip.
 - The documentation tip is intentionally resolved live rather than written
   into this file, because committing a self-referenced hash would immediately
   create a different tip. The tested runtime checkpoint above is immutable.
-- Publication status: draft PR #62, stacked directly on PR #61.
+- Publication status: draft PR #63, stacked directly on PR #62.
 - Current draft stack, reviewed from bottom to top:
 
 | PR | Draft outcome | Direct base |
@@ -46,8 +46,9 @@ to replace it with a newly invented benchmark.
 | #60 | Recover bounded ruled table topology | PR #59 |
 | #61 | Recover the first qualified legacy Type-3 glyph batch | PR #60 |
 | #62 | Recover the primary vetted Type-3 glyph batch | PR #61 |
+| #63 | Restore narrowly supported prose/math spacing | PR #62 |
 
-All eight local branch tips matched their live GitHub PR heads during the
+All nine local branch tips matched their live GitHub PR heads during the
 2026-08-04 review. Each draft was open and mergeable with no comments, reviews,
 or reported checks. The cumulative top branch passed the complete verification
 described below.
@@ -66,8 +67,8 @@ Examples now include `−8.69`, `0.411`, `t/2`, and `ω`. All sampled heading,
 reading-order, paragraph, equation-anchor, footnote, and table-topology metrics
 remain unchanged.
 
-The active next tranche adds 1,021 exact recoveries from nine primary glyph
-groups: 345 periods, 315 commas, 216 minuses, 55 pi characters, 27 rho
+PR #62 adds 1,021 exact recoveries from nine primary glyph groups: 345
+periods, 315 commas, 216 minuses, 55 pi characters, 27 rho
 characters, 27 square roots, 22 greater-or-equal characters, 8 slashes, and 6
 omega characters. The tested draft implementation totals 1,052 exact
 characters from 13 registered groups. Replacement characters fall from 831 to
@@ -81,16 +82,26 @@ because the source control character interfered with an existing exact
 recovery during an experiment, and a 64-occurrence minus variant lacks two
 qualified witness glyphs. Do not register either by guess.
 
-The active clean full repository run passed 1,886 tests with 79 intentional
+PR #63 restores exactly two source-supported spaces: `storeN bits` becomes
+`store N bits`, and `capacityC of a discrete channel` becomes `capacity C of a
+discrete channel`. It requires a matching nearby compact equation, exact font
+identity, same column, tight geometry, and a prose-font sandwich. The sampled
+reading-order score improves from 23/24 across 5/6 complete groups to 24/24
+across 6/6 groups. The evaluator also stops treating the legitimate prose
+reference `In Table I` as a duplicated standalone table label, improving that
+sampled score from 6/7 to 7/7 without changing table output. Paragraph
+continuity remains 2/4.
+
+The active clean full repository run passed 1,888 tests with 80 intentional
 skips and zero failures. The separate native Mac safety suite passed 62 with 9
-intentional skips and zero failures. The clean Shannon evaluation ran three
+intentional skips and zero failures. The PR #63 Shannon evaluation ran three
 fresh repetitions with byte-identical Markdown. Its report SHA-256 is
-`a785b07f9638be5419319330bb9102fe53b40259e3432f528aec83d6cf95d502`,
+`6f9ec8aac28c9b25f181cbb91809e7ca300213be72fbb6fc16771ede94930572`,
 stored outside the repository at:
 
-`/Users/silverbook/Sites/pdf-tools-extraction-sidecars/shannon-primary-type3-final-20260803-clean-578f517`
+`/Users/silverbook/Sites/pdf-tools-extraction-sidecars/shannon-prose-math-spacing-final3-20260804-0845`
 
-The active MCPB passed its packed smoke test and grew by only 2,075 bytes
+The exact PR #62 MCPB passed its packed smoke test and grew by only 2,075 bytes
 (approximately 0.0028%) over PR #61. First-party documentation, tests, and
 maintainer scripts, plus private evaluation outputs, are excluded from the
 distributable package.
@@ -108,14 +119,16 @@ backup remains at
 A Shannon conversion initiated inside a Claude chat remains an unrun UI-level
 check; do not silently claim that narrower proof.
 
-As of this handoff, PR #62 is an open draft stacked on PR #61. Local, native
-installation, Claude host-loading, and installed-bundle server verification are
-available; do not silently upgrade them into release, cross-platform, or
-Claude-chat proof.
+As of this handoff, PR #63 is an open draft stacked on PR #62. PR #63 has clean
+source-checkout, deterministic Shannon, native Mac safety, and transactional
+share-contract proof. It has not been repacked or installed. The native
+installation, Claude host-loading, and installed-bundle server proof belongs
+only to the exact PR #62 artifact; do not silently transfer it to PR #63 or
+upgrade either result into release, cross-platform, or Claude-chat proof.
 
 ## Current decision boundary
 
-PR #62 is the active review target. Do not wander off to locate a different
+PR #63 is the active review target. Do not wander off to locate a different
 Kepano PDF. First recover the exact state above from Git and the evidence
 record, inspect the draft, and preserve its narrow safety claim.
 
@@ -130,7 +143,7 @@ his actual issue is honestly solved; otherwise do not ping him.
 
 If Mat later authorizes landing, preserve the order above. Merge PR #55 first,
 retarget PR #56 to `master`, verify its diff, and continue one PR at a time
-through #62. Never merge a higher draft while its direct base is still an
+through #63. Never merge a higher draft while its direct base is still an
 unmerged feature branch. Re-run the cumulative tests and package proof after
 the final landing; any repack has a new artifact identity. Installed Claude
 Desktop proof must be repeated for that new artifact identity after the code
@@ -150,7 +163,7 @@ shasum -a 256 /Users/silverbook/Sites/pdf-tools-extraction-sidecars/shannon-entr
 The focused feature checks are:
 
 ```sh
-PDF_TOOLS_SHANNON_SOURCE=/Users/silverbook/Sites/pdf-tools-extraction-sidecars/shannon-entropy.pdf npm test -- --run test/shannon-type3-live.test.js test/type3-glyph-inventory.test.js test/pdfjs-worker-contract.test.js test/read-pdf-layout.test.js test/eval/extraction-phase1-layout-evidence.test.js
+npx vitest run test/test-runner-contract.test.js test/mcp-contract.test.js test/eval/markdown-bakeoff.test.js test/convert-pdf-to-markdown.test.js test/markdown-conversion.test.js
 ```
 
 The clean Shannon runner command is:
@@ -160,8 +173,8 @@ node scripts/eval-run-shannon-markdown-bakeoff.mjs --source /Users/silverbook/Si
 ```
 
 Use a new output directory for every run. The active detailed evidence record
-is `docs/evidence/shannon-primary-type3-glyph-batch-2026-08.md`; the preceding
-record is `docs/evidence/shannon-qualified-type3-glyphs-2026-08.md`.
+is `docs/evidence/shannon-prose-math-spacing-2026-08.md`; the preceding record
+is `docs/evidence/shannon-primary-type3-glyph-batch-2026-08.md`.
 
 ## Working with Mat
 

--- a/pdf-toolkit-mcp-share/server/markdown-conversion.js
+++ b/pdf-toolkit-mcp-share/server/markdown-conversion.js
@@ -6,7 +6,7 @@ import {
 
 const RENDERER = Object.freeze({
   name: "pdf-tools.layout-markdown-renderer",
-  version: "1.8.0",
+  version: "1.9.0",
 });
 
 // Bounded geometric table inference. A run of adjacent lines is treated as a
@@ -52,7 +52,7 @@ const GAP_CODES = new Set([
 const LIMITATIONS = Object.freeze([
   "Headings are emitted only from consistent enlarged font metrics or centered English-language source structure with section spacing for a first-page title, introduction, part, or appendix. Ambiguous, very short, or unsupported heading styles remain body text.",
   "A geometrically overlapping initial capital may be joined to its following uppercase word remainder. Line-end hyphens are preserved because source geometry cannot reliably distinguish a split word from an intentional compound. The source Extraction IR retains the original lines.",
-  "A missing space after a separate source text item that is exactly the mathematical operator log is restored only in a short, compact left-to-right math run when a single-letter variable from a different embedded-font resource follows on the same baseline with a small positive geometric gap and independent local math-layout evidence. A small version-pinned registry may recover a legacy Computer Modern Type-3 character only after an exact official-metric family match, exact target and two-witness glyph-program matches, and a complete operator/text sequence binding. General equations, scripts, fraction bars, unregistered raster variants, and other damaged mathematical glyphs remain source reading-order text rather than being guessed.",
+  "A missing space after a separate source text item that is exactly the mathematical operator log is restored only in a short, compact left-to-right math run when a single-letter variable from a different source font resource follows on the same baseline with a small positive geometric gap and independent local math-layout evidence. A missing prose-to-variable space is restored only when a multiword prose item, a separate uppercase letter from a different source font resource, and continuing prose from the original prose font share one baseline with distinct positive boundary gaps, and the same letter/font pair occurs in a nearby compact equation on the same page and column. A small version-pinned registry may recover a legacy Computer Modern Type-3 character only after an exact official-metric family match, exact target and two-witness glyph-program matches, and a complete operator/text sequence binding. General equations, scripts, fraction bars, unregistered raster variants, and other damaged mathematical glyphs remain source reading-order text rather than being guessed.",
   "Lists are emitted only for literal bullet glyphs or decimal markers present in the source text.",
   "Links are emitted only for source-validated http or https annotation targets that map to exactly one contiguous run of text on one line. Internal destinations, actions, other schemes, ambiguous or partially covered labels, and links inside reconstructed tables remain escaped text reported as a conversion gap, and URL-looking source text is escaped to resist host autolinking.",
   "Tables are reconstructed only from either complete text-item column geometry or one unambiguous complete closed grid of bounded axis-aligned solid-mask rectangles. Ruled grids require every text item to fit exactly one cell, reject aligned partial dividers that evidence merged or spanning topology, and require independent caption and header evidence because Markdown imposes header semantics. Unsupported text remains escaped reading-order text with a conversion gap. Stroked paths are omitted and reported as vector-content gaps. Cell artwork is omitted and reported as a vector-content gap; only independently qualified exact legacy glyph variants are recovered.",
@@ -618,6 +618,86 @@ function mathOperatorSpacedText(row, {
     text = `${text.slice(0, offset)} ${text.slice(offset)}`;
   }
   return text;
+}
+
+/**
+ * Restore a prose-to-variable boundary only when three separate source items
+ * prove the intended transition: multiword prose, one uppercase math-font
+ * variable, and continuing prose in the original font. Requiring both a
+ * smaller first gap and an already preserved second space avoids lowering the
+ * general line-grouping threshold or interpreting compact identifiers.
+ */
+function proseMathVariableSpacedText(row, {
+  headingLevel,
+  linked,
+  rows,
+  rowIndex,
+  unsafePage,
+}) {
+  const { line, cells } = row;
+  if (headingLevel || linked || unsafePage || rewritesLineStructure(line)
+    || line.direction !== "ltr" || line.text.length > 160 || cells.length < 3) return null;
+  const offsets = itemOffsets(line, cells);
+  if (offsets === null) return null;
+  const insertions = [];
+  for (let index = 0; index < cells.length - 2; index += 1) {
+    const prose = cells[index];
+    const variable = cells[index + 1];
+    const continuation = cells[index + 2];
+    const proseWords = prose.text.trim().split(/\s+/u);
+    const continuationWords = continuation.text.trim().split(/\s+/u);
+    if (proseWords.length < 3 || continuationWords.length < 3
+      || !/\p{Ll}{4,}$/u.test(prose.text.trim())
+      || !/^\p{Lu}$/u.test(variable.text.trim())
+      || !/^\p{Ll}/u.test(continuation.text.trim())
+      || typeof prose.font_name !== "string"
+      || typeof variable.font_name !== "string"
+      || typeof continuation.font_name !== "string"
+      || prose.font_name !== continuation.font_name
+      || prose.font_name === variable.font_name
+      || !sameMathBaseline(prose, variable)
+      || !sameMathBaseline(variable, continuation)
+      || !hasNearbyMathVariableEvidence(row, variable, rows, rowIndex)) continue;
+    const gap = operatorVariableGap(prose, variable);
+    const continuationGap = operatorVariableGap(variable, continuation);
+    const height = Math.max(prose.line_height, variable.line_height, continuation.line_height);
+    if (!(gap > height * 0.15 && gap <= height * 0.25)
+      || !(continuationGap > gap && continuationGap <= height * 0.5)) continue;
+    const from = offsets[index].end;
+    const to = offsets[index + 1].start;
+    const after = line.text.slice(offsets[index + 1].end, offsets[index + 2].start);
+    if (from !== to || /\s/u.test(line.text.slice(from, to)) || !/^\s+$/u.test(after)) continue;
+    insertions.push(from);
+  }
+  if (insertions.length === 0) return null;
+  let text = line.text;
+  for (const offset of insertions.sort((left, right) => right - left)) {
+    text = `${text.slice(0, offset)} ${text.slice(offset)}`;
+  }
+  return text;
+}
+
+function hasNearbyMathVariableEvidence(row, variable, rows, rowIndex) {
+  const start = Math.max(0, rowIndex - 3);
+  const end = Math.min(rows.length - 1, rowIndex + 3);
+  for (let index = start; index <= end; index += 1) {
+    if (index === rowIndex) continue;
+    const candidate = rows[index];
+    if (candidate.line.column_index !== row.line.column_index
+      || candidate.line.direction !== "ltr"
+      || candidate.line.text.length > 80
+      || !candidate.cells.every(item => (compactMathItemText(item.text)
+        || /^(?:Lim|Max|Min)$/u.test(item.text.trim()))
+        && !containsUnsafeText(item.text))
+      || !candidate.cells.some(item => item.text.trim() === variable.text.trim()
+        && item.font_name === variable.font_name)
+      || !candidate.cells.some(item => item.text.trim() === "=")
+      || containsUnsafeText(candidate.line.text)) continue;
+    const verticalDistance = Math.abs(candidate.line.y - row.line.y);
+    const height = Math.max(candidate.line.height, row.line.height);
+    if (verticalDistance <= height * 4) return true;
+  }
+  return false;
 }
 
 function columnAnchors(rows) {
@@ -1193,23 +1273,28 @@ function renderPage(page) {
           const linked = renderLinkedLine(line, offsets, spans);
           if (linked !== null) return { text: linked, line, joinable: false };
         }
+        const projectionOptions = {
+          headingLevel: headings.get(line.id),
+          linked: Boolean(spans?.length),
+          rows,
+          rowIndex,
+          unsafePage: analysis.tableReason !== null
+            || linkState.unavailable
+            || linkState.ambiguous
+            || linkState.unsupportedTarget,
+        };
         const mathText = mathOperatorSpacedText(
           { line, cells },
-          {
-            headingLevel: headings.get(line.id),
-            linked: Boolean(spans?.length),
-            rows,
-            rowIndex,
-            unsafePage: analysis.tableReason !== null
-              || linkState.unavailable
-              || linkState.ambiguous
-              || linkState.unsupportedTarget,
-          },
+          projectionOptions,
         );
+        const proseMathText = mathText === null
+          ? proseMathVariableSpacedText({ line, cells }, projectionOptions)
+          : null;
+        const projectedText = mathText ?? proseMathText;
         return {
-          text: renderLine(line, headings.get(line.id), mathText ?? line.text),
+          text: renderLine(line, headings.get(line.id), projectedText ?? line.text),
           line,
-          joinable: mathText === null && !headings.get(line.id) && !rewritesLineStructure(line),
+          joinable: projectedText === null && !headings.get(line.id) && !rewritesLineStructure(line),
         };
       })
   ));

--- a/pdf-toolkit-mcp-share/server/output-schemas.js
+++ b/pdf-toolkit-mcp-share/server/output-schemas.js
@@ -589,7 +589,7 @@ export const TOOL_SUCCESS_OUTPUT_SCHEMAS = Object.freeze({
   convert_pdf_to_markdown: object({
     renderer: object({
       name: { const: "pdf-tools.layout-markdown-renderer" },
-      version: { const: "1.8.0" },
+      version: { const: "1.9.0" },
     }),
     conversion_status: enumString(["complete", "partial", "failed"]),
     markdown: string,

--- a/scripts/eval-run-markdown-bakeoff.mjs
+++ b/scripts/eval-run-markdown-bakeoff.mjs
@@ -193,7 +193,7 @@ export function validateMarkdownResult(result, binding) {
     throw new Error(`Markdown conversion failed for ${binding.fixture.id}`);
   }
   const value = result.structuredContent;
-  if (value.renderer?.name !== "pdf-tools.layout-markdown-renderer" || value.renderer?.version !== "1.8.0"
+  if (value.renderer?.name !== "pdf-tools.layout-markdown-renderer" || value.renderer?.version !== "1.9.0"
     || value.options?.include_page_boundaries !== true || value.limits?.max_markdown_bytes !== 200000
     || value.provenance?.source?.file_name !== binding.retained.filename
     || value.provenance?.source?.sha256 !== binding.retained.sha256

--- a/scripts/macos-claude-installed-shannon.mjs
+++ b/scripts/macos-claude-installed-shannon.mjs
@@ -12,8 +12,8 @@ if (!process.argv[2] || !process.argv[3]) {
 }
 
 const EXPECTED_SOURCE_SHA256 = "6e4e3411984f3edf99dbfe8b941cb5e8a321379ff0cae6ae5c1f592ad8882ca8";
-const EXPECTED_MARKDOWN_SHA256 = "8b1d2520e4fdbbb1ec3aa1b9fa3ee3604f72712c0b0a37b53a4e4c9d3962ca94";
-const EXPECTED_TOOL_CONTRACT_SHA256 = "223c8ec6b37d600e2918b5b4b124af80845a51cb9530819024b2426a9c101c06";
+const EXPECTED_MARKDOWN_SHA256 = "5aefe08bd0228379f0dc8a23c57bbc906899a1995baadd92c67a5aae0065e602";
+const EXPECTED_TOOL_CONTRACT_SHA256 = "d358ad9e6b7ee830a41c7b64a5ee612decd9ac4c8bb58e76f6c5dbc0529aa555";
 const EXPECTED_PAGE_COUNT = 55;
 const PAGE_SPAN = 10;
 
@@ -77,7 +77,7 @@ try {
     });
     const value = result.structuredContent;
     assert(!result.isError && value, `Installed conversion failed for pages ${startPage}-${endPage}`);
-    assert(value.renderer?.version === "1.8.0", "Installed Markdown renderer version differs");
+    assert(value.renderer?.version === "1.9.0", "Installed Markdown renderer version differs");
     assert(value.provenance?.layout?.parser_version === "5.4.624", "Installed PDF parser version differs");
     assert(value.provenance?.source?.sha256 === sourceSha256, "Installed conversion source identity differs");
     assert(value.provenance?.layout?.page_range?.start_page === startPage, "Installed conversion start page differs");

--- a/scripts/macos-claude-installed-smoke.mjs
+++ b/scripts/macos-claude-installed-smoke.mjs
@@ -29,7 +29,7 @@ const textFixture = path.join(fixtureDirectory, "synthetic-text-two-page.pdf");
 const rasterFixture = path.join(fixtureDirectory, "synthetic-raster-only.pdf");
 const mutationDirectory = path.join(fixtureDirectory, "mutation-output");
 const toolNames = [];
-const EXPECTED_TOOL_CONTRACT_SHA256 = "223c8ec6b37d600e2918b5b4b124af80845a51cb9530819024b2426a9c101c06";
+const EXPECTED_TOOL_CONTRACT_SHA256 = "d358ad9e6b7ee830a41c7b64a5ee612decd9ac4c8bb58e76f6c5dbc0529aa555";
 let toolContractSha256;
 let structuredToolCount;
 let markdownHash;

--- a/scripts/smoke-mcpb.mjs
+++ b/scripts/smoke-mcpb.mjs
@@ -146,7 +146,7 @@ async function main() {
       arguments: { pdf_path: fixturePath, max_markdown_bytes: 200000 },
     });
     if (markdown.isError
-      || markdown.structuredContent?.renderer?.version !== "1.8.0"
+      || markdown.structuredContent?.renderer?.version !== "1.9.0"
       || markdown.structuredContent?.markdown_bytes !== Buffer.byteLength(markdown.structuredContent?.markdown || "", "utf8")
       || markdown.structuredContent?.markdown_sha256 !== sha256(Buffer.from(markdown.structuredContent?.markdown || "", "utf8"))) {
       throw new Error("Packed convert_pdf_to_markdown contract smoke failed");

--- a/scripts/test-share-contract.mjs
+++ b/scripts/test-share-contract.mjs
@@ -838,7 +838,7 @@ async function main() {
       arguments: { pdf_path: fixturePath, max_markdown_bytes: 200000 },
     });
     if (markdown.isError
-      || markdown.structuredContent?.renderer?.version !== "1.8.0"
+      || markdown.structuredContent?.renderer?.version !== "1.9.0"
       || markdown.structuredContent?.markdown_bytes !== Buffer.byteLength(markdown.structuredContent?.markdown || "", "utf8")
       || markdown.structuredContent?.markdown_sha256 !== sha256(Buffer.from(markdown.structuredContent?.markdown || "", "utf8"))) {
       throw new Error("Share convert_pdf_to_markdown contract smoke failed");

--- a/scripts/test-suite-classification.mjs
+++ b/scripts/test-suite-classification.mjs
@@ -141,6 +141,16 @@ export const REVIEWED_COMPUTED_MODULE_LOADS = Object.freeze([
     reason: "Loads the selected generated qpdf module URL.",
   }),
   Object.freeze({
+    file: "scripts/macos-claude-installed-shannon.mjs",
+    count: 2,
+    kinds: Object.freeze(["dynamic-import", "dynamic-import"]),
+    fingerprints: Object.freeze([
+      "0bea25bcef085af91e6d4364375bbdde843149fa1d65f834db34ae52fcae5ef7",
+      "28c033735ea9fb0f4f12abf4ed9d905107b81abef289f9e5315316809b5440c7",
+    ]),
+    reason: "Loads an installed SDK by validated absolute file URL for the Shannon proof.",
+  }),
+  Object.freeze({
     file: "scripts/macos-claude-installed-smoke.mjs",
     count: 2,
     kinds: Object.freeze(["dynamic-import", "dynamic-import"]),

--- a/server/markdown-conversion.js
+++ b/server/markdown-conversion.js
@@ -6,7 +6,7 @@ import {
 
 const RENDERER = Object.freeze({
   name: "pdf-tools.layout-markdown-renderer",
-  version: "1.8.0",
+  version: "1.9.0",
 });
 
 // Bounded geometric table inference. A run of adjacent lines is treated as a
@@ -52,7 +52,7 @@ const GAP_CODES = new Set([
 const LIMITATIONS = Object.freeze([
   "Headings are emitted only from consistent enlarged font metrics or centered English-language source structure with section spacing for a first-page title, introduction, part, or appendix. Ambiguous, very short, or unsupported heading styles remain body text.",
   "A geometrically overlapping initial capital may be joined to its following uppercase word remainder. Line-end hyphens are preserved because source geometry cannot reliably distinguish a split word from an intentional compound. The source Extraction IR retains the original lines.",
-  "A missing space after a separate source text item that is exactly the mathematical operator log is restored only in a short, compact left-to-right math run when a single-letter variable from a different embedded-font resource follows on the same baseline with a small positive geometric gap and independent local math-layout evidence. A small version-pinned registry may recover a legacy Computer Modern Type-3 character only after an exact official-metric family match, exact target and two-witness glyph-program matches, and a complete operator/text sequence binding. General equations, scripts, fraction bars, unregistered raster variants, and other damaged mathematical glyphs remain source reading-order text rather than being guessed.",
+  "A missing space after a separate source text item that is exactly the mathematical operator log is restored only in a short, compact left-to-right math run when a single-letter variable from a different source font resource follows on the same baseline with a small positive geometric gap and independent local math-layout evidence. A missing prose-to-variable space is restored only when a multiword prose item, a separate uppercase letter from a different source font resource, and continuing prose from the original prose font share one baseline with distinct positive boundary gaps, and the same letter/font pair occurs in a nearby compact equation on the same page and column. A small version-pinned registry may recover a legacy Computer Modern Type-3 character only after an exact official-metric family match, exact target and two-witness glyph-program matches, and a complete operator/text sequence binding. General equations, scripts, fraction bars, unregistered raster variants, and other damaged mathematical glyphs remain source reading-order text rather than being guessed.",
   "Lists are emitted only for literal bullet glyphs or decimal markers present in the source text.",
   "Links are emitted only for source-validated http or https annotation targets that map to exactly one contiguous run of text on one line. Internal destinations, actions, other schemes, ambiguous or partially covered labels, and links inside reconstructed tables remain escaped text reported as a conversion gap, and URL-looking source text is escaped to resist host autolinking.",
   "Tables are reconstructed only from either complete text-item column geometry or one unambiguous complete closed grid of bounded axis-aligned solid-mask rectangles. Ruled grids require every text item to fit exactly one cell, reject aligned partial dividers that evidence merged or spanning topology, and require independent caption and header evidence because Markdown imposes header semantics. Unsupported text remains escaped reading-order text with a conversion gap. Stroked paths are omitted and reported as vector-content gaps. Cell artwork is omitted and reported as a vector-content gap; only independently qualified exact legacy glyph variants are recovered.",
@@ -618,6 +618,86 @@ function mathOperatorSpacedText(row, {
     text = `${text.slice(0, offset)} ${text.slice(offset)}`;
   }
   return text;
+}
+
+/**
+ * Restore a prose-to-variable boundary only when three separate source items
+ * prove the intended transition: multiword prose, one uppercase math-font
+ * variable, and continuing prose in the original font. Requiring both a
+ * smaller first gap and an already preserved second space avoids lowering the
+ * general line-grouping threshold or interpreting compact identifiers.
+ */
+function proseMathVariableSpacedText(row, {
+  headingLevel,
+  linked,
+  rows,
+  rowIndex,
+  unsafePage,
+}) {
+  const { line, cells } = row;
+  if (headingLevel || linked || unsafePage || rewritesLineStructure(line)
+    || line.direction !== "ltr" || line.text.length > 160 || cells.length < 3) return null;
+  const offsets = itemOffsets(line, cells);
+  if (offsets === null) return null;
+  const insertions = [];
+  for (let index = 0; index < cells.length - 2; index += 1) {
+    const prose = cells[index];
+    const variable = cells[index + 1];
+    const continuation = cells[index + 2];
+    const proseWords = prose.text.trim().split(/\s+/u);
+    const continuationWords = continuation.text.trim().split(/\s+/u);
+    if (proseWords.length < 3 || continuationWords.length < 3
+      || !/\p{Ll}{4,}$/u.test(prose.text.trim())
+      || !/^\p{Lu}$/u.test(variable.text.trim())
+      || !/^\p{Ll}/u.test(continuation.text.trim())
+      || typeof prose.font_name !== "string"
+      || typeof variable.font_name !== "string"
+      || typeof continuation.font_name !== "string"
+      || prose.font_name !== continuation.font_name
+      || prose.font_name === variable.font_name
+      || !sameMathBaseline(prose, variable)
+      || !sameMathBaseline(variable, continuation)
+      || !hasNearbyMathVariableEvidence(row, variable, rows, rowIndex)) continue;
+    const gap = operatorVariableGap(prose, variable);
+    const continuationGap = operatorVariableGap(variable, continuation);
+    const height = Math.max(prose.line_height, variable.line_height, continuation.line_height);
+    if (!(gap > height * 0.15 && gap <= height * 0.25)
+      || !(continuationGap > gap && continuationGap <= height * 0.5)) continue;
+    const from = offsets[index].end;
+    const to = offsets[index + 1].start;
+    const after = line.text.slice(offsets[index + 1].end, offsets[index + 2].start);
+    if (from !== to || /\s/u.test(line.text.slice(from, to)) || !/^\s+$/u.test(after)) continue;
+    insertions.push(from);
+  }
+  if (insertions.length === 0) return null;
+  let text = line.text;
+  for (const offset of insertions.sort((left, right) => right - left)) {
+    text = `${text.slice(0, offset)} ${text.slice(offset)}`;
+  }
+  return text;
+}
+
+function hasNearbyMathVariableEvidence(row, variable, rows, rowIndex) {
+  const start = Math.max(0, rowIndex - 3);
+  const end = Math.min(rows.length - 1, rowIndex + 3);
+  for (let index = start; index <= end; index += 1) {
+    if (index === rowIndex) continue;
+    const candidate = rows[index];
+    if (candidate.line.column_index !== row.line.column_index
+      || candidate.line.direction !== "ltr"
+      || candidate.line.text.length > 80
+      || !candidate.cells.every(item => (compactMathItemText(item.text)
+        || /^(?:Lim|Max|Min)$/u.test(item.text.trim()))
+        && !containsUnsafeText(item.text))
+      || !candidate.cells.some(item => item.text.trim() === variable.text.trim()
+        && item.font_name === variable.font_name)
+      || !candidate.cells.some(item => item.text.trim() === "=")
+      || containsUnsafeText(candidate.line.text)) continue;
+    const verticalDistance = Math.abs(candidate.line.y - row.line.y);
+    const height = Math.max(candidate.line.height, row.line.height);
+    if (verticalDistance <= height * 4) return true;
+  }
+  return false;
 }
 
 function columnAnchors(rows) {
@@ -1193,23 +1273,28 @@ function renderPage(page) {
           const linked = renderLinkedLine(line, offsets, spans);
           if (linked !== null) return { text: linked, line, joinable: false };
         }
+        const projectionOptions = {
+          headingLevel: headings.get(line.id),
+          linked: Boolean(spans?.length),
+          rows,
+          rowIndex,
+          unsafePage: analysis.tableReason !== null
+            || linkState.unavailable
+            || linkState.ambiguous
+            || linkState.unsupportedTarget,
+        };
         const mathText = mathOperatorSpacedText(
           { line, cells },
-          {
-            headingLevel: headings.get(line.id),
-            linked: Boolean(spans?.length),
-            rows,
-            rowIndex,
-            unsafePage: analysis.tableReason !== null
-              || linkState.unavailable
-              || linkState.ambiguous
-              || linkState.unsupportedTarget,
-          },
+          projectionOptions,
         );
+        const proseMathText = mathText === null
+          ? proseMathVariableSpacedText({ line, cells }, projectionOptions)
+          : null;
+        const projectedText = mathText ?? proseMathText;
         return {
-          text: renderLine(line, headings.get(line.id), mathText ?? line.text),
+          text: renderLine(line, headings.get(line.id), projectedText ?? line.text),
           line,
-          joinable: mathText === null && !headings.get(line.id) && !rewritesLineStructure(line),
+          joinable: projectedText === null && !headings.get(line.id) && !rewritesLineStructure(line),
         };
       })
   ));

--- a/server/output-schemas.js
+++ b/server/output-schemas.js
@@ -589,7 +589,7 @@ export const TOOL_SUCCESS_OUTPUT_SCHEMAS = Object.freeze({
   convert_pdf_to_markdown: object({
     renderer: object({
       name: { const: "pdf-tools.layout-markdown-renderer" },
-      version: { const: "1.8.0" },
+      version: { const: "1.9.0" },
     }),
     conversion_status: enumString(["complete", "partial", "failed"]),
     markdown: string,

--- a/test/convert-pdf-to-markdown.test.js
+++ b/test/convert-pdf-to-markdown.test.js
@@ -305,7 +305,7 @@ describe("convert_pdf_to_markdown MCP tool", () => {
     expect(first.isError).not.toBe(true);
     expect(second.structuredContent).toEqual(first.structuredContent);
     expect(first.structuredContent).toMatchObject({
-      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.8.0" },
+      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.9.0" },
       conversion_status: "complete",
       saved_output: null,
       provenance: {

--- a/test/eval/markdown-bakeoff.test.js
+++ b/test/eval/markdown-bakeoff.test.js
@@ -64,7 +64,7 @@ async function handle(message) {
     const pageBoundaries = Array.from({ length: pageCount }, (_, index) => "<!-- PDF page " + (index + 1) + " -->");
     const markdown = pageBoundaries.join("\n\n") + "\n\nINV-1001 fixture evidence\n";
     const value = {
-      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.8.0" },
+      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.9.0" },
       conversion_status: "complete",
       markdown,
       markdown_sha256: digest(Buffer.from(markdown)),
@@ -146,7 +146,7 @@ function resultFor(binding) {
   const markdown = "<!-- PDF page 1 -->\n\nFixture text\n";
   return {
     structuredContent: {
-      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.8.0" },
+      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.9.0" },
       conversion_status: "complete",
       markdown,
       markdown_sha256: sha256(Buffer.from(markdown)),
@@ -234,8 +234,8 @@ describe("Markdown bakeoff renderer version binding", () => {
   });
 
   it("accepts the current renderer version and rejects the superseded one", () => {
-    expect(validateMarkdownResult(resultFor("1.8.0"), binding).renderer.version).toBe("1.8.0");
-    for (const stale of ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.6.0", "1.7.0"]) {
+    expect(validateMarkdownResult(resultFor("1.9.0"), binding).renderer.version).toBe("1.9.0");
+    for (const stale of ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.6.0", "1.7.0", "1.8.0"]) {
       expect(() => validateMarkdownResult(resultFor(stale), binding), stale)
         .toThrow(/Markdown result evidence is invalid/u);
     }

--- a/test/eval/shannon-markdown-scorer.js
+++ b/test/eval/shannon-markdown-scorer.js
@@ -35,6 +35,15 @@ function normalizedCount(haystack, needle) {
   return count;
 }
 
+function normalizedStandaloneLineCount(markdown, needle) {
+  const target = normalizeShannonText(needle);
+  if (!target) return 0;
+  return String(markdown ?? "")
+    .split(/\r?\n/u)
+    .filter(line => normalizeShannonText(line) === target)
+    .length;
+}
+
 function headingRecords(markdown) {
   return String(markdown ?? "")
     .split(/\r?\n/u)
@@ -185,8 +194,7 @@ function parseMarkdownTables(markdown) {
 
 function scoreTable(markdown, normalized, oracle) {
   const tables = parseMarkdownTables(markdown);
-  const label = normalizeShannonText(oracle.table.label);
-  const labelOffset = normalized.indexOf(label);
+  const labelCount = normalizedStandaloneLineCount(markdown, oracle.table.label);
   const headerTerms = oracle.table.required_header_terms.map(term => ({
     term,
     present: normalized.includes(normalizeShannonText(term)),
@@ -196,7 +204,7 @@ function scoreTable(markdown, normalized, oracle) {
     return oracle.table.required_header_terms.every(term => normalizedHeader.includes(normalizeShannonText(term)));
   });
   return {
-    label_present: labelOffset >= 0,
+    label_present: labelCount > 0,
     markdown_table_count: tables.length,
     required_header_terms: headerTerms,
     qualifying_table_count: qualifying.length,
@@ -205,10 +213,13 @@ function scoreTable(markdown, normalized, oracle) {
   };
 }
 
-function scoreDuplication(normalized, oracle) {
+function scoreDuplication(markdown, normalized, oracle) {
+  const tableLabel = normalizeShannonText(oracle.table.label);
   const details = oracle.exactly_once_anchors.map(anchor => ({
     anchor,
-    count: normalizedCount(normalized, anchor),
+    count: normalizeShannonText(anchor) === tableLabel
+      ? normalizedStandaloneLineCount(markdown, anchor)
+      : normalizedCount(normalized, anchor),
   }));
   return {
     expected: details.length,
@@ -233,7 +244,7 @@ export function scoreShannonMarkdown({ markdown, oracle, evidence }) {
     equations: scoreEquations(markdown, oracle),
     footnotes: scorePresence(normalized, oracle.footnote_anchors, "anchor"),
     table_topology: scoreTable(markdown, normalized, oracle),
-    omissions_and_duplication: scoreDuplication(normalized, oracle),
+    omissions_and_duplication: scoreDuplication(markdown, normalized, oracle),
     evidence: {
       page_identity: evidence?.page_identity === true,
       typed_coverage_gaps: evidence?.typed_coverage_gaps === true,

--- a/test/eval/shannon-markdown-scorer.test.js
+++ b/test/eval/shannon-markdown-scorer.test.js
@@ -130,4 +130,38 @@ describe("Shannon Markdown adversarial scorer", () => {
     const table = result.omissions_and_duplication.details.find(item => item.anchor === "TABLE I");
     expect(table.count).toBe(1);
   });
+
+  it("does not count a prose reference as a duplicate Table I label", async () => {
+    const manifestOracle = await oracle();
+    const result = scoreShannonMarkdown({
+      markdown: "TABLE I\n\nIn Table I the final entropy power is discussed.\n",
+      oracle: manifestOracle,
+      evidence: {},
+    });
+    const table = result.omissions_and_duplication.details.find(item => item.anchor === "TABLE I");
+    expect(table.count).toBe(1);
+    expect(result.omissions_and_duplication.duplicated.some(item => item.anchor === "TABLE I")).toBe(false);
+    expect(result.table_topology.label_present).toBe(true);
+
+    const proseOnly = scoreShannonMarkdown({
+      markdown: "In Table I the final entropy power is discussed.\n",
+      oracle: manifestOracle,
+      evidence: {},
+    });
+    const proseOnlyTable = proseOnly.omissions_and_duplication.details.find(item => item.anchor === "TABLE I");
+    expect(proseOnlyTable.count).toBe(0);
+    expect(proseOnly.table_topology.label_present).toBe(false);
+  });
+
+  it("reports two standalone Table I labels as duplicated despite a prose reference", async () => {
+    const manifestOracle = await oracle();
+    const result = scoreShannonMarkdown({
+      markdown: "TABLE I\n\nIn Table I the final entropy power is discussed.\n\n**TABLE I**\n",
+      oracle: manifestOracle,
+      evidence: {},
+    });
+    const table = result.omissions_and_duplication.details.find(item => item.anchor === "TABLE I");
+    expect(table.count).toBe(2);
+    expect(result.omissions_and_duplication.duplicated).toContainEqual({ anchor: "TABLE I", count: 2 });
+  });
 });

--- a/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
+++ b/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
@@ -67,14 +67,14 @@
     {
       "role": "markdown_conversion_module",
       "path": "server/markdown-conversion.js",
-      "bytes": 61249,
-      "sha256": "29b359045ff889892e67645d5d014787977e7f252334f48d1207f000218a57c7"
+      "bytes": 65532,
+      "sha256": "9246fddaeebfb4180c683bbb27abf631f88b609f83dfd6051925872cd5fa8e76"
     },
     {
       "role": "output_schemas_module",
       "path": "server/output-schemas.js",
       "bytes": 31191,
-      "sha256": "3ef838638e259730c1920ff16923bf4cee99d95bd09da3fe375384606ba61871"
+      "sha256": "4be1da29cea1e7ea2a7388731e3e16d8ca3a2d1c3d3fc8cf5de10ff3d54d537b"
     },
     {
       "role": "package_json",
@@ -101,7 +101,7 @@
       "sha256": "6e4429db62fcbe1dd73141d8c20a48b564d41f8bf8920d88775846995e1daf94"
     }
   ],
-  "validator_source_set_sha256": "74e695ed2bc79e45f3d51f0ffd57f64f083f30396f9e2439e445e186f5005603",
+  "validator_source_set_sha256": "5160557e861eab0dd7c6b8d84ae7a513a763f699db8529d4cbef2fd9148c64cb",
   "pdfjs_version": "5.4.624",
   "generation_contract": {
     "source_path": "source.pdf",

--- a/test/fixtures/eval/shannon/manifest.v1.json
+++ b/test/fixtures/eval/shannon/manifest.v1.json
@@ -22,7 +22,7 @@
     "pdf_tools": {
       "slot": "control.current_product.v0",
       "renderer_name": "pdf-tools.layout-markdown-renderer",
-      "renderer_version": "1.8.0",
+      "renderer_version": "1.9.0",
       "parser_name": "pdfjs-dist",
       "parser_version": "5.4.624"
     },

--- a/test/markdown-conversion.test.js
+++ b/test/markdown-conversion.test.js
@@ -469,6 +469,43 @@ describe("layout Markdown renderer", () => {
     expect(validateMarkdownConversionSemantics(result, { layout })).toBe(result);
   });
 
+  it("restores only a three-item geometrically proven prose-to-variable space", async () => {
+    const layout = await validatedSyntheticLayout([
+      { items: [
+        positionedTextItem("C", { top: 80, left: 120, width: 6.67, fontName: "f2" }),
+        positionedTextItem("=", { top: 80, left: 129, width: 7.8 }),
+        positionedTextItem("Lim", { top: 80, left: 139, width: 16.65, eol: true }),
+        positionedTextItem("Definition: The capacity", { top: 100, left: 91.92, width: 97.54 }),
+        positionedTextItem("C", { top: 100, left: 191.394, width: 6.67, fontName: "f2" }),
+        positionedTextItem("of a discrete channel is given by", { top: 100, left: 200.754, width: 127.99, eol: true }),
+      ] },
+      { items: [
+        positionedTextItem("Model", { top: 100, left: 100, width: 25 }),
+        positionedTextItem("C", { top: 100, left: 126.9, width: 6.7, fontName: "f2" }),
+        positionedTextItem("interface remains compact here", { top: 100, left: 136.3, width: 130, eol: true }),
+      ] },
+      { items: [
+        positionedTextItem("This document uses model", { top: 100, left: 100, width: 100 }),
+        positionedTextItem("C", { top: 100, left: 201.9, width: 6.7, fontName: "f2" }),
+        positionedTextItem("interface remains compact here", { top: 100, left: 211.3, width: 130, eol: true }),
+      ] },
+      { items: [
+        positionedTextItem("Definition: The capacity", { top: 100, left: 100, width: 97.54 }),
+        positionedTextItem("c", { top: 100, left: 199.474, width: 6.67, fontName: "f2" }),
+        positionedTextItem("of a discrete channel is given by", { top: 100, left: 208.834, width: 127.99, eol: true }),
+      ] },
+    ]);
+    const originalLines = layout.pages.map(page => page.lines.map(line => line.text));
+    const result = renderPdfLayoutToMarkdown(layout, { includePageBoundaries: false });
+
+    expect(result.markdown).toContain("Definition: The capacity C of a discrete channel is given by");
+    expect(result.markdown).toContain("ModelC interface remains compact here");
+    expect(result.markdown).toContain("This document uses modelC interface remains compact here");
+    expect(result.markdown).toContain("Definition: The capacityc of a discrete channel is given by");
+    expect(layout.pages.map(page => page.lines.map(line => line.text))).toEqual(originalLines);
+    expect(validateMarkdownConversionSemantics(result, { layout })).toBe(result);
+  });
+
   it("does not rewrite math-like lists, ambiguous tables, or unsupported link pages", async () => {
     const compactScript = top => [
       positionedTextItem("p", { top, left: 100, width: 5, fontName: "f2" }),

--- a/test/mcp-contract.test.js
+++ b/test/mcp-contract.test.js
@@ -57,7 +57,10 @@ const EXAMPLE_PDF = path.join(REPO_ROOT, "example-fw9.pdf");
 // 2026-08-03: extraction IR 1.3.0 and Markdown renderer 1.8.0 preserve only
 // independently qualified exact legacy Computer Modern Type-3 glyphs.
 // Previously 9947d16e32562981651216c95598786d9f3324d5f1fae3b53fa8d7f089d2ea05.
-const TOOL_CONTRACT_SHA256 = "223c8ec6b37d600e2918b5b4b124af80845a51cb9530819024b2426a9c101c06";
+// 2026-08-04: Markdown renderer 1.9.0 restores only source-proven boundaries
+// between multiword prose and a separate uppercase math variable. Previously
+// 223c8ec6b37d600e2918b5b4b124af80845a51cb9530819024b2426a9c101c06.
+const TOOL_CONTRACT_SHA256 = "d358ad9e6b7ee830a41c7b64a5ee612decd9ac4c8bb58e76f6c5dbc0529aa555";
 
 const CLOSED_READ = Object.freeze({
   readOnlyHint: true,

--- a/test/mcp-contract.test.js
+++ b/test/mcp-contract.test.js
@@ -57,7 +57,8 @@ const EXAMPLE_PDF = path.join(REPO_ROOT, "example-fw9.pdf");
 // 2026-08-03: extraction IR 1.3.0 and Markdown renderer 1.8.0 preserve only
 // independently qualified exact legacy Computer Modern Type-3 glyphs.
 // Previously 9947d16e32562981651216c95598786d9f3324d5f1fae3b53fa8d7f089d2ea05.
-// 2026-08-04: Markdown renderer 1.9.0 restores only source-proven boundaries
+// 2026-08-04: Markdown renderer 1.9.0 restores only narrowly source-supported
+// boundaries
 // between multiword prose and a separate uppercase math variable. Previously
 // 223c8ec6b37d600e2918b5b4b124af80845a51cb9530819024b2426a9c101c06.
 const TOOL_CONTRACT_SHA256 = "d358ad9e6b7ee830a41c7b64a5ee612decd9ac4c8bb58e76f6c5dbc0529aa555";


### PR DESCRIPTION
## What changed

- Restore two narrowly source-supported spaces at prose-to-variable boundaries in the 55-page Shannon paper.
- Require a matching nearby compact equation, exact font identity, same column, tight geometry, and a prose-font sandwich before changing output.
- Correct the Shannon evaluator so a prose reference to Table I is not counted as a duplicate standalone table label.
- Advance the Markdown renderer contract to 1.9.0 and update all package, installed-copy, schema, and evaluation pins.

## Why

PDF source items can switch from prose into a separately embedded mathematical variable without carrying a literal space. The ordinary line-grouping threshold correctly abstained, producing `storeN bits` and `capacityC of a discrete channel`. Lowering that general threshold would risk damaging compact identifiers, so this draft adds a narrow evidence-backed exception instead.

## Impact

On the pinned public Shannon PDF, sampled reading order improves from 23/24 anchors across 5/6 complete groups to 24/24 across 6/6 groups. The paper content changes only at the two reviewed boundaries. Paragraph continuity remains 2/4, and known replacement characters and extraction gaps remain visible.

## Verification

- Complete clean repository suite: 1,888 passed, 80 intentionally skipped, 0 failed.
- Combined targeted checks: 131 passed, 6 intentionally skipped, 0 failed.
- Native macOS/Node suite: 62 passed, 9 intentionally skipped, 0 failed.
- Transactional share contract passed: 40 tools, 14 prompts, 112 SBOM components, native raster output.
- Three fresh Shannon runs were byte-identical; report SHA-256 `6f9ec8aac28c9b25f181cbb91809e7ca300213be72fbb6fc16771ede94930572`.
- Two isolated MCPB builds were byte-identical: 3,000 files, 73,643,660 bytes, SHA-256 `23ba42f4c9f9c2949021c5b098748cd54e0f46145b6346d6478c9fe0dd118f18`.
- Packed MCPB smoke passed on macOS arm64 with all 40 tools, 14 prompts, verified PDF mutation, and native raster output.
- Independent review approved the tightened implementation after catching and correcting one stale installed-output pin.

## Limits

This draft is stacked directly on draft PR #62. It is not merged, released, or installed. It does not prove general formula reconstruction, OCR, mathematical layout fidelity, general spacing repair, cross-platform behavior, or that Kepano’s complete issue is solved.