### PR TITLE
Bind comparison exclusions to exact render geometry

### DIFF
--- a/pdf-toolkit-mcp-share/server/pdf-comparison.js
+++ b/pdf-toolkit-mcp-share/server/pdf-comparison.js
@@ -339,8 +339,8 @@ function comparisonRenderLogicalExtent(render) {
   const pageView = render?.page_view;
   const pageWidth = pageView?.width_points;
   const pageHeight = pageView?.height_points;
-  const exactPageWidth = render?.comparison_view?.width_points;
-  const exactPageHeight = render?.comparison_view?.height_points;
+  const rawPageWidth = render?.comparison_view?.raw_width_pixels;
+  const rawPageHeight = render?.comparison_view?.raw_height_pixels;
   const viewBox = pageView?.view_box;
   const rotation = pageView?.rotation;
   const userUnit = pageView?.user_unit;
@@ -355,18 +355,22 @@ function comparisonRenderLogicalExtent(render) {
     || !Number.isFinite(userUnit) || userUnit <= 0
     || !Number.isFinite(pageWidth) || pageWidth <= 0
     || !Number.isFinite(pageHeight) || pageHeight <= 0
-    || !Number.isFinite(exactPageWidth) || exactPageWidth <= 0
-    || !Number.isFinite(exactPageHeight) || exactPageHeight <= 0
-    || Number(exactPageWidth.toFixed(6)) !== pageWidth
-    || Number(exactPageHeight.toFixed(6)) !== pageHeight
+    || !Number.isFinite(rawPageWidth) || rawPageWidth <= 0
+    || !Number.isFinite(rawPageHeight) || rawPageHeight <= 0
     || !requested || requested.x !== 0 || requested.y !== 0
     || requested.width !== pageWidth || requested.height !== pageHeight
     || !Number.isSafeInteger(render.width) || render.width <= 0
     || !Number.isSafeInteger(render.height) || render.height <= 0
     || !rendered || rendered.x !== 0 || rendered.y !== 0
     || rendered.width !== render.width || rendered.height !== render.height
-    || Math.ceil(exactPageWidth * render.scale) !== render.width
-    || Math.ceil(exactPageHeight * render.scale) !== render.height) return null;
+    || Math.ceil(rawPageWidth) !== render.width
+    || Math.ceil(rawPageHeight) !== render.height) return null;
+  const exactPageWidth = rawPageWidth / render.scale;
+  const exactPageHeight = rawPageHeight / render.scale;
+  const roundsToPublished = (exact, published) => Math.abs(exact - published)
+    <= 0.00000051 + Number.EPSILON * Math.max(1, Math.abs(exact), Math.abs(published));
+  if (!roundsToPublished(exactPageWidth, pageWidth)
+    || !roundsToPublished(exactPageHeight, pageHeight)) return null;
   const nativeWidth = (viewBox[2] - viewBox[0]) * userUnit;
   const nativeHeight = (viewBox[3] - viewBox[1]) * userUnit;
   const expectedWidth = rotation % 180 === 0 ? nativeWidth : nativeHeight;

--- a/pdf-toolkit-mcp-share/server/pdf-comparison.js
+++ b/pdf-toolkit-mcp-share/server/pdf-comparison.js
@@ -335,25 +335,74 @@ function cropRgba(render, region) {
   return { bytes, sha256: comparisonSha256(bytes) };
 }
 
