### PR TITLE
docs: record v0.9.3 installed-copy proof

### DIFF
--- a/docs/evidence/v0.9.3-installed-proof-2026-08.md
+++ b/docs/evidence/v0.9.3-installed-proof-2026-08.md
@@ -1,0 +1,40 @@
+# PDF Tools v0.9.3 installed-copy proof — 2026-08
+
+The public GitHub release assets were downloaded again before installation.
+
+- Release: `https://github.com/Open-Document-Alliance/PDF-Tools/releases/tag/v0.9.3`
+- Release commit: `8c3c00cd854b6ac3a6ef09e8ef15bfd0bef08b21`.
+- Public MCPB: 73,689,797 bytes, SHA-256
+  `99bf12fb66c3fc2481c2ac641b1d59af49fbcfd89b3e7be92d090e8aaee3b4e0`.
+- Public ZIP: 1,166,911 bytes, SHA-256
+  `67acd4c79b8c9ff8d7a31f2f11ac78ef9b8f564d8ab6429bac657d1927091b1d`.
+
+The exact public MCPB was unpacked into Claude Desktop with the prior enabled
+installation preserved as a recoverable backup. Claude's installation registry
+records version `0.9.3`, the exact public MCPB SHA-256, and the matching
+embedded manifest.
+
+Claude's host log records a fresh launch at `2026-08-05T00:00:15Z`, successful
+initialization, and tool, prompt, and resource discovery.
+
+The final installed directory passed a fresh smoke test:
+
+- 41 tools, including `compare_pdfs`;
+- 37 structured tools and 4 text-only tools;
+- exact tool-contract SHA-256
+  `109df9e468513e07377804bff842ac9c398923d88dc07c0ffd68c12a8c075e82`;
+- configured-folder access allowed and outside-folder access denied;
+- text and Markdown extraction, a fresh session, PDF splitting, and native
+  raster rendering passed.
+
+The installed directory converted the verified 55-page Shannon PDF in six
+bounded calls. The result is 182,565 bytes with exactly 49 recovered alpha
+symbols, 498 replacement characters, 68 explicit gaps, and Markdown SHA-256
+`2e7e4fb71d0ea116a352eb1aa1ed1b06c089969643073394d82e23eb5f6ffee3`.
+This exactly matches the reviewed v0.9.2 and v0.9.3 source evaluations, as
+expected because v0.9.3 changes comparison safety rather than extraction.
+
+This proof covers the public artifact, Claude host loading and discovery, and
+direct installed-copy behavior. It does not claim a Shannon conversion was
+initiated from a Claude chat UI, general Type-3 decoding, OCR, paper-wide
+mathematical fidelity, or semantic equivalence from visual comparison.

--- a/docs/handoffs/KEPANO_SHANNON.md
+++ b/docs/handoffs/KEPANO_SHANNON.md
@@ -20,14 +20,14 @@ refusing unsupported guesses.
 
 ## Shipped state
 
-PDF Tools v0.9.2 is public:
-`https://github.com/Open-Document-Alliance/PDF-Tools/releases/tag/v0.9.2`.
+PDF Tools v0.9.3 is public:
+`https://github.com/Open-Document-Alliance/PDF-Tools/releases/tag/v0.9.3`.
 It includes the cumulative Shannon extraction work, the PDF comparison product,
 the 59-character remaining qualified Type-3 batch, 49 source-supported alpha
-recoveries, and the exact-page-bound comparison safety repair.
+recoveries, and the final fail-closed comparison-geometry hardening.
 
-- v0.9.2 release commit:
-  `c2f2853e2362d724c6744e8a60026ad3d1974e7e`.
+- v0.9.3 release commit:
+  `8c3c00cd854b6ac3a6ef09e8ef15bfd0bef08b21`.
 - The release MCPB was downloaded, hash-checked, installed in Claude Desktop,
   loaded successfully, and tested from the installed copy.
 - Exactly one current PDF Tools identity remained enabled after installation.
@@ -84,12 +84,13 @@ companion evidence.
 ## Current gates
 
 The implementation, independent review, merge, reproducible package, public
-v0.9.2 release, exact public re-download, Claude installation, registry match,
+v0.9.3 release, exact public re-download, Claude installation, registry match,
 host discovery, installed-copy smoke, and installed Shannon proof are complete.
-PR #73 merged as `c2f2853e2362d724c6744e8a60026ad3d1974e7e`.
+PR #75 landed the final comparison-geometry repair. PR #76 merged the v0.9.3
+release as `8c3c00cd854b6ac3a6ef09e8ef15bfd0bef08b21`.
 
 No public reply to Kepano has been sent yet. A concise reply may now point him
-to the public repository and v0.9.2 while honestly saying that the named paper
+to the public repository and v0.9.3 while honestly saying that the named paper
 is substantially improved, not universally or mathematically reconstructed.
 The 64-minus and 5-comma groups remain blocked on missing companion evidence;
 11 alpha cases intentionally abstain under the alignment rules.

--- a/docs/releases/v0.9.3.md
+++ b/docs/releases/v0.9.3.md
@@ -53,8 +53,8 @@ arbitrary formulas, or infer ambiguous merged tables.
 
 The release checkpoint is `c302bf7104d0e66a087a7d660e9e28cdaabc77d8`.
 Its exact tree `bc87fa7be0fcc8b0a9d0f9b5b8f8cfdef80eb1a0` is byte-identical
-to the full-tested candidate. Installation and installed-copy proof are
-performed again from the public merged release commit.
+to the full-tested candidate. The release PR merged as
+`8c3c00cd854b6ac3a6ef09e8ef15bfd0bef08b21`.
 
 ## Artifacts
 
@@ -72,5 +72,8 @@ Claude Desktop users can download and open `pdf-toolkit-mcp.mcpb` from the
 release assets. Cursor and other local stdio MCP hosts can use
 `pdf-toolkit-mcp.zip` or the checked-out `server/index.js`.
 
-Installed-copy evidence is added after the merged public release is downloaded
-again, installed, and verified.
+The public MCPB was downloaded again, hash-checked, installed in Claude
+Desktop, loaded successfully, and tested from the installed copy. The ordinary
+installed-copy smoke passed all 41 tools and the installed Shannon conversion
+exactly reproduced the reviewed 55-page Markdown SHA-256. See
+`docs/evidence/v0.9.3-installed-proof-2026-08.md`.


### PR DESCRIPTION
## Summary
- record the exact public v0.9.3 asset hashes and Claude Desktop installation
- record successful host discovery and 41-tool installed-copy smoke
- record exact reproduction of the reviewed 55-page Shannon output
- update the release and Kepano handoff to the shipped v0.9.3 state

## Validation
- `npx vitest run test/documentation-claims.test.js` (63/63)
- `git diff --check`
- public MCPB hash and size match the GitHub release
- Claude host initialized and completed tools, prompts, and resources discovery
- installed-copy smoke passed
- installed Shannon proof reproduced exact SHA-256 `2e7e4fb71d0ea116a352eb1aa1ed1b06c089969643073394d82e23eb5f6ffee3`