### PR TITLE
Complete Adam numbered headings

### DIFF
--- a/docs/evidence/general-numbered-research-headings-2026-08.md
+++ b/docs/evidence/general-numbered-research-headings-2026-08.md
@@ -32,14 +32,16 @@ labels such as the arXiv margin stamp.
   `eab9c73ae2ceda884b94830bda99312254bac4806f6c9f045cbab90721ecda31`
 - Pages: 15
 - Visually checked rendered pages: 1, 2, and 9
-- v0.9.4: 0 of 18 labeled numbered headings; the vertical arXiv label was
+- v0.9.4: 0 of 17 genuinely numbered headings; the vertical arXiv label was
   falsely a heading
-- Candidate: 9 of 18 numbered headings, covering only the proven single-line
-  small-caps main sections; the vertical arXiv label is not a heading
+- First candidate: 9 of 17 numbered headings
+- Follow-up candidate: 17 of 17, using the same exact two-size small-caps
+  relationship already present in the first nine; the unnumbered References
+  title remains unnumbered and the vertical arXiv label is not a heading
 - Candidate Markdown SHA-256:
-  `503c3471ae7f1c4c408d8ea9158741c11c66bb6eaa1eca40646440e3d6676215`
+  `b015c3a552e428e649f1f6fd5445f2490fc8deb95d9efdabe261ee9a44bfb11a`
 
-Across the two papers, numbered-heading recall moves from 0 of 40 to 31 of 40,
+Across the two papers, numbered-heading recall moves from 0 of 39 to 39 of 39,
 and false arXiv-label headings move from two to zero.
 
 ## Content preservation
@@ -75,11 +77,14 @@ bounded width and height, and either a consistent distinct font or exact
 same-font small-caps geometry. It rejects terminal punctuation and narrow,
 tall vertical labels.
 
-Adam's nine remaining numbered subsections stay plain text because their
-numbers and titles are split into separate source lines or blocks. Joining
-those fragments needs separate evidence and is not guessed here. Tables,
-figures, equations, and complete mathematical reconstruction are outside this
-claim.
+Adam's eight previously missed subsections use the same source line, font, left
+edge, section break, and exact two-level small-caps geometry as the already
+recognized sections. The follow-up accepts that exact relationship without
+joining fragments or guessing text. The generic large-font detector still has
+pre-existing false headings on Adam's chart-heavy page 7; that is recorded as
+separate follow-up work and is not concealed by the numbered-heading result.
+Tables, figures, equations, and complete mathematical reconstruction are
+outside this claim.
 
 ## Verification
 
@@ -90,5 +95,14 @@ claim.
 - Focused comparison check: 12/12 passed when rerun alone; the earlier
   full-suite metadata mismatch did not reproduce
 - Refreshed extraction-layout oracle checks: 21 passed, 6 skipped
+- Follow-up exact implementation commit:
+  `fbf5db638360f2e511950ef03e5b6332a39ee972`
+- Follow-up focused checks: 156 passed, 6 skipped; real-paper checks 2/2;
+  reproducible share contract passed with 41 tools, 14 prompts, and 112 SBOM
+  components
+- Follow-up Shannon report SHA-256:
+  `3c067c231ac77f4a5d0c7cfae6d3d8b55c880cc5f217d6d6bba8d3a1ac3fb1ec`;
+  all three Markdown runs remain byte-identical at the previously recorded
+  SHA-256 and all sampled quality scores remain unchanged
 
 No public release or Kepano reply is authorized by this evidence alone.

--- a/docs/handoffs/KEPANO_SHANNON.md
+++ b/docs/handoffs/KEPANO_SHANNON.md
@@ -117,12 +117,16 @@ claim the paper or arbitrary mathematical PDFs are completely solved.
 
 Branch `agent/general-numbered-headings`, implementation commit
 `b74d110f2faad440c24915bb4f62546d6b5221da`, broadens the heading work beyond
