### PR TITLE
Record installed Shannon alpha proof

### DIFF
--- a/docs/evidence/shannon-alpha-alignment-2026-08.md
+++ b/docs/evidence/shannon-alpha-alignment-2026-08.md
@@ -52,3 +52,26 @@ failure exposed a process-runner race in which a deadline termination was
 misreported as a late `EPERM` spawn failure. Deadline evidence now takes
 precedence after a process has started and timed out; the complete 21-test
 runner file then passed.
+
+## Merge, package, and installed proof
+
+- PR #71 merged as
+  `cce500f693df597160ae21f332ec1292dd9ee5c6`.
+- Two clean MCPB builds were byte-identical: 2,996 files, 73,688,901 bytes,
+  SHA-256
+  `5d64d3e33168020f8f7304706eb2200821d6600dfaab162e8e48cff4867788ef`.
+- The packed macOS arm64 smoke passed with 41 tools, 14 prompts, PDF mutation,
+  source-bound comparison, and native raster rendering.
+- The installed Claude extension's extraction runtime is byte-identical to the
+  merged source. Its existing enabled setting was preserved, and the prior
+  extension was moved to the recoverable host-validation backup directory.
+- Claude's host log records a fresh server start, successful initialization,
+  and tool, prompt, and resource discovery after installation.
+- Installed-copy smoke passed with 41 unique tools, tool-contract SHA-256
+  `109df9e468513e07377804bff842ac9c398923d88dc07c0ffd68c12a8c075e82`,
+  native raster rendering, PDF mutation, allowed-directory success, and
+  outside-directory denial.
+- The installed copy reproduced the reviewed 55-page Shannon output exactly:
+  49 alphas, 498 replacement characters, 68 explicit gaps, 182,565 bytes, and
+  Markdown SHA-256
+  `2e7e4fb71d0ea116a352eb1aa1ed1b06c089969643073394d82e23eb5f6ffee3`.

--- a/docs/handoffs/KEPANO_SHANNON.md
+++ b/docs/handoffs/KEPANO_SHANNON.md
@@ -85,11 +85,12 @@ companion evidence.
 
 ## Current gates
 
-The v0.9.1 release and installed-copy gates are complete. The alpha candidate's
-focused tests and full-paper evaluation are complete. It still needs a clean
-full suite, package build, independent review, merge, installed-copy proof, and
-release decision. The 64-minus and 5-comma groups remain blocked on missing
-companion evidence.
+The alpha implementation, independent review, merge, reproducible package,
+packed smoke, Claude installation, host discovery, installed-copy smoke, and
+installed Shannon proof are complete. PR #71 merged as
+`cce500f693df597160ae21f332ec1292dd9ee5c6`. The public release and Kepano
+reply remain the next decisions. The 64-minus and 5-comma groups remain blocked
+on missing companion evidence.
 
 Mat has authorized routine merge and installation. A new public release should
 still be based on the complete checks above. No public reply to Kepano has been

--- a/scripts/macos-claude-installed-shannon.mjs
+++ b/scripts/macos-claude-installed-shannon.mjs
@@ -12,7 +12,7 @@ if (!process.argv[2] || !process.argv[3]) {
 }
 
 const EXPECTED_SOURCE_SHA256 = "6e4e3411984f3edf99dbfe8b941cb5e8a321379ff0cae6ae5c1f592ad8882ca8";
-const EXPECTED_MARKDOWN_SHA256 = "1f1abbc9a6d652c40b7295dc67a0640218d6287aa212a9f0743fd618ff18bd82";
+const EXPECTED_MARKDOWN_SHA256 = "2e7e4fb71d0ea116a352eb1aa1ed1b06c089969643073394d82e23eb5f6ffee3";
 const EXPECTED_TOOL_CONTRACT_SHA256 = "109df9e468513e07377804bff842ac9c398923d88dc07c0ffd68c12a8c075e82";
 const EXPECTED_PAGE_COUNT = 55;
 const PAGE_SPAN = 10;
@@ -92,10 +92,12 @@ try {
 
 const markdown = chunks.map(chunk => chunk.markdown).join("\n\n");
 const markdownSha256 = sha256(Buffer.from(markdown, "utf8"));
+const alphaCount = [...markdown].filter(character => character === "α").length;
 assert(
   markdownSha256 === EXPECTED_MARKDOWN_SHA256,
   `Installed Shannon Markdown differs from the reviewed output: expected ${EXPECTED_MARKDOWN_SHA256}, received ${markdownSha256}`,
 );
+assert(alphaCount === 49, `Installed Shannon alpha count differs: expected 49, received ${alphaCount}`);
 
 process.stdout.write(`${JSON.stringify({
   installed_extension: extensionDirectory,
@@ -105,6 +107,7 @@ process.stdout.write(`${JSON.stringify({
   conversion_statuses: [...new Set(chunks.map(chunk => chunk.conversion_status))].sort(),
   total_gap_count: chunks.reduce((total, chunk) => total + chunk.gaps.length, 0),
   replacement_character_count: [...markdown].filter(character => character === "\uFFFD").length,
+  alpha_count: alphaCount,
   markdown_bytes: Buffer.byteLength(markdown, "utf8"),
   markdown_sha256: markdownSha256,
   elapsed_ms: Number(process.hrtime.bigint() - started) / 1e6,


### PR DESCRIPTION
## What changed
- update the installed Shannon checker for the source-bound alpha recovery
- record the exact packaged and installed-copy proof
- update the Kepano handoff with the verified result

## Verification
- installed Claude copy started successfully and exposed all 41 tools
- installed Shannon extraction: 55 pages, 49 recovered alpha glyphs, exact expected Markdown hash
- package smoke and deterministic build evidence recorded in the repository