### PR TITLE
Render explicitly barred prose fractions

### DIFF
--- a/docs/evidence/shannon-explicit-stacked-fraction-2026-08.md
+++ b/docs/evidence/shannon-explicit-stacked-fraction-2026-08.md
@@ -102,22 +102,27 @@ ten-page conversion chunk.
   `33ea0d18a9bff9eb11aa0109a5c63b2169f92e6de30572c496a795091a449326`.
 - Complete clean repository suite: 1,889 passed, 80 intentionally skipped,
   zero failed.
+- Reproducible packed MCPB:
+  `/Users/silverbook/Sites/pdf-tools-extraction-sidecars/pdf-toolkit-fraction-a6a2f79.mcpb`;
+  73,645,475 bytes, 3,000 files, SHA-256
+  `fa4431ca17894413484a5e940283b99ec6458e35031dee083a96b6fb4898287d`.
+  Two clean isolated builds were byte-identical; peak isolated-build RSS was
+  856,176 KiB.
+- Packed-copy smoke on macOS arm64: 40 tools, 14 prompts, canonical resources,
+  PDF-lib mutation, and native raster rendering passed.
 
 The first complete clean attempt had one timing-sensitive macOS Docling
 process-supervision assertion fail after 1,888 passes. That unrelated check
 passed immediately in isolation, and the second complete clean run passed with
 the counts above. No PDF conversion test failed in either run.
 
-Reproducible packed-MCPB and packed-copy smoke proof remains required before a
-draft PR is opened.
-
 ## Claim boundary
 
-This work is stacked above draft PR #63. It is not merged, released, packed,
-installed, or shipped. It does not prove general fraction reconstruction,
-equation reconstruction, mathematical layout fidelity, OCR, hidden/clipped
-text fidelity, cross-platform behavior, release readiness, or that Kepano's
-complete issue is solved.
+This work is stacked above draft PR #63. It is packed for review, but is not
+merged, released, installed, or shipped. It does not prove general fraction
+reconstruction, equation reconstruction, mathematical layout fidelity, OCR,
+hidden/clipped text fidelity, cross-platform behavior, release readiness, or
+that Kepano's complete issue is solved.
 
 The remaining paragraph miss is an ordinary literal line-end hyphen in
 `ap-` / `proximately`. The same paper contains intentional compounds with

--- a/docs/evidence/shannon-explicit-stacked-fraction-2026-08.md
+++ b/docs/evidence/shannon-explicit-stacked-fraction-2026-08.md
@@ -1,0 +1,116 @@
+# Shannon explicit stacked fraction — 2026-08
+
+## Outcome
+
+The stacked draft renders one explicitly barred, single-digit stacked fraction
+inside Shannon's prose as `3 1/3`. The preceding output placed it in source
+reading order as:
+
+```text
+a decimal digit is about 31
+3
+bits.
+```
+
+The new output is:
+
+```text
+a decimal digit is about 3 1/3 bits.
+```
+
+This improves sampled paragraph continuity from 2/4 phrases to 3/4. It is a
+bounded interpretation of explicit source text and one source-painted bar, not
+general fraction or formula reconstruction.
+
+## Exact source evidence
+
+The pinned source is Shannon's 55-page paper with SHA-256
+`6e4e3411984f3edf99dbfe8b941cb5e8a321379ff0cae6ae5c1f592ad8882ca8`.
+On page 2, Extraction IR 1.3.0 with PDF.js 5.4.624 retains:
+
+| Source item | Text | x | y | width | height |
+| --- | --- | ---: | ---: | ---: | ---: |
+| body prose | `a decimal digit is about 3` | 91.92 | 272.74 | 103.18 | 10 |
+| numerator | `1` | 196.32 | 270.86 | 3.70 | 7.40 |
+| denominator | `3` | 196.32 | 278.30 | 3.70 | 7.40 |
+| continuation | `bits. A digit wheel…` | 204.12 | 272.74 | 315.39 | 10 |
+
+The numerator and denominator have the same font, x coordinate, width, and
+height. They are 74% of the body-text height. The body items have the same font,
+height, and baseline. The raw source sequence contains explicit whitespace
+immediately before and after the stack.
+
+The page's complete, untruncated painted-rectangle evidence contains exactly
+one item: a solid-color image mask at x 196.308, y 277.992, width 3.72, and
+height 0.48. Its horizontal center differs from the digit centers by about
+0.002 points, and it lies at the numerator/denominator boundary. This is the
+printed fraction bar.
+
+## Fail-closed rule
+
+The renderer changes output only when all of these conditions agree:
+
+- exactly two host-line source items, one denominator item, and one continuing
+  prose item occur in the required consecutive raw-source order;
+- explicit source whitespace surrounds the stack;
+- the smaller numerator and denominator are one ASCII digit each, exactly
+  aligned, identically sized, and use the same font as both prose sides;
+- body prose on the left contains at least five words and ends in a full-size
+  digit; continuing prose contains at least five words and begins lowercase;
+- all text is axis-aligned, left-to-right, same-column safe text outside
+  headings, links, lists, and table regions;
+- both prose gaps are positive and tightly bounded; and
+- complete rectangle evidence contains exactly one thin solid-mask bar whose
+  width and center match both digits and whose vertical position meets their
+  boundary.
+
+Missing, shifted, thick, or competing bars abstain. So do missing source
+whitespace, changed prose shape, changed prose font, and an unbarred stacked
+script. The accepted projection does not mutate the Extraction IR.
+
+## Deterministic Shannon proof
+
+- Fresh report directory:
+  `/Users/silverbook/Sites/pdf-tools-extraction-sidecars/shannon-simple-fraction-final3-20260804-0924`.
+- Report SHA-256:
+  `e5339902bd55b9aabe2a1a2f60ccc76844323f0db83935bd641e0f43fddb8ccd`.
+- PDF Tools Markdown SHA-256 in all three repetitions:
+  `bb3f7586a3268fc2ed5a1de2d57bad3ca63321720f1af4d5e62dbe46716e187e`.
+- Markdown size: 181,478 bytes.
+- Median elapsed time: 3,954.919 ms.
+- Median maximum RSS: 330,596,352 bytes.
+- Sampled scores: headings 14/14, reading order 24/24 across 6/6 groups,
+  paragraphs 3/4, equations 4/4, footnotes 4/4, table topology present, and
+  omissions/duplication 7/7.
+
+All three outputs are byte-identical. Compared with PR #63, paper content
+changes only at the one fraction region. The renderer limitation text also
+changes to disclose the new narrow interpretation and appears once per
+ten-page conversion chunk.
+
+## Verification state
+
+- Focused renderer, contract, bakeoff, conversion, and extraction-oracle bank:
+  134 passed, 6 intentionally skipped, zero failed.
+- Renderer-only suite: 46/46 passed, including eight negative fraction pages.
+- Native macOS/Node safety suite: 62 passed, 9 intentionally skipped, zero
+  failed.
+- Transactional share contract: 40 tools, 14 prompts, 112 SBOM components,
+  native raster image; SHA-256
+  `33ea0d18a9bff9eb11aa0109a5c63b2169f92e6de30572c496a795091a449326`.
+
+The complete repository suite and reproducible packed-MCPB smoke must be run
+from the committed clean draft before a draft PR is opened.
+
+## Claim boundary
+
+This work is stacked above draft PR #63. It is not merged, released, packed,
+installed, or shipped. It does not prove general fraction reconstruction,
+equation reconstruction, mathematical layout fidelity, OCR, hidden/clipped
+text fidelity, cross-platform behavior, release readiness, or that Kepano's
+complete issue is solved.
+
+The remaining paragraph miss is an ordinary literal line-end hyphen in
+`ap-` / `proximately`. The same paper contains intentional compounds with
+indistinguishable geometry, so the renderer continues to preserve that source
+hyphen rather than guessing.

--- a/docs/evidence/shannon-explicit-stacked-fraction-2026-08.md
+++ b/docs/evidence/shannon-explicit-stacked-fraction-2026-08.md
@@ -90,6 +90,8 @@ ten-page conversion chunk.
 
 ## Verification state
 
+- Evaluated implementation/evidence commit:
+  `a6a2f79aaeb292d9dc8f65433feaf00ca7ea3705`.
 - Focused renderer, contract, bakeoff, conversion, and extraction-oracle bank:
   134 passed, 6 intentionally skipped, zero failed.
 - Renderer-only suite: 46/46 passed, including eight negative fraction pages.
@@ -98,9 +100,16 @@ ten-page conversion chunk.
 - Transactional share contract: 40 tools, 14 prompts, 112 SBOM components,
   native raster image; SHA-256
   `33ea0d18a9bff9eb11aa0109a5c63b2169f92e6de30572c496a795091a449326`.
+- Complete clean repository suite: 1,889 passed, 80 intentionally skipped,
+  zero failed.
 
-The complete repository suite and reproducible packed-MCPB smoke must be run
-from the committed clean draft before a draft PR is opened.
+The first complete clean attempt had one timing-sensitive macOS Docling
+process-supervision assertion fail after 1,888 passes. That unrelated check
+passed immediately in isolation, and the second complete clean run passed with
+the counts above. No PDF conversion test failed in either run.
+
+Reproducible packed-MCPB and packed-copy smoke proof remains required before a
+draft PR is opened.
 
 ## Claim boundary
 

--- a/docs/handoffs/KEPANO_SHANNON.md
+++ b/docs/handoffs/KEPANO_SHANNON.md
@@ -24,16 +24,16 @@ to replace it with a newly invented benchmark.
 ## Verified current state
 
 - Active worktree:
-  `/Users/silverbook/Sites/pdf-tools-worktrees/codex-shannon-prose-math-spacing`
-- Active branch: `codex/shannon-prose-math-spacing`
+  `/Users/silverbook/Sites/pdf-tools-worktrees/codex-shannon-simple-fraction`
+- Active branch: `codex/shannon-simple-fraction`
 - Exact current implementation and clean-suite checkpoint:
-  `7208abd739f394493278996f57d514fa6f4fda58`
+  `a6a2f79aaeb292d9dc8f65433feaf00ca7ea3705`
 - Later commits on the branch update evidence and this handoff only; use
   `git rev-parse HEAD` for the current published branch tip.
 - The documentation tip is intentionally resolved live rather than written
   into this file, because committing a self-referenced hash would immediately
   create a different tip. The tested runtime checkpoint above is immutable.
-- Publication status: draft PR #63, stacked directly on PR #62.
+- Publication status: draft PR #64, stacked directly on PR #63.
 - Current draft stack, reviewed from bottom to top:
 
 | PR | Draft outcome | Direct base |
@@ -47,11 +47,12 @@ to replace it with a newly invented benchmark.
 | #61 | Recover the first qualified legacy Type-3 glyph batch | PR #60 |
 | #62 | Recover the primary vetted Type-3 glyph batch | PR #61 |
 | #63 | Restore narrowly supported prose/math spacing | PR #62 |
+| #64 | Render explicitly barred prose fractions | PR #63 |
 
-All nine local branch tips matched their live GitHub PR heads during the
-2026-08-04 review. Each draft was open and mergeable with no comments, reviews,
-or reported checks. The cumulative top branch passed the complete verification
-described below.
+All ten local branch tips through PR #64 match their live GitHub PR heads.
+Each draft was open and mergeable during its live review. PR #64 is open,
+draft, mergeable, and clean with no comments, reviews, or reported checks. The
+cumulative top branch passed the complete verification described below.
 
 PR #61 is stacked directly on PR #60. On the verified Shannon PDF it changes
 exactly 31 intended codepoint positions without changing output length:
@@ -92,14 +93,21 @@ reference `In Table I` as a duplicated standalone table label, improving that
 sampled score from 6/7 to 7/7 without changing table output. Paragraph
 continuity remains 2/4.
 
-The active clean full repository run passed 1,888 tests with 80 intentional
+PR #64 converts one explicitly barred, single-digit stacked fraction from the
+split output `31` / `3` into `3 1/3`. It requires exact surrounding source
+whitespace, aligned same-font digits, same-line prose on both sides, and one
+matching thin source-painted bar. Missing, shifted, thick, or competing bars
+abstain. This improves sampled paragraph continuity from 2/4 to 3/4. It is not
+general formula or fraction reconstruction.
+
+The active clean full repository run passed 1,889 tests with 80 intentional
 skips and zero failures. The separate native Mac safety suite passed 62 with 9
-intentional skips and zero failures. The PR #63 Shannon evaluation ran three
+intentional skips and zero failures. The PR #64 Shannon evaluation ran three
 fresh repetitions with byte-identical Markdown. Its report SHA-256 is
-`6f9ec8aac28c9b25f181cbb91809e7ca300213be72fbb6fc16771ede94930572`,
+`e5339902bd55b9aabe2a1a2f60ccc76844323f0db83935bd641e0f43fddb8ccd`,
 stored outside the repository at:
 
-`/Users/silverbook/Sites/pdf-tools-extraction-sidecars/shannon-prose-math-spacing-final3-20260804-0845`
+`/Users/silverbook/Sites/pdf-tools-extraction-sidecars/shannon-simple-fraction-final3-20260804-0924`
 
 The exact PR #62 MCPB passed its packed smoke test and grew by only 2,075 bytes
 (approximately 0.0028%) over PR #61. First-party documentation, tests, and
@@ -119,20 +127,26 @@ backup remains at
 A Shannon conversion initiated inside a Claude chat remains an unrun UI-level
 check; do not silently claim that narrower proof.
 
-As of this handoff, PR #63 is an open draft stacked on PR #62. PR #63 has clean
-source-checkout, deterministic Shannon, native Mac safety, and transactional
-share-contract proof. Its two isolated MCPB builds were byte-identical: 3,000
-files, 73,643,660 bytes, SHA-256
+PR #63 remains an open draft stacked on PR #62. It has clean source-checkout,
+deterministic Shannon, native Mac safety, and transactional share-contract
+proof. Its two isolated MCPB builds were byte-identical: 3,000 files,
+73,643,660 bytes, SHA-256
 `23ba42f4c9f9c2949021c5b098748cd54e0f46145b6346d6478c9fe0dd118f18`.
 The packed copy passed its macOS arm64 smoke with all 40 tools, but has not been
 installed. The native installation, Claude host-loading, and installed-bundle
 server proof belongs only to the exact PR #62 artifact; do not silently
-transfer it to PR #63 or upgrade either result into release, cross-platform,
+transfer it to PR #63 or a later draft, or upgrade either result into release, cross-platform,
 or Claude-chat proof.
+
+PR #64's two isolated MCPB builds were byte-identical: 3,000 files, 73,645,475
+bytes, SHA-256
+`fa4431ca17894413484a5e940283b99ec6458e35031dee083a96b6fb4898287d`.
+The packed copy passed its macOS arm64 smoke with all 40 tools, all 14 prompts,
+PDF mutation, and native raster rendering. It has not been installed.
 
 ## Current decision boundary
 
-PR #63 is the active review target. Do not wander off to locate a different
+PR #64 is the active review target. Do not wander off to locate a different
 Kepano PDF. First recover the exact state above from Git and the evidence
 record, inspect the draft, and preserve its narrow safety claim.
 
@@ -147,7 +161,7 @@ his actual issue is honestly solved; otherwise do not ping him.
 
 If Mat later authorizes landing, preserve the order above. Merge PR #55 first,
 retarget PR #56 to `master`, verify its diff, and continue one PR at a time
-through #63. Never merge a higher draft while its direct base is still an
+through #64. Never merge a higher draft while its direct base is still an
 unmerged feature branch. Re-run the cumulative tests and package proof after
 the final landing; any repack has a new artifact identity. Installed Claude
 Desktop proof must be repeated for that new artifact identity after the code
@@ -177,8 +191,8 @@ node scripts/eval-run-shannon-markdown-bakeoff.mjs --source /Users/silverbook/Si
 ```
 
 Use a new output directory for every run. The active detailed evidence record
-is `docs/evidence/shannon-prose-math-spacing-2026-08.md`; the preceding record
-is `docs/evidence/shannon-primary-type3-glyph-batch-2026-08.md`.
+is `docs/evidence/shannon-explicit-stacked-fraction-2026-08.md`; the preceding
+record is `docs/evidence/shannon-prose-math-spacing-2026-08.md`.
 
 ## Working with Mat
 

--- a/pdf-toolkit-mcp-share/server/markdown-conversion.js
+++ b/pdf-toolkit-mcp-share/server/markdown-conversion.js
@@ -6,7 +6,7 @@ import {
 
 const RENDERER = Object.freeze({
   name: "pdf-tools.layout-markdown-renderer",
-  version: "1.9.0",
+  version: "1.10.0",
 });
 
 // Bounded geometric table inference. A run of adjacent lines is treated as a
@@ -52,7 +52,7 @@ const GAP_CODES = new Set([
 const LIMITATIONS = Object.freeze([
   "Headings are emitted only from consistent enlarged font metrics or centered English-language source structure with section spacing for a first-page title, introduction, part, or appendix. Ambiguous, very short, or unsupported heading styles remain body text.",
   "A geometrically overlapping initial capital may be joined to its following uppercase word remainder. Line-end hyphens are preserved because source geometry cannot reliably distinguish a split word from an intentional compound. The source Extraction IR retains the original lines.",
-  "A missing space after a separate source text item that is exactly the mathematical operator log is restored only in a short, compact left-to-right math run when a single-letter variable from a different source font resource follows on the same baseline with a small positive geometric gap and independent local math-layout evidence. A missing prose-to-variable space is restored only when a multiword prose item, a separate uppercase letter from a different source font resource, and continuing prose from the original prose font share one baseline with distinct positive boundary gaps, and the same letter/font pair occurs in a nearby compact equation on the same page and column. A small version-pinned registry may recover a legacy Computer Modern Type-3 character only after an exact official-metric family match, exact target and two-witness glyph-program matches, and a complete operator/text sequence binding. General equations, scripts, fraction bars, unregistered raster variants, and other damaged mathematical glyphs remain source reading-order text rather than being guessed.",
+  "A missing space after a separate source text item that is exactly the mathematical operator log is restored only in a short, compact left-to-right math run when a single-letter variable from a different source font resource follows on the same baseline with a small positive geometric gap and independent local math-layout evidence. A missing prose-to-variable space is restored only when a multiword prose item, a separate uppercase letter from a different source font resource, and continuing prose from the original prose font share one baseline with distinct positive boundary gaps, and the same letter/font pair occurs in a nearby compact equation on the same page and column. An inline single-digit stacked fraction is rendered only when consecutive same-font source items, explicit source whitespace, smaller exactly aligned numerator and denominator digits, ordinary prose on both sides, and exactly one thin matching solid-mask bar agree. A small version-pinned registry may recover a legacy Computer Modern Type-3 character only after an exact official-metric family match, exact target and two-witness glyph-program matches, and a complete operator/text sequence binding. General equations, scripts, other fraction bars, unregistered raster variants, and other damaged mathematical glyphs remain source reading-order text rather than being guessed.",
   "Lists are emitted only for literal bullet glyphs or decimal markers present in the source text.",
   "Links are emitted only for source-validated http or https annotation targets that map to exactly one contiguous run of text on one line. Internal destinations, actions, other schemes, ambiguous or partially covered labels, and links inside reconstructed tables remain escaped text reported as a conversion gap, and URL-looking source text is escaped to resist host autolinking.",
   "Tables are reconstructed only from either complete text-item column geometry or one unambiguous complete closed grid of bounded axis-aligned solid-mask rectangles. Ruled grids require every text item to fit exactly one cell, reject aligned partial dividers that evidence merged or spanning topology, and require independent caption and header evidence because Markdown imposes header semantics. Unsupported text remains escaped reading-order text with a conversion gap. Stroked paths are omitted and reported as vector-content gaps. Cell artwork is omitted and reported as a vector-content gap; only independently qualified exact legacy glyph variants are recovered.",
@@ -700,6 +700,152 @@ function hasNearbyMathVariableEvidence(row, variable, rows, rowIndex) {
   return false;
 }
 
+function alignedFractionBar(page, numerator, denominator) {
+  const evidence = page.painted_rectangles;
+  if (evidence?.status !== "available" || evidence.truncated === true) return null;
+  const tolerance = numerator.line_height * 0.05;
+  const matches = (evidence.items ?? []).filter(item => {
+    const box = item.bbox;
+    const transform = item.graphics_transform;
+    return item.source_kind === "solid_color_image_mask"
+      && box
+      && Array.isArray(transform)
+      && transform.length === 6
+      && transform.every(Number.isFinite)
+      && transform[0] > 0
+      && transform[3] < 0
+      && Math.abs(transform[1]) <= 1e-6
+      && Math.abs(transform[2]) <= 1e-6
+      && box.height > 0
+      && box.height <= numerator.line_height * 0.1
+      && Math.abs(box.x - numerator.x) <= tolerance
+      && Math.abs(box.width - numerator.width) <= tolerance
+      && Math.abs((box.x + box.width / 2) - (numerator.x + numerator.width / 2)) <= tolerance
+      && Math.abs((box.x + box.width / 2) - (denominator.x + denominator.width / 2)) <= tolerance
+      && box.y <= numerator.y + numerator.height + tolerance
+      && box.y + box.height >= denominator.y - tolerance;
+  });
+  return matches.length === 1 ? matches[0] : null;
+}
+
+function axisAlignedTextItem(item) {
+  const transform = item.raw_transform;
+  return Array.isArray(transform) && transform.length === 6
+    && transform.every(Number.isFinite)
+    && transform[0] > 0 && transform[3] > 0
+    && Math.abs(transform[1]) <= 1e-6
+    && Math.abs(transform[2]) <= 1e-6;
+}
+
+function exactFractionSourceSequence(page, prose, numerator, denominator, continuation) {
+  const byIndex = new Map(page.raw_items.map(item => [item.source_index, item]));
+  const before = byIndex.get(prose.source_index + 1);
+  const after = byIndex.get(denominator.source_index + 1);
+  return numerator.source_index === prose.source_index + 2
+    && denominator.source_index === numerator.source_index + 1
+    && continuation.source_index === denominator.source_index + 2
+    && before?.text_kind === "whitespace"
+    && after?.text_kind === "whitespace"
+    && /^\s+$/u.test(before.text)
+    && /^\s+$/u.test(after.text)
+    && before.font_name === prose.font_name
+    && after.font_name === denominator.font_name;
+}
+
+/**
+ * Interpret only a single-digit stacked fraction whose exact source geometry
+ * includes a matching solid-mask bar and whose three rows form one ordinary
+ * prose sentence. Other stacked scripts and fraction-like layouts remain in
+ * source reading order.
+ */
+function simpleStackedFractionPlan(page, rows, {
+  headings,
+  linkState,
+  unsafePage,
+}) {
+  const replacements = new Map();
+  const skipped = new Set();
+  if (unsafePage) return { replacements, skipped };
+  for (let index = 0; index < rows.length - 2; index += 1) {
+    const host = rows[index];
+    const denominatorRow = rows[index + 1];
+    const continuation = rows[index + 2];
+    const numerator = host.cells.at(-1);
+    const prose = host.cells.at(-2);
+    const denominator = denominatorRow.cells[0];
+    const continuationItem = continuation.cells[0];
+    if (host.cells.length !== 2 || denominatorRow.cells.length !== 1
+      || continuation.cells.length !== 1 || !numerator || !prose || !denominator
+      || !continuationItem || headings.get(host.line.id)
+      || headings.get(denominatorRow.line.id) || headings.get(continuation.line.id)
+      || linkState.spansByLine.get(host.line.id)?.length
+      || linkState.spansByLine.get(denominatorRow.line.id)?.length
+      || linkState.spansByLine.get(continuation.line.id)?.length
+      || [host.line, denominatorRow.line, continuation.line]
+        .some(line => line.direction !== "ltr" || rewritesLineStructure(line)
+          || containsUnsafeText(line.text))
+      || host.line.column_index !== denominatorRow.line.column_index
+      || host.line.column_index !== continuation.line.column_index
+      || !/\d$/u.test(prose.text.trim())
+      || (prose.text.trim().match(/[\p{L}\p{N}]+/gu)?.length ?? 0) < 5
+      || !/^\p{Ll}/u.test(continuationItem.text.trim())
+      || (continuationItem.text.trim().match(/[\p{L}\p{N}]+/gu)?.length ?? 0) < 5
+      || !/^\d$/u.test(numerator.text.trim())
+      || !/^\d$/u.test(denominator.text.trim())
+      || typeof prose.font_name !== "string"
+      || prose.font_name !== numerator.font_name
+      || prose.font_name !== denominator.font_name
+      || prose.font_name !== continuationItem.font_name
+      || ![prose, numerator, denominator, continuationItem].every(axisAlignedTextItem)
+      || !exactFractionSourceSequence(page, prose, numerator, denominator, continuationItem)) continue;
+    const proseHeight = Math.max(prose.line_height, continuationItem.line_height);
+    const digitHeight = Math.max(numerator.line_height, denominator.line_height);
+    const leftGap = numerator.x - (prose.x + prose.width);
+    const rightGap = continuationItem.x - (numerator.x + numerator.width);
+    if (!(digitHeight >= proseHeight * 0.65 && digitHeight <= proseHeight * 0.8)
+      || Math.abs(numerator.x - denominator.x) > digitHeight * 0.05
+      || Math.abs(numerator.width - denominator.width) > digitHeight * 0.05
+      || Math.abs(numerator.line_height - denominator.line_height) > digitHeight * 0.05
+      || Math.abs(prose.line_height - continuationItem.line_height) > proseHeight * 0.05
+      || !(numerator.y < prose.y && denominator.y > prose.y)
+      || Math.abs(prose.y - continuationItem.y) > proseHeight * 0.05
+      || !(leftGap > 0 && leftGap <= proseHeight * 0.2)
+      || !(rightGap > proseHeight * 0.25 && rightGap <= proseHeight * 0.6)
+      || alignedFractionBar(page, numerator, denominator) === null) continue;
+    const offsets = itemOffsets(host.line, host.cells);
+    const numeratorOffset = offsets?.at(-1);
+    if (!numeratorOffset || numeratorOffset.start !== numeratorOffset.end - 1
+      || numeratorOffset.end !== host.line.text.length
+      || /\s/u.test(host.line.text.slice(offsets.at(-2).end, numeratorOffset.start))) continue;
+    replacements.set(
+      host.line.id,
+      `${host.line.text.slice(0, numeratorOffset.start)} ${numerator.text.trim()}/${denominator.text.trim()} ${continuation.line.text.trim()}`,
+    );
+    skipped.add(denominatorRow.line.id);
+    skipped.add(continuation.line.id);
+    index += 2;
+  }
+  return { replacements, skipped };
+}
+
+function pageStackedFractionPlan(page, segments, options) {
+  const replacements = new Map();
+  const skipped = new Set();
+  let contiguousTextRows = [];
+  const flush = () => {
+    const plan = simpleStackedFractionPlan(page, contiguousTextRows, options);
+    for (const [lineId, text] of plan.replacements) replacements.set(lineId, text);
+    for (const lineId of plan.skipped) skipped.add(lineId);
+    contiguousTextRows = [];
+  };
+  for (const segment of segments) {
+    if (segment.kind === "table") flush();
+    else contiguousTextRows.push(...segment.rows);
+  }
+  flush();
+  return { replacements, skipped };
+}
+
 function columnAnchors(rows) {
   const xs = rows
     .flatMap(row => row.cells.map(itemStartX))
@@ -1263,41 +1409,49 @@ function renderPage(page) {
   const headings = headingLevels(page);
   const analysis = segmentPageLines(page);
   const linkState = analyzePageLinks(page, analysis, headings);
-  const records = analysis.segments.flatMap(segment => (
-    segment.kind === "table"
-      ? renderTable(segment.grid).map(text => ({ text, line: null, joinable: false }))
-      : segment.rows.map(({ line, cells }, rowIndex, rows) => {
-        const spans = linkState.spansByLine.get(line.id);
-        const offsets = linkState.offsetsByLine.get(line.id);
-        if (spans && spans.length > 0 && offsets && !headings.get(line.id)) {
-          const linked = renderLinkedLine(line, offsets, spans);
-          if (linked !== null) return { text: linked, line, joinable: false };
-        }
-        const projectionOptions = {
-          headingLevel: headings.get(line.id),
-          linked: Boolean(spans?.length),
-          rows,
-          rowIndex,
-          unsafePage: analysis.tableReason !== null
-            || linkState.unavailable
-            || linkState.ambiguous
-            || linkState.unsupportedTarget,
-        };
-        const mathText = mathOperatorSpacedText(
-          { line, cells },
-          projectionOptions,
-        );
-        const proseMathText = mathText === null
-          ? proseMathVariableSpacedText({ line, cells }, projectionOptions)
-          : null;
-        const projectedText = mathText ?? proseMathText;
-        return {
-          text: renderLine(line, headings.get(line.id), projectedText ?? line.text),
-          line,
-          joinable: projectedText === null && !headings.get(line.id) && !rewritesLineStructure(line),
-        };
-      })
-  ));
+  const unsafePage = analysis.tableReason !== null
+    || linkState.unavailable
+    || linkState.ambiguous
+    || linkState.unsupportedTarget;
+  const fractionPlan = pageStackedFractionPlan(page, analysis.segments, {
+    headings,
+    linkState,
+    unsafePage,
+  });
+  const records = analysis.segments.flatMap(segment => {
+    if (segment.kind === "table") {
+      return renderTable(segment.grid).map(text => ({ text, line: null, joinable: false }));
+    }
+    return segment.rows.flatMap(({ line, cells }, rowIndex, rows) => {
+      if (fractionPlan.skipped.has(line.id)) return [];
+      const spans = linkState.spansByLine.get(line.id);
+      const offsets = linkState.offsetsByLine.get(line.id);
+      if (spans && spans.length > 0 && offsets && !headings.get(line.id)) {
+        const linked = renderLinkedLine(line, offsets, spans);
+        if (linked !== null) return { text: linked, line, joinable: false };
+      }
+      const projectionOptions = {
+        headingLevel: headings.get(line.id),
+        linked: Boolean(spans?.length),
+        rows,
+        rowIndex,
+        unsafePage,
+      };
+      const mathText = mathOperatorSpacedText(
+        { line, cells },
+        projectionOptions,
+      );
+      const proseMathText = mathText === null
+        ? proseMathVariableSpacedText({ line, cells }, projectionOptions)
+        : null;
+      const projectedText = fractionPlan.replacements.get(line.id) ?? mathText ?? proseMathText;
+      return {
+        text: renderLine(line, headings.get(line.id), projectedText ?? line.text),
+        line,
+        joinable: projectedText === null && !headings.get(line.id) && !rewritesLineStructure(line),
+      };
+    });
+  });
   const lines = joinParagraphContinuity(records);
   const markdown = lines.length > 0
     ? lines.join("\n")

--- a/pdf-toolkit-mcp-share/server/output-schemas.js
+++ b/pdf-toolkit-mcp-share/server/output-schemas.js
@@ -589,7 +589,7 @@ export const TOOL_SUCCESS_OUTPUT_SCHEMAS = Object.freeze({
   convert_pdf_to_markdown: object({
     renderer: object({
       name: { const: "pdf-tools.layout-markdown-renderer" },
-      version: { const: "1.9.0" },
+      version: { const: "1.10.0" },
     }),
     conversion_status: enumString(["complete", "partial", "failed"]),
     markdown: string,

--- a/scripts/eval-run-markdown-bakeoff.mjs
+++ b/scripts/eval-run-markdown-bakeoff.mjs
@@ -193,7 +193,7 @@ export function validateMarkdownResult(result, binding) {
     throw new Error(`Markdown conversion failed for ${binding.fixture.id}`);
   }
   const value = result.structuredContent;
-  if (value.renderer?.name !== "pdf-tools.layout-markdown-renderer" || value.renderer?.version !== "1.9.0"
+  if (value.renderer?.name !== "pdf-tools.layout-markdown-renderer" || value.renderer?.version !== "1.10.0"
     || value.options?.include_page_boundaries !== true || value.limits?.max_markdown_bytes !== 200000
     || value.provenance?.source?.file_name !== binding.retained.filename
     || value.provenance?.source?.sha256 !== binding.retained.sha256

--- a/scripts/macos-claude-installed-shannon.mjs
+++ b/scripts/macos-claude-installed-shannon.mjs
@@ -12,8 +12,8 @@ if (!process.argv[2] || !process.argv[3]) {
 }
 
 const EXPECTED_SOURCE_SHA256 = "6e4e3411984f3edf99dbfe8b941cb5e8a321379ff0cae6ae5c1f592ad8882ca8";
-const EXPECTED_MARKDOWN_SHA256 = "5aefe08bd0228379f0dc8a23c57bbc906899a1995baadd92c67a5aae0065e602";
-const EXPECTED_TOOL_CONTRACT_SHA256 = "d358ad9e6b7ee830a41c7b64a5ee612decd9ac4c8bb58e76f6c5dbc0529aa555";
+const EXPECTED_MARKDOWN_SHA256 = "bb3f7586a3268fc2ed5a1de2d57bad3ca63321720f1af4d5e62dbe46716e187e";
+const EXPECTED_TOOL_CONTRACT_SHA256 = "922bc866cd2c338ee3f3cc3ca5b888aed339b65680c9cba9ac71ce62eecf3ac3";
 const EXPECTED_PAGE_COUNT = 55;
 const PAGE_SPAN = 10;
 
@@ -77,7 +77,7 @@ try {
     });
     const value = result.structuredContent;
     assert(!result.isError && value, `Installed conversion failed for pages ${startPage}-${endPage}`);
-    assert(value.renderer?.version === "1.9.0", "Installed Markdown renderer version differs");
+    assert(value.renderer?.version === "1.10.0", "Installed Markdown renderer version differs");
     assert(value.provenance?.layout?.parser_version === "5.4.624", "Installed PDF parser version differs");
     assert(value.provenance?.source?.sha256 === sourceSha256, "Installed conversion source identity differs");
     assert(value.provenance?.layout?.page_range?.start_page === startPage, "Installed conversion start page differs");

--- a/scripts/macos-claude-installed-smoke.mjs
+++ b/scripts/macos-claude-installed-smoke.mjs
@@ -29,7 +29,7 @@ const textFixture = path.join(fixtureDirectory, "synthetic-text-two-page.pdf");
 const rasterFixture = path.join(fixtureDirectory, "synthetic-raster-only.pdf");
 const mutationDirectory = path.join(fixtureDirectory, "mutation-output");
 const toolNames = [];
-const EXPECTED_TOOL_CONTRACT_SHA256 = "d358ad9e6b7ee830a41c7b64a5ee612decd9ac4c8bb58e76f6c5dbc0529aa555";
+const EXPECTED_TOOL_CONTRACT_SHA256 = "922bc866cd2c338ee3f3cc3ca5b888aed339b65680c9cba9ac71ce62eecf3ac3";
 let toolContractSha256;
 let structuredToolCount;
 let markdownHash;

--- a/scripts/smoke-mcpb.mjs
+++ b/scripts/smoke-mcpb.mjs
@@ -146,7 +146,7 @@ async function main() {
       arguments: { pdf_path: fixturePath, max_markdown_bytes: 200000 },
     });
     if (markdown.isError
-      || markdown.structuredContent?.renderer?.version !== "1.9.0"
+      || markdown.structuredContent?.renderer?.version !== "1.10.0"
       || markdown.structuredContent?.markdown_bytes !== Buffer.byteLength(markdown.structuredContent?.markdown || "", "utf8")
       || markdown.structuredContent?.markdown_sha256 !== sha256(Buffer.from(markdown.structuredContent?.markdown || "", "utf8"))) {
       throw new Error("Packed convert_pdf_to_markdown contract smoke failed");

--- a/scripts/test-share-contract.mjs
+++ b/scripts/test-share-contract.mjs
@@ -838,7 +838,7 @@ async function main() {
       arguments: { pdf_path: fixturePath, max_markdown_bytes: 200000 },
     });
     if (markdown.isError
-      || markdown.structuredContent?.renderer?.version !== "1.9.0"
+      || markdown.structuredContent?.renderer?.version !== "1.10.0"
       || markdown.structuredContent?.markdown_bytes !== Buffer.byteLength(markdown.structuredContent?.markdown || "", "utf8")
       || markdown.structuredContent?.markdown_sha256 !== sha256(Buffer.from(markdown.structuredContent?.markdown || "", "utf8"))) {
       throw new Error("Share convert_pdf_to_markdown contract smoke failed");

--- a/server/markdown-conversion.js
+++ b/server/markdown-conversion.js
@@ -6,7 +6,7 @@ import {
 
 const RENDERER = Object.freeze({
   name: "pdf-tools.layout-markdown-renderer",
-  version: "1.9.0",
+  version: "1.10.0",
 });
 
 // Bounded geometric table inference. A run of adjacent lines is treated as a
@@ -52,7 +52,7 @@ const GAP_CODES = new Set([
 const LIMITATIONS = Object.freeze([
   "Headings are emitted only from consistent enlarged font metrics or centered English-language source structure with section spacing for a first-page title, introduction, part, or appendix. Ambiguous, very short, or unsupported heading styles remain body text.",
   "A geometrically overlapping initial capital may be joined to its following uppercase word remainder. Line-end hyphens are preserved because source geometry cannot reliably distinguish a split word from an intentional compound. The source Extraction IR retains the original lines.",
-  "A missing space after a separate source text item that is exactly the mathematical operator log is restored only in a short, compact left-to-right math run when a single-letter variable from a different source font resource follows on the same baseline with a small positive geometric gap and independent local math-layout evidence. A missing prose-to-variable space is restored only when a multiword prose item, a separate uppercase letter from a different source font resource, and continuing prose from the original prose font share one baseline with distinct positive boundary gaps, and the same letter/font pair occurs in a nearby compact equation on the same page and column. A small version-pinned registry may recover a legacy Computer Modern Type-3 character only after an exact official-metric family match, exact target and two-witness glyph-program matches, and a complete operator/text sequence binding. General equations, scripts, fraction bars, unregistered raster variants, and other damaged mathematical glyphs remain source reading-order text rather than being guessed.",
+  "A missing space after a separate source text item that is exactly the mathematical operator log is restored only in a short, compact left-to-right math run when a single-letter variable from a different source font resource follows on the same baseline with a small positive geometric gap and independent local math-layout evidence. A missing prose-to-variable space is restored only when a multiword prose item, a separate uppercase letter from a different source font resource, and continuing prose from the original prose font share one baseline with distinct positive boundary gaps, and the same letter/font pair occurs in a nearby compact equation on the same page and column. An inline single-digit stacked fraction is rendered only when consecutive same-font source items, explicit source whitespace, smaller exactly aligned numerator and denominator digits, ordinary prose on both sides, and exactly one thin matching solid-mask bar agree. A small version-pinned registry may recover a legacy Computer Modern Type-3 character only after an exact official-metric family match, exact target and two-witness glyph-program matches, and a complete operator/text sequence binding. General equations, scripts, other fraction bars, unregistered raster variants, and other damaged mathematical glyphs remain source reading-order text rather than being guessed.",
   "Lists are emitted only for literal bullet glyphs or decimal markers present in the source text.",
   "Links are emitted only for source-validated http or https annotation targets that map to exactly one contiguous run of text on one line. Internal destinations, actions, other schemes, ambiguous or partially covered labels, and links inside reconstructed tables remain escaped text reported as a conversion gap, and URL-looking source text is escaped to resist host autolinking.",
   "Tables are reconstructed only from either complete text-item column geometry or one unambiguous complete closed grid of bounded axis-aligned solid-mask rectangles. Ruled grids require every text item to fit exactly one cell, reject aligned partial dividers that evidence merged or spanning topology, and require independent caption and header evidence because Markdown imposes header semantics. Unsupported text remains escaped reading-order text with a conversion gap. Stroked paths are omitted and reported as vector-content gaps. Cell artwork is omitted and reported as a vector-content gap; only independently qualified exact legacy glyph variants are recovered.",
@@ -700,6 +700,152 @@ function hasNearbyMathVariableEvidence(row, variable, rows, rowIndex) {
   return false;
 }
 
+function alignedFractionBar(page, numerator, denominator) {
+  const evidence = page.painted_rectangles;
+  if (evidence?.status !== "available" || evidence.truncated === true) return null;
+  const tolerance = numerator.line_height * 0.05;
+  const matches = (evidence.items ?? []).filter(item => {
+    const box = item.bbox;
+    const transform = item.graphics_transform;
+    return item.source_kind === "solid_color_image_mask"
+      && box
+      && Array.isArray(transform)
+      && transform.length === 6
+      && transform.every(Number.isFinite)
+      && transform[0] > 0
+      && transform[3] < 0
+      && Math.abs(transform[1]) <= 1e-6
+      && Math.abs(transform[2]) <= 1e-6
+      && box.height > 0
+      && box.height <= numerator.line_height * 0.1
+      && Math.abs(box.x - numerator.x) <= tolerance
+      && Math.abs(box.width - numerator.width) <= tolerance
+      && Math.abs((box.x + box.width / 2) - (numerator.x + numerator.width / 2)) <= tolerance
+      && Math.abs((box.x + box.width / 2) - (denominator.x + denominator.width / 2)) <= tolerance
+      && box.y <= numerator.y + numerator.height + tolerance
+      && box.y + box.height >= denominator.y - tolerance;
+  });
+  return matches.length === 1 ? matches[0] : null;
+}
+
+function axisAlignedTextItem(item) {
+  const transform = item.raw_transform;
+  return Array.isArray(transform) && transform.length === 6
+    && transform.every(Number.isFinite)
+    && transform[0] > 0 && transform[3] > 0
+    && Math.abs(transform[1]) <= 1e-6
+    && Math.abs(transform[2]) <= 1e-6;
+}
+
+function exactFractionSourceSequence(page, prose, numerator, denominator, continuation) {
+  const byIndex = new Map(page.raw_items.map(item => [item.source_index, item]));
+  const before = byIndex.get(prose.source_index + 1);
+  const after = byIndex.get(denominator.source_index + 1);
+  return numerator.source_index === prose.source_index + 2
+    && denominator.source_index === numerator.source_index + 1
+    && continuation.source_index === denominator.source_index + 2
+    && before?.text_kind === "whitespace"
+    && after?.text_kind === "whitespace"
+    && /^\s+$/u.test(before.text)
+    && /^\s+$/u.test(after.text)
+    && before.font_name === prose.font_name
+    && after.font_name === denominator.font_name;
+}
+
+/**
+ * Interpret only a single-digit stacked fraction whose exact source geometry
+ * includes a matching solid-mask bar and whose three rows form one ordinary
+ * prose sentence. Other stacked scripts and fraction-like layouts remain in
+ * source reading order.
+ */
+function simpleStackedFractionPlan(page, rows, {
+  headings,
+  linkState,
+  unsafePage,
+}) {
+  const replacements = new Map();
+  const skipped = new Set();
+  if (unsafePage) return { replacements, skipped };
+  for (let index = 0; index < rows.length - 2; index += 1) {
+    const host = rows[index];
+    const denominatorRow = rows[index + 1];
+    const continuation = rows[index + 2];
+    const numerator = host.cells.at(-1);
+    const prose = host.cells.at(-2);
+    const denominator = denominatorRow.cells[0];
+    const continuationItem = continuation.cells[0];
+    if (host.cells.length !== 2 || denominatorRow.cells.length !== 1
+      || continuation.cells.length !== 1 || !numerator || !prose || !denominator
+      || !continuationItem || headings.get(host.line.id)
+      || headings.get(denominatorRow.line.id) || headings.get(continuation.line.id)
+      || linkState.spansByLine.get(host.line.id)?.length
+      || linkState.spansByLine.get(denominatorRow.line.id)?.length
+      || linkState.spansByLine.get(continuation.line.id)?.length
+      || [host.line, denominatorRow.line, continuation.line]
+        .some(line => line.direction !== "ltr" || rewritesLineStructure(line)
+          || containsUnsafeText(line.text))
+      || host.line.column_index !== denominatorRow.line.column_index
+      || host.line.column_index !== continuation.line.column_index
+      || !/\d$/u.test(prose.text.trim())
+      || (prose.text.trim().match(/[\p{L}\p{N}]+/gu)?.length ?? 0) < 5
+      || !/^\p{Ll}/u.test(continuationItem.text.trim())
+      || (continuationItem.text.trim().match(/[\p{L}\p{N}]+/gu)?.length ?? 0) < 5
+      || !/^\d$/u.test(numerator.text.trim())
+      || !/^\d$/u.test(denominator.text.trim())
+      || typeof prose.font_name !== "string"
+      || prose.font_name !== numerator.font_name
+      || prose.font_name !== denominator.font_name
+      || prose.font_name !== continuationItem.font_name
+      || ![prose, numerator, denominator, continuationItem].every(axisAlignedTextItem)
+      || !exactFractionSourceSequence(page, prose, numerator, denominator, continuationItem)) continue;
+    const proseHeight = Math.max(prose.line_height, continuationItem.line_height);
+    const digitHeight = Math.max(numerator.line_height, denominator.line_height);
+    const leftGap = numerator.x - (prose.x + prose.width);
+    const rightGap = continuationItem.x - (numerator.x + numerator.width);
+    if (!(digitHeight >= proseHeight * 0.65 && digitHeight <= proseHeight * 0.8)
+      || Math.abs(numerator.x - denominator.x) > digitHeight * 0.05
+      || Math.abs(numerator.width - denominator.width) > digitHeight * 0.05
+      || Math.abs(numerator.line_height - denominator.line_height) > digitHeight * 0.05
+      || Math.abs(prose.line_height - continuationItem.line_height) > proseHeight * 0.05
+      || !(numerator.y < prose.y && denominator.y > prose.y)
+      || Math.abs(prose.y - continuationItem.y) > proseHeight * 0.05
+      || !(leftGap > 0 && leftGap <= proseHeight * 0.2)
+      || !(rightGap > proseHeight * 0.25 && rightGap <= proseHeight * 0.6)
+      || alignedFractionBar(page, numerator, denominator) === null) continue;
+    const offsets = itemOffsets(host.line, host.cells);
+    const numeratorOffset = offsets?.at(-1);
+    if (!numeratorOffset || numeratorOffset.start !== numeratorOffset.end - 1
+      || numeratorOffset.end !== host.line.text.length
+      || /\s/u.test(host.line.text.slice(offsets.at(-2).end, numeratorOffset.start))) continue;
+    replacements.set(
+      host.line.id,
+      `${host.line.text.slice(0, numeratorOffset.start)} ${numerator.text.trim()}/${denominator.text.trim()} ${continuation.line.text.trim()}`,
+    );
+    skipped.add(denominatorRow.line.id);
+    skipped.add(continuation.line.id);
+    index += 2;
+  }
+  return { replacements, skipped };
+}
+
+function pageStackedFractionPlan(page, segments, options) {
+  const replacements = new Map();
+  const skipped = new Set();
+  let contiguousTextRows = [];
+  const flush = () => {
+    const plan = simpleStackedFractionPlan(page, contiguousTextRows, options);
+    for (const [lineId, text] of plan.replacements) replacements.set(lineId, text);
+    for (const lineId of plan.skipped) skipped.add(lineId);
+    contiguousTextRows = [];
+  };
+  for (const segment of segments) {
+    if (segment.kind === "table") flush();
+    else contiguousTextRows.push(...segment.rows);
+  }
+  flush();
+  return { replacements, skipped };
+}
+
 function columnAnchors(rows) {
   const xs = rows
     .flatMap(row => row.cells.map(itemStartX))
@@ -1263,41 +1409,49 @@ function renderPage(page) {
   const headings = headingLevels(page);
   const analysis = segmentPageLines(page);
   const linkState = analyzePageLinks(page, analysis, headings);
-  const records = analysis.segments.flatMap(segment => (
-    segment.kind === "table"
-      ? renderTable(segment.grid).map(text => ({ text, line: null, joinable: false }))
-      : segment.rows.map(({ line, cells }, rowIndex, rows) => {
-        const spans = linkState.spansByLine.get(line.id);
-        const offsets = linkState.offsetsByLine.get(line.id);
-        if (spans && spans.length > 0 && offsets && !headings.get(line.id)) {
-          const linked = renderLinkedLine(line, offsets, spans);
-          if (linked !== null) return { text: linked, line, joinable: false };
-        }
-        const projectionOptions = {
-          headingLevel: headings.get(line.id),
-          linked: Boolean(spans?.length),
-          rows,
-          rowIndex,
-          unsafePage: analysis.tableReason !== null
-            || linkState.unavailable
-            || linkState.ambiguous
-            || linkState.unsupportedTarget,
-        };
-        const mathText = mathOperatorSpacedText(
-          { line, cells },
-          projectionOptions,
-        );
-        const proseMathText = mathText === null
-          ? proseMathVariableSpacedText({ line, cells }, projectionOptions)
-          : null;
-        const projectedText = mathText ?? proseMathText;
-        return {
-          text: renderLine(line, headings.get(line.id), projectedText ?? line.text),
-          line,
-          joinable: projectedText === null && !headings.get(line.id) && !rewritesLineStructure(line),
-        };
-      })
-  ));
+  const unsafePage = analysis.tableReason !== null
+    || linkState.unavailable
+    || linkState.ambiguous
+    || linkState.unsupportedTarget;
+  const fractionPlan = pageStackedFractionPlan(page, analysis.segments, {
+    headings,
+    linkState,
+    unsafePage,
+  });
+  const records = analysis.segments.flatMap(segment => {
+    if (segment.kind === "table") {
+      return renderTable(segment.grid).map(text => ({ text, line: null, joinable: false }));
+    }
+    return segment.rows.flatMap(({ line, cells }, rowIndex, rows) => {
+      if (fractionPlan.skipped.has(line.id)) return [];
+      const spans = linkState.spansByLine.get(line.id);
+      const offsets = linkState.offsetsByLine.get(line.id);
+      if (spans && spans.length > 0 && offsets && !headings.get(line.id)) {
+        const linked = renderLinkedLine(line, offsets, spans);
+        if (linked !== null) return { text: linked, line, joinable: false };
+      }
+      const projectionOptions = {
+        headingLevel: headings.get(line.id),
+        linked: Boolean(spans?.length),
+        rows,
+        rowIndex,
+        unsafePage,
+      };
+      const mathText = mathOperatorSpacedText(
+        { line, cells },
+        projectionOptions,
+      );
+      const proseMathText = mathText === null
+        ? proseMathVariableSpacedText({ line, cells }, projectionOptions)
+        : null;
+      const projectedText = fractionPlan.replacements.get(line.id) ?? mathText ?? proseMathText;
+      return {
+        text: renderLine(line, headings.get(line.id), projectedText ?? line.text),
+        line,
+        joinable: projectedText === null && !headings.get(line.id) && !rewritesLineStructure(line),
+      };
+    });
+  });
   const lines = joinParagraphContinuity(records);
   const markdown = lines.length > 0
     ? lines.join("\n")

--- a/server/output-schemas.js
+++ b/server/output-schemas.js
@@ -589,7 +589,7 @@ export const TOOL_SUCCESS_OUTPUT_SCHEMAS = Object.freeze({
   convert_pdf_to_markdown: object({
     renderer: object({
       name: { const: "pdf-tools.layout-markdown-renderer" },
-      version: { const: "1.9.0" },
+      version: { const: "1.10.0" },
     }),
     conversion_status: enumString(["complete", "partial", "failed"]),
     markdown: string,

--- a/test/convert-pdf-to-markdown.test.js
+++ b/test/convert-pdf-to-markdown.test.js
@@ -305,7 +305,7 @@ describe("convert_pdf_to_markdown MCP tool", () => {
     expect(first.isError).not.toBe(true);
     expect(second.structuredContent).toEqual(first.structuredContent);
     expect(first.structuredContent).toMatchObject({
-      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.9.0" },
+      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.10.0" },
       conversion_status: "complete",
       saved_output: null,
       provenance: {

--- a/test/eval/markdown-bakeoff.test.js
+++ b/test/eval/markdown-bakeoff.test.js
@@ -64,7 +64,7 @@ async function handle(message) {
     const pageBoundaries = Array.from({ length: pageCount }, (_, index) => "<!-- PDF page " + (index + 1) + " -->");
     const markdown = pageBoundaries.join("\n\n") + "\n\nINV-1001 fixture evidence\n";
     const value = {
-      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.9.0" },
+      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.10.0" },
       conversion_status: "complete",
       markdown,
       markdown_sha256: digest(Buffer.from(markdown)),
@@ -146,7 +146,7 @@ function resultFor(binding) {
   const markdown = "<!-- PDF page 1 -->\n\nFixture text\n";
   return {
     structuredContent: {
-      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.9.0" },
+      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.10.0" },
       conversion_status: "complete",
       markdown,
       markdown_sha256: sha256(Buffer.from(markdown)),
@@ -233,9 +233,9 @@ describe("Markdown bakeoff renderer version binding", () => {
     },
   });
 
-  it("accepts the current renderer version and rejects the superseded one", () => {
-    expect(validateMarkdownResult(resultFor("1.9.0"), binding).renderer.version).toBe("1.9.0");
-    for (const stale of ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.6.0", "1.7.0", "1.8.0"]) {
+  it("accepts the current renderer version and rejects all superseded ones", () => {
+    expect(validateMarkdownResult(resultFor("1.10.0"), binding).renderer.version).toBe("1.10.0");
+    for (const stale of ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.6.0", "1.7.0", "1.8.0", "1.9.0"]) {
       expect(() => validateMarkdownResult(resultFor(stale), binding), stale)
         .toThrow(/Markdown result evidence is invalid/u);
     }

--- a/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
+++ b/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
@@ -67,14 +67,14 @@
     {
       "role": "markdown_conversion_module",
       "path": "server/markdown-conversion.js",
-      "bytes": 65532,
-      "sha256": "9246fddaeebfb4180c683bbb27abf631f88b609f83dfd6051925872cd5fa8e76"
+      "bytes": 72942,
+      "sha256": "dc4038b925d41e1564abadf40e7afcb394ee3656eef25744cbcc75377bc3bf97"
     },
     {
       "role": "output_schemas_module",
       "path": "server/output-schemas.js",
-      "bytes": 31191,
-      "sha256": "4be1da29cea1e7ea2a7388731e3e16d8ca3a2d1c3d3fc8cf5de10ff3d54d537b"
+      "bytes": 31192,
+      "sha256": "e20f17c33e6b30c843575856eed138fd628022909d7af94b8b55fbfb034f5f61"
     },
     {
       "role": "package_json",
@@ -101,7 +101,7 @@
       "sha256": "6e4429db62fcbe1dd73141d8c20a48b564d41f8bf8920d88775846995e1daf94"
     }
   ],
-  "validator_source_set_sha256": "5160557e861eab0dd7c6b8d84ae7a513a763f699db8529d4cbef2fd9148c64cb",
+  "validator_source_set_sha256": "3f25b8b02ba69841b5d45c6c22c9d8f063ba2d006ebf483a8b058680f1dfb0df",
   "pdfjs_version": "5.4.624",
   "generation_contract": {
     "source_path": "source.pdf",

--- a/test/fixtures/eval/shannon/manifest.v1.json
+++ b/test/fixtures/eval/shannon/manifest.v1.json
@@ -22,7 +22,7 @@
     "pdf_tools": {
       "slot": "control.current_product.v0",
       "renderer_name": "pdf-tools.layout-markdown-renderer",
-      "renderer_version": "1.9.0",
+      "renderer_version": "1.10.0",
       "parser_name": "pdfjs-dist",
       "parser_version": "5.4.624"
     },

--- a/test/markdown-conversion.test.js
+++ b/test/markdown-conversion.test.js
@@ -159,6 +159,18 @@ function combinePaintedOperations(...groups) {
   };
 }
 
+function paintedFractionBarOperations({ x, y, width, height = 0.48 }) {
+  return {
+    operations: [4, 6, 7, 5],
+    operatorArgs: [
+      null,
+      [width, 0, 0, -height, x, 792 - y],
+      [],
+      null,
+    ],
+  };
+}
+
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
 describe("layout Markdown renderer", () => {
@@ -502,6 +514,67 @@ describe("layout Markdown renderer", () => {
     expect(result.markdown).toContain("ModelC interface remains compact here");
     expect(result.markdown).toContain("This document uses modelC interface remains compact here");
     expect(result.markdown).toContain("Definition: The capacityc of a discrete channel is given by");
+    expect(layout.pages.map(page => page.lines.map(line => line.text))).toEqual(originalLines);
+    expect(validateMarkdownConversionSemantics(result, { layout })).toBe(result);
+  });
+
+  it("renders only an explicitly barred single-digit stacked fraction in prose", async () => {
+    const alignedBar = paintedFractionBarOperations({ x: 211.208, y: 105.252, width: 3.72 });
+    const misalignedBar = paintedFractionBarOperations({ x: 225, y: 105.252, width: 3.72 });
+    const thickBar = paintedFractionBarOperations({ x: 211.208, y: 105.252, width: 3.72, height: 1.2 });
+    const fractionItems = [
+      positionedTextItem("A decimal digit is about 3", { top: 98, left: 100, width: 110 }),
+      positionedTextItem(" ", { top: 98, left: 210, width: 0.165 }),
+      positionedTextItem("1", { top: 96.64, left: 211.22, width: 3.7, fontSize: 7.4 }),
+      positionedTextItem("3", { top: 104.08, left: 211.22, width: 3.7, fontSize: 7.4 }),
+      positionedTextItem(" ", { top: 104.08, left: 214.92, width: 0.41, fontSize: 7.4 }),
+      positionedTextItem("bits. A digit wheel remains stable here", {
+        top: 98,
+        left: 219.02,
+        width: 170,
+        eol: true,
+      }),
+    ];
+    const negativePages = [
+      { items: fractionItems },
+      { items: fractionItems, ...misalignedBar },
+      { items: fractionItems, ...thickBar },
+      { items: fractionItems, ...combinePaintedOperations(alignedBar, alignedBar) },
+      { items: fractionItems.filter(item => item.str !== " "), ...alignedBar },
+      {
+        items: fractionItems.map((item, index) => index === 0
+          ? { ...item, str: "A decimal digit is about three" }
+          : item),
+        ...alignedBar,
+      },
+      {
+        items: fractionItems.map((item, index) => index === fractionItems.length - 1
+          ? { ...item, str: "Bits. A digit wheel remains stable here" }
+          : item),
+        ...alignedBar,
+      },
+      {
+        items: fractionItems.map((item, index) => index === fractionItems.length - 1
+          ? { ...item, fontName: "f2" }
+          : item),
+        ...alignedBar,
+      },
+    ];
+    const layout = await validatedSyntheticLayout([
+      { items: fractionItems, ...alignedBar },
+      ...negativePages,
+    ]);
+    const originalLines = layout.pages.map(page => page.lines.map(line => line.text));
+    const result = renderPdfLayoutToMarkdown(layout, { includePageBoundaries: false });
+
+    expect(result.markdown).toContain("A decimal digit is about 3 1/3 bits. A digit wheel remains stable here");
+    expect(result.markdown.match(/A decimal digit is about 31\n3\nbits\./gu)).toHaveLength(6);
+    expect(result.markdown).toContain("A decimal digit is about three1\n3\nbits.");
+    expect(result.markdown).toContain("A decimal digit is about 31\n3\nBits.");
+    expect(result.pages[0].rendered_line_count).toBe(layout.pages[0].lines.length - 2);
+    for (let index = 1; index < result.pages.length; index += 1) {
+      expect(result.pages[index].rendered_line_count).toBe(layout.pages[index].lines.length);
+    }
     expect(layout.pages.map(page => page.lines.map(line => line.text))).toEqual(originalLines);
     expect(validateMarkdownConversionSemantics(result, { layout })).toBe(result);
   });

--- a/test/mcp-contract.test.js
+++ b/test/mcp-contract.test.js
@@ -58,10 +58,13 @@ const EXAMPLE_PDF = path.join(REPO_ROOT, "example-fw9.pdf");
 // independently qualified exact legacy Computer Modern Type-3 glyphs.
 // Previously 9947d16e32562981651216c95598786d9f3324d5f1fae3b53fa8d7f089d2ea05.
 // 2026-08-04: Markdown renderer 1.9.0 restores only narrowly source-supported
-// boundaries
-// between multiword prose and a separate uppercase math variable. Previously
+// boundaries between multiword prose and a separate uppercase math variable.
+// Previously
 // 223c8ec6b37d600e2918b5b4b124af80845a51cb9530819024b2426a9c101c06.
-const TOOL_CONTRACT_SHA256 = "d358ad9e6b7ee830a41c7b64a5ee612decd9ac4c8bb58e76f6c5dbc0529aa555";
+// 2026-08-04: Markdown renderer 1.10.0 interprets only explicitly barred,
+// single-digit stacked fractions in an ordinary prose sandwich. Previously
+// d358ad9e6b7ee830a41c7b64a5ee612decd9ac4c8bb58e76f6c5dbc0529aa555.
+const TOOL_CONTRACT_SHA256 = "922bc866cd2c338ee3f3cc3ca5b888aed339b65680c9cba9ac71ce62eecf3ac3";
 
 const CLOSED_READ = Object.freeze({
   readOnlyHint: true,


### PR DESCRIPTION
## What

Render one explicitly barred, single-digit stacked fraction in Shannon's prose as `3 1/3` instead of splitting it across lines.

## Why

The source PDF provides unusually strong evidence: aligned numerator and denominator text, explicit surrounding whitespace, and one matching painted fraction bar. The renderer now uses that evidence through a narrow, fail-closed rule.

## Impact

- Shannon sampled paragraph continuity improves from 2/4 to 3/4.
- Paper content changes only at `a decimal digit is about 3 1/3 bits`.
- Missing, shifted, thick, or competing bars abstain.
- The literal `ap-` / `proximately` source hyphen remains unchanged because intentional compounds in the paper are geometrically indistinguishable.

## Verification

- Renderer suite: 46/46 passed.
- Focused bank: 134 passed, 6 skipped, 0 failed.
- Native Mac suite: 62 passed, 9 skipped, 0 failed.
- Complete clean suite: 1,889 passed, 80 skipped, 0 failed.
- Three Shannon runs were byte-identical; Markdown SHA-256: `bb3f7586a3268fc2ed5a1de2d57bad3ca63321720f1af4d5e62dbe46716e187e`.
- Reproducible MCPB: 73,645,475 bytes, 3,000 files, SHA-256 `fa4431ca17894413484a5e940283b99ec6458e35031dee083a96b6fb4898287d`.
- Packed-copy smoke passed on macOS arm64: 40 tools, 14 prompts, PDF mutation, and native raster rendering.
- Evidence: `docs/evidence/shannon-explicit-stacked-fraction-2026-08.md`.

## Boundaries

This draft is stacked on draft PR #63. It is not merged, released, installed, or shipped. It does not claim general fraction reconstruction, full mathematical layout fidelity, release readiness, or that Kepano's complete issue is solved.