-Shannon. On two additional public research papers it recovers 31 of 40 numbered
-headings that v0.9.4 missed and removes both false headings caused by vertical
-arXiv margin labels. Attention is 22/22; Adam is deliberately 9/18 because its
-remaining subsection numbers and titles are split across source lines or
-blocks. Shannon's existing sampled quality is unchanged across three complete,
-byte-identical 55-page runs.
+Shannon. It merged in PR #81 as
+`945c94376d5d254b8d38b7b33af29e04d5ebc703`. The follow-up branch
+`agent/split-numbered-headings`, exact implementation
+`fbf5db638360f2e511950ef03e5b6332a39ee972`, completes Adam's exact same-font
+small-caps pattern. Across two additional public research papers the combined
+candidate recovers all 39 genuinely numbered headings that v0.9.4 missed and
+removes both false headings caused by vertical arXiv margin labels. Attention
+is 22/22 and Adam is 17/17; Adam's References title is visibly unnumbered and
+stays unnumbered. Shannon's existing sampled quality is unchanged across three
+complete, byte-identical 55-page runs.
 
 The detailed evidence is
 `docs/evidence/general-numbered-research-headings-2026-08.md`. This is a
@@ -137,9 +141,9 @@ Maintainer retest requests for the current v0.9.4 package are open at:
 - macOS stable-tool exposure issue #47:
   `https://github.com/Open-Document-Alliance/PDF-Tools/issues/47#issuecomment-5186253859`
 
-Do not reply to Kepano yet. First merge this candidate cleanly and preserve the
-honest boundary above; a later reply should point to a tested public release,
-not unreleased master.
+Do not reply to Kepano yet. First merge the follow-up candidate cleanly and
+address or explicitly accept the pre-existing chart-page false-heading issue;
+a later reply should point to a tested public release, not unreleased master.
 
 ## Fast recovery commands
 

--- a/pdf-toolkit-mcp-share/server/markdown-conversion.js
+++ b/pdf-toolkit-mcp-share/server/markdown-conversion.js
@@ -6,7 +6,7 @@ import {
 
 const RENDERER = Object.freeze({
   name: "pdf-tools.layout-markdown-renderer",
-  version: "1.11.0",
+  version: "1.12.0",
 });
 const SUPPORTED_LAYOUT_IR_VERSION = "1.4.0";
 
@@ -254,11 +254,18 @@ function smallCapsNumberedHeadingEvidence(page, line, bodyHeight, headingWords) 
   if (heights.length < 3 || fontNames.size !== 1 || fontNames.has(null)) return false;
   const minimum = Math.min(...heights);
   const maximum = Math.max(...heights);
-  return minimum >= bodyHeight * 0.9
+  const enlargedInitials = minimum >= bodyHeight * 0.9
     && minimum <= bodyHeight * 1.05
     && maximum >= bodyHeight * 1.15
     && maximum <= bodyHeight * 1.3
     && maximum / minimum >= 1.15;
+  const bodySizedInitials = minimum >= bodyHeight * 0.75
+    && minimum <= bodyHeight * 0.85
+    && maximum >= bodyHeight * 0.95
+    && maximum <= bodyHeight * 1.05
+    && maximum / minimum >= 1.2
+    && maximum / minimum <= 1.3;
+  return enlargedInitials || bodySizedInitials;
 }
 
 function numberedSectionHeadingLevel(page, evidence, index, bodyHeight, bodyFontName, bodyLeft) {

--- a/pdf-toolkit-mcp-share/server/output-schemas.js
+++ b/pdf-toolkit-mcp-share/server/output-schemas.js
@@ -878,7 +878,7 @@ export const TOOL_SUCCESS_OUTPUT_SCHEMAS = Object.freeze({
   convert_pdf_to_markdown: object({
     renderer: object({
       name: { const: "pdf-tools.layout-markdown-renderer" },
-      version: { const: "1.11.0" },
+      version: { const: "1.12.0" },
     }),
     conversion_status: enumString(["complete", "partial", "failed"]),
     markdown: string,

--- a/scripts/eval-run-markdown-bakeoff.mjs
+++ b/scripts/eval-run-markdown-bakeoff.mjs
@@ -193,7 +193,7 @@ export function validateMarkdownResult(result, binding) {
     throw new Error(`Markdown conversion failed for ${binding.fixture.id}`);
   }
   const value = result.structuredContent;
-  if (value.renderer?.name !== "pdf-tools.layout-markdown-renderer" || value.renderer?.version !== "1.11.0"
+  if (value.renderer?.name !== "pdf-tools.layout-markdown-renderer" || value.renderer?.version !== "1.12.0"
     || value.options?.include_page_boundaries !== true || value.limits?.max_markdown_bytes !== 200000
     || value.provenance?.source?.file_name !== binding.retained.filename
     || value.provenance?.source?.sha256 !== binding.retained.sha256

--- a/scripts/macos-claude-installed-shannon.mjs
+++ b/scripts/macos-claude-installed-shannon.mjs
@@ -13,7 +13,7 @@ if (!process.argv[2] || !process.argv[3]) {
 
 const EXPECTED_SOURCE_SHA256 = "6e4e3411984f3edf99dbfe8b941cb5e8a321379ff0cae6ae5c1f592ad8882ca8";
 const EXPECTED_MARKDOWN_SHA256 = "2c4773511afe32d99ef44311406dbfeac42f4b3923696ef0fc59da56088eabe9";
-const EXPECTED_TOOL_CONTRACT_SHA256 = "77564e375ce70f9696d25bf5d1887cb105891a3096ee8b6777cf57572e1ba7f2";
+const EXPECTED_TOOL_CONTRACT_SHA256 = "91342726919adc874a2af77997cafae9d95c656246c7a3c2800b0372dbeafef0";
 const EXPECTED_PAGE_COUNT = 55;
 const EXPECTED_GAP_COUNT = 68;
 const EXPECTED_REPLACEMENT_CHARACTER_COUNT = 434;
@@ -81,7 +81,7 @@ try {
     });
     const value = result.structuredContent;
     assert(!result.isError && value, `Installed conversion failed for pages ${startPage}-${endPage}`);
-    assert(value.renderer?.version === "1.11.0", "Installed Markdown renderer version differs");
+    assert(value.renderer?.version === "1.12.0", "Installed Markdown renderer version differs");
     assert(value.provenance?.layout?.parser_version === "5.4.624", "Installed PDF parser version differs");
     assert(value.provenance?.source?.sha256 === sourceSha256, "Installed conversion source identity differs");
     assert(value.provenance?.layout?.page_range?.start_page === startPage, "Installed conversion start page differs");

--- a/scripts/macos-claude-installed-smoke.mjs
+++ b/scripts/macos-claude-installed-smoke.mjs
@@ -29,7 +29,7 @@ const textFixture = path.join(fixtureDirectory, "synthetic-text-two-page.pdf");
 const rasterFixture = path.join(fixtureDirectory, "synthetic-raster-only.pdf");
 const mutationDirectory = path.join(fixtureDirectory, "mutation-output");
 const toolNames = [];
-const EXPECTED_TOOL_CONTRACT_SHA256 = "77564e375ce70f9696d25bf5d1887cb105891a3096ee8b6777cf57572e1ba7f2";
+const EXPECTED_TOOL_CONTRACT_SHA256 = "91342726919adc874a2af77997cafae9d95c656246c7a3c2800b0372dbeafef0";
 let toolContractSha256;
 let structuredToolCount;
 let markdownHash;

--- a/scripts/smoke-mcpb.mjs
+++ b/scripts/smoke-mcpb.mjs
@@ -150,7 +150,7 @@ async function main() {
       arguments: { pdf_path: fixturePath, max_markdown_bytes: 200000 },
     });
     if (markdown.isError
-      || markdown.structuredContent?.renderer?.version !== "1.11.0"
+      || markdown.structuredContent?.renderer?.version !== "1.12.0"
       || markdown.structuredContent?.markdown_bytes !== Buffer.byteLength(markdown.structuredContent?.markdown || "", "utf8")
       || markdown.structuredContent?.markdown_sha256 !== sha256(Buffer.from(markdown.structuredContent?.markdown || "", "utf8"))) {
       throw new Error("Packed convert_pdf_to_markdown contract smoke failed");

--- a/scripts/test-share-contract.mjs
+++ b/scripts/test-share-contract.mjs
@@ -840,7 +840,7 @@ async function main() {
       arguments: { pdf_path: fixturePath, max_markdown_bytes: 200000 },
     });
     if (markdown.isError
-      || markdown.structuredContent?.renderer?.version !== "1.11.0"
+      || markdown.structuredContent?.renderer?.version !== "1.12.0"
       || markdown.structuredContent?.markdown_bytes !== Buffer.byteLength(markdown.structuredContent?.markdown || "", "utf8")
       || markdown.structuredContent?.markdown_sha256 !== sha256(Buffer.from(markdown.structuredContent?.markdown || "", "utf8"))) {
       throw new Error("Share convert_pdf_to_markdown contract smoke failed");

--- a/server/markdown-conversion.js
+++ b/server/markdown-conversion.js
@@ -6,7 +6,7 @@ import {
 
 const RENDERER = Object.freeze({
   name: "pdf-tools.layout-markdown-renderer",
-  version: "1.11.0",
+  version: "1.12.0",
 });
 const SUPPORTED_LAYOUT_IR_VERSION = "1.4.0";
 
@@ -254,11 +254,18 @@ function smallCapsNumberedHeadingEvidence(page, line, bodyHeight, headingWords) 
   if (heights.length < 3 || fontNames.size !== 1 || fontNames.has(null)) return false;
   const minimum = Math.min(...heights);
   const maximum = Math.max(...heights);
-  return minimum >= bodyHeight * 0.9
+  const enlargedInitials = minimum >= bodyHeight * 0.9
     && minimum <= bodyHeight * 1.05
     && maximum >= bodyHeight * 1.15
     && maximum <= bodyHeight * 1.3
     && maximum / minimum >= 1.15;
+  const bodySizedInitials = minimum >= bodyHeight * 0.75
+    && minimum <= bodyHeight * 0.85
+    && maximum >= bodyHeight * 0.95
+    && maximum <= bodyHeight * 1.05
+    && maximum / minimum >= 1.2
+    && maximum / minimum <= 1.3;
+  return enlargedInitials || bodySizedInitials;
 }
 
 function numberedSectionHeadingLevel(page, evidence, index, bodyHeight, bodyFontName, bodyLeft) {

--- a/server/output-schemas.js
+++ b/server/output-schemas.js
@@ -878,7 +878,7 @@ export const TOOL_SUCCESS_OUTPUT_SCHEMAS = Object.freeze({
   convert_pdf_to_markdown: object({
     renderer: object({
       name: { const: "pdf-tools.layout-markdown-renderer" },
-      version: { const: "1.11.0" },
+      version: { const: "1.12.0" },
     }),
     conversion_status: enumString(["complete", "partial", "failed"]),
     markdown: string,

--- a/test/convert-pdf-to-markdown.test.js
+++ b/test/convert-pdf-to-markdown.test.js
@@ -305,7 +305,7 @@ describe("convert_pdf_to_markdown MCP tool", () => {
     expect(first.isError).not.toBe(true);
     expect(second.structuredContent).toEqual(first.structuredContent);
     expect(first.structuredContent).toMatchObject({
-      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.11.0" },
+      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.12.0" },
       conversion_status: "complete",
       saved_output: null,
       provenance: {

--- a/test/eval/markdown-bakeoff.test.js
+++ b/test/eval/markdown-bakeoff.test.js
@@ -64,7 +64,7 @@ async function handle(message) {
     const pageBoundaries = Array.from({ length: pageCount }, (_, index) => "<!-- PDF page " + (index + 1) + " -->");
     const markdown = pageBoundaries.join("\n\n") + "\n\nINV-1001 fixture evidence\n";
     const value = {
-      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.11.0" },
+      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.12.0" },
       conversion_status: "complete",
       markdown,
       markdown_sha256: digest(Buffer.from(markdown)),
@@ -146,7 +146,7 @@ function resultFor(binding) {
   const markdown = "<!-- PDF page 1 -->\n\nFixture text\n";
   return {
     structuredContent: {
-      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.11.0" },
+      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.12.0" },
       conversion_status: "complete",
       markdown,
       markdown_sha256: sha256(Buffer.from(markdown)),
@@ -234,8 +234,8 @@ describe("Markdown bakeoff renderer version binding", () => {
   });
 
   it("accepts the current renderer version and rejects all superseded ones", () => {
-    expect(validateMarkdownResult(resultFor("1.11.0"), binding).renderer.version).toBe("1.11.0");
-    for (const stale of ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.6.0", "1.7.0", "1.8.0", "1.9.0", "1.10.0"]) {
+    expect(validateMarkdownResult(resultFor("1.12.0"), binding).renderer.version).toBe("1.12.0");
+    for (const stale of ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.6.0", "1.7.0", "1.8.0", "1.9.0", "1.10.0", "1.11.0"]) {
       expect(() => validateMarkdownResult(resultFor(stale), binding), stale)
         .toThrow(/Markdown result evidence is invalid/u);
     }

--- a/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
+++ b/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
@@ -67,14 +67,14 @@
     {
       "role": "markdown_conversion_module",
       "path": "server/markdown-conversion.js",
-      "bytes": 103217,
-      "sha256": "11516ed7a249c6e6a83eb6b61829b3c4606f3fe681654aa72e3f6def6891085d"
+      "bytes": 103513,
+      "sha256": "b49a580f87563a722cb376b66c7148a6dcb3239929552726fd8a696d64dfdae8"
     },
     {
       "role": "output_schemas_module",
       "path": "server/output-schemas.js",
       "bytes": 48015,
-      "sha256": "8c46fedf5c6e97a8420002e4346ca2806dddb7740557e4d69aab12152ab9d814"
+      "sha256": "61dbaf5e0b62ac1ec4d6f4f1f8a3bc0132bbb4ed781f7d736b395129fb01e0e0"
     },
     {
       "role": "package_json",
@@ -113,7 +113,7 @@
       "sha256": "6e4429db62fcbe1dd73141d8c20a48b564d41f8bf8920d88775846995e1daf94"
     }
   ],
-  "validator_source_set_sha256": "c88ace433c09da7ea4691eea0e0bf21393f6093b1826d527206607e3de0a8217",
+  "validator_source_set_sha256": "d78b4bbfaeb6c276b0193d76dfa15e38b989e6be9be67a8b5eeffea6c9dfed1b",
   "pdfjs_version": "5.4.624",
   "generation_contract": {
     "source_path": "source.pdf",

--- a/test/fixtures/eval/shannon/manifest.v1.json
+++ b/test/fixtures/eval/shannon/manifest.v1.json
@@ -22,7 +22,7 @@
     "pdf_tools": {
       "slot": "control.current_product.v0",
       "renderer_name": "pdf-tools.layout-markdown-renderer",
-      "renderer_version": "1.11.0",
+      "renderer_version": "1.12.0",
       "parser_name": "pdfjs-dist",
       "parser_version": "5.4.624"
     },

--- a/test/markdown-conversion.test.js
+++ b/test/markdown-conversion.test.js
@@ -364,7 +364,7 @@ describe("layout Markdown renderer", () => {
     // invocation, so any unreviewed serialized delta fails this regression.
     const serialized = JSON.stringify(pinnable);
     expect(createHash("sha256").update(serialized).digest("hex"))
-      .toBe("cd29e33513f44fc6d7e9e48e3400a0ca236834410f34629bcf25bd27ee37ce64");
+      .toBe("8543161d1af6514352da5b73db66c493167b7d851124def6870ba0590ec01716");
     const body = result.markdown.split("\n\n## Conversion gaps\n\n", 1)[0];
     expect(JSON.stringify({
       body,
@@ -372,7 +372,7 @@ describe("layout Markdown renderer", () => {
     })).toBe(NON_RECT_EXPECTED);
     expect(result.renderer).toEqual({
       name: "pdf-tools.layout-markdown-renderer",
-      version: "1.11.0",
+      version: "1.12.0",
     });
     expect(result.gaps[0].message).toMatch(/beyond reconstructed ruled or bounded solid-mask table grids/);
     expect(result.limitations.some(value => value.includes("clean ruled-rectangle grid evidence"))).toBe(true);
@@ -1118,6 +1118,23 @@ describe("layout Markdown renderer", () => {
     const result = renderPdfLayoutToMarkdown(layout, { includePageBoundaries: false });
 
     expect(result.markdown).toMatch(/^## 1 INTRODUCTION$/mu);
+  });
+
+  it("recognizes numbered small-caps subsections whose initials match the body height", async () => {
+    const layout = await validatedSyntheticLayout([{
+      items: [
+        textItem("Ordinary body text establishes the page font", { top: 40, left: 108, fontSize: 10 }),
+        positionedTextItem("6.1", { top: 80, left: 108, width: 14, fontSize: 10, fontName: "f1" }),
+        positionedTextItem("E", { top: 80, left: 132, width: 6, fontSize: 10, fontName: "f1" }),
+        positionedTextItem("XPERIMENT", { top: 82, left: 139, width: 48, fontSize: 8, fontName: "f1", eol: true }),
+        textItem("First ordinary line below the subsection", { top: 105, left: 108, fontSize: 10 }),
+        textItem("Second ordinary line keeps the body height stable", { top: 120, left: 108, fontSize: 10 }),
+        textItem("Third ordinary line completes body evidence", { top: 135, left: 108, fontSize: 10 }),
+      ],
+    }]);
+    const result = renderPdfLayoutToMarkdown(layout, { includePageBoundaries: false });
+
+    expect(result.markdown).toMatch(/^### 6\.1 EXPERIMENT$/mu);
   });
 
   it("refuses numbered-heading lookalikes without every structural witness", async () => {

--- a/test/mcp-contract.test.js
+++ b/test/mcp-contract.test.js
@@ -61,12 +61,12 @@ const EXAMPLE_PDF = path.join(REPO_ROOT, "example-fw9.pdf");
 // independently qualified exact legacy Computer Modern Type-3 glyphs.
 // 2026-08-04: Markdown renderer 1.9.0 restores only narrowly source-supported
 // boundaries between multiword prose and a separate uppercase math variable.
-// 2026-08-04: Markdown renderer 1.11.0 interprets only explicitly barred,
+// 2026-08-04: Markdown renderer 1.12.0 interprets only explicitly barred,
 // single-digit stacked fractions in an ordinary prose sandwich. The final
 // combined contract digest is refreshed after the integration replay.
 // 2026-08-04: additive deterministic compare_pdfs contract with source-bound
 // evidence, exact whole-document limits, and typed channel coverage.
-const TOOL_CONTRACT_SHA256 = "77564e375ce70f9696d25bf5d1887cb105891a3096ee8b6777cf57572e1ba7f2";
+const TOOL_CONTRACT_SHA256 = "91342726919adc874a2af77997cafae9d95c656246c7a3c2800b0372dbeafef0";
 
 const CLOSED_READ = Object.freeze({
   readOnlyHint: true,

--- a/test/mcp-contract.test.js
+++ b/test/mcp-contract.test.js
@@ -61,9 +61,12 @@ const EXAMPLE_PDF = path.join(REPO_ROOT, "example-fw9.pdf");
 // independently qualified exact legacy Computer Modern Type-3 glyphs.
 // 2026-08-04: Markdown renderer 1.9.0 restores only narrowly source-supported
 // boundaries between multiword prose and a separate uppercase math variable.
-// 2026-08-04: Markdown renderer 1.12.0 interprets only explicitly barred,
-// single-digit stacked fractions in an ordinary prose sandwich. The final
-// combined contract digest is refreshed after the integration replay.
+// 2026-08-04: Markdown renderer 1.10.0 interprets only explicitly barred,
+// single-digit stacked fractions in an ordinary prose sandwich.
+// 2026-08-04: Markdown renderer 1.11.0 recognizes fail-closed numbered
+// research headings and rejects narrow vertical labels.
+// 2026-08-04: Markdown renderer 1.12.0 accepts the second exact same-font
+// small-caps height relationship when heading initials match the body height.
 // 2026-08-04: additive deterministic compare_pdfs contract with source-bound
 // evidence, exact whole-document limits, and typed channel coverage.
 const TOOL_CONTRACT_SHA256 = "91342726919adc874a2af77997cafae9d95c656246c7a3c2800b0372dbeafef0";

--- a/test/numbered-research-headings-live.test.js
+++ b/test/numbered-research-headings-live.test.js
@@ -93,13 +93,21 @@ describe("external numbered research-paper headings", () => {
     expect(numberedHeadings(markdown)).toEqual([
       "1 INTRODUCTION",
       "2 ALGORITHM",
+      "2.1 ADAM’S UPDATE RULE",
       "3 INITIALIZATION BIAS CORRECTION",
       "4 CONVERGENCE ANALYSIS",
       "5 RELATED WORK",
       "6 EXPERIMENTS",
+      "6.1 EXPERIMENT: LOGISTIC REGRESSION",
+      "6.2 EXPERIMENT: MULTI-LAYER NEURAL NETWORKS",
+      "6.3 EXPERIMENT: CONVOLUTIONAL NEURAL NETWORKS",
+      "6.4 EXPERIMENT: BIAS-CORRECTION TERM",
       "7 EXTENSIONS",
+      "7.1 ADAMAX",
+      "7.2 TEMPORAL AVERAGING",
       "8 CONCLUSION",
       "10 APPENDIX",
+      "10.1 CONVERGENCE PROOF",
     ]);
     expect(markdown).not.toMatch(/^#{1,6}\s+arXiv:/gmu);
   }, 60_000);


### PR DESCRIPTION
## What changed

- recognize Adam's second exact same-font small-caps height relationship
- complete its numbered subsection hierarchy without joining or inventing text
- advance and bind the Markdown renderer contract to 1.12
- refresh generated layout evidence and cross-paper documentation

## Result

- Attention Is All You Need: remains 22/22 numbered headings
- Adam: improves from 9/17 to 17/17 genuinely numbered headings
- Adam's visibly unnumbered References title remains unnumbered
- vertical arXiv labels remain plain text
- Shannon's 55-page result remains byte-identical with every sampled score unchanged

## Safety boundary

The added lane requires the existing numbered syntax, uppercase heading text, same font, at least three source items, body-left alignment, a section break, bounded width, and an exact two-level height relationship. Independent boundary probes accepted the exact 8/10 relationship and rejected nearby 8.6/10 and 7.4/10 variants.

## Validation

- independent exact-commit review: ACCEPT
- focused checks: 162 passed, 6 unrelated/platform skips
- real hash-locked paper checks: 2/2
- complete suite: 2,000 passed, 84 skipped; one unrelated process-cleanup setup case missed its grandchild PID under aggregate load, then the complete file passed 22/22 immediately in isolation
- Shannon replay: three byte-identical full-paper runs, exact prior Markdown SHA
- reproducible share contract: 41 tools, 14 prompts, 112 SBOM components
- source/share runtime and schema files are byte-identical

This PR does not publish a release or contact Kepano. Pre-existing false generic headings on Adam's chart-heavy page 7 remain explicitly documented as separate follow-up work.
