### PR TITLE
Repair PDF Tools 0.9.0 installed-copy proof

### DIFF
--- a/docs/releases/v0.9.0.md
+++ b/docs/releases/v0.9.0.md
@@ -65,6 +65,15 @@ benchmark or full transcript ground truth.
 - Required online golden-document gate: 4/4 passed.
 - Packed MCPB smoke on macOS ARM64: 41 tools, 14 prompts, canonical resources,
   PDF mutation, source-bound comparison, and native raster rendering passed.
+- Claude Desktop installation registry: version `0.9.0`, one enabled current
+  identity, no duplicate, and installed SHA-256 exactly matched the release
+  MCPB.
+- Installed-copy macOS smoke: 41 tools, 37 structured tools, folder-policy
+  denial, text and Markdown conversion, PDF mutation, fresh-session discovery,
+  and native raster rendering passed.
+- Installed-copy Shannon proof: all 55 pages converted to the exact reviewed
+  Markdown SHA-256 with 511 retained replacement characters and 68 explicit
+  gaps.
 - Transactional share-package contract: 41 tools, 14 prompts, 112 SBOM
   components, and native raster rendering passed.
 - MCPB reproducibility: two clean isolated builds were byte-identical.

--- a/scripts/macos-claude-installed-shannon.mjs
+++ b/scripts/macos-claude-installed-shannon.mjs
@@ -12,8 +12,8 @@ if (!process.argv[2] || !process.argv[3]) {
 }
 
 const EXPECTED_SOURCE_SHA256 = "6e4e3411984f3edf99dbfe8b941cb5e8a321379ff0cae6ae5c1f592ad8882ca8";
-const EXPECTED_MARKDOWN_SHA256 = "bb3f7586a3268fc2ed5a1de2d57bad3ca63321720f1af4d5e62dbe46716e187e";
-const EXPECTED_TOOL_CONTRACT_SHA256 = "922bc866cd2c338ee3f3cc3ca5b888aed339b65680c9cba9ac71ce62eecf3ac3";
+const EXPECTED_MARKDOWN_SHA256 = "eb95044865294fcb086d6f003fdaa277cfaac98270b8cf63e26d4216c8275269";
+const EXPECTED_TOOL_CONTRACT_SHA256 = "941d6bd50b2a3930defb0526919d714ff9d4bc51acef2b2ad88c99c7533e8c98";
 const EXPECTED_PAGE_COUNT = 55;
 const PAGE_SPAN = 10;
 
