### PR TITLE
Record v0.9.4 installed proof

### DIFF
--- a/docs/evidence/v0.9.4-installed-proof-2026-08.md
+++ b/docs/evidence/v0.9.4-installed-proof-2026-08.md
@@ -1,0 +1,42 @@
+# PDF Tools v0.9.4 installed-copy proof — 2026-08
+
+The canonical public GitHub release assets were downloaded again before
+installation.
+
+- Release: `https://github.com/Open-Document-Alliance/PDF-Tools/releases/tag/v0.9.4`
+- Release commit: `50f3ccc378856611ef22d86e507bd10740edc33a`.
+- Public MCPB: 73,690,110 bytes, SHA-256
+  `15ca06a4088626586d1289d81000d511ce5c85b4d5400688503a4e150cda9b91`.
+- Public ZIP: 1,167,199 bytes, SHA-256
+  `f1479ea8688cce8082b55a69aa302f2cac26a2bb7cf3e88e756213b10b25343c`.
+
+The exact public MCPB was unpacked into Claude Desktop with the prior v0.9.3
+installation preserved as a recoverable backup. Claude's installation registry
+records version `0.9.4`, the exact public MCPB SHA-256, and the matching embedded
+manifest. A separate registry check found exactly one installation with the
+Open Document Alliance PDF Tools identity.
+
+Claude's host log records a fresh launch at `2026-08-05T00:38:15Z`, successful
+connection and initialization, and tool, prompt, and resource discovery.
+
+The final installed directory passed a fresh ordinary smoke test:
+
+- 41 tools, including `compare_pdfs`;
+- 37 structured tools and 4 text-only tools;
+- exact tool-contract SHA-256
+  `109df9e468513e07377804bff842ac9c398923d88dc07c0ffd68c12a8c075e82`;
+- configured-folder access allowed and outside-folder access denied;
+- text and Markdown extraction, a fresh session, PDF splitting, and native
+  raster rendering passed.
+
+The installed directory converted the verified 55-page Shannon PDF in six
+bounded calls. The result is 182,565 bytes with exactly 49 recovered alpha
+symbols, 434 replacement characters, 68 explicit gaps, and Markdown SHA-256
+`723ca1614c6516ee698c596aab6acb84c0437983e6f96c1f871dea9668b79985`.
+This exactly matches the reviewed v0.9.4 source evaluation.
+
+This proof covers the canonical public artifact, Claude host loading and
+discovery, and direct installed-copy behavior. It does not claim a Shannon
+conversion was initiated from a Claude chat UI, general Type-3 decoding, OCR,
+paper-wide mathematical fidelity, or semantic equivalence from visual
+comparison.

--- a/docs/handoffs/KEPANO_SHANNON.md
+++ b/docs/handoffs/KEPANO_SHANNON.md
@@ -20,19 +20,22 @@ refusing unsupported guesses.
 
 ## Shipped state
 
-PDF Tools v0.9.3 is public:
-`https://github.com/Open-Document-Alliance/PDF-Tools/releases/tag/v0.9.3`.
+PDF Tools v0.9.4 is public:
+`https://github.com/Open-Document-Alliance/PDF-Tools/releases/tag/v0.9.4`.
 It includes the cumulative Shannon extraction work, the PDF comparison product,
-the 59-character remaining qualified Type-3 batch, 49 source-supported alpha
-recoveries, and the final fail-closed comparison-geometry hardening.
+49 source-supported alpha recoveries, the final fail-closed comparison-geometry
+hardening, and safe recovery of the final 64 minus signs and five commas.
 
-- v0.9.3 release commit:
-  `8c3c00cd854b6ac3a6ef09e8ef15bfd0bef08b21`.
+- v0.9.4 release commit:
+  `50f3ccc378856611ef22d86e507bd10740edc33a`.
 - The release MCPB was downloaded, hash-checked, installed in Claude Desktop,
   loaded successfully, and tested from the installed copy.
 - Exactly one current PDF Tools identity remained enabled after installation.
-- Installed Shannon conversion: 55 pages, 498 replacement characters, 68
-  explicit gaps, exact reviewed Markdown SHA-256.
+- Installed Shannon conversion: 55 pages, 434 replacement characters, 49
+  recovered alpha symbols, 68 explicit gaps, 182,565 bytes, and exact reviewed
+  Markdown SHA-256
+  `723ca1614c6516ee698c596aab6acb84c0437983e6f96c1f871dea9668b79985`.
+- The named but unrecovered Type-3 census is now 11, down from 80 in v0.9.3.
 - Current sampled quality: headings 14/14, reading order 24/24, paragraphs
   3/4, equations 4/4, footnotes 4/4, one qualifying table, and zero false
   equation headings.
@@ -82,9 +85,9 @@ alpha had a reviewed source-bound alignment design while the minus and comma
 groups still lacked sufficient companion evidence. The candidate below closes
 the latter evidence gap.
 
-## Qualified 69-character candidate
+## Qualified 69-character recovery shipped in v0.9.4
 
-Commit `942d80405d4949033765f7e5c49c16467c27f9f7` supplies the missing companion
+Implementation commit `942d80405d4949033765f7e5c49c16467c27f9f7` supplies the missing companion
 evidence for all 64 minus signs and all five commas. It reduces the named but
 unrecovered census from 80 to 11; the only remaining named cases are the eleven
 alpha placements that deliberately fail the alignment rules.
@@ -99,20 +102,16 @@ an independent exact-commit review accepted the fail-closed evidence. See
 ## Current gates
 
 The implementation, independent review, merge, reproducible package, public
-v0.9.3 release, exact public re-download, Claude installation, registry match,
+v0.9.4 release, exact public re-download, Claude installation, registry match,
 host discovery, installed-copy smoke, and installed Shannon proof are complete.
-PR #75 landed the final comparison-geometry repair. PR #76 merged the v0.9.3
-release as `8c3c00cd854b6ac3a6ef09e8ef15bfd0bef08b21`.
-
-The 69-character Shannon candidate is implemented, independently accepted,
-and fully tested. Merge, release packaging, public installation, and installed
-Shannon proof remain pending.
+PR #78 landed the 69-character Shannon recovery. PR #79 merged the v0.9.4
+release as `50f3ccc378856611ef22d86e507bd10740edc33a`.
 
 No public reply to Kepano has been sent yet. A concise reply may now point him
-to the public repository and v0.9.3 while honestly saying that the named paper
+to the public repository and v0.9.4 while honestly saying that the named paper
 is substantially improved, not universally or mathematically reconstructed.
-The 64-minus and 5-comma groups remain blocked on missing companion evidence;
-11 alpha cases intentionally abstain under the alignment rules.
+Eleven alpha cases intentionally abstain under the alignment rules. Do not
+claim the paper or arbitrary mathematical PDFs are completely solved.
 
 ## Fast recovery commands
 

--- a/docs/releases/v0.9.4.md
+++ b/docs/releases/v0.9.4.md
@@ -74,5 +74,18 @@ Claude Desktop users can download and open `pdf-toolkit-mcp.mcpb` from the
 release assets. Cursor and other local stdio MCP hosts can use
 `pdf-toolkit-mcp.zip` or the checked-out `server/index.js`.
 
-Installed-copy evidence is added after the merged public release is downloaded
-again, installed, and verified.
+## Installed-copy proof
+
+The canonical public MCPB was downloaded again, matched to the published
+SHA-256 above, and installed in Claude Desktop with the prior installation
+preserved as a recoverable backup. Claude loaded it successfully and completed
+tool, prompt, and resource discovery.
+
+The installed copy passed the ordinary smoke test with all 41 tools, text and
+Markdown extraction, PDF splitting, native raster rendering, configured-folder
+access, and outside-folder denial. It also converted all 55 pages of the
+verified Shannon PDF in six bounded calls, producing exactly 434 replacement
+characters, 49 recovered alpha symbols, 68 explicit gaps, 182,565 bytes, and
+the reviewed Markdown SHA-256 above.
+
+See `docs/evidence/v0.9.4-installed-proof-2026-08.md` for the exact record.

--- a/scripts/macos-claude-installed-shannon.mjs
+++ b/scripts/macos-claude-installed-shannon.mjs
@@ -12,9 +12,13 @@ if (!process.argv[2] || !process.argv[3]) {
 }
 
 const EXPECTED_SOURCE_SHA256 = "6e4e3411984f3edf99dbfe8b941cb5e8a321379ff0cae6ae5c1f592ad8882ca8";
-const EXPECTED_MARKDOWN_SHA256 = "2e7e4fb71d0ea116a352eb1aa1ed1b06c089969643073394d82e23eb5f6ffee3";
+const EXPECTED_MARKDOWN_SHA256 = "723ca1614c6516ee698c596aab6acb84c0437983e6f96c1f871dea9668b79985";
 const EXPECTED_TOOL_CONTRACT_SHA256 = "109df9e468513e07377804bff842ac9c398923d88dc07c0ffd68c12a8c075e82";
 const EXPECTED_PAGE_COUNT = 55;
+const EXPECTED_GAP_COUNT = 68;
+const EXPECTED_REPLACEMENT_CHARACTER_COUNT = 434;
+const EXPECTED_ALPHA_COUNT = 49;
+const EXPECTED_MARKDOWN_BYTES = 182565;
 const PAGE_SPAN = 10;
 
 function sha256(bytes) {
@@ -93,11 +97,20 @@ try {
 const markdown = chunks.map(chunk => chunk.markdown).join("\n\n");
 const markdownSha256 = sha256(Buffer.from(markdown, "utf8"));
 const alphaCount = [...markdown].filter(character => character === "α").length;
+const gapCount = chunks.reduce((total, chunk) => total + chunk.gaps.length, 0);
+const replacementCharacterCount = [...markdown].filter(character => character === "\uFFFD").length;
+const markdownBytes = Buffer.byteLength(markdown, "utf8");
 assert(
   markdownSha256 === EXPECTED_MARKDOWN_SHA256,
   `Installed Shannon Markdown differs from the reviewed output: expected ${EXPECTED_MARKDOWN_SHA256}, received ${markdownSha256}`,
 );
-assert(alphaCount === 49, `Installed Shannon alpha count differs: expected 49, received ${alphaCount}`);
+assert(alphaCount === EXPECTED_ALPHA_COUNT, `Installed Shannon alpha count differs: expected ${EXPECTED_ALPHA_COUNT}, received ${alphaCount}`);
+assert(gapCount === EXPECTED_GAP_COUNT, `Installed Shannon gap count differs: expected ${EXPECTED_GAP_COUNT}, received ${gapCount}`);
+assert(
+  replacementCharacterCount === EXPECTED_REPLACEMENT_CHARACTER_COUNT,
+  `Installed Shannon replacement-character count differs: expected ${EXPECTED_REPLACEMENT_CHARACTER_COUNT}, received ${replacementCharacterCount}`,
+);
+assert(markdownBytes === EXPECTED_MARKDOWN_BYTES, `Installed Shannon byte count differs: expected ${EXPECTED_MARKDOWN_BYTES}, received ${markdownBytes}`);
 
 process.stdout.write(`${JSON.stringify({
   installed_extension: extensionDirectory,
@@ -105,10 +118,10 @@ process.stdout.write(`${JSON.stringify({
   page_count: EXPECTED_PAGE_COUNT,
   page_calls: chunks.map(chunk => chunk.provenance.layout.page_range),
   conversion_statuses: [...new Set(chunks.map(chunk => chunk.conversion_status))].sort(),
-  total_gap_count: chunks.reduce((total, chunk) => total + chunk.gaps.length, 0),
-  replacement_character_count: [...markdown].filter(character => character === "\uFFFD").length,
+  total_gap_count: gapCount,
+  replacement_character_count: replacementCharacterCount,
   alpha_count: alphaCount,
-  markdown_bytes: Buffer.byteLength(markdown, "utf8"),
+  markdown_bytes: markdownBytes,
   markdown_sha256: markdownSha256,
   elapsed_ms: Number(process.hrtime.bigint() - started) / 1e6,
 }, null, 2)}\n`);


### PR DESCRIPTION
## What changed

- records the canonical public v0.9.4 artifact and Claude installation proof
- updates the Shannon handoff to the shipped 80-to-11 result
- updates the installed-copy checker to assert every reviewed v0.9.4 output count

## Impact

This closes the release evidence loop without changing the v0.9.4 runtime or creating another release.

## Validation

- exact public MCPB registry hash and single installed identity verified
- Claude host connected and discovered tools, prompts, and resources
- installed ordinary smoke passed with 41 tools
- installed 55-page Shannon conversion matched the reviewed SHA and counts
- documentation claims: 63/63 passed
- suite-classification check passed