### PR TITLE
Reject chart labels as headings

### DIFF
--- a/docs/evidence/general-numbered-research-headings-2026-08.md
+++ b/docs/evidence/general-numbered-research-headings-2026-08.md
@@ -80,11 +80,31 @@ tall vertical labels.
 Adam's eight previously missed subsections use the same source line, font, left
 edge, section break, and exact two-level small-caps geometry as the already
 recognized sections. The follow-up accepts that exact relationship without
-joining fragments or guessing text. The generic large-font detector still has
-pre-existing false headings on Adam's chart-heavy page 7; that is recorded as
-separate follow-up work and is not concealed by the numbered-heading result.
-Tables, figures, equations, and complete mathematical reconstruction are
-outside this claim.
+joining fragments or guessing text. Tables, figures, equations, and complete
+mathematical reconstruction are outside this claim.
+
+## Chart and diagram heading guard
+
+Exact follow-up implementation
+`e90e0ed57f308e46a7ca6507c13b0d1bc7172890` fixes a separate generic-heading
+failure exposed by the cross-paper review:
+
+- Adam page 7: eleven ordinary chart captions or prose lines falsely emitted as
+  H1 become plain text
+- Attention pages 13 through 15: three `Input-Input Layer5` diagram labels
+  falsely emitted as H1 become plain text
+- Both true paper titles remain H1
+- Attention remains 22/22 and Adam remains 17/17 for genuinely numbered
+  headings, with no other content headings
+
+The guard estimates ordinary body height from wide prose when a page contains
+many tiny chart labels. A generic enlarged-font heading must also be followed
+by a normal text line. The numbered-heading path remains independent. A bounded
+first-page title scan preserves centered title-case titles that appear after a
+short attribution preamble.
+
+The live tests now pin every content heading in both papers, not only the
+numbered subset, so a new chart or diagram false heading fails the test.
 
 ## Verification
 
@@ -104,5 +124,12 @@ outside this claim.
   `3c067c231ac77f4a5d0c7cfae6d3d8b55c880cc5f217d6d6bba8d3a1ac3fb1ec`;
   all three Markdown runs remain byte-identical at the previously recorded
   SHA-256 and all sampled quality scores remain unchanged
+- Chart-guard focused checks: 157 passed, 6 skipped; real-paper checks 2/2;
+  reproducible share contract passed with SHA-256
+  `c8e32fec5ea1d9d6204e1c0e83d158504cace0fe692fa1be3830940b2a797a2f`
+- Chart-guard Shannon report SHA-256:
+  `6cf36e04778c9baf04f309c08954c1910434f2a0588b91f57fc93804a26f8171`;
+  all three 55-page Markdown outputs remain byte-identical at SHA-256
+  `2c4773511afe32d99ef44311406dbfeac42f4b3923696ef0fc59da56088eabe9`
 
 No public release or Kepano reply is authorized by this evidence alone.

--- a/docs/evidence/general-numbered-research-headings-2026-08.md
+++ b/docs/evidence/general-numbered-research-headings-2026-08.md
@@ -86,7 +86,8 @@ mathematical reconstruction are outside this claim.
 ## Chart and diagram heading guard
 
 Exact follow-up implementation
-`e90e0ed57f308e46a7ca6507c13b0d1bc7172890` fixes a separate generic-heading
+`e90e0ed57f308e46a7ca6507c13b0d1bc7172890`, with exact compatibility repair
+tip `bec9fb4683aca1384391e7d8b3b43aaa7eef326d`, fixes a separate generic-heading
 failure exposed by the cross-paper review:
 
 - Adam page 7: eleven ordinary chart captions or prose lines falsely emitted as
@@ -105,6 +106,8 @@ short attribution preamble.
 
 The live tests now pin every content heading in both papers, not only the
 numbered subset, so a new chart or diagram false heading fails the test.
+The compatibility repair preserves the exact first-page structural title
+`CONTENTS`; it does not reopen generic chart-label promotion.
 
 ## Verification
 
@@ -126,7 +129,12 @@ numbered subset, so a new chart or diagram false heading fails the test.
   SHA-256 and all sampled quality scores remain unchanged
 - Chart-guard focused checks: 157 passed, 6 skipped; real-paper checks 2/2;
   reproducible share contract passed with SHA-256
-  `c8e32fec5ea1d9d6204e1c0e83d158504cace0fe692fa1be3830940b2a797a2f`
+  `30b320f8cca0b2a95a06671c75bc37961b3bb6f2cae408b88b763dc714b96e13`
+- Final focused bank after the contents-title repair: 166 passed, 6 skipped;
+  the aggregate suite passed 1,998 checks and exposed one real contents-title
+  regression plus three resource-load timeouts. After the repair, the exact
+  heading/baseline bank passed 77/77, the worker file 13/13, and the malformed
+  campaign 114/114 in isolated runs.
 - Chart-guard Shannon report SHA-256:
   `6cf36e04778c9baf04f309c08954c1910434f2a0588b91f57fc93804a26f8171`;
   all three 55-page Markdown outputs remain byte-identical at SHA-256

--- a/docs/handoffs/KEPANO_SHANNON.md
+++ b/docs/handoffs/KEPANO_SHANNON.md
@@ -134,6 +134,9 @@ lines from Adam's chart-heavy page 7 and three false H1 diagram labels from
 Attention pages 13 through 15. It preserves both true titles and the complete
 39/39 numbered-heading result. Shannon remains byte-identical with unchanged
 sampled quality.
+Exact compatibility repair tip `bec9fb4683aca1384391e7d8b3b43aaa7eef326d`
+preserves a true first-page `CONTENTS` title after the full-suite regression
+check without weakening the chart-label guard.
 
 The detailed evidence is
 `docs/evidence/general-numbered-research-headings-2026-08.md`. This is a

--- a/docs/handoffs/KEPANO_SHANNON.md
+++ b/docs/handoffs/KEPANO_SHANNON.md
@@ -128,6 +128,13 @@ is 22/22 and Adam is 17/17; Adam's References title is visibly unnumbered and
 stays unnumbered. Shannon's existing sampled quality is unchanged across three
 complete, byte-identical 55-page runs.
 
+The separate chart/diagram guard branch `agent/chart-heading-guard`, exact
+implementation `e90e0ed57f308e46a7ca6507c13b0d1bc7172890`, removes eleven false H1
+lines from Adam's chart-heavy page 7 and three false H1 diagram labels from
+Attention pages 13 through 15. It preserves both true titles and the complete
+39/39 numbered-heading result. Shannon remains byte-identical with unchanged
+sampled quality.
+
 The detailed evidence is
 `docs/evidence/general-numbered-research-headings-2026-08.md`. This is a
 merge-quality candidate, not a reason on its own to publish v0.9.5. Keep the
@@ -141,9 +148,8 @@ Maintainer retest requests for the current v0.9.4 package are open at:
 - macOS stable-tool exposure issue #47:
   `https://github.com/Open-Document-Alliance/PDF-Tools/issues/47#issuecomment-5186253859`
 
-Do not reply to Kepano yet. First merge the follow-up candidate cleanly and
-address or explicitly accept the pre-existing chart-page false-heading issue;
-a later reply should point to a tested public release, not unreleased master.
+Do not reply to Kepano yet. First merge the chart/diagram guard cleanly. A
+later reply should point to a tested public release, not unreleased master.
 
 ## Fast recovery commands
 

--- a/pdf-toolkit-mcp-share/server/markdown-conversion.js
+++ b/pdf-toolkit-mcp-share/server/markdown-conversion.js
@@ -6,7 +6,7 @@ import {
 
 const RENDERER = Object.freeze({
   name: "pdf-tools.layout-markdown-renderer",
-  version: "1.12.0",
+  version: "1.13.0",
 });
 const SUPPORTED_LAYOUT_IR_VERSION = "1.4.0";
 
@@ -245,6 +245,29 @@ function bodyLeftEdge(evidence, bodyHeight) {
   return bodyLines.length > 0 ? median(bodyLines) : null;
 }
 
+function pageBodyHeight(page, evidence) {
+  const heights = evidence.map(value => value.height).filter(Number.isFinite);
+  const pageWidth = page.geometry?.display_width;
+  if (!Number.isFinite(pageWidth)) return median(heights);
+  const proseHeights = evidence.filter(({ line, height }) => (
+    Number.isFinite(height)
+    && line.width >= pageWidth * 0.25
+    && (line.text.match(/[\p{L}\p{N}]/gu) ?? []).length >= 20
+  )).map(value => value.height);
+  return proseHeights.length >= 3 ? median(proseHeights) : median(heights);
+}
+
+function hasBodyTextAfter(page, evidence, index, bodyHeight) {
+  const next = evidence[index + 1];
+  if (!next || !Number.isFinite(page.geometry?.display_width) || !Number.isFinite(next.height)) return false;
+  const gap = next.line.y - (evidence[index].line.y + evidence[index].line.height);
+  return next.height >= bodyHeight * 0.9
+    && next.height <= bodyHeight * 1.1
+    && (next.line.text.match(/[\p{L}\p{N}]/gu) ?? []).length >= 10
+    && gap >= 0
+    && gap <= bodyHeight * 8;
+}
+
 function smallCapsNumberedHeadingEvidence(page, line, bodyHeight, headingWords) {
   if (headingWords !== headingWords.toLocaleUpperCase("en-US")) return false;
   const itemById = new Map(page.raw_items.map(item => [item.id, item]));
@@ -309,10 +332,12 @@ function structuralHeadingLevels(page, evidence, bodyHeight) {
     if (level !== null) structural.set(evidence[index].line.id, level);
   }
   if (page.page !== 1) return structural;
-  const titleCandidates = evidence.slice(0, 3).filter(({ line, height }) => (
+  const titleCandidates = evidence.filter(({ line, height }) => (
     headingTextEligible(line.text)
     && titleCaseHeading(line.text)
     && lineIsCentered(page, line)
+    && Number.isFinite(page.geometry?.display_height)
+    && line.y <= page.geometry.display_height * 0.35
     && Number.isFinite(height)
     && height >= bodyHeight * 1.2
   ));
@@ -330,17 +355,18 @@ function headingLevels(page) {
   const evidence = lineFontEvidence(page);
   const heights = evidence.map(value => value.height).filter(Number.isFinite);
   if (heights.length < 4) return new Map();
-  const bodyHeight = median(heights);
+  const bodyHeight = pageBodyHeight(page, evidence);
   const structural = structuralHeadingLevels(page, evidence, bodyHeight);
   const bodyEvidence = heights.filter(height => Math.abs(height - bodyHeight) <= bodyHeight * 0.1);
   if (bodyEvidence.length < 3) return structural;
-  const candidates = evidence.filter(({ line, height, consistentHeight, consistentFont }) => (
+  const candidates = evidence.filter(({ line, height, consistentHeight, consistentFont }, index) => (
     consistentHeight
       && consistentFont
       && height >= bodyHeight * 1.5
       && line.text.length > 0
       && line.text.length <= 120
       && headingTextEligible(line.text)
+      && hasBodyTextAfter(page, evidence, index, bodyHeight)
       && line.width >= line.height * 2
       && height <= bodyHeight * 4
       && !/[.!?;]$/u.test(line.text)

--- a/pdf-toolkit-mcp-share/server/markdown-conversion.js
+++ b/pdf-toolkit-mcp-share/server/markdown-conversion.js
@@ -312,8 +312,9 @@ function numberedSectionHeadingLevel(page, evidence, index, bodyHeight, bodyFont
 function structuralHeadingLevel(page, evidence, index, bodyHeight) {
   const line = evidence[index].line;
   const text = line.text.trim();
-  if (!headingTextEligible(text) || !lineIsCentered(page, line)
-    || !hasSectionBreakBefore(page, evidence, index, bodyHeight)) return null;
+  if (page.page === 1 && text === "CONTENTS" && headingTextEligible(text)) return 1;
+  if (!headingTextEligible(text) || !lineIsCentered(page, line)) return null;
+  if (!hasSectionBreakBefore(page, evidence, index, bodyHeight)) return null;
   if (page.page === 1 && text === "INTRODUCTION") return 2;
   if (/^PART\s+[IVXLCDM]+:\s+.+$/u.test(text) && text === text.toLocaleUpperCase("en-US")) return 2;
   if (/^APPENDIX\s+(?:\d+|[IVXLCDM]+)$/u.test(text)) return 2;

--- a/pdf-toolkit-mcp-share/server/output-schemas.js
+++ b/pdf-toolkit-mcp-share/server/output-schemas.js
@@ -878,7 +878,7 @@ export const TOOL_SUCCESS_OUTPUT_SCHEMAS = Object.freeze({
   convert_pdf_to_markdown: object({
     renderer: object({
       name: { const: "pdf-tools.layout-markdown-renderer" },
-      version: { const: "1.12.0" },
+      version: { const: "1.13.0" },
     }),
     conversion_status: enumString(["complete", "partial", "failed"]),
     markdown: string,

--- a/scripts/eval-run-markdown-bakeoff.mjs
+++ b/scripts/eval-run-markdown-bakeoff.mjs
@@ -193,7 +193,7 @@ export function validateMarkdownResult(result, binding) {
     throw new Error(`Markdown conversion failed for ${binding.fixture.id}`);
   }
   const value = result.structuredContent;
-  if (value.renderer?.name !== "pdf-tools.layout-markdown-renderer" || value.renderer?.version !== "1.12.0"
+  if (value.renderer?.name !== "pdf-tools.layout-markdown-renderer" || value.renderer?.version !== "1.13.0"
     || value.options?.include_page_boundaries !== true || value.limits?.max_markdown_bytes !== 200000
     || value.provenance?.source?.file_name !== binding.retained.filename
     || value.provenance?.source?.sha256 !== binding.retained.sha256

--- a/scripts/macos-claude-installed-shannon.mjs
+++ b/scripts/macos-claude-installed-shannon.mjs
@@ -13,7 +13,7 @@ if (!process.argv[2] || !process.argv[3]) {
 
 const EXPECTED_SOURCE_SHA256 = "6e4e3411984f3edf99dbfe8b941cb5e8a321379ff0cae6ae5c1f592ad8882ca8";
 const EXPECTED_MARKDOWN_SHA256 = "2c4773511afe32d99ef44311406dbfeac42f4b3923696ef0fc59da56088eabe9";
-const EXPECTED_TOOL_CONTRACT_SHA256 = "91342726919adc874a2af77997cafae9d95c656246c7a3c2800b0372dbeafef0";
+const EXPECTED_TOOL_CONTRACT_SHA256 = "5953b963a95d73056b8bd27341aad62200fecf9c434af3db6601ee978081dce4";
 const EXPECTED_PAGE_COUNT = 55;
 const EXPECTED_GAP_COUNT = 68;
 const EXPECTED_REPLACEMENT_CHARACTER_COUNT = 434;
@@ -81,7 +81,7 @@ try {
     });
     const value = result.structuredContent;
     assert(!result.isError && value, `Installed conversion failed for pages ${startPage}-${endPage}`);
-    assert(value.renderer?.version === "1.12.0", "Installed Markdown renderer version differs");
+    assert(value.renderer?.version === "1.13.0", "Installed Markdown renderer version differs");
     assert(value.provenance?.layout?.parser_version === "5.4.624", "Installed PDF parser version differs");
     assert(value.provenance?.source?.sha256 === sourceSha256, "Installed conversion source identity differs");
     assert(value.provenance?.layout?.page_range?.start_page === startPage, "Installed conversion start page differs");

--- a/scripts/macos-claude-installed-smoke.mjs
+++ b/scripts/macos-claude-installed-smoke.mjs
@@ -29,7 +29,7 @@ const textFixture = path.join(fixtureDirectory, "synthetic-text-two-page.pdf");
 const rasterFixture = path.join(fixtureDirectory, "synthetic-raster-only.pdf");
 const mutationDirectory = path.join(fixtureDirectory, "mutation-output");
 const toolNames = [];
-const EXPECTED_TOOL_CONTRACT_SHA256 = "91342726919adc874a2af77997cafae9d95c656246c7a3c2800b0372dbeafef0";
+const EXPECTED_TOOL_CONTRACT_SHA256 = "5953b963a95d73056b8bd27341aad62200fecf9c434af3db6601ee978081dce4";
 let toolContractSha256;
 let structuredToolCount;
 let markdownHash;

--- a/scripts/smoke-mcpb.mjs
+++ b/scripts/smoke-mcpb.mjs
@@ -150,7 +150,7 @@ async function main() {
       arguments: { pdf_path: fixturePath, max_markdown_bytes: 200000 },
     });
     if (markdown.isError
-      || markdown.structuredContent?.renderer?.version !== "1.12.0"
+      || markdown.structuredContent?.renderer?.version !== "1.13.0"
       || markdown.structuredContent?.markdown_bytes !== Buffer.byteLength(markdown.structuredContent?.markdown || "", "utf8")
       || markdown.structuredContent?.markdown_sha256 !== sha256(Buffer.from(markdown.structuredContent?.markdown || "", "utf8"))) {
       throw new Error("Packed convert_pdf_to_markdown contract smoke failed");

--- a/scripts/test-share-contract.mjs
+++ b/scripts/test-share-contract.mjs
@@ -840,7 +840,7 @@ async function main() {
       arguments: { pdf_path: fixturePath, max_markdown_bytes: 200000 },
     });
     if (markdown.isError
-      || markdown.structuredContent?.renderer?.version !== "1.12.0"
+      || markdown.structuredContent?.renderer?.version !== "1.13.0"
       || markdown.structuredContent?.markdown_bytes !== Buffer.byteLength(markdown.structuredContent?.markdown || "", "utf8")
       || markdown.structuredContent?.markdown_sha256 !== sha256(Buffer.from(markdown.structuredContent?.markdown || "", "utf8"))) {
       throw new Error("Share convert_pdf_to_markdown contract smoke failed");

--- a/server/markdown-conversion.js
+++ b/server/markdown-conversion.js
@@ -6,7 +6,7 @@ import {
 
 const RENDERER = Object.freeze({
   name: "pdf-tools.layout-markdown-renderer",
-  version: "1.12.0",
+  version: "1.13.0",
 });
 const SUPPORTED_LAYOUT_IR_VERSION = "1.4.0";
 
@@ -245,6 +245,29 @@ function bodyLeftEdge(evidence, bodyHeight) {
   return bodyLines.length > 0 ? median(bodyLines) : null;
 }
 
+function pageBodyHeight(page, evidence) {
+  const heights = evidence.map(value => value.height).filter(Number.isFinite);
+  const pageWidth = page.geometry?.display_width;
+  if (!Number.isFinite(pageWidth)) return median(heights);
+  const proseHeights = evidence.filter(({ line, height }) => (
+    Number.isFinite(height)
+    && line.width >= pageWidth * 0.25
+    && (line.text.match(/[\p{L}\p{N}]/gu) ?? []).length >= 20
+  )).map(value => value.height);
+  return proseHeights.length >= 3 ? median(proseHeights) : median(heights);
+}
+
+function hasBodyTextAfter(page, evidence, index, bodyHeight) {
+  const next = evidence[index + 1];
+  if (!next || !Number.isFinite(page.geometry?.display_width) || !Number.isFinite(next.height)) return false;
+  const gap = next.line.y - (evidence[index].line.y + evidence[index].line.height);
+  return next.height >= bodyHeight * 0.9
+    && next.height <= bodyHeight * 1.1
+    && (next.line.text.match(/[\p{L}\p{N}]/gu) ?? []).length >= 10
+    && gap >= 0
+    && gap <= bodyHeight * 8;
+}
+
 function smallCapsNumberedHeadingEvidence(page, line, bodyHeight, headingWords) {
   if (headingWords !== headingWords.toLocaleUpperCase("en-US")) return false;
   const itemById = new Map(page.raw_items.map(item => [item.id, item]));
@@ -309,10 +332,12 @@ function structuralHeadingLevels(page, evidence, bodyHeight) {
     if (level !== null) structural.set(evidence[index].line.id, level);
   }
   if (page.page !== 1) return structural;
-  const titleCandidates = evidence.slice(0, 3).filter(({ line, height }) => (
+  const titleCandidates = evidence.filter(({ line, height }) => (
     headingTextEligible(line.text)
     && titleCaseHeading(line.text)
     && lineIsCentered(page, line)
+    && Number.isFinite(page.geometry?.display_height)
+    && line.y <= page.geometry.display_height * 0.35
     && Number.isFinite(height)
     && height >= bodyHeight * 1.2
   ));
@@ -330,17 +355,18 @@ function headingLevels(page) {
   const evidence = lineFontEvidence(page);
   const heights = evidence.map(value => value.height).filter(Number.isFinite);
   if (heights.length < 4) return new Map();
-  const bodyHeight = median(heights);
+  const bodyHeight = pageBodyHeight(page, evidence);
   const structural = structuralHeadingLevels(page, evidence, bodyHeight);
   const bodyEvidence = heights.filter(height => Math.abs(height - bodyHeight) <= bodyHeight * 0.1);
   if (bodyEvidence.length < 3) return structural;
-  const candidates = evidence.filter(({ line, height, consistentHeight, consistentFont }) => (
+  const candidates = evidence.filter(({ line, height, consistentHeight, consistentFont }, index) => (
     consistentHeight
       && consistentFont
       && height >= bodyHeight * 1.5
       && line.text.length > 0
       && line.text.length <= 120
       && headingTextEligible(line.text)
+      && hasBodyTextAfter(page, evidence, index, bodyHeight)
       && line.width >= line.height * 2
       && height <= bodyHeight * 4
       && !/[.!?;]$/u.test(line.text)

--- a/server/markdown-conversion.js
+++ b/server/markdown-conversion.js
@@ -312,8 +312,9 @@ function numberedSectionHeadingLevel(page, evidence, index, bodyHeight, bodyFont
 function structuralHeadingLevel(page, evidence, index, bodyHeight) {
   const line = evidence[index].line;
   const text = line.text.trim();
-  if (!headingTextEligible(text) || !lineIsCentered(page, line)
-    || !hasSectionBreakBefore(page, evidence, index, bodyHeight)) return null;
+  if (page.page === 1 && text === "CONTENTS" && headingTextEligible(text)) return 1;
+  if (!headingTextEligible(text) || !lineIsCentered(page, line)) return null;
+  if (!hasSectionBreakBefore(page, evidence, index, bodyHeight)) return null;
   if (page.page === 1 && text === "INTRODUCTION") return 2;
   if (/^PART\s+[IVXLCDM]+:\s+.+$/u.test(text) && text === text.toLocaleUpperCase("en-US")) return 2;
   if (/^APPENDIX\s+(?:\d+|[IVXLCDM]+)$/u.test(text)) return 2;

--- a/server/output-schemas.js
+++ b/server/output-schemas.js
@@ -878,7 +878,7 @@ export const TOOL_SUCCESS_OUTPUT_SCHEMAS = Object.freeze({
   convert_pdf_to_markdown: object({
     renderer: object({
       name: { const: "pdf-tools.layout-markdown-renderer" },
-      version: { const: "1.12.0" },
+      version: { const: "1.13.0" },
     }),
     conversion_status: enumString(["complete", "partial", "failed"]),
     markdown: string,

--- a/test/convert-pdf-to-markdown.test.js
+++ b/test/convert-pdf-to-markdown.test.js
@@ -305,7 +305,7 @@ describe("convert_pdf_to_markdown MCP tool", () => {
     expect(first.isError).not.toBe(true);
     expect(second.structuredContent).toEqual(first.structuredContent);
     expect(first.structuredContent).toMatchObject({
-      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.12.0" },
+      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.13.0" },
       conversion_status: "complete",
       saved_output: null,
       provenance: {

--- a/test/eval/markdown-bakeoff.test.js
+++ b/test/eval/markdown-bakeoff.test.js
@@ -64,7 +64,7 @@ async function handle(message) {
     const pageBoundaries = Array.from({ length: pageCount }, (_, index) => "<!-- PDF page " + (index + 1) + " -->");
     const markdown = pageBoundaries.join("\n\n") + "\n\nINV-1001 fixture evidence\n";
     const value = {
-      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.12.0" },
+      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.13.0" },
       conversion_status: "complete",
       markdown,
       markdown_sha256: digest(Buffer.from(markdown)),
@@ -146,7 +146,7 @@ function resultFor(binding) {
   const markdown = "<!-- PDF page 1 -->\n\nFixture text\n";
   return {
     structuredContent: {
-      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.12.0" },
+      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.13.0" },
       conversion_status: "complete",
       markdown,
       markdown_sha256: sha256(Buffer.from(markdown)),
@@ -234,8 +234,8 @@ describe("Markdown bakeoff renderer version binding", () => {
   });
 
   it("accepts the current renderer version and rejects all superseded ones", () => {
-    expect(validateMarkdownResult(resultFor("1.12.0"), binding).renderer.version).toBe("1.12.0");
-    for (const stale of ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.6.0", "1.7.0", "1.8.0", "1.9.0", "1.10.0", "1.11.0"]) {
+    expect(validateMarkdownResult(resultFor("1.13.0"), binding).renderer.version).toBe("1.13.0");
+    for (const stale of ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.6.0", "1.7.0", "1.8.0", "1.9.0", "1.10.0", "1.11.0", "1.12.0"]) {
       expect(() => validateMarkdownResult(resultFor(stale), binding), stale)
         .toThrow(/Markdown result evidence is invalid/u);
     }

--- a/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
+++ b/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
@@ -67,8 +67,8 @@
     {
       "role": "markdown_conversion_module",
       "path": "server/markdown-conversion.js",
-      "bytes": 104713,
-      "sha256": "4fb3791893154db53af95cde2eca9ce2ebb23352c71d6c147a19141f6877d05c"
+      "bytes": 104811,
+      "sha256": "1561a68998c77959ff8a9eec01562342818a7fc03025e5da1768d49285c1c810"
     },
     {
       "role": "output_schemas_module",
@@ -113,7 +113,7 @@
       "sha256": "6e4429db62fcbe1dd73141d8c20a48b564d41f8bf8920d88775846995e1daf94"
     }
   ],
-  "validator_source_set_sha256": "2df04a933cd2a9c4fa4832eb21b4e2628d082b968673d8edf1ba0959cc7257cb",
+  "validator_source_set_sha256": "0d738a919485a557246eb0eb61ca427b49feb8dbd0c88b750e877efc7524d7b2",
   "pdfjs_version": "5.4.624",
   "generation_contract": {
     "source_path": "source.pdf",

--- a/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
+++ b/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
@@ -67,14 +67,14 @@
     {
       "role": "markdown_conversion_module",
       "path": "server/markdown-conversion.js",
-      "bytes": 103513,
-      "sha256": "b49a580f87563a722cb376b66c7148a6dcb3239929552726fd8a696d64dfdae8"
+      "bytes": 104713,
+      "sha256": "4fb3791893154db53af95cde2eca9ce2ebb23352c71d6c147a19141f6877d05c"
     },
     {
       "role": "output_schemas_module",
       "path": "server/output-schemas.js",
       "bytes": 48015,
-      "sha256": "61dbaf5e0b62ac1ec4d6f4f1f8a3bc0132bbb4ed781f7d736b395129fb01e0e0"
+      "sha256": "de3be1f85f6524fd90504135fdee9b8c1daad54bd8d6800834307c3f192cf53a"
     },
     {
       "role": "package_json",
@@ -113,7 +113,7 @@
       "sha256": "6e4429db62fcbe1dd73141d8c20a48b564d41f8bf8920d88775846995e1daf94"
     }
   ],
-  "validator_source_set_sha256": "d78b4bbfaeb6c276b0193d76dfa15e38b989e6be9be67a8b5eeffea6c9dfed1b",
+  "validator_source_set_sha256": "2df04a933cd2a9c4fa4832eb21b4e2628d082b968673d8edf1ba0959cc7257cb",
   "pdfjs_version": "5.4.624",
   "generation_contract": {
     "source_path": "source.pdf",

--- a/test/fixtures/eval/shannon/manifest.v1.json
+++ b/test/fixtures/eval/shannon/manifest.v1.json
@@ -22,7 +22,7 @@
     "pdf_tools": {
       "slot": "control.current_product.v0",
       "renderer_name": "pdf-tools.layout-markdown-renderer",
-      "renderer_version": "1.12.0",
+      "renderer_version": "1.13.0",
       "parser_name": "pdfjs-dist",
       "parser_version": "5.4.624"
     },

--- a/test/markdown-conversion.test.js
+++ b/test/markdown-conversion.test.js
@@ -364,7 +364,7 @@ describe("layout Markdown renderer", () => {
     // invocation, so any unreviewed serialized delta fails this regression.
     const serialized = JSON.stringify(pinnable);
     expect(createHash("sha256").update(serialized).digest("hex"))
-      .toBe("8543161d1af6514352da5b73db66c493167b7d851124def6870ba0590ec01716");
+      .toBe("a0d64f0c2fbd9b39685a9e2ae1fff3af5a5ff7cba40c70411f0d3d4cc0986ab0");
     const body = result.markdown.split("\n\n## Conversion gaps\n\n", 1)[0];
     expect(JSON.stringify({
       body,
@@ -372,7 +372,7 @@ describe("layout Markdown renderer", () => {
     })).toBe(NON_RECT_EXPECTED);
     expect(result.renderer).toEqual({
       name: "pdf-tools.layout-markdown-renderer",
-      version: "1.12.0",
+      version: "1.13.0",
     });
     expect(result.gaps[0].message).toMatch(/beyond reconstructed ruled or bounded solid-mask table grids/);
     expect(result.limitations.some(value => value.includes("clean ruled-rectangle grid evidence"))).toBe(true);
@@ -1171,6 +1171,29 @@ describe("layout Markdown renderer", () => {
 
     expect(result.markdown).toContain("arXiv:1706.03762v7 \\[cs&#46;CL\\] 2 Aug 2023");
     expect(result.markdown).not.toMatch(/^#{1,6}\s+arXiv:/gmu);
+  });
+
+  it("does not let dense chart labels redefine ordinary prose as headings", async () => {
+    const layout = await validatedSyntheticLayout([{
+      items: [
+        textItem("Input-Input Layer5", { top: 20, left: 108, fontSize: 20 }),
+        textItem("0", { top: 40, left: 120, fontSize: 4 }),
+        textItem("20", { top: 46, left: 140, fontSize: 4 }),
+        textItem("40", { top: 52, left: 160, fontSize: 4 }),
+        textItem("60", { top: 58, left: 180, fontSize: 4 }),
+        textItem("80", { top: 64, left: 200, fontSize: 4 }),
+        textItem("100", { top: 70, left: 220, fontSize: 4 }),
+        textItem("training cost", { top: 76, left: 240, fontSize: 4 }),
+        textItem("Adam", { top: 82, left: 260, fontSize: 4 }),
+        textItem("Figure 2: Training results for the complete experiment", { top: 120, left: 108, fontSize: 10 }),
+        textItem("Ordinary prose continues beneath the chart without a heading", { top: 140, left: 108, fontSize: 10 }),
+        textItem("Another full body line explains the experimental comparison", { top: 155, left: 108, fontSize: 10 }),
+        textItem("The final body line preserves the page reading flow", { top: 170, left: 108, fontSize: 10 }),
+      ],
+    }]);
+    const result = renderPdfLayoutToMarkdown(layout, { includePageBoundaries: false });
+
+    expect(result.markdown).not.toMatch(/^#{1,6}\s+(?:Input-Input|Figure 2:|Ordinary prose|Another full|The final)/gmu);
   });
 
   it("emits at most one first-page H1 when a title and subtitle share the strongest style", async () => {

--- a/test/markdown-conversion.test.js
+++ b/test/markdown-conversion.test.js
@@ -1196,6 +1196,21 @@ describe("layout Markdown renderer", () => {
     expect(result.markdown).not.toMatch(/^#{1,6}\s+(?:Input-Input|Figure 2:|Ordinary prose|Another full|The final)/gmu);
   });
 
+  it("preserves an exact centered first-page contents title", async () => {
+    const layout = await validatedSyntheticLayout([{
+      items: [
+        centeredTextItem("CONTENTS", { top: 50, fontSize: 18 }),
+        textItem("Preface ... ii", { top: 90, left: 108, fontSize: 10 }),
+        textItem("Chapter 1: Scope ... 1", { top: 110, left: 108, fontSize: 10 }),
+        textItem("Chapter 2: Inputs ... 7", { top: 130, left: 108, fontSize: 10 }),
+        textItem("Chapter 3: Methods ... 12", { top: 150, left: 108, fontSize: 10 }),
+      ],
+    }]);
+    const result = renderPdfLayoutToMarkdown(layout, { includePageBoundaries: false });
+
+    expect(result.markdown).toMatch(/^# CONTENTS$/mu);
+  });
+
   it("emits at most one first-page H1 when a title and subtitle share the strongest style", async () => {
     const layout = await validatedSyntheticLayout([{
       items: [

--- a/test/mcp-contract.test.js
+++ b/test/mcp-contract.test.js
@@ -67,9 +67,11 @@ const EXAMPLE_PDF = path.join(REPO_ROOT, "example-fw9.pdf");
 // research headings and rejects narrow vertical labels.
 // 2026-08-04: Markdown renderer 1.12.0 accepts the second exact same-font
 // small-caps height relationship when heading initials match the body height.
+// 2026-08-04: Markdown renderer 1.13.0 uses wide prose to estimate body height
+// on chart-heavy pages and requires generic enlarged headings to lead text.
 // 2026-08-04: additive deterministic compare_pdfs contract with source-bound
 // evidence, exact whole-document limits, and typed channel coverage.
-const TOOL_CONTRACT_SHA256 = "91342726919adc874a2af77997cafae9d95c656246c7a3c2800b0372dbeafef0";
+const TOOL_CONTRACT_SHA256 = "5953b963a95d73056b8bd27341aad62200fecf9c434af3db6601ee978081dce4";
 
 const CLOSED_READ = Object.freeze({
   readOnlyHint: true,

--- a/test/numbered-research-headings-live.test.js
+++ b/test/numbered-research-headings-live.test.js
@@ -51,6 +51,12 @@ function numberedHeadings(markdown) {
     .map(match => match[1]);
 }
 
+function contentHeadings(markdown) {
+  return [...markdown.matchAll(/^(#{1,6})\s+(.+)$/gmu)]
+    .map(match => `${match[1]} ${match[2]}`)
+    .filter(heading => heading !== "## Conversion gaps" && heading !== "## Conversion limitations");
+}
+
 describe("external numbered research-paper headings", () => {
   it.runIf(Boolean(ATTENTION_SOURCE))("recovers the complete numbered hierarchy in Attention Is All You Need", async () => {
     const markdown = await renderExternalPdf(
@@ -83,6 +89,31 @@ describe("external numbered research-paper headings", () => {
     ]);
     expect(markdown).toMatch(/^# Attention Is All You Need$/mu);
     expect(markdown).not.toMatch(/^#{1,6}\s+arXiv:/gmu);
+    expect(contentHeadings(markdown)).toEqual([
+      "# Attention Is All You Need",
+      "## 1 Introduction",
+      "## 2 Background",
+      "## 3 Model Architecture",
+      "### 3.1 Encoder and Decoder Stacks",
+      "### 3.2 Attention",
+      "#### 3.2.1 Scaled Dot-Product Attention",
+      "#### 3.2.2 Multi-Head Attention",
+      "#### 3.2.3 Applications of Attention in our Model",
+      "### 3.3 Position-wise Feed-Forward Networks",
+      "### 3.4 Embeddings and Softmax",
+      "### 3.5 Positional Encoding",
+      "## 4 Why Self-Attention",
+      "## 5 Training",
+      "### 5.1 Training Data and Batching",
+      "### 5.2 Hardware and Schedule",
+      "### 5.3 Optimizer",
+      "### 5.4 Regularization",
+      "## 6 Results",
+      "### 6.1 Machine Translation",
+      "### 6.2 Model Variations",
+      "### 6.3 English Constituency Parsing",
+      "## 7 Conclusion",
+    ]);
   }, 60_000);
 
   it.runIf(Boolean(ADAM_SOURCE))("recovers only the currently proven Adam small-caps main sections", async () => {
@@ -110,5 +141,25 @@ describe("external numbered research-paper headings", () => {
       "10.1 CONVERGENCE PROOF",
     ]);
     expect(markdown).not.toMatch(/^#{1,6}\s+arXiv:/gmu);
+    expect(contentHeadings(markdown)).toEqual([
+      "# ADAM: A METHOD FOR STOCHASTIC OPTIMIZATION",
+      "## 1 INTRODUCTION",
+      "## 2 ALGORITHM",
+      "### 2.1 ADAM’S UPDATE RULE",
+      "## 3 INITIALIZATION BIAS CORRECTION",
+      "## 4 CONVERGENCE ANALYSIS",
+      "## 5 RELATED WORK",
+      "## 6 EXPERIMENTS",
+      "### 6.1 EXPERIMENT: LOGISTIC REGRESSION",
+      "### 6.2 EXPERIMENT: MULTI-LAYER NEURAL NETWORKS",
+      "### 6.3 EXPERIMENT: CONVOLUTIONAL NEURAL NETWORKS",
+      "### 6.4 EXPERIMENT: BIAS-CORRECTION TERM",
+      "## 7 EXTENSIONS",
+      "### 7.1 ADAMAX",
+      "### 7.2 TEMPORAL AVERAGING",
+      "## 8 CONCLUSION",
+      "## 10 APPENDIX",
+      "### 10.1 CONVERGENCE PROOF",
+    ]);
   }, 60_000);
 });


### PR DESCRIPTION
## What changed

- estimate body text from wide prose on chart-heavy pages
- require generic enlarged headings to lead a normal text line
- preserve bounded first-page titles, including the exact structural title `CONTENTS`
- pin complete content-heading arrays for the Transformer and Adam papers
- advance the renderer contract to 1.13 and refresh generated evidence

## Result

- Adam page 7: 11 false H1 chart-caption/prose lines removed
- Attention pages 13–15: 3 false H1 diagram labels removed
- Attention remains 22/22 numbered headings
- Adam remains 17/17 numbered headings
- both real paper titles remain H1
- the genuine compact-TOC `CONTENTS` title remains H1
- Shannon remains byte-identical across three complete runs

## Validation

- independent exact implementation and compatibility-repair reviews: ACCEPT
- final focused bank: 166 passed, 6 unrelated/platform skips
- live hash-locked paper checks: 2/2, asserting every content heading
- complete aggregate run: 1,998 passed, 84 skipped; it exposed the repaired `CONTENTS` regression plus three resource-load timeouts
- all reported aggregate failures then passed cleanly: heading/baseline 77/77, worker 13/13, malformed campaign 114/114
- share contract: 41 tools, 14 prompts, 112 SBOM components, reproducible SHA `30b320f8cca0b2a95a06671c75bc37961b3bb6f2cae408b88b763dc714b96e13`
- source/share runtime files are byte-identical

One intentional precision-over-recall choice remains: the visible `Attention Visualizations` chart label stays plain text because it does not introduce body prose.

This PR does not publish a release or contact Kepano.