@@ -55,7 +55,7 @@ const chunks = [];
 try {
   await client.connect(transport);
   const tools = await client.listTools();
-  assert(tools.tools.length === 40, `Expected 40 installed tools, received ${tools.tools.length}`);
+  assert(tools.tools.length === 41, `Expected 41 installed tools, received ${tools.tools.length}`);
   assert(
     sha256(Buffer.from(JSON.stringify(tools.tools))) === EXPECTED_TOOL_CONTRACT_SHA256,
     "Installed tool contract differs from the reviewed build",
@@ -92,7 +92,10 @@ try {
 
 const markdown = chunks.map(chunk => chunk.markdown).join("\n\n");
 const markdownSha256 = sha256(Buffer.from(markdown, "utf8"));
-assert(markdownSha256 === EXPECTED_MARKDOWN_SHA256, "Installed Shannon Markdown differs from the reviewed output");
+assert(
+  markdownSha256 === EXPECTED_MARKDOWN_SHA256,
+  `Installed Shannon Markdown differs from the reviewed output: expected ${EXPECTED_MARKDOWN_SHA256}, received ${markdownSha256}`,
+);
 
 process.stdout.write(`${JSON.stringify({
   installed_extension: extensionDirectory,

--- a/scripts/macos-claude-installed-smoke.mjs
+++ b/scripts/macos-claude-installed-smoke.mjs
@@ -29,7 +29,7 @@ const textFixture = path.join(fixtureDirectory, "synthetic-text-two-page.pdf");
 const rasterFixture = path.join(fixtureDirectory, "synthetic-raster-only.pdf");
 const mutationDirectory = path.join(fixtureDirectory, "mutation-output");
 const toolNames = [];
-const EXPECTED_TOOL_CONTRACT_SHA256 = "922bc866cd2c338ee3f3cc3ca5b888aed339b65680c9cba9ac71ce62eecf3ac3";
+const EXPECTED_TOOL_CONTRACT_SHA256 = "941d6bd50b2a3930defb0526919d714ff9d4bc51acef2b2ad88c99c7533e8c98";
 let toolContractSha256;
 let structuredToolCount;
 let markdownHash;
@@ -78,7 +78,7 @@ try {
     `Tool contract digest drifted: ${toolContractSha256}`,
   );
   structuredToolCount = tools.tools.filter(tool => tool.outputSchema).length;
-  assert(structuredToolCount === 35, `Expected 35 structured tools, received ${structuredToolCount}`);
+  assert(structuredToolCount === 37, `Expected 37 structured tools, received ${structuredToolCount}`);
 
   const listed = await first.client.callTool({
     name: "list_pdfs",
@@ -94,7 +94,11 @@ try {
     arguments: { pdf_path: textFixture },
   });
   assert(!info.isError, "get_pdf_info failed for the text fixture");
-  assert(/Pages:\s*2\b/.test(textContent(info)), "get_pdf_info did not report two pages");
+  assert(
+    info.structuredContent?.pages?.total_count === 2
+      && info.structuredContent?.pages?.observed_count === 2,
+    "get_pdf_info did not report two observed pages",
+  );
 
   const identity = await first.client.callTool({
     name: "get_pdf_identity",
@@ -158,8 +162,9 @@ try {
     },
   });
   assert(
-    textContent(denied).includes("only allowed to access"),
-    "Path outside the configured directory was not denied with the policy error",
+    denied.isError
+      && denied.structuredContent?.error?.code === "path_policy_denied",
+    `Path outside the configured directory was not denied with the typed policy error: ${textContent(denied)}`,
   );
 
   const split = await first.client.callTool({
@@ -189,7 +194,11 @@ try {
     arguments: { pdf_path: path.join(mutationDirectory, mutationFiles[1]) },
   });
   assert(!info.isError, "Fresh-session get_pdf_info call failed");
-  assert(/Pages:\s*1\b/.test(textContent(info)), "Fresh-session mutation output was not one page");
+  assert(
+    info.structuredContent?.pages?.total_count === 1
+      && info.structuredContent?.pages?.observed_count === 1,
+    "Fresh-session mutation output was not one observed page",
+  );
 } finally {
   await fresh.transport.close();
 }


### PR DESCRIPTION
## Outcome

Updates the macOS installed-copy proof to the exact merged 0.9.0 tool contract and structured output contract, then records the completed Claude Desktop installation evidence.

## Repairs

- pins the reviewed 41-tool contract fingerprint
- expects 37 structured tools
- checks get_pdf_info through its structured page observations
- checks folder denial through the typed path_policy_denied code
- pins the final Shannon Markdown fingerprint
- improves mismatch diagnostics

## Direct installed evidence

- Claude registry: one enabled current identity, version 0.9.0, artifact SHA-256 e29b0cdea7179664ee0e4ef2f671b18561a86ad9c3a00e5015884eb96a247921
- installed synthetic smoke: 41 tools, 37 structured tools, text/Markdown extraction, native raster, mutation, fresh-session read, and folder denial passed
- installed Shannon: all 55 pages, 68 explicit gaps, 511 retained replacement characters, Markdown SHA-256 eb95044865294fcb086d6f003fdaa277cfaac98270b8cf63e26d4216c8275269
- documentation claims guard: 63 of 63 passed
- both scripts pass syntax checks and were executed successfully against the installed extension.