-function comparisonIgnoredPixelMask(render, regions) {
+function comparisonRenderLogicalExtent(render) {
+  const pageView = render?.page_view;
+  const pageWidth = pageView?.width_points;
+  const pageHeight = pageView?.height_points;
+  const exactPageWidth = render?.comparison_view?.width_points;
+  const exactPageHeight = render?.comparison_view?.height_points;
+  const viewBox = pageView?.view_box;
+  const rotation = pageView?.rotation;
+  const userUnit = pageView?.user_unit;
+  const requested = render?.requested_region;
+  const rendered = render?.rendered_region;
+  if (render?.renderer !== PDF_COMPARISON_ENGINE.renderer.name
+    || render?.scale !== PDF_COMPARISON_RENDERER.scale
+    || pageView?.coordinate_space !== "pdfjs_viewport_top_left_points"
+    || !Array.isArray(viewBox) || viewBox.length !== 4 || !viewBox.every(Number.isFinite)
+    || viewBox[2] <= viewBox[0] || viewBox[3] <= viewBox[1]
+    || ![0, 90, 180, 270].includes(rotation)
+    || !Number.isFinite(userUnit) || userUnit <= 0
+    || !Number.isFinite(pageWidth) || pageWidth <= 0
+    || !Number.isFinite(pageHeight) || pageHeight <= 0
+    || !Number.isFinite(exactPageWidth) || exactPageWidth <= 0
+    || !Number.isFinite(exactPageHeight) || exactPageHeight <= 0
+    || Number(exactPageWidth.toFixed(6)) !== pageWidth
+    || Number(exactPageHeight.toFixed(6)) !== pageHeight
+    || !requested || requested.x !== 0 || requested.y !== 0
+    || requested.width !== pageWidth || requested.height !== pageHeight
+    || !Number.isSafeInteger(render.width) || render.width <= 0
+    || !Number.isSafeInteger(render.height) || render.height <= 0
+    || !rendered || rendered.x !== 0 || rendered.y !== 0
+    || rendered.width !== render.width || rendered.height !== render.height
+    || Math.ceil(exactPageWidth * render.scale) !== render.width
+    || Math.ceil(exactPageHeight * render.scale) !== render.height) return null;
+  const nativeWidth = (viewBox[2] - viewBox[0]) * userUnit;
+  const nativeHeight = (viewBox[3] - viewBox[1]) * userUnit;
+  const expectedWidth = rotation % 180 === 0 ? nativeWidth : nativeHeight;
+  const expectedHeight = rotation % 180 === 0 ? nativeHeight : nativeWidth;
+  const nearlyEqual = (left, right) => Math.abs(left - right)
+    <= 0.000001 * Math.max(1, Math.abs(left), Math.abs(right));
+  if (!Number.isFinite(expectedWidth) || !Number.isFinite(expectedHeight)
+    || !nearlyEqual(pageWidth, expectedWidth)
+    || !nearlyEqual(pageHeight, expectedHeight)) return null;
+  return { width: exactPageWidth, height: exactPageHeight };
+}
+
+function comparisonSharedLogicalExtent(before, after) {
+  const beforeExtent = comparisonRenderLogicalExtent(before);
+  const afterExtent = comparisonRenderLogicalExtent(after);
+  if (!beforeExtent || !afterExtent
+    || canonical(before.page_view) !== canonical(after.page_view)
+    || canonical(before.comparison_view) !== canonical(after.comparison_view)
+    || canonical(before.requested_region) !== canonical(after.requested_region)
+    || beforeExtent.width !== afterExtent.width
+    || beforeExtent.height !== afterExtent.height) return null;
+  return beforeExtent;
+}
+
+function comparisonIgnoredPixelMask(render, regions, logicalExtent) {
   const mask = new Uint8Array(render.width * render.height);
+  if (!logicalExtent) return mask;
   const clamp = (value, maximum) => Math.max(0, Math.min(maximum, value));
-  const requestedRegion = render.requested_region;
-  const pageLeft = Number.isFinite(requestedRegion?.x) ? requestedRegion.x : 0;
-  const pageTop = Number.isFinite(requestedRegion?.y) ? requestedRegion.y : 0;
-  const pageRight = Number.isFinite(requestedRegion?.width) && requestedRegion.width > 0
-    ? pageLeft + requestedRegion.width
-    : render.width / render.scale;
-  const pageBottom = Number.isFinite(requestedRegion?.height) && requestedRegion.height > 0
-    ? pageTop + requestedRegion.height
-    : render.height / render.scale;
   for (const region of regions) {
     if (!Array.isArray(region) || region.length !== 4 || !region.every(Number.isFinite)
       || region[2] <= 0 || region[3] <= 0) continue;
     const regionRight = region[0] + region[2];
     const regionBottom = region[1] + region[3];
-    if (regionRight <= pageLeft || regionBottom <= pageTop
-      || region[0] >= pageRight || region[1] >= pageBottom) continue;
+    if (regionRight <= 0 || regionBottom <= 0
+      || region[0] >= logicalExtent.width
+      || region[1] >= logicalExtent.height) continue;
     const x0 = clamp(Math.floor(region[0] * render.scale) - 1, render.width);
     const y0 = clamp(Math.floor(region[1] * render.scale) - 1, render.height);
     const x1 = clamp(Math.ceil((region[0] + region[2]) * render.scale) + 1, render.width);
@@ -371,7 +420,11 @@ export function diffComparisonRgba(before, after, ignoredRegions = []) {
     return { dimension_mismatch: true, raw_changed_pixels: null, changed_pixels: null, changed_fraction: null, bounds: null, components: [] };
   }
   const pixelCount = before.width * before.height;
-  const ignoredPixels = comparisonIgnoredPixelMask(before, ignoredRegions);
+  const ignoredPixels = comparisonIgnoredPixelMask(
+    before,
+    ignoredRegions,
+    comparisonSharedLogicalExtent(before, after),
+  );
   const threshold = new Uint8Array(pixelCount);
   let rawChangedPixels = 0;
   for (let pixel = 0; pixel < pixelCount; pixel += 1) {

--- a/pdf-toolkit-mcp-share/server/pdfjs-worker.js
+++ b/pdf-toolkit-mcp-share/server/pdfjs-worker.js
@@ -1496,6 +1496,7 @@ async function nativeRenderPage(bytes, password, options) {
     const page = await document.getPage(options.page);
     try {
       const pageView = pageViewFromPdfjs(page);
+      const comparisonView = page.getViewport({ scale: 1 });
       const scale = options.scale_override ?? getPageRenderScale({
         width: pageView.width_points,
         height: pageView.height_points,
@@ -1513,6 +1514,10 @@ async function nativeRenderPage(bytes, password, options) {
       );
       const buffer = canvas.toBuffer("image/png");
       return pngResult(buffer, {
+        comparison_view: {
+          width_points: comparisonView.width,
+          height_points: comparisonView.height,
+        },
         height: pixels.height,
         height_points: geometry.height,
         page_geometry: pageGeometry,

--- a/pdf-toolkit-mcp-share/server/pdfjs-worker.js
+++ b/pdf-toolkit-mcp-share/server/pdfjs-worker.js
@@ -1496,7 +1496,6 @@ async function nativeRenderPage(bytes, password, options) {
     const page = await document.getPage(options.page);
     try {
       const pageView = pageViewFromPdfjs(page);
-      const comparisonView = page.getViewport({ scale: 1 });
       const scale = options.scale_override ?? getPageRenderScale({
         width: pageView.width_points,
         height: pageView.height_points,
@@ -1515,8 +1514,8 @@ async function nativeRenderPage(bytes, password, options) {
       const buffer = canvas.toBuffer("image/png");
       return pngResult(buffer, {
         comparison_view: {
-          width_points: comparisonView.width,
-          height_points: comparisonView.height,
+          raw_width_pixels: viewport.width,
+          raw_height_pixels: viewport.height,
         },
         height: pixels.height,
         height_points: geometry.height,

--- a/scripts/test-suite-classification.mjs
+++ b/scripts/test-suite-classification.mjs
@@ -79,6 +79,7 @@ export const CHECKOUT_LOCAL_MUTATING_TEST_SUITES = Object.freeze([
   "test/integration.test.js",
   "test/metadata-provenance.test.js",
   "test/mutation-input-limits.test.js",
+  "test/pdfjs-worker-contract.test.js",
   "test/render-pdf-page.test.js",
   "test/signatures.test.js",
   "test/temp-directory.test.js",

--- a/server/pdf-comparison.js
+++ b/server/pdf-comparison.js
@@ -339,8 +339,8 @@ function comparisonRenderLogicalExtent(render) {
   const pageView = render?.page_view;
   const pageWidth = pageView?.width_points;
   const pageHeight = pageView?.height_points;
-  const exactPageWidth = render?.comparison_view?.width_points;
-  const exactPageHeight = render?.comparison_view?.height_points;
+  const rawPageWidth = render?.comparison_view?.raw_width_pixels;
+  const rawPageHeight = render?.comparison_view?.raw_height_pixels;
   const viewBox = pageView?.view_box;
   const rotation = pageView?.rotation;
   const userUnit = pageView?.user_unit;
@@ -355,18 +355,22 @@ function comparisonRenderLogicalExtent(render) {
     || !Number.isFinite(userUnit) || userUnit <= 0
     || !Number.isFinite(pageWidth) || pageWidth <= 0
     || !Number.isFinite(pageHeight) || pageHeight <= 0
-    || !Number.isFinite(exactPageWidth) || exactPageWidth <= 0
-    || !Number.isFinite(exactPageHeight) || exactPageHeight <= 0
-    || Number(exactPageWidth.toFixed(6)) !== pageWidth
-    || Number(exactPageHeight.toFixed(6)) !== pageHeight
+    || !Number.isFinite(rawPageWidth) || rawPageWidth <= 0
+    || !Number.isFinite(rawPageHeight) || rawPageHeight <= 0
     || !requested || requested.x !== 0 || requested.y !== 0
     || requested.width !== pageWidth || requested.height !== pageHeight
     || !Number.isSafeInteger(render.width) || render.width <= 0
     || !Number.isSafeInteger(render.height) || render.height <= 0
     || !rendered || rendered.x !== 0 || rendered.y !== 0
     || rendered.width !== render.width || rendered.height !== render.height
-    || Math.ceil(exactPageWidth * render.scale) !== render.width
-    || Math.ceil(exactPageHeight * render.scale) !== render.height) return null;
+    || Math.ceil(rawPageWidth) !== render.width
+    || Math.ceil(rawPageHeight) !== render.height) return null;
+  const exactPageWidth = rawPageWidth / render.scale;
+  const exactPageHeight = rawPageHeight / render.scale;
+  const roundsToPublished = (exact, published) => Math.abs(exact - published)
+    <= 0.00000051 + Number.EPSILON * Math.max(1, Math.abs(exact), Math.abs(published));
+  if (!roundsToPublished(exactPageWidth, pageWidth)
+    || !roundsToPublished(exactPageHeight, pageHeight)) return null;
   const nativeWidth = (viewBox[2] - viewBox[0]) * userUnit;
   const nativeHeight = (viewBox[3] - viewBox[1]) * userUnit;
   const expectedWidth = rotation % 180 === 0 ? nativeWidth : nativeHeight;

--- a/server/pdf-comparison.js
+++ b/server/pdf-comparison.js
@@ -335,25 +335,74 @@ function cropRgba(render, region) {
   return { bytes, sha256: comparisonSha256(bytes) };
 }
 
-function comparisonIgnoredPixelMask(render, regions) {
+function comparisonRenderLogicalExtent(render) {
+  const pageView = render?.page_view;
+  const pageWidth = pageView?.width_points;
+  const pageHeight = pageView?.height_points;
+  const exactPageWidth = render?.comparison_view?.width_points;
+  const exactPageHeight = render?.comparison_view?.height_points;
+  const viewBox = pageView?.view_box;
+  const rotation = pageView?.rotation;
+  const userUnit = pageView?.user_unit;
+  const requested = render?.requested_region;
+  const rendered = render?.rendered_region;
+  if (render?.renderer !== PDF_COMPARISON_ENGINE.renderer.name
+    || render?.scale !== PDF_COMPARISON_RENDERER.scale
+    || pageView?.coordinate_space !== "pdfjs_viewport_top_left_points"
+    || !Array.isArray(viewBox) || viewBox.length !== 4 || !viewBox.every(Number.isFinite)
+    || viewBox[2] <= viewBox[0] || viewBox[3] <= viewBox[1]
+    || ![0, 90, 180, 270].includes(rotation)
+    || !Number.isFinite(userUnit) || userUnit <= 0
+    || !Number.isFinite(pageWidth) || pageWidth <= 0
+    || !Number.isFinite(pageHeight) || pageHeight <= 0
+    || !Number.isFinite(exactPageWidth) || exactPageWidth <= 0
+    || !Number.isFinite(exactPageHeight) || exactPageHeight <= 0
+    || Number(exactPageWidth.toFixed(6)) !== pageWidth
+    || Number(exactPageHeight.toFixed(6)) !== pageHeight
+    || !requested || requested.x !== 0 || requested.y !== 0
+    || requested.width !== pageWidth || requested.height !== pageHeight
+    || !Number.isSafeInteger(render.width) || render.width <= 0
+    || !Number.isSafeInteger(render.height) || render.height <= 0
+    || !rendered || rendered.x !== 0 || rendered.y !== 0
+    || rendered.width !== render.width || rendered.height !== render.height
+    || Math.ceil(exactPageWidth * render.scale) !== render.width
+    || Math.ceil(exactPageHeight * render.scale) !== render.height) return null;
+  const nativeWidth = (viewBox[2] - viewBox[0]) * userUnit;
+  const nativeHeight = (viewBox[3] - viewBox[1]) * userUnit;
+  const expectedWidth = rotation % 180 === 0 ? nativeWidth : nativeHeight;
+  const expectedHeight = rotation % 180 === 0 ? nativeHeight : nativeWidth;
+  const nearlyEqual = (left, right) => Math.abs(left - right)
+    <= 0.000001 * Math.max(1, Math.abs(left), Math.abs(right));
+  if (!Number.isFinite(expectedWidth) || !Number.isFinite(expectedHeight)
+    || !nearlyEqual(pageWidth, expectedWidth)
+    || !nearlyEqual(pageHeight, expectedHeight)) return null;
+  return { width: exactPageWidth, height: exactPageHeight };
+}
+
+function comparisonSharedLogicalExtent(before, after) {
+  const beforeExtent = comparisonRenderLogicalExtent(before);
+  const afterExtent = comparisonRenderLogicalExtent(after);
+  if (!beforeExtent || !afterExtent
+    || canonical(before.page_view) !== canonical(after.page_view)
+    || canonical(before.comparison_view) !== canonical(after.comparison_view)
+    || canonical(before.requested_region) !== canonical(after.requested_region)
+    || beforeExtent.width !== afterExtent.width
+    || beforeExtent.height !== afterExtent.height) return null;
+  return beforeExtent;
+}
+
+function comparisonIgnoredPixelMask(render, regions, logicalExtent) {
   const mask = new Uint8Array(render.width * render.height);
+  if (!logicalExtent) return mask;
   const clamp = (value, maximum) => Math.max(0, Math.min(maximum, value));
-  const requestedRegion = render.requested_region;
-  const pageLeft = Number.isFinite(requestedRegion?.x) ? requestedRegion.x : 0;
-  const pageTop = Number.isFinite(requestedRegion?.y) ? requestedRegion.y : 0;
-  const pageRight = Number.isFinite(requestedRegion?.width) && requestedRegion.width > 0
-    ? pageLeft + requestedRegion.width
-    : render.width / render.scale;
-  const pageBottom = Number.isFinite(requestedRegion?.height) && requestedRegion.height > 0
-    ? pageTop + requestedRegion.height
-    : render.height / render.scale;
   for (const region of regions) {
     if (!Array.isArray(region) || region.length !== 4 || !region.every(Number.isFinite)
       || region[2] <= 0 || region[3] <= 0) continue;
     const regionRight = region[0] + region[2];
     const regionBottom = region[1] + region[3];
-    if (regionRight <= pageLeft || regionBottom <= pageTop
-      || region[0] >= pageRight || region[1] >= pageBottom) continue;
+    if (regionRight <= 0 || regionBottom <= 0
+      || region[0] >= logicalExtent.width
+      || region[1] >= logicalExtent.height) continue;
     const x0 = clamp(Math.floor(region[0] * render.scale) - 1, render.width);
     const y0 = clamp(Math.floor(region[1] * render.scale) - 1, render.height);
     const x1 = clamp(Math.ceil((region[0] + region[2]) * render.scale) + 1, render.width);
@@ -371,7 +420,11 @@ export function diffComparisonRgba(before, after, ignoredRegions = []) {
     return { dimension_mismatch: true, raw_changed_pixels: null, changed_pixels: null, changed_fraction: null, bounds: null, components: [] };
   }
   const pixelCount = before.width * before.height;
-  const ignoredPixels = comparisonIgnoredPixelMask(before, ignoredRegions);
+  const ignoredPixels = comparisonIgnoredPixelMask(
+    before,
+    ignoredRegions,
+    comparisonSharedLogicalExtent(before, after),
+  );
   const threshold = new Uint8Array(pixelCount);
   let rawChangedPixels = 0;
   for (let pixel = 0; pixel < pixelCount; pixel += 1) {

--- a/server/pdfjs-worker.js
+++ b/server/pdfjs-worker.js
@@ -1496,6 +1496,7 @@ async function nativeRenderPage(bytes, password, options) {
     const page = await document.getPage(options.page);
     try {
       const pageView = pageViewFromPdfjs(page);
+      const comparisonView = page.getViewport({ scale: 1 });
       const scale = options.scale_override ?? getPageRenderScale({
         width: pageView.width_points,
         height: pageView.height_points,
@@ -1513,6 +1514,10 @@ async function nativeRenderPage(bytes, password, options) {
       );
       const buffer = canvas.toBuffer("image/png");
       return pngResult(buffer, {
+        comparison_view: {
+          width_points: comparisonView.width,
+          height_points: comparisonView.height,
+        },
         height: pixels.height,
         height_points: geometry.height,
         page_geometry: pageGeometry,

--- a/server/pdfjs-worker.js
+++ b/server/pdfjs-worker.js
@@ -1496,7 +1496,6 @@ async function nativeRenderPage(bytes, password, options) {
     const page = await document.getPage(options.page);
     try {
       const pageView = pageViewFromPdfjs(page);
-      const comparisonView = page.getViewport({ scale: 1 });
       const scale = options.scale_override ?? getPageRenderScale({
         width: pageView.width_points,
         height: pageView.height_points,
@@ -1515,8 +1514,8 @@ async function nativeRenderPage(bytes, password, options) {
       const buffer = canvas.toBuffer("image/png");
       return pngResult(buffer, {
         comparison_view: {
-          width_points: comparisonView.width,
-          height_points: comparisonView.height,
+          raw_width_pixels: viewport.width,
+          raw_height_pixels: viewport.height,
         },
         height: pixels.height,
         height_points: geometry.height,

--- a/test/pdf-comparison.test.js
+++ b/test/pdf-comparison.test.js
@@ -26,17 +26,35 @@ function page(pageNumber, text, { width = 100, height = 100, rotation = 0 } = {}
   };
 }
 
-function render(width, height, fill = 0, requestedRegion = {
-  x: 0,
-  y: 0,
-  width: width / 1.5,
-  height: height / 1.5,
-}) {
+function render(width, height, fill = 0, options = {}) {
+  const scale = options.scale ?? 1.5;
+  const logicalWidth = options.logicalWidth ?? width / scale;
+  const logicalHeight = options.logicalHeight ?? height / scale;
+  const exactLogicalWidth = options.exactLogicalWidth ?? logicalWidth;
+  const exactLogicalHeight = options.exactLogicalHeight ?? logicalHeight;
+  const rotation = options.rotation ?? 0;
+  const userUnit = options.userUnit ?? 1;
+  const nativeWidth = (rotation % 180 === 0 ? logicalWidth : logicalHeight) / userUnit;
+  const nativeHeight = (rotation % 180 === 0 ? logicalHeight : logicalWidth) / userUnit;
   return {
     width,
     height,
-    scale: 1.5,
-    requested_region: requestedRegion,
+    scale,
+    renderer: "native-canvas",
+    comparison_view: {
+      width_points: exactLogicalWidth,
+      height_points: exactLogicalHeight,
+    },
+    page_view: {
+      view_box: [0, 0, nativeWidth, nativeHeight],
+      width_points: logicalWidth,
+      height_points: logicalHeight,
+      rotation,
+      user_unit: userUnit,
+      coordinate_space: "pdfjs_viewport_top_left_points",
+    },
+    requested_region: { x: 0, y: 0, width: logicalWidth, height: logicalHeight },
+    rendered_region: { x: 0, y: 0, width, height },
     binary: Buffer.alloc(width * height * 4, fill),
   };
 }
@@ -196,14 +214,14 @@ describe("PDF comparison primitives", () => {
   });
 
   it("uses exact page points instead of rounded raster dimensions at right and bottom edges", () => {
-    const requestedRegion = { x: 0, y: 0, width: 8.1, height: 4.1 };
+    const options = { logicalWidth: 8.1, logicalHeight: 4.1 };
     const cases = [
       { region: [8.2, 1, 0.2, 1], pixel: [12, 3] },
       { region: [2, 4.2, 1, 0.2], pixel: [4, 6] },
     ];
     for (const { region, pixel: [x, y] } of cases) {
-      const before = render(13, 7, 0, requestedRegion);
-      const after = render(13, 7, 0, requestedRegion);
+      const before = render(13, 7, 0, options);
+      const after = render(13, 7, 0, options);
       after.binary[(y * 13 + x) * 4] = 20;
       const baseline = diffComparisonRgba(before, after);
       expect(diffComparisonRgba(before, after, [region]), JSON.stringify(region))
@@ -245,6 +263,110 @@ describe("PDF comparison primitives", () => {
       expect(diffComparisonRgba(before, after, [region]), JSON.stringify(region))
         .toEqual(baseline);
     }
+  });
+
+  it("disables masking when equal pixel canvases bind different logical render mappings", () => {
+    const before = render(151, 76, 0, {
+      logicalWidth: 100.2,
+      logicalHeight: 50.2,
+    });
+    const after = render(151, 76, 0, {
+      logicalWidth: 100.4,
+      logicalHeight: 50.4,
+    });
+    after.binary[(15 * 151 + 150) * 4] = 20;
+    const baseline = diffComparisonRgba(before, after);
+    expect(diffComparisonRgba(before, after, [[100.3, 10, 0.05, 1]]))
+      .toEqual(baseline);
+
+    const rotatedAfter = render(151, 76, 0, {
+      logicalWidth: 100.2,
+      logicalHeight: 50.2,
+    });
+    rotatedAfter.page_view.rotation = 90;
+    rotatedAfter.binary[(15 * 151 + 150) * 4] = 20;
+    const rotatedBaseline = diffComparisonRgba(before, rotatedAfter);
+    expect(diffComparisonRgba(before, rotatedAfter, [[99, 9, 2, 2]]))
+      .toEqual(rotatedBaseline);
+  });
+
+  it("fails closed when both render mappings share the same invalid metadata", () => {
+    const mutations = [
+      ["wrong coordinate space", value => { value.page_view.coordinate_space = "pdf_user_space_bottom_left_points"; }],
+      ["missing coordinate space", value => { delete value.page_view.coordinate_space; }],
+      ["non-finite view box", value => { value.page_view.view_box = [Number.NaN, 0, 8, 4]; }],
+      ["missing view box", value => { delete value.page_view.view_box; }],
+      ["degenerate view box", value => { value.page_view.view_box = [0, 0, 0, 4]; }],
+      ["inconsistent view box", value => { value.page_view.view_box = [0, 0, 1, 1]; }],
+      ["invalid rotation", value => { value.page_view.rotation = 45; }],
+      ["missing rotation", value => { delete value.page_view.rotation; }],
+      ["negative UserUnit", value => { value.page_view.user_unit = -1; }],
+      ["missing UserUnit", value => { delete value.page_view.user_unit; }],
+      ["wrong renderer", value => { value.renderer = "macos-quicklook"; }],
+      ["missing exact viewport", value => { delete value.comparison_view; }],
+      ["non-finite exact viewport", value => { value.comparison_view.width_points = Number.NaN; }],
+      ["unbound exact viewport", value => { value.comparison_view.width_points += 0.001; }],
+      ["shifted requested region", value => { value.requested_region.x = 1; }],
+      ["cropped requested region", value => { value.requested_region.width -= 1; }],
+      ["missing rendered region", value => { delete value.rendered_region; }],
+      ["shifted rendered region", value => { value.rendered_region.x = 1; }],
+      ["cropped rendered region", value => { value.rendered_region.width -= 1; }],
+    ];
+    for (const [label, mutate] of mutations) {
+      const before = render(12, 6);
+      const after = render(12, 6);
+      mutate(before);
+      mutate(after);
+      after.binary[(2 * 12 + 2) * 4] = 20;
+      const baseline = diffComparisonRgba(before, after);
+      expect(diffComparisonRgba(before, after, [[0, 0, 3, 3]]), label).toEqual(baseline);
+    }
+  });
+
+  it("fails closed when both renders drift from the frozen comparison scale", () => {
+    const before = render(16, 8, 0, { scale: 2 });
+    const after = render(16, 8, 0, { scale: 2 });
+    after.binary[(2 * 16 + 2) * 4] = 20;
+    const baseline = diffComparisonRgba(before, after);
+    expect(diffComparisonRgba(before, after, [[0, 0, 3, 3]])).toEqual(baseline);
+  });
+
+  it("accepts a self-consistent rotated page view with a positive UserUnit", () => {
+    const options = { rotation: 90, userUnit: 2 };
+    const before = render(12, 6, 0, options);
+    const after = render(12, 6, 0, options);
+    after.binary[(2 * 12 + 2) * 4] = 20;
+    after.binary[(2 * 12 + 9) * 4] = 20;
+    expect(diffComparisonRgba(before, after, [[0, 0, 3, 3]])).toMatchObject({
+      raw_changed_pixels: 1,
+    });
+  });
+
+  it("uses the producer's unrounded viewport at a raster ceiling boundary", () => {
+    const options = {
+      logicalWidth: 100,
+      logicalHeight: 50.2,
+      exactLogicalWidth: 100.0000001,
+    };
+    const before = render(151, 76, 0, options);
+    const after = render(151, 76, 0, options);
+    after.binary[(2 * 151 + 2) * 4] = 20;
+    after.binary[(2 * 151 + 9) * 4] = 20;
+    expect(diffComparisonRgba(before, after, [[0, 0, 3, 3]])).toMatchObject({
+      raw_changed_pixels: 1,
+    });
+    const baseline = diffComparisonRgba(before, after);
+    expect(diffComparisonRgba(before, after, [[100.0000002, 1, 0.1, 1]]))
+      .toEqual(baseline);
+  });
+
+  it("fails closed to no masking when exact logical render metadata is unavailable", () => {
+    const before = render(12, 6);
+    const after = render(12, 6);
+    delete before.page_view;
+    after.binary[(2 * 12 + 2) * 4] = 20;
+    const baseline = diffComparisonRgba(before, after);
+    expect(diffComparisonRgba(before, after, [[0, 0, 3, 3]])).toEqual(baseline);
   });
 
   it("marks visual coverage unavailable when any requested native render is unavailable", () => {

--- a/test/pdf-comparison.test.js
+++ b/test/pdf-comparison.test.js
@@ -32,6 +32,8 @@ function render(width, height, fill = 0, options = {}) {
   const logicalHeight = options.logicalHeight ?? height / scale;
   const exactLogicalWidth = options.exactLogicalWidth ?? logicalWidth;
   const exactLogicalHeight = options.exactLogicalHeight ?? logicalHeight;
+  const rawWidth = options.rawWidth ?? exactLogicalWidth * scale;
+  const rawHeight = options.rawHeight ?? exactLogicalHeight * scale;
   const rotation = options.rotation ?? 0;
   const userUnit = options.userUnit ?? 1;
   const nativeWidth = (rotation % 180 === 0 ? logicalWidth : logicalHeight) / userUnit;
@@ -42,8 +44,8 @@ function render(width, height, fill = 0, options = {}) {
     scale,
     renderer: "native-canvas",
     comparison_view: {
-      width_points: exactLogicalWidth,
-      height_points: exactLogicalHeight,
+      raw_width_pixels: rawWidth,
+      raw_height_pixels: rawHeight,
     },
     page_view: {
       view_box: [0, 0, nativeWidth, nativeHeight],
@@ -304,8 +306,8 @@ describe("PDF comparison primitives", () => {
       ["missing UserUnit", value => { delete value.page_view.user_unit; }],
       ["wrong renderer", value => { value.renderer = "macos-quicklook"; }],
       ["missing exact viewport", value => { delete value.comparison_view; }],
-      ["non-finite exact viewport", value => { value.comparison_view.width_points = Number.NaN; }],
-      ["unbound exact viewport", value => { value.comparison_view.width_points += 0.001; }],
+      ["non-finite exact viewport", value => { value.comparison_view.raw_width_pixels = Number.NaN; }],
+      ["unbound exact viewport", value => { value.comparison_view.raw_width_pixels -= 0.000001; }],
       ["shifted requested region", value => { value.requested_region.x = 1; }],
       ["cropped requested region", value => { value.requested_region.width -= 1; }],
       ["missing rendered region", value => { delete value.rendered_region; }],

--- a/test/pdfjs-worker-contract.test.js
+++ b/test/pdfjs-worker-contract.test.js
@@ -19,6 +19,7 @@ import {
   runRendererPolicy,
   runSystemCommand,
 } from "../server/pdfjs-worker.js";
+import { createTestTempDirectory } from "./helpers/temp-directory.js";
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const EXAMPLE_PDF = path.join(REPO_ROOT, "example-fw9.pdf");
@@ -260,9 +261,7 @@ describe.sequential("one-shot PDF.js worker contracts", () => {
   });
 
   it("binds comparison masking to the producer's exact unrounded viewport", async () => {
-    const root = await fs.realpath(
-      await fs.mkdtemp(path.join(REPO_ROOT, ".pdfjs-comparison-view-")),
-    );
+    const root = await createTestTempDirectory(REPO_ROOT, "pdfjs-comparison-view");
     roots.push(root);
     const pdfPath = path.join(root, "fractional-raster-boundary.pdf");
     const pdf = await PDFDocument.create();

--- a/test/pdfjs-worker-contract.test.js
+++ b/test/pdfjs-worker-contract.test.js
@@ -5,7 +5,7 @@ import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { PDFDocument } from "pdf-lib";
+import { PDFDocument, PDFName, PDFNumber } from "pdf-lib";
 import {
   hashBoundedPdfFileSafely,
 } from "../server/bounded-pdf-file.js";
@@ -267,20 +267,32 @@ describe.sequential("one-shot PDF.js worker contracts", () => {
     const pdfPath = path.join(root, "fractional-raster-boundary.pdf");
     const pdf = await PDFDocument.create();
     pdf.addPage([100.0000001, 50.2]);
+    const nonAssociativePage = pdf.addPage([67.32371565966767, 50]);
+    nonAssociativePage.node.set(
+      PDFName.of("UserUnit"),
+      PDFNumber.of(1.0001428571428572),
+    );
     await fs.writeFile(pdfPath, await pdf.save());
 
-    const rendered = await run("render_comparison_page", {
-      page: 1,
+    const renderPage = async page => await run("render_comparison_page", {
+      page,
       max_dimension_px: null,
       renderer_policy: "native",
       scale_override: 1.5,
     }, null, await sourceBinding(pdfPath));
-    expect(rendered.page_view.width_points).toBe(100);
-    expect(rendered.comparison_view.width_points).toBeGreaterThan(100);
-    expect(rendered.width).toBe(151);
-    expect(rendered.width).toBe(Math.ceil(
-      rendered.comparison_view.width_points * rendered.scale,
-    ));
+    const roundedBoundary = await renderPage(1);
+    expect(roundedBoundary.page_view.width_points).toBe(100);
+    expect(roundedBoundary.comparison_view.raw_width_pixels).toBeGreaterThan(150);
+    expect(roundedBoundary.width).toBe(151);
+
+    const rendered = await renderPage(2);
+    expect(rendered.page_view).toMatchObject({
+      width_points: 67.333333,
+      user_unit: 1.000143,
+    });
+    expect(rendered.comparison_view.raw_width_pixels).toBe(101);
+    expect(rendered.width).toBe(101);
+    expect(rendered.width).toBe(Math.ceil(rendered.comparison_view.raw_width_pixels));
 
     const before = { ...rendered, binary: Buffer.from(rendered.binary) };
     const after = { ...rendered, binary: Buffer.from(rendered.binary) };

--- a/test/pdfjs-worker-contract.test.js
+++ b/test/pdfjs-worker-contract.test.js
@@ -5,9 +5,11 @@ import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { PDFDocument } from "pdf-lib";
 import {
   hashBoundedPdfFileSafely,
 } from "../server/bounded-pdf-file.js";
+import { diffComparisonRgba } from "../server/pdf-comparison.js";
 import {
   createPdfjsSubprocessRequest,
   runPdfjsSubprocess,
@@ -256,6 +258,41 @@ describe.sequential("one-shot PDF.js worker contracts", () => {
       expect(systemPage.renderer).toBe("macos-quicklook");
     }
   });
+
+  it("binds comparison masking to the producer's exact unrounded viewport", async () => {
+    const root = await fs.realpath(
+      await fs.mkdtemp(path.join(REPO_ROOT, ".pdfjs-comparison-view-")),
+    );
+    roots.push(root);
+    const pdfPath = path.join(root, "fractional-raster-boundary.pdf");
+    const pdf = await PDFDocument.create();
+    pdf.addPage([100.0000001, 50.2]);
+    await fs.writeFile(pdfPath, await pdf.save());
+
+    const rendered = await run("render_comparison_page", {
+      page: 1,
+      max_dimension_px: null,
+      renderer_policy: "native",
+      scale_override: 1.5,
+    }, null, await sourceBinding(pdfPath));
+    expect(rendered.page_view.width_points).toBe(100);
+    expect(rendered.comparison_view.width_points).toBeGreaterThan(100);
+    expect(rendered.width).toBe(151);
+    expect(rendered.width).toBe(Math.ceil(
+      rendered.comparison_view.width_points * rendered.scale,
+    ));
+
+    const before = { ...rendered, binary: Buffer.from(rendered.binary) };
+    const after = { ...rendered, binary: Buffer.from(rendered.binary) };
+    for (const [x, y] of [[2, 2], [9, 2]]) {
+      const offset = (y * rendered.width + x) * 4;
+      after.binary[offset] = before.binary[offset] > 127 ? 0 : 255;
+    }
+    expect(diffComparisonRgba(before, after)).toMatchObject({ raw_changed_pixels: 2 });
+    expect(diffComparisonRgba(before, after, [[0, 0, 3, 3]])).toMatchObject({
+      raw_changed_pixels: 1,
+    });
+  }, 30_000);
 
   it("runs page operators and signature text heuristics inside the worker", async () => {
     const analysis = await run("analyze_pages", { max_pages: 200 });


### PR DESCRIPTION
## Summary

This keeps comparison exclusions tied to the exact render geometry that produced the pixel canvas.

- Carry the raw fractional extent from the same PDF.js viewport used for rendering.
- Enable ignored-region masking only when renderer, scale, coordinate mapping, page view, whole-page request, and raster extent all agree.
- Fail closed when both sides share the same malformed or drifted metadata.
- Preserve fractional page-edge behavior without letting the one-pixel padding pull wholly off-page regions onto the canvas.
- Add real-producer regressions for six-decimal publication rounding and a non-associative UserUnit and scale boundary.
- Use the shared repository temp-directory helper and classify the worker contract suite as checkout-local mutating work.

## Verification

Exact accepted tip: `9ff23eff8c5a16e6c28711b777d6656f824336fe`

On Stonebook, Intel macOS with Node 22.22.3:

- At the exact tip, the temp-directory, runner-contract, and PDF.js worker-contract bank passed 34/34 tests.
- At direct parent `27d27fa4e7521b35d42205ca14ca30c18867d185`, whose runtime and test-behavior blobs are identical, 7 focused files passed 108/108 tests.
- The bounded seven-role comparison product run passed all 7 pairs with event F1 1, per-channel F1 1, and evidence completeness 1. This is not a benchmark-claim receipt.
- Source and share comparator files are byte-identical.
- Source and share PDF.js worker files are byte-identical.

Independent review accepted the exact tip after replaying malformed twin mappings, one-sided drift, fractional edges and corners, rotations, nonzero origins, UserUnits, 64 real PDF.js producer pages, 500,000 bounded numeric cases, and the aggregate temp-directory classification invariants.

## Boundaries

This PR does not bump the version, build or publish an MCPB, install into Claude Desktop, merge, or release. Aggregate, package, host, and release qualification remain separate v0.9.3 gates.