### PR TITLE
Recognize numbered research headings

### DIFF
--- a/docs/evidence/general-numbered-research-headings-2026-08.md
+++ b/docs/evidence/general-numbered-research-headings-2026-08.md
@@ -1,0 +1,94 @@
+# General numbered research headings evidence
+
+Date: 2026-08-04 (America/Los_Angeles)
+
+## Decision
+
+The candidate is safe to merge as a general extraction improvement, but it is
+not a release by itself. It recovers numbered research-paper headings only when
+the PDF supplies consistent geometric evidence, and it rejects narrow vertical
+labels such as the arXiv margin stamp.
+
+## Public sources
+
+### Attention Is All You Need
+
+- Source: `https://arxiv.org/pdf/1706.03762`
+- PDF SHA-256:
+  `bdfaa68d8984f0dc02beaca527b76f207d99b666d31d1da728ee0728182df697`
+- Pages: 15
+- Visually checked rendered pages: 1, 3, and 6
+- v0.9.4: 0 of 22 numbered headings; the vertical arXiv label was falsely a
+  heading
+- Candidate: 22 of 22 numbered headings with the correct hierarchy; the real
+  title is H1; the vertical arXiv label is not a heading
+- Candidate Markdown SHA-256:
+  `afd64c7ce130a75f306a02e9f273da0c265e768c7ba061f961a7688c2619d819`
+
+### Adam: A Method for Stochastic Optimization
+
+- Source: `https://arxiv.org/pdf/1412.6980`
+- PDF SHA-256:
+  `eab9c73ae2ceda884b94830bda99312254bac4806f6c9f045cbab90721ecda31`
+- Pages: 15
+- Visually checked rendered pages: 1, 2, and 9
+- v0.9.4: 0 of 18 labeled numbered headings; the vertical arXiv label was
+  falsely a heading
+- Candidate: 9 of 18 numbered headings, covering only the proven single-line
+  small-caps main sections; the vertical arXiv label is not a heading
+- Candidate Markdown SHA-256:
+  `503c3471ae7f1c4c408d8ea9158741c11c66bb6eaa1eca40646440e3d6676215`
+
+Across the two papers, numbered-heading recall moves from 0 of 40 to 31 of 40,
+and false arXiv-label headings move from two to zero.
+
+## Content preservation
+
+After removing only Markdown heading markers and the expected renderer
+limitation-line revision, baseline and candidate source text is byte-equivalent
+for Attention, Adam, and Shannon. The normalized SHA-256 values are:
+
+- Attention:
+  `321ebc620438e1b8fe4763d15ba67f04d66f02cdc97c14e8851f7e66343b79fc`
+- Adam:
+  `37226c85fe338632824facd2e8fd26d7cf29cc40e25772503f5080e7b3`
+- Shannon:
+  `e1df3b1ac9a8d35d205905a0e3c6252fb23f0f2e3790c68a28a59c16a6094521`
+
+The candidate does not change the existing gap or replacement-character
+counts in either new paper.
+
+## Shannon regression
+
+Three complete 55-page Shannon runs are byte-identical at Markdown SHA-256
+`2c4773511afe32d99ef44311406dbfeac42f4b3923696ef0fc59da56088eabe9`.
+Existing quality remains unchanged: headings 14/14, reading order 24/24,
+paragraphs 3/4, equations 4/4, footnotes 4/4, one qualifying table, and zero
+false equation or malformed headings. The only content change from v0.9.4 is
+the expected renderer limitation-line revision.
+
+## Fail-closed boundary
+
+The numbered-heading path accepts one to three numeric hierarchy levels and an
+uppercase-leading title. It requires body-left alignment, a section break,
+bounded width and height, and either a consistent distinct font or exact
+same-font small-caps geometry. It rejects terminal punctuation and narrow,
+tall vertical labels.
+
+Adam's nine remaining numbered subsections stay plain text because their
+numbers and titles are split into separate source lines or blocks. Joining
+those fragments needs separate evidence and is not guessed here. Tables,
+figures, equations, and complete mathematical reconstruction are outside this
+claim.
+
+## Verification
+
+- Exact implementation commit reviewed: `b74d110f2faad440c24915bb4f62546d6b5221da`
+- Independent result: ACCEPT with the real hash-locked Attention and Adam
+  sources, the full Shannon replay, focused checks, schema/archive checks, and
+  source/share byte identity
+- Focused comparison check: 12/12 passed when rerun alone; the earlier
+  full-suite metadata mismatch did not reproduce
+- Refreshed extraction-layout oracle checks: 21 passed, 6 skipped
+
+No public release or Kepano reply is authorized by this evidence alone.

--- a/docs/handoffs/KEPANO_SHANNON.md
+++ b/docs/handoffs/KEPANO_SHANNON.md
@@ -113,6 +113,34 @@ is substantially improved, not universally or mathematically reconstructed.
 Eleven alpha cases intentionally abstain under the alignment rules. Do not
 claim the paper or arbitrary mathematical PDFs are completely solved.
 
+## Post-v0.9.4 cross-paper candidate
+
+Branch `agent/general-numbered-headings`, implementation commit
+`b74d110f2faad440c24915bb4f62546d6b5221da`, broadens the heading work beyond
+Shannon. On two additional public research papers it recovers 31 of 40 numbered
+headings that v0.9.4 missed and removes both false headings caused by vertical
+arXiv margin labels. Attention is 22/22; Adam is deliberately 9/18 because its
+remaining subsection numbers and titles are split across source lines or
+blocks. Shannon's existing sampled quality is unchanged across three complete,
+byte-identical 55-page runs.
+
+The detailed evidence is
+`docs/evidence/general-numbered-research-headings-2026-08.md`. This is a
+merge-quality candidate, not a reason on its own to publish v0.9.5. Keep the
+installed and public package on exact v0.9.4 until a worthy release bundle is
+ready.
+
+Maintainer retest requests for the current v0.9.4 package are open at:
+
+- Windows issue #42:
+  `https://github.com/Open-Document-Alliance/PDF-Tools/issues/42#issuecomment-5186253739`
+- macOS stable-tool exposure issue #47:
+  `https://github.com/Open-Document-Alliance/PDF-Tools/issues/47#issuecomment-5186253859`
+
+Do not reply to Kepano yet. First merge this candidate cleanly and preserve the
+honest boundary above; a later reply should point to a tested public release,
+not unreleased master.
+
 ## Fast recovery commands
 
 Run from a fresh clean worktree based on current `origin/master`:

--- a/pdf-toolkit-mcp-share/server/markdown-conversion.js
+++ b/pdf-toolkit-mcp-share/server/markdown-conversion.js
@@ -6,7 +6,7 @@ import {
 
 const RENDERER = Object.freeze({
   name: "pdf-tools.layout-markdown-renderer",
-  version: "1.10.0",
+  version: "1.11.0",
 });
 const SUPPORTED_LAYOUT_IR_VERSION = "1.4.0";
 
@@ -69,7 +69,7 @@ const GAP_CODES = new Set([
 ]);
 
 const LIMITATIONS = Object.freeze([
-  "Headings are emitted only from consistent enlarged font metrics or centered English-language source structure with section spacing for a first-page title, introduction, part, or appendix. Ambiguous, very short, or unsupported heading styles remain body text.",
+  "Headings are emitted only from consistent enlarged font metrics, centered English-language source structure with section spacing, or left-aligned numbered research-paper structure with spacing plus either font contrast or exact small-caps geometry. Narrow vertical labels and ambiguous, very short, or unsupported heading styles remain body text.",
   "A geometrically overlapping initial capital may be joined to its following uppercase word remainder. Line-end hyphens are preserved because source geometry cannot reliably distinguish a split word from an intentional compound. The source Extraction IR retains the original lines.",
   "A missing space after a separate source text item that is exactly the mathematical operator log is restored only in a short, compact left-to-right math run when a single-letter variable from a different source font resource follows on the same baseline with a small positive geometric gap and independent local math-layout evidence. A missing prose-to-variable space is restored only when a multiword prose item, a separate uppercase letter from a different source font resource, and continuing prose from the original prose font share one baseline with distinct positive boundary gaps, and the same letter/font pair occurs in a nearby compact equation on the same page and column. An inline single-digit stacked fraction is rendered only when consecutive same-font source items, explicit source whitespace, smaller exactly aligned numerator and denominator digits, ordinary prose on both sides, and exactly one thin matching solid-mask bar agree. A small version-pinned registry may recover a legacy Computer Modern Type-3 character only after an exact official-metric family match, exact target and two-witness glyph-program matches, and a complete operator/text sequence binding. General equations, scripts, other fraction bars, unregistered raster variants, and other damaged mathematical glyphs remain source reading-order text rather than being guessed.",
   "Lists are emitted only for literal bullet glyphs or decimal markers present in the source text.",
@@ -181,6 +181,7 @@ function lineFontEvidence(page) {
       consistentHeight: heights.length > 0
         && Math.max(...heights) - Math.min(...heights) <= Math.max(0.5, median(heights) * 0.1),
       consistentFont: fontNames.size === 1 && !fontNames.has(null),
+      fontName: fontNames.size === 1 ? [...fontNames][0] : null,
     };
   });
 }
@@ -223,6 +224,61 @@ function hasSectionBreakBefore(page, evidence, index, bodyHeight) {
   return gap >= Math.max(line.height, bodyHeight) * 1.15;
 }
 
+function dominantBodyFont(page, bodyHeight) {
+  const weights = new Map();
+  for (const item of page.raw_items) {
+    if (item.is_whitespace || !Number.isFinite(item.line_height)
+      || Math.abs(item.line_height - bodyHeight) > bodyHeight * 0.1
+      || typeof item.font_name !== "string") continue;
+    const weight = (item.text.match(/[\p{L}\p{N}]/gu) ?? []).length;
+    if (weight > 0) weights.set(item.font_name, (weights.get(item.font_name) ?? 0) + weight);
+  }
+  return [...weights.entries()].sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]))[0]?.[0] ?? null;
+}
+
+function bodyLeftEdge(evidence, bodyHeight) {
+  const bodyLines = evidence.filter(({ line, height }) => (
+    Number.isFinite(height)
+    && Math.abs(height - bodyHeight) <= bodyHeight * 0.1
+    && line.text.trim().length >= 20
+  )).map(({ line }) => line.x).filter(Number.isFinite);
+  return bodyLines.length > 0 ? median(bodyLines) : null;
+}
+
+function smallCapsNumberedHeadingEvidence(page, line, bodyHeight, headingWords) {
+  if (headingWords !== headingWords.toLocaleUpperCase("en-US")) return false;
+  const itemById = new Map(page.raw_items.map(item => [item.id, item]));
+  const items = line.item_ids.map(id => itemById.get(id)).filter(item => item && !item.is_whitespace);
+  const heights = items.map(item => item.line_height).filter(Number.isFinite);
+  const fontNames = new Set(items.map(item => item.font_name));
+  if (heights.length < 3 || fontNames.size !== 1 || fontNames.has(null)) return false;
+  const minimum = Math.min(...heights);
+  const maximum = Math.max(...heights);
+  return minimum >= bodyHeight * 0.9
+    && minimum <= bodyHeight * 1.05
+    && maximum >= bodyHeight * 1.15
+    && maximum <= bodyHeight * 1.3
+    && maximum / minimum >= 1.15;
+}
+
+function numberedSectionHeadingLevel(page, evidence, index, bodyHeight, bodyFontName, bodyLeft) {
+  const { line, height, consistentHeight, consistentFont, fontName } = evidence[index];
+  const text = line.text.trim();
+  const match = text.match(/^(\d{1,3})(?:\.(\d{1,3}))?(?:\.(\d{1,3}))?\s+([\p{Lu}][^\n]{1,100})$/u);
+  const pageWidth = page.geometry?.display_width;
+  const contrastingFontEvidence = consistentHeight && consistentFont && fontName && fontName !== bodyFontName
+    && Number.isFinite(height) && height >= bodyHeight * 0.95 && height <= bodyHeight * 1.35;
+  const smallCapsEvidence = match
+    ? smallCapsNumberedHeadingEvidence(page, line, bodyHeight, match[4])
+    : false;
+  if (!match || !headingTextEligible(text) || /[.!?;:]$/u.test(text)
+    || (!contrastingFontEvidence && !smallCapsEvidence)
+    || !Number.isFinite(pageWidth) || line.width < line.height * 2 || line.width > pageWidth * 0.7
+    || !Number.isFinite(bodyLeft) || Math.abs(line.x - bodyLeft) > Math.max(4, bodyHeight)
+    || !hasSectionBreakBefore(page, evidence, index, bodyHeight)) return null;
+  return match[3] === undefined ? (match[2] === undefined ? 2 : 3) : 4;
+}
+
 function structuralHeadingLevel(page, evidence, index, bodyHeight) {
   const line = evidence[index].line;
   const text = line.text.trim();
@@ -239,6 +295,12 @@ function structuralHeadingLevels(page, evidence, bodyHeight) {
     const level = structuralHeadingLevel(page, evidence, index, bodyHeight);
     return level === null ? [] : [[line.id, level]];
   }));
+  const bodyFontName = dominantBodyFont(page, bodyHeight);
+  const bodyLeft = bodyLeftEdge(evidence, bodyHeight);
+  for (let index = 0; index < evidence.length; index += 1) {
+    const level = numberedSectionHeadingLevel(page, evidence, index, bodyHeight, bodyFontName, bodyLeft);
+    if (level !== null) structural.set(evidence[index].line.id, level);
+  }
   if (page.page !== 1) return structural;
   const titleCandidates = evidence.slice(0, 3).filter(({ line, height }) => (
     headingTextEligible(line.text)
@@ -272,6 +334,8 @@ function headingLevels(page) {
       && line.text.length > 0
       && line.text.length <= 120
       && headingTextEligible(line.text)
+      && line.width >= line.height * 2
+      && height <= bodyHeight * 4
       && !/[.!?;]$/u.test(line.text)
       && !/^\s*(?:[\u2022\u2023\u25e6\u2043\u2219]|\d{1,3}[.)])\s+/u.test(line.text)
   ));

--- a/pdf-toolkit-mcp-share/server/output-schemas.js
+++ b/pdf-toolkit-mcp-share/server/output-schemas.js
@@ -878,7 +878,7 @@ export const TOOL_SUCCESS_OUTPUT_SCHEMAS = Object.freeze({
   convert_pdf_to_markdown: object({
     renderer: object({
       name: { const: "pdf-tools.layout-markdown-renderer" },
-      version: { const: "1.10.0" },
+      version: { const: "1.11.0" },
     }),
     conversion_status: enumString(["complete", "partial", "failed"]),
     markdown: string,

--- a/scripts/eval-run-markdown-bakeoff.mjs
+++ b/scripts/eval-run-markdown-bakeoff.mjs
@@ -193,7 +193,7 @@ export function validateMarkdownResult(result, binding) {
     throw new Error(`Markdown conversion failed for ${binding.fixture.id}`);
   }
   const value = result.structuredContent;
-  if (value.renderer?.name !== "pdf-tools.layout-markdown-renderer" || value.renderer?.version !== "1.10.0"
+  if (value.renderer?.name !== "pdf-tools.layout-markdown-renderer" || value.renderer?.version !== "1.11.0"
     || value.options?.include_page_boundaries !== true || value.limits?.max_markdown_bytes !== 200000
     || value.provenance?.source?.file_name !== binding.retained.filename
     || value.provenance?.source?.sha256 !== binding.retained.sha256

--- a/scripts/macos-claude-installed-shannon.mjs
+++ b/scripts/macos-claude-installed-shannon.mjs
@@ -12,13 +12,13 @@ if (!process.argv[2] || !process.argv[3]) {
 }
 
 const EXPECTED_SOURCE_SHA256 = "6e4e3411984f3edf99dbfe8b941cb5e8a321379ff0cae6ae5c1f592ad8882ca8";
-const EXPECTED_MARKDOWN_SHA256 = "723ca1614c6516ee698c596aab6acb84c0437983e6f96c1f871dea9668b79985";
-const EXPECTED_TOOL_CONTRACT_SHA256 = "109df9e468513e07377804bff842ac9c398923d88dc07c0ffd68c12a8c075e82";
+const EXPECTED_MARKDOWN_SHA256 = "2c4773511afe32d99ef44311406dbfeac42f4b3923696ef0fc59da56088eabe9";
+const EXPECTED_TOOL_CONTRACT_SHA256 = "77564e375ce70f9696d25bf5d1887cb105891a3096ee8b6777cf57572e1ba7f2";
 const EXPECTED_PAGE_COUNT = 55;
 const EXPECTED_GAP_COUNT = 68;
 const EXPECTED_REPLACEMENT_CHARACTER_COUNT = 434;
 const EXPECTED_ALPHA_COUNT = 49;
-const EXPECTED_MARKDOWN_BYTES = 182565;
+const EXPECTED_MARKDOWN_BYTES = 183093;
 const PAGE_SPAN = 10;
 
 function sha256(bytes) {
@@ -81,7 +81,7 @@ try {
     });
     const value = result.structuredContent;
     assert(!result.isError && value, `Installed conversion failed for pages ${startPage}-${endPage}`);
-    assert(value.renderer?.version === "1.10.0", "Installed Markdown renderer version differs");
+    assert(value.renderer?.version === "1.11.0", "Installed Markdown renderer version differs");
     assert(value.provenance?.layout?.parser_version === "5.4.624", "Installed PDF parser version differs");
     assert(value.provenance?.source?.sha256 === sourceSha256, "Installed conversion source identity differs");
     assert(value.provenance?.layout?.page_range?.start_page === startPage, "Installed conversion start page differs");

--- a/scripts/macos-claude-installed-smoke.mjs
+++ b/scripts/macos-claude-installed-smoke.mjs
@@ -29,7 +29,7 @@ const textFixture = path.join(fixtureDirectory, "synthetic-text-two-page.pdf");
 const rasterFixture = path.join(fixtureDirectory, "synthetic-raster-only.pdf");
 const mutationDirectory = path.join(fixtureDirectory, "mutation-output");
 const toolNames = [];
-const EXPECTED_TOOL_CONTRACT_SHA256 = "109df9e468513e07377804bff842ac9c398923d88dc07c0ffd68c12a8c075e82";
+const EXPECTED_TOOL_CONTRACT_SHA256 = "77564e375ce70f9696d25bf5d1887cb105891a3096ee8b6777cf57572e1ba7f2";
 let toolContractSha256;
 let structuredToolCount;
 let markdownHash;

--- a/scripts/smoke-mcpb.mjs
+++ b/scripts/smoke-mcpb.mjs
@@ -150,7 +150,7 @@ async function main() {
       arguments: { pdf_path: fixturePath, max_markdown_bytes: 200000 },
     });
     if (markdown.isError
-      || markdown.structuredContent?.renderer?.version !== "1.10.0"
+      || markdown.structuredContent?.renderer?.version !== "1.11.0"
       || markdown.structuredContent?.markdown_bytes !== Buffer.byteLength(markdown.structuredContent?.markdown || "", "utf8")
       || markdown.structuredContent?.markdown_sha256 !== sha256(Buffer.from(markdown.structuredContent?.markdown || "", "utf8"))) {
       throw new Error("Packed convert_pdf_to_markdown contract smoke failed");

--- a/scripts/test-share-contract.mjs
+++ b/scripts/test-share-contract.mjs
@@ -840,7 +840,7 @@ async function main() {
       arguments: { pdf_path: fixturePath, max_markdown_bytes: 200000 },
     });
     if (markdown.isError
-      || markdown.structuredContent?.renderer?.version !== "1.10.0"
+      || markdown.structuredContent?.renderer?.version !== "1.11.0"
       || markdown.structuredContent?.markdown_bytes !== Buffer.byteLength(markdown.structuredContent?.markdown || "", "utf8")
       || markdown.structuredContent?.markdown_sha256 !== sha256(Buffer.from(markdown.structuredContent?.markdown || "", "utf8"))) {
       throw new Error("Share convert_pdf_to_markdown contract smoke failed");

--- a/server/markdown-conversion.js
+++ b/server/markdown-conversion.js
@@ -6,7 +6,7 @@ import {
 
 const RENDERER = Object.freeze({
   name: "pdf-tools.layout-markdown-renderer",
-  version: "1.10.0",
+  version: "1.11.0",
 });
 const SUPPORTED_LAYOUT_IR_VERSION = "1.4.0";
 
@@ -69,7 +69,7 @@ const GAP_CODES = new Set([
 ]);
 
 const LIMITATIONS = Object.freeze([
-  "Headings are emitted only from consistent enlarged font metrics or centered English-language source structure with section spacing for a first-page title, introduction, part, or appendix. Ambiguous, very short, or unsupported heading styles remain body text.",
+  "Headings are emitted only from consistent enlarged font metrics, centered English-language source structure with section spacing, or left-aligned numbered research-paper structure with spacing plus either font contrast or exact small-caps geometry. Narrow vertical labels and ambiguous, very short, or unsupported heading styles remain body text.",
   "A geometrically overlapping initial capital may be joined to its following uppercase word remainder. Line-end hyphens are preserved because source geometry cannot reliably distinguish a split word from an intentional compound. The source Extraction IR retains the original lines.",
   "A missing space after a separate source text item that is exactly the mathematical operator log is restored only in a short, compact left-to-right math run when a single-letter variable from a different source font resource follows on the same baseline with a small positive geometric gap and independent local math-layout evidence. A missing prose-to-variable space is restored only when a multiword prose item, a separate uppercase letter from a different source font resource, and continuing prose from the original prose font share one baseline with distinct positive boundary gaps, and the same letter/font pair occurs in a nearby compact equation on the same page and column. An inline single-digit stacked fraction is rendered only when consecutive same-font source items, explicit source whitespace, smaller exactly aligned numerator and denominator digits, ordinary prose on both sides, and exactly one thin matching solid-mask bar agree. A small version-pinned registry may recover a legacy Computer Modern Type-3 character only after an exact official-metric family match, exact target and two-witness glyph-program matches, and a complete operator/text sequence binding. General equations, scripts, other fraction bars, unregistered raster variants, and other damaged mathematical glyphs remain source reading-order text rather than being guessed.",
   "Lists are emitted only for literal bullet glyphs or decimal markers present in the source text.",
@@ -181,6 +181,7 @@ function lineFontEvidence(page) {
       consistentHeight: heights.length > 0
         && Math.max(...heights) - Math.min(...heights) <= Math.max(0.5, median(heights) * 0.1),
       consistentFont: fontNames.size === 1 && !fontNames.has(null),
+      fontName: fontNames.size === 1 ? [...fontNames][0] : null,
     };
   });
 }
@@ -223,6 +224,61 @@ function hasSectionBreakBefore(page, evidence, index, bodyHeight) {
   return gap >= Math.max(line.height, bodyHeight) * 1.15;
 }
 
+function dominantBodyFont(page, bodyHeight) {
+  const weights = new Map();
+  for (const item of page.raw_items) {
+    if (item.is_whitespace || !Number.isFinite(item.line_height)
+      || Math.abs(item.line_height - bodyHeight) > bodyHeight * 0.1
+      || typeof item.font_name !== "string") continue;
+    const weight = (item.text.match(/[\p{L}\p{N}]/gu) ?? []).length;
+    if (weight > 0) weights.set(item.font_name, (weights.get(item.font_name) ?? 0) + weight);
+  }
+  return [...weights.entries()].sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]))[0]?.[0] ?? null;
+}
+
+function bodyLeftEdge(evidence, bodyHeight) {
+  const bodyLines = evidence.filter(({ line, height }) => (
+    Number.isFinite(height)
+    && Math.abs(height - bodyHeight) <= bodyHeight * 0.1
+    && line.text.trim().length >= 20
+  )).map(({ line }) => line.x).filter(Number.isFinite);
+  return bodyLines.length > 0 ? median(bodyLines) : null;
+}
+
+function smallCapsNumberedHeadingEvidence(page, line, bodyHeight, headingWords) {
+  if (headingWords !== headingWords.toLocaleUpperCase("en-US")) return false;
+  const itemById = new Map(page.raw_items.map(item => [item.id, item]));
+  const items = line.item_ids.map(id => itemById.get(id)).filter(item => item && !item.is_whitespace);
+  const heights = items.map(item => item.line_height).filter(Number.isFinite);
+  const fontNames = new Set(items.map(item => item.font_name));
+  if (heights.length < 3 || fontNames.size !== 1 || fontNames.has(null)) return false;
+  const minimum = Math.min(...heights);
+  const maximum = Math.max(...heights);
+  return minimum >= bodyHeight * 0.9
+    && minimum <= bodyHeight * 1.05
+    && maximum >= bodyHeight * 1.15
+    && maximum <= bodyHeight * 1.3
+    && maximum / minimum >= 1.15;
+}
+
+function numberedSectionHeadingLevel(page, evidence, index, bodyHeight, bodyFontName, bodyLeft) {
+  const { line, height, consistentHeight, consistentFont, fontName } = evidence[index];
+  const text = line.text.trim();
+  const match = text.match(/^(\d{1,3})(?:\.(\d{1,3}))?(?:\.(\d{1,3}))?\s+([\p{Lu}][^\n]{1,100})$/u);
+  const pageWidth = page.geometry?.display_width;
+  const contrastingFontEvidence = consistentHeight && consistentFont && fontName && fontName !== bodyFontName
+    && Number.isFinite(height) && height >= bodyHeight * 0.95 && height <= bodyHeight * 1.35;
+  const smallCapsEvidence = match
+    ? smallCapsNumberedHeadingEvidence(page, line, bodyHeight, match[4])
+    : false;
+  if (!match || !headingTextEligible(text) || /[.!?;:]$/u.test(text)
+    || (!contrastingFontEvidence && !smallCapsEvidence)
+    || !Number.isFinite(pageWidth) || line.width < line.height * 2 || line.width > pageWidth * 0.7
+    || !Number.isFinite(bodyLeft) || Math.abs(line.x - bodyLeft) > Math.max(4, bodyHeight)
+    || !hasSectionBreakBefore(page, evidence, index, bodyHeight)) return null;
+  return match[3] === undefined ? (match[2] === undefined ? 2 : 3) : 4;
+}
+
 function structuralHeadingLevel(page, evidence, index, bodyHeight) {
   const line = evidence[index].line;
   const text = line.text.trim();
@@ -239,6 +295,12 @@ function structuralHeadingLevels(page, evidence, bodyHeight) {
     const level = structuralHeadingLevel(page, evidence, index, bodyHeight);
     return level === null ? [] : [[line.id, level]];
   }));
+  const bodyFontName = dominantBodyFont(page, bodyHeight);
+  const bodyLeft = bodyLeftEdge(evidence, bodyHeight);
+  for (let index = 0; index < evidence.length; index += 1) {
+    const level = numberedSectionHeadingLevel(page, evidence, index, bodyHeight, bodyFontName, bodyLeft);
+    if (level !== null) structural.set(evidence[index].line.id, level);
+  }
   if (page.page !== 1) return structural;
   const titleCandidates = evidence.slice(0, 3).filter(({ line, height }) => (
     headingTextEligible(line.text)
@@ -272,6 +334,8 @@ function headingLevels(page) {
       && line.text.length > 0
       && line.text.length <= 120
       && headingTextEligible(line.text)
+      && line.width >= line.height * 2
+      && height <= bodyHeight * 4
       && !/[.!?;]$/u.test(line.text)
       && !/^\s*(?:[\u2022\u2023\u25e6\u2043\u2219]|\d{1,3}[.)])\s+/u.test(line.text)
   ));

--- a/server/output-schemas.js
+++ b/server/output-schemas.js
@@ -878,7 +878,7 @@ export const TOOL_SUCCESS_OUTPUT_SCHEMAS = Object.freeze({
   convert_pdf_to_markdown: object({
     renderer: object({
       name: { const: "pdf-tools.layout-markdown-renderer" },
-      version: { const: "1.10.0" },
+      version: { const: "1.11.0" },
     }),
     conversion_status: enumString(["complete", "partial", "failed"]),
     markdown: string,

--- a/test/convert-pdf-to-markdown.test.js
+++ b/test/convert-pdf-to-markdown.test.js
@@ -305,7 +305,7 @@ describe("convert_pdf_to_markdown MCP tool", () => {
     expect(first.isError).not.toBe(true);
     expect(second.structuredContent).toEqual(first.structuredContent);
     expect(first.structuredContent).toMatchObject({
-      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.10.0" },
+      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.11.0" },
       conversion_status: "complete",
       saved_output: null,
       provenance: {

--- a/test/eval/markdown-bakeoff.test.js
+++ b/test/eval/markdown-bakeoff.test.js
@@ -64,7 +64,7 @@ async function handle(message) {
     const pageBoundaries = Array.from({ length: pageCount }, (_, index) => "<!-- PDF page " + (index + 1) + " -->");
     const markdown = pageBoundaries.join("\n\n") + "\n\nINV-1001 fixture evidence\n";
     const value = {
-      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.10.0" },
+      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.11.0" },
       conversion_status: "complete",
       markdown,
       markdown_sha256: digest(Buffer.from(markdown)),
@@ -146,7 +146,7 @@ function resultFor(binding) {
   const markdown = "<!-- PDF page 1 -->\n\nFixture text\n";
   return {
     structuredContent: {
-      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.10.0" },
+      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.11.0" },
       conversion_status: "complete",
       markdown,
       markdown_sha256: sha256(Buffer.from(markdown)),
@@ -234,7 +234,7 @@ describe("Markdown bakeoff renderer version binding", () => {
   });
 
   it("accepts the current renderer version and rejects all superseded ones", () => {
-    expect(validateMarkdownResult(resultFor("1.10.0"), binding).renderer.version).toBe("1.10.0");
+    expect(validateMarkdownResult(resultFor("1.11.0"), binding).renderer.version).toBe("1.11.0");
     for (const stale of ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.6.0", "1.7.0", "1.8.0", "1.9.0"]) {
       expect(() => validateMarkdownResult(resultFor(stale), binding), stale)
         .toThrow(/Markdown result evidence is invalid/u);

--- a/test/eval/markdown-bakeoff.test.js
+++ b/test/eval/markdown-bakeoff.test.js
@@ -235,7 +235,7 @@ describe("Markdown bakeoff renderer version binding", () => {
 
   it("accepts the current renderer version and rejects all superseded ones", () => {
     expect(validateMarkdownResult(resultFor("1.11.0"), binding).renderer.version).toBe("1.11.0");
-    for (const stale of ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.6.0", "1.7.0", "1.8.0", "1.9.0"]) {
+    for (const stale of ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.6.0", "1.7.0", "1.8.0", "1.9.0", "1.10.0"]) {
       expect(() => validateMarkdownResult(resultFor(stale), binding), stale)
         .toThrow(/Markdown result evidence is invalid/u);
     }

--- a/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
+++ b/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
@@ -67,14 +67,14 @@
     {
       "role": "markdown_conversion_module",
       "path": "server/markdown-conversion.js",
-      "bytes": 99701,
-      "sha256": "31f7b6f7027d5ade27d5d2a3d6ebe7a701e894e04b3d1b13b0c90947f5afad33"
+      "bytes": 103217,
+      "sha256": "11516ed7a249c6e6a83eb6b61829b3c4606f3fe681654aa72e3f6def6891085d"
     },
     {
       "role": "output_schemas_module",
       "path": "server/output-schemas.js",
       "bytes": 48015,
-      "sha256": "39f98158583218c3e46a9936fb7d1d4809d934f7eb457ea2d16c54198032f9e7"
+      "sha256": "8c46fedf5c6e97a8420002e4346ca2806dddb7740557e4d69aab12152ab9d814"
     },
     {
       "role": "package_json",
@@ -113,7 +113,7 @@
       "sha256": "6e4429db62fcbe1dd73141d8c20a48b564d41f8bf8920d88775846995e1daf94"
     }
   ],
-  "validator_source_set_sha256": "16052336512af1e1d382b541a6b7a20001e4f243a2c8df3603e36d688a272cc0",
+  "validator_source_set_sha256": "c88ace433c09da7ea4691eea0e0bf21393f6093b1826d527206607e3de0a8217",
   "pdfjs_version": "5.4.624",
   "generation_contract": {
     "source_path": "source.pdf",

--- a/test/fixtures/eval/shannon/manifest.v1.json
+++ b/test/fixtures/eval/shannon/manifest.v1.json
@@ -22,7 +22,7 @@
     "pdf_tools": {
       "slot": "control.current_product.v0",
       "renderer_name": "pdf-tools.layout-markdown-renderer",
-      "renderer_version": "1.10.0",
+      "renderer_version": "1.11.0",
       "parser_name": "pdfjs-dist",
       "parser_version": "5.4.624"
     },

--- a/test/markdown-conversion.test.js
+++ b/test/markdown-conversion.test.js
@@ -25,14 +25,14 @@ function multiply(left, right) {
   ];
 }
 
-function textItem(text, { top, fontSize = 12, left = 50, eol = true } = {}) {
+function textItem(text, { top, fontSize = 12, left = 50, fontName = "f1", eol = true } = {}) {
   return {
     str: text,
     dir: "ltr",
     width: Math.max(20, text.length * fontSize * 0.5),
     height: fontSize,
     transform: [fontSize, 0, 0, fontSize, left, 792 - top - fontSize],
-    fontName: "f1",
+    fontName,
     hasEOL: eol,
   };
 }
@@ -364,7 +364,7 @@ describe("layout Markdown renderer", () => {
     // invocation, so any unreviewed serialized delta fails this regression.
     const serialized = JSON.stringify(pinnable);
     expect(createHash("sha256").update(serialized).digest("hex"))
-      .toBe("01182c0a1fc5e0cf112e9c1c8e00959406b67e32e4b31820cc3ad66395c50deb");
+      .toBe("cd29e33513f44fc6d7e9e48e3400a0ca236834410f34629bcf25bd27ee37ce64");
     const body = result.markdown.split("\n\n## Conversion gaps\n\n", 1)[0];
     expect(JSON.stringify({
       body,
@@ -372,7 +372,7 @@ describe("layout Markdown renderer", () => {
     })).toBe(NON_RECT_EXPECTED);
     expect(result.renderer).toEqual({
       name: "pdf-tools.layout-markdown-renderer",
-      version: "1.10.0",
+      version: "1.11.0",
     });
     expect(result.gaps[0].message).toMatch(/beyond reconstructed ruled or bounded solid-mask table grids/);
     expect(result.limitations.some(value => value.includes("clean ruled-rectangle grid evidence"))).toBe(true);
@@ -1081,6 +1081,79 @@ describe("layout Markdown renderer", () => {
     expect(result.markdown).toMatch(/^## PART IV: THE CONTINUOUS CHANNEL$/mu);
     expect(result.markdown).toMatch(/^## APPENDIX 7$/mu);
     expect(result.markdown).not.toMatch(/^#{1,6}\s+(?:PART I = H|INTRODUCTION = H)$/gmu);
+  });
+
+  it("recognizes left-aligned numbered research-paper sections from spacing and font contrast", async () => {
+    const layout = await validatedSyntheticLayout([{
+      items: [
+        textItem("Opening body text establishes the ordinary font", { top: 40, left: 108, fontSize: 10 }),
+        textItem("1 Introduction", { top: 80, left: 108, fontSize: 12, fontName: "f2" }),
+        textItem("First paragraph under the main section heading", { top: 105, left: 108, fontSize: 10 }),
+        textItem("More body evidence keeps the body font dominant", { top: 120, left: 108, fontSize: 10 }),
+        textItem("3.2 Attention", { top: 160, left: 108, fontSize: 10, fontName: "f2" }),
+        textItem("Body beneath the subsection continues normally", { top: 185, left: 108, fontSize: 10 }),
+        textItem("3.2.1 Scaled Dot-Product Attention", { top: 225, left: 108, fontSize: 10, fontName: "f2" }),
+        textItem("Final body line preserves the ordinary reading flow", { top: 250, left: 108, fontSize: 10 }),
+      ],
+    }]);
+    const result = renderPdfLayoutToMarkdown(layout, { includePageBoundaries: false });
+
+    expect(result.markdown).toMatch(/^## 1 Introduction$/mu);
+    expect(result.markdown).toMatch(/^### 3\.2 Attention$/mu);
+    expect(result.markdown).toMatch(/^#### 3\.2\.1 Scaled Dot-Product Attention$/mu);
+  });
+
+  it("recognizes numbered small-caps sections without relying on a different font resource", async () => {
+    const layout = await validatedSyntheticLayout([{
+      items: [
+        textItem("Ordinary body text establishes the page font", { top: 40, left: 108, fontSize: 10 }),
+        positionedTextItem("1", { top: 80, left: 108, width: 6, fontSize: 12, fontName: "f1" }),
+        positionedTextItem("I", { top: 80, left: 126, width: 4, fontSize: 12, fontName: "f1" }),
+        positionedTextItem("NTRODUCTION", { top: 82, left: 131, width: 72, fontSize: 9.5, fontName: "f1", eol: true }),
+        textItem("First body line below the small-caps section", { top: 105, left: 108, fontSize: 10 }),
+        textItem("Second ordinary line keeps the page font dominant", { top: 120, left: 108, fontSize: 10 }),
+        textItem("Third ordinary line completes body evidence", { top: 135, left: 108, fontSize: 10 }),
+      ],
+    }]);
+    const result = renderPdfLayoutToMarkdown(layout, { includePageBoundaries: false });
+
+    expect(result.markdown).toMatch(/^## 1 INTRODUCTION$/mu);
+  });
+
+  it("refuses numbered-heading lookalikes without every structural witness", async () => {
+    const layout = await validatedSyntheticLayout([{
+      items: [
+        textItem("Ordinary body evidence begins on this line", { top: 40, left: 108, fontSize: 10 }),
+        textItem("2 Background", { top: 55, left: 108, fontSize: 10 }),
+        textItem("Ordinary prose immediately follows without a section break", { top: 70, left: 108, fontSize: 10 }),
+        textItem("3 Model Architecture", { top: 110, left: 160, fontSize: 12, fontName: "f2" }),
+        textItem("Another ordinary line anchors the body margin", { top: 135, left: 108, fontSize: 10 }),
+        textItem("4 Results.", { top: 175, left: 108, fontSize: 12, fontName: "f2" }),
+        textItem("5 Training", { top: 215, left: 108, fontSize: 14, fontName: "f2" }),
+        textItem("Closing ordinary body evidence", { top: 240, left: 108, fontSize: 10 }),
+      ],
+    }]);
+    const result = renderPdfLayoutToMarkdown(layout, { includePageBoundaries: false });
+
+    expect(result.markdown).not.toMatch(/^#{1,6}\s+(?:2 Background|3 Model Architecture|4 Results\.|5 Training)$/gmu);
+  });
+
+  it("does not promote narrow vertical page labels as oversized headings", async () => {
+    const layout = await validatedSyntheticLayout([{
+      items: [
+        positionedTextItem("arXiv:1706.03762v7 [cs.CL] 2 Aug 2023", {
+          top: 80, left: 16, width: 20, fontSize: 120, fontName: "f2",
+        }),
+        textItem("First body line", { top: 220, left: 108, fontSize: 10 }),
+        textItem("Second body line", { top: 240, left: 108, fontSize: 10 }),
+        textItem("Third body line", { top: 260, left: 108, fontSize: 10 }),
+        textItem("Fourth body line", { top: 280, left: 108, fontSize: 10 }),
+      ],
+    }]);
+    const result = renderPdfLayoutToMarkdown(layout, { includePageBoundaries: false });
+
+    expect(result.markdown).toContain("arXiv:1706.03762v7 \\[cs&#46;CL\\] 2 Aug 2023");
+    expect(result.markdown).not.toMatch(/^#{1,6}\s+arXiv:/gmu);
   });
 
   it("emits at most one first-page H1 when a title and subtitle share the strongest style", async () => {

--- a/test/mcp-contract.test.js
+++ b/test/mcp-contract.test.js
@@ -61,12 +61,12 @@ const EXAMPLE_PDF = path.join(REPO_ROOT, "example-fw9.pdf");
 // independently qualified exact legacy Computer Modern Type-3 glyphs.
 // 2026-08-04: Markdown renderer 1.9.0 restores only narrowly source-supported
 // boundaries between multiword prose and a separate uppercase math variable.
-// 2026-08-04: Markdown renderer 1.10.0 interprets only explicitly barred,
+// 2026-08-04: Markdown renderer 1.11.0 interprets only explicitly barred,
 // single-digit stacked fractions in an ordinary prose sandwich. The final
 // combined contract digest is refreshed after the integration replay.
 // 2026-08-04: additive deterministic compare_pdfs contract with source-bound
 // evidence, exact whole-document limits, and typed channel coverage.
-const TOOL_CONTRACT_SHA256 = "109df9e468513e07377804bff842ac9c398923d88dc07c0ffd68c12a8c075e82";
+const TOOL_CONTRACT_SHA256 = "77564e375ce70f9696d25bf5d1887cb105891a3096ee8b6777cf57572e1ba7f2";
 
 const CLOSED_READ = Object.freeze({
   readOnlyHint: true,

--- a/test/numbered-research-headings-live.test.js
+++ b/test/numbered-research-headings-live.test.js
@@ -1,0 +1,106 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { hashBoundedPdfFileSafely } from "../server/bounded-pdf-file.js";
+import { renderPdfLayoutToMarkdown } from "../server/markdown-conversion.js";
+import {
+  createPdfjsSubprocessRequest,
+  runPdfjsSubprocess,
+} from "../server/pdfjs-subprocess.js";
+
+const ATTENTION_SOURCE = process.env.PDF_TOOLS_ATTENTION_SOURCE;
+const ADAM_SOURCE = process.env.PDF_TOOLS_ADAM_SOURCE;
+
+async function renderExternalPdf(sourcePath, expectedSha256) {
+  const sourceFile = await hashBoundedPdfFileSafely(sourcePath, 250 * 1024 * 1024, {
+    assertPathAllowed: candidate => candidate,
+  });
+  expect(sourceFile.sha256).toBe(expectedSha256);
+  const source = {
+    canonical_path: sourceFile.canonicalPath,
+    file_identity: sourceFile.fileIdentity,
+    sha256: sourceFile.sha256,
+    size_bytes: sourceFile.sizeBytes,
+  };
+  const markdown = [];
+  for (const [startPage, endPage] of [[1, 5], [6, 10], [11, 15]]) {
+    const response = await runPdfjsSubprocess(createPdfjsSubprocessRequest({
+      operation: "extract_layout_for_markdown",
+      source,
+      password: null,
+      allowedDirectories: [path.dirname(sourcePath)],
+      options: {
+        source_path: sourcePath,
+        source_file_name: path.basename(sourcePath),
+        start_page: startPage,
+        end_page: endPage,
+        max_items: 5000,
+        max_characters: 100_000,
+        max_output_characters: 200_000,
+      },
+    }), { timeoutMs: 30_000 });
+    markdown.push(renderPdfLayoutToMarkdown(response.layout, {
+      includePageBoundaries: true,
+      maxMarkdownBytes: 200_000,
+    }).markdown);
+  }
+  return markdown.join("\n\n");
+}
+
+function numberedHeadings(markdown) {
+  return [...markdown.matchAll(/^#{2,4}\s+(\d{1,3}(?:\.\d{1,3}){0,2}\s+.+)$/gmu)]
+    .map(match => match[1]);
+}
+
+describe("external numbered research-paper headings", () => {
+  it.runIf(Boolean(ATTENTION_SOURCE))("recovers the complete numbered hierarchy in Attention Is All You Need", async () => {
+    const markdown = await renderExternalPdf(
+      ATTENTION_SOURCE,
+      "bdfaa68d8984f0dc02beaca527b76f207d99b666d31d1da728ee0728182df697",
+    );
+    expect(numberedHeadings(markdown)).toEqual([
+      "1 Introduction",
+      "2 Background",
+      "3 Model Architecture",
+      "3.1 Encoder and Decoder Stacks",
+      "3.2 Attention",
+      "3.2.1 Scaled Dot-Product Attention",
+      "3.2.2 Multi-Head Attention",
+      "3.2.3 Applications of Attention in our Model",
+      "3.3 Position-wise Feed-Forward Networks",
+      "3.4 Embeddings and Softmax",
+      "3.5 Positional Encoding",
+      "4 Why Self-Attention",
+      "5 Training",
+      "5.1 Training Data and Batching",
+      "5.2 Hardware and Schedule",
+      "5.3 Optimizer",
+      "5.4 Regularization",
+      "6 Results",
+      "6.1 Machine Translation",
+      "6.2 Model Variations",
+      "6.3 English Constituency Parsing",
+      "7 Conclusion",
+    ]);
+    expect(markdown).toMatch(/^# Attention Is All You Need$/mu);
+    expect(markdown).not.toMatch(/^#{1,6}\s+arXiv:/gmu);
+  }, 60_000);
+
+  it.runIf(Boolean(ADAM_SOURCE))("recovers only the currently proven Adam small-caps main sections", async () => {
+    const markdown = await renderExternalPdf(
+      ADAM_SOURCE,
+      "eab9c73ae2ceda884b94830bda99312254bac4806f6c9f045cbab90721ecda31",
+    );
+    expect(numberedHeadings(markdown)).toEqual([
+      "1 INTRODUCTION",
+      "2 ALGORITHM",
+      "3 INITIALIZATION BIAS CORRECTION",
+      "4 CONVERGENCE ANALYSIS",
+      "5 RELATED WORK",
+      "6 EXPERIMENTS",
+      "7 EXTENSIONS",
+      "8 CONCLUSION",
+      "10 APPENDIX",
+    ]);
+    expect(markdown).not.toMatch(/^#{1,6}\s+arXiv:/gmu);
+  }, 60_000);
+});


### PR DESCRIPTION
## What changed

- recognize safely evidenced numbered research-paper headings with one to three numeric levels
- refuse narrow vertical labels such as arXiv margin stamps
- preserve the renderer contract across the source and packaged share
- add hash-locked live checks for Attention Is All You Need and Adam
- record cross-paper and Shannon regression evidence

## Why

PDF Tools v0.9.4 handled Shannon's headings but missed conventional numbered headings in other research-paper layouts. It could also mistake vertical arXiv margin text for a heading.

## Result

- Attention: 0/22 to 22/22 numbered headings
- Adam: 0/18 to 9/18, deliberately leaving split-line subsections as plain text
- false vertical arXiv headings: 2 to 0
- Shannon sampled quality unchanged across three byte-identical full-paper runs
- normalized source text remains byte-equivalent on all three papers

## Validation

- independent exact-commit review: ACCEPT
- real hash-locked Attention and Adam checks: 2/2
- refreshed extraction-layout checks: 21 passed, 6 skipped
- comparison product isolated rerun: 12/12
- complete suite: 1,999 passed, 84 skipped; one unrelated process-timing case missed its test setup under full load, then its complete file passed 22/22 immediately in isolation
- source/share runtime files are byte-identical

This PR does not publish a release and does not claim complete mathematical reconstruction.
