### PR TITLE
Improve two-column research paper headings

### DIFF
--- a/docs/evidence/general-numbered-research-headings-2026-08.md
+++ b/docs/evidence/general-numbered-research-headings-2026-08.md
@@ -5,9 +5,9 @@ Date: 2026-08-04 (America/Los_Angeles)
 ## Decision
 
 The candidate is safe to merge as a general extraction improvement, but it is
-not a release by itself. It recovers numbered research-paper headings only when
-the PDF supplies consistent geometric evidence, and it rejects narrow vertical
-labels such as the arXiv margin stamp.
+not a release by itself. It recovers numbered and lettered research-paper
+headings only when the PDF supplies consistent geometric evidence, and it
+rejects narrow vertical labels such as the arXiv margin stamp.
 
 ## Public sources
 
@@ -44,6 +44,28 @@ labels such as the arXiv margin stamp.
 Across the two papers, numbered-heading recall moves from 0 of 39 to 39 of 39,
 and false arXiv-label headings move from two to zero.
 
+### BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding
+
+- Source: `https://arxiv.org/pdf/1810.04805`
+- PDF SHA-256:
+  `5692a5514787a8c6727b4ff3b726a3385798bc68e12138d1d4af83947e2acf6e`
+- Pages: 16
+- Visually checked rendered pages: 1, 2, 8, 12, 13, and 16
+- Pre-trial master: 6 of 31 content headings
+- Candidate: 31 of 31 content headings with the correct hierarchy, including
+  the wrapped two-line title, the centered three-line appendix title, both body
+  columns, six numbered main sections, numbered subsections, and lettered A/B/C
+  appendix sections and subsections
+- Candidate Markdown: 86,071 bytes, zero replacement characters, zero explicit
+  gaps, SHA-256
+  `b6ddd6dcf982a4c7cea5418d9ed93b5af64413ce34d74e36e298cebb744c06c5`
+- The vertical arXiv stamp, figure and table labels, diagram text, and inline
+  bold labels remain plain text rather than headings
+
+Across Attention, Adam, and BERT, the candidate now pins every visually proven
+research-paper heading: 39 of 39 in the first two papers and 31 of 31 content
+headings in the independent two-column BERT trial.
+
 ## Content preservation
 
 After removing only Markdown heading markers and the expected renderer
@@ -71,11 +93,14 @@ the expected renderer limitation-line revision.
 
 ## Fail-closed boundary
 
-The numbered-heading path accepts one to three numeric hierarchy levels and an
-uppercase-leading title. It requires body-left alignment, a section break,
-bounded width and height, and either a consistent distinct font or exact
-same-font small-caps geometry. It rejects terminal punctuation and narrow,
-tall vertical labels.
+The research-heading path accepts one to three numeric hierarchy levels or an
+uppercase letter with one numeric subsection level and an uppercase-leading
+title. It requires an independently established body margin, a section break,
+bounded width and height, and either a consistent distinct font, a small
+enlargement, or exact same-font small-caps geometry. A continuation is joined
+only when the source supplies the same font and height, a very small vertical
+gap, and tightly bounded horizontal alignment. Narrow, tall vertical labels
+remain rejected.
 
 Adam's eight previously missed subsections use the same source line, font, left
 edge, section break, and exact two-level small-caps geometry as the already
@@ -139,5 +164,30 @@ The compatibility repair preserves the exact first-page structural title
   `6cf36e04778c9baf04f309c08954c1910434f2a0588b91f57fc93804a26f8171`;
   all three 55-page Markdown outputs remain byte-identical at SHA-256
   `2c4773511afe32d99ef44311406dbfeac42f4b3923696ef0fc59da56088eabe9`
+- Fourth-paper live check: BERT 31/31 content headings, zero false content
+  headings, zero replacement characters, and zero explicit gaps; focused
+  renderer and live-paper checks passed after refreshing the renderer-version
+  oracle.
+- Final focused bank with all three public research papers and the refreshed
+  extraction-integrity oracle: 167 passed and 6
+  optional checks skipped.
+- Reproducible share contract: 41 tools, 14 prompts, 112 SBOM components, and
+  SHA-256
+  `132c9c3f45551be58794819ff09ab9d1744b45ff5c0e8792ca13b261355d9148`.
+- Fourth-paper Shannon replay report SHA-256:
+  `6b389f586d1171317d7fd7161001addfd75fb23642cdaea7e584938f1ce58620`;
+  all three complete 55-page outputs are byte-identical at Markdown SHA-256
+  `4cdc3a17728bb07100752ad841745a5ecf49a0aade0cd39af69bca899217e203`.
+  Shannon's extracted content remains byte-identical to the prior candidate;
+  only the renderer's heading-limitations disclosure changes.
+- The installed-copy Shannon checker was refreshed to the renderer 1.14 tool
+  contract and output identity, then passed against the exact candidate
+  runtime: 55 pages, 68 gaps, 434 replacement characters, 49 recovered alpha
+  symbols, 183,927 bytes, and Markdown SHA-256
+  `4cdc3a17728bb07100752ad841745a5ecf49a0aade0cd39af69bca899217e203`.
+- The aggregate suite stalled after unrelated extraction-evaluation failures
+  under parallel load, including a missing optional native canvas binding in
+  this fresh worktree. Those files are outside the Markdown renderer path; the
+  exact focused banks above and the reproducible share contract pass.
 
 No public release or Kepano reply is authorized by this evidence alone.

--- a/docs/handoffs/KEPANO_SHANNON.md
+++ b/docs/handoffs/KEPANO_SHANNON.md
@@ -144,6 +144,21 @@ merge-quality candidate, not a reason on its own to publish v0.9.5. Keep the
 installed and public package on exact v0.9.4 until a worthy release bundle is
 ready.
 
+A fourth independent trial now uses the 16-page BERT paper, an ACL-style
+two-column document with tables, figures, wrapped headings, and lettered
+appendices. Pre-trial master recovered only 6 of its 31 content headings. The
+candidate recovers all 31 with the correct hierarchy, including the full
+two-line title, the centered three-line appendix title, and A/B/C appendix
+structure, while leaving the vertical arXiv stamp, chart labels, and inline
+bold labels as plain text. The exact PDF is
+hash-locked at
+`5692a5514787a8c6727b4ff3b726a3385798bc68e12138d1d4af83947e2acf6e`;
+the candidate Markdown is 86,071 bytes with zero replacement characters, zero
+explicit gaps, and SHA-256
+`b6ddd6dcf982a4c7cea5418d9ed93b5af64413ce34d74e36e298cebb744c06c5`.
+This is worthy merge evidence, but it remains deliberately unreleased pending
+the rest of the v0.9.5 bundle and independent review.
+
 Maintainer retest requests for the current v0.9.4 package are open at:
 
 - Windows issue #42:

--- a/pdf-toolkit-mcp-share/server/markdown-conversion.js
+++ b/pdf-toolkit-mcp-share/server/markdown-conversion.js
@@ -6,7 +6,7 @@ import {
 
 const RENDERER = Object.freeze({
   name: "pdf-tools.layout-markdown-renderer",
-  version: "1.13.0",
+  version: "1.14.0",
 });
 const SUPPORTED_LAYOUT_IR_VERSION = "1.4.0";
 
@@ -69,7 +69,7 @@ const GAP_CODES = new Set([
 ]);
 
 const LIMITATIONS = Object.freeze([
-  "Headings are emitted only from consistent enlarged font metrics, centered English-language source structure with section spacing, or left-aligned numbered research-paper structure with spacing plus either font contrast or exact small-caps geometry. Narrow vertical labels and ambiguous, very short, or unsupported heading styles remain body text.",
+  "Headings are emitted only from consistent enlarged font metrics, centered English-language source structure with section spacing, or numbered or lettered research-paper structure at an established body margin with spacing plus font, size, or exact small-caps evidence. Wrapped heading lines are joined only from matching font and height, a very small vertical gap, and bounded alignment. Narrow vertical labels and ambiguous, very short, or unsupported heading styles remain body text.",
   "A geometrically overlapping initial capital may be joined to its following uppercase word remainder. Line-end hyphens are preserved because source geometry cannot reliably distinguish a split word from an intentional compound. The source Extraction IR retains the original lines.",
   "A missing space after a separate source text item that is exactly the mathematical operator log is restored only in a short, compact left-to-right math run when a single-letter variable from a different source font resource follows on the same baseline with a small positive geometric gap and independent local math-layout evidence. A missing prose-to-variable space is restored only when a multiword prose item, a separate uppercase letter from a different source font resource, and continuing prose from the original prose font share one baseline with distinct positive boundary gaps, and the same letter/font pair occurs in a nearby compact equation on the same page and column. An inline single-digit stacked fraction is rendered only when consecutive same-font source items, explicit source whitespace, smaller exactly aligned numerator and denominator digits, ordinary prose on both sides, and exactly one thin matching solid-mask bar agree. A small version-pinned registry may recover a legacy Computer Modern Type-3 character only after an exact official-metric family match, exact target and two-witness glyph-program matches, and a complete operator/text sequence binding. General equations, scripts, other fraction bars, unregistered raster variants, and other damaged mathematical glyphs remain source reading-order text rather than being guessed.",
   "Lists are emitted only for literal bullet glyphs or decimal markers present in the source text.",
@@ -195,7 +195,7 @@ function headingTextEligible(value) {
 }
 
 function titleCaseHeading(value) {
-  const words = String(value).trim().match(/[\p{L}\p{N}]+/gu) ?? [];
+  const words = String(value).trim().match(/[\p{L}\p{N}]+(?:-[\p{L}\p{N}]+)*/gu) ?? [];
   if (words.length < 3 || words.length > 15) return false;
   const minorWords = new Set(["a", "an", "and", "as", "at", "by", "for", "in", "of", "on", "or", "the", "to"]);
   return words.every((word, index) => {
@@ -224,6 +224,17 @@ function hasSectionBreakBefore(page, evidence, index, bodyHeight) {
   return gap >= Math.max(line.height, bodyHeight) * 1.15;
 }
 
+function hasNumberedSectionBreakBefore(page, evidence, index, bodyHeight) {
+  const line = evidence[index].line;
+  if (index === 0) {
+    return Number.isFinite(page.geometry?.display_height)
+      && line.y >= page.geometry.display_height * 0.07;
+  }
+  const previous = evidence[index - 1].line;
+  const gap = line.y - (previous.y + previous.height);
+  return gap >= Math.max(line.height, bodyHeight) * 0.8;
+}
+
 function dominantBodyFont(page, bodyHeight) {
   const weights = new Map();
   for (const item of page.raw_items) {
@@ -236,13 +247,33 @@ function dominantBodyFont(page, bodyHeight) {
   return [...weights.entries()].sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]))[0]?.[0] ?? null;
 }
 
-function bodyLeftEdge(evidence, bodyHeight) {
+function bodyLeftAligned(evidence, bodyHeight, line) {
   const bodyLines = evidence.filter(({ line, height }) => (
     Number.isFinite(height)
     && Math.abs(height - bodyHeight) <= bodyHeight * 0.1
     && line.text.trim().length >= 20
   )).map(({ line }) => line.x).filter(Number.isFinite);
-  return bodyLines.length > 0 ? median(bodyLines) : null;
+  return Number.isFinite(line.x)
+    && bodyLines.filter(x => Math.abs(x - line.x) <= Math.max(4, bodyHeight)).length >= 3;
+}
+
+function lineIsBodyColumnCentered(page, evidence, bodyHeight, line) {
+  const pageWidth = page.geometry?.display_width;
+  if (!Number.isFinite(pageWidth)) return false;
+  const lineCenter = line.x + line.width / 2;
+  const sameHalf = candidate => (candidate.x + candidate.width / 2 < pageWidth / 2)
+    === (lineCenter < pageWidth / 2);
+  const prose = evidence.filter(({ line: candidate, height }) => (
+    Number.isFinite(height)
+    && Math.abs(height - bodyHeight) <= bodyHeight * 0.1
+    && candidate.width >= pageWidth * 0.25
+    && (candidate.text.match(/[\p{L}\p{N}]/gu) ?? []).length >= 20
+    && sameHalf(candidate)
+  )).map(({ line: candidate }) => candidate);
+  if (prose.length < 3) return false;
+  const columnCenter = (median(prose.map(candidate => candidate.x))
+    + median(prose.map(candidate => candidate.x + candidate.width))) / 2;
+  return Math.abs(lineCenter - columnCenter) <= Math.max(4, line.height);
 }
 
 function pageBodyHeight(page, evidence) {
@@ -291,22 +322,52 @@ function smallCapsNumberedHeadingEvidence(page, line, bodyHeight, headingWords) 
   return enlargedInitials || bodySizedInitials;
 }
 
-function numberedSectionHeadingLevel(page, evidence, index, bodyHeight, bodyFontName, bodyLeft) {
+function numberedSectionHeadingLevel(page, evidence, index, bodyHeight, bodyFontName) {
   const { line, height, consistentHeight, consistentFont, fontName } = evidence[index];
   const text = line.text.trim();
-  const match = text.match(/^(\d{1,3})(?:\.(\d{1,3}))?(?:\.(\d{1,3}))?\s+([\p{Lu}][^\n]{1,100})$/u);
+  const match = text.match(/^(?:(\d{1,3})(?:\.(\d{1,3}))?(?:\.(\d{1,3}))?|([A-Z])(?:\.(\d{1,3}))?)\s+([\p{Lu}][^\n]{1,100})$/u);
   const pageWidth = page.geometry?.display_width;
   const contrastingFontEvidence = consistentHeight && consistentFont && fontName && fontName !== bodyFontName
     && Number.isFinite(height) && height >= bodyHeight * 0.95 && height <= bodyHeight * 1.35;
+  const enlargedTextEvidence = consistentHeight && consistentFont
+    && Number.isFinite(height) && height >= bodyHeight * 1.08 && height <= bodyHeight * 1.35;
   const smallCapsEvidence = match
-    ? smallCapsNumberedHeadingEvidence(page, line, bodyHeight, match[4])
+    ? smallCapsNumberedHeadingEvidence(page, line, bodyHeight, match[6])
     : false;
   if (!match || !headingTextEligible(text) || /[.!?;:]$/u.test(text)
-    || (!contrastingFontEvidence && !smallCapsEvidence)
+    || (!contrastingFontEvidence && !enlargedTextEvidence && !smallCapsEvidence)
     || !Number.isFinite(pageWidth) || line.width < line.height * 2 || line.width > pageWidth * 0.7
-    || !Number.isFinite(bodyLeft) || Math.abs(line.x - bodyLeft) > Math.max(4, bodyHeight)
-    || !hasSectionBreakBefore(page, evidence, index, bodyHeight)) return null;
+    || !bodyLeftAligned(evidence, bodyHeight, line)
+    || !hasNumberedSectionBreakBefore(page, evidence, index, bodyHeight)) return null;
+  if (match[4] !== undefined) return match[5] === undefined ? 2 : 3;
   return match[3] === undefined ? (match[2] === undefined ? 2 : 3) : 4;
+}
+
+function wrappedResearchTitleLevel(page, evidence, index, bodyHeight, bodyFontName) {
+  const first = evidence[index];
+  if (!first.consistentHeight || !first.consistentFont || !first.fontName
+    || !Number.isFinite(first.height)
+    || first.height < bodyHeight * 1.08 || first.height > bodyHeight * 1.35
+    || (first.fontName === bodyFontName && first.height < bodyHeight * 1.15)
+    || !lineIsBodyColumnCentered(page, evidence, bodyHeight, first.line)
+    || !hasSectionBreakBefore(page, evidence, index, bodyHeight)
+    || /^(?:Figure|Table|Algorithm)\b/iu.test(first.line.text.trim())) return null;
+  let end = index;
+  while (end < evidence.length - 1 && end - index < 2) {
+    const current = evidence[end];
+    const next = evidence[end + 1];
+    const gap = next.line.y - (current.line.y + current.line.height);
+    if (!next.consistentHeight || !next.consistentFont
+      || next.fontName !== first.fontName
+      || !Number.isFinite(next.height)
+      || Math.abs(next.height - first.height) > first.height * 0.05
+      || gap < 0 || gap > Math.max(4, bodyHeight * 0.5)
+      || !lineIsBodyColumnCentered(page, evidence, bodyHeight, next.line)) break;
+    end += 1;
+  }
+  if (end === index || !hasBodyTextAfter(page, evidence, end, bodyHeight)) return null;
+  const text = evidence.slice(index, end + 1).map(item => item.line.text.trim()).join(" ");
+  return headingTextEligible(text) && titleCaseHeading(text) ? 2 : null;
 }
 
 function structuralHeadingLevel(page, evidence, index, bodyHeight) {
@@ -327,10 +388,11 @@ function structuralHeadingLevels(page, evidence, bodyHeight) {
     return level === null ? [] : [[line.id, level]];
   }));
   const bodyFontName = dominantBodyFont(page, bodyHeight);
-  const bodyLeft = bodyLeftEdge(evidence, bodyHeight);
   for (let index = 0; index < evidence.length; index += 1) {
-    const level = numberedSectionHeadingLevel(page, evidence, index, bodyHeight, bodyFontName, bodyLeft);
+    const level = numberedSectionHeadingLevel(page, evidence, index, bodyHeight, bodyFontName);
     if (level !== null) structural.set(evidence[index].line.id, level);
+    const wrappedLevel = wrappedResearchTitleLevel(page, evidence, index, bodyHeight, bodyFontName);
+    if (wrappedLevel !== null) structural.set(evidence[index].line.id, wrappedLevel);
   }
   if (page.page !== 1) return structural;
   const titleCandidates = evidence.filter(({ line, height }) => (
@@ -384,6 +446,31 @@ function headingLevels(page) {
     }
   }
   return combined;
+}
+
+function headingContinuationIds(page, headings) {
+  const evidence = lineFontEvidence(page);
+  const bodyHeight = pageBodyHeight(page, evidence);
+  const continuations = new Set();
+  for (let index = 0; index < evidence.length - 1; index += 1) {
+    const current = evidence[index];
+    const next = evidence[index + 1];
+    if ((!headings.has(current.line.id) && !continuations.has(current.line.id)) || headings.has(next.line.id)
+      || !current.consistentHeight || !next.consistentHeight
+      || !current.consistentFont || !next.consistentFont
+      || current.fontName !== next.fontName
+      || !Number.isFinite(current.height) || !Number.isFinite(next.height)
+      || Math.abs(current.height - next.height) > current.height * 0.05
+      || !headingTextEligible(next.line.text)) continue;
+    const gap = next.line.y - (current.line.y + current.line.height);
+    const aligned = (next.line.x >= current.line.x - Math.max(4, bodyHeight * 0.25)
+        && next.line.x - current.line.x <= bodyHeight * 3)
+      || (lineIsCentered(page, current.line) && lineIsCentered(page, next.line));
+    if (gap >= 0 && gap <= Math.max(4, bodyHeight * 0.5) && aligned) {
+      continuations.add(next.line.id);
+    }
+  }
+  return continuations;
 }
 
 /**
@@ -2035,12 +2122,30 @@ function joinParagraphContinuity(records) {
   return joined;
 }
 
+function joinHeadingContinuations(records) {
+  const joined = [];
+  for (const record of records) {
+    const previous = joined[joined.length - 1];
+    if (record.headingContinuation && previous?.headingLevel) {
+      joined[joined.length - 1] = {
+        ...previous,
+        text: `${previous.text} ${record.text}`,
+        sourceText: `${previous.sourceText} ${record.sourceText}`,
+      };
+    } else {
+      joined.push(record);
+    }
+  }
+  return joined;
+}
+
 function renderPage(page, {
   compact = false,
   pageBoundaryBefore = false,
   pageBoundaryAfter = false,
 } = {}) {
   const headings = headingLevels(page);
+  const headingContinuations = headingContinuationIds(page, headings);
   const analysis = segmentPageLines(page);
   const linkState = analyzePageLinks(page, analysis, headings);
   const unsafePage = analysis.tableReason !== null
@@ -2066,7 +2171,8 @@ function renderPage(page, {
         if (fractionPlan.skipped.has(line.id)) return [];
         const spans = linkState.spansByLine.get(line.id);
         const offsets = linkState.offsetsByLine.get(line.id);
-        if (spans && spans.length > 0 && offsets && !headings.get(line.id)) {
+        if (spans && spans.length > 0 && offsets && !headings.get(line.id)
+          && !headingContinuations.has(line.id)) {
           const linked = renderLinkedLine(line, offsets, spans);
           if (linked !== null) {
             return {
@@ -2099,10 +2205,12 @@ function renderPage(page, {
           normalizable: true,
           line,
           joinable: projectedText === null && !headings.get(line.id) && !rewritesLineStructure(line),
+          headingLevel: headings.get(line.id),
+          headingContinuation: headingContinuations.has(line.id),
         };
       });
   });
-  const entries = joinParagraphContinuity(records);
+  const entries = joinParagraphContinuity(joinHeadingContinuations(records));
   const normalized = compact
     ? normalizePlainLines(entries, { page: page.page, pageBoundaryBefore, pageBoundaryAfter })
     : { lines: entries.map(entry => entry.text), normalizations: emptyNormalizations() };

--- a/pdf-toolkit-mcp-share/server/output-schemas.js
+++ b/pdf-toolkit-mcp-share/server/output-schemas.js
@@ -878,7 +878,7 @@ export const TOOL_SUCCESS_OUTPUT_SCHEMAS = Object.freeze({
   convert_pdf_to_markdown: object({
     renderer: object({
       name: { const: "pdf-tools.layout-markdown-renderer" },
-      version: { const: "1.13.0" },
+      version: { const: "1.14.0" },
     }),
     conversion_status: enumString(["complete", "partial", "failed"]),
     markdown: string,

--- a/scripts/eval-run-markdown-bakeoff.mjs
+++ b/scripts/eval-run-markdown-bakeoff.mjs
@@ -193,7 +193,7 @@ export function validateMarkdownResult(result, binding) {
     throw new Error(`Markdown conversion failed for ${binding.fixture.id}`);
   }
   const value = result.structuredContent;
-  if (value.renderer?.name !== "pdf-tools.layout-markdown-renderer" || value.renderer?.version !== "1.13.0"
+  if (value.renderer?.name !== "pdf-tools.layout-markdown-renderer" || value.renderer?.version !== "1.14.0"
     || value.options?.include_page_boundaries !== true || value.limits?.max_markdown_bytes !== 200000
     || value.provenance?.source?.file_name !== binding.retained.filename
     || value.provenance?.source?.sha256 !== binding.retained.sha256

--- a/scripts/macos-claude-installed-shannon.mjs
+++ b/scripts/macos-claude-installed-shannon.mjs
@@ -12,13 +12,13 @@ if (!process.argv[2] || !process.argv[3]) {
 }
 
 const EXPECTED_SOURCE_SHA256 = "6e4e3411984f3edf99dbfe8b941cb5e8a321379ff0cae6ae5c1f592ad8882ca8";
-const EXPECTED_MARKDOWN_SHA256 = "2c4773511afe32d99ef44311406dbfeac42f4b3923696ef0fc59da56088eabe9";
-const EXPECTED_TOOL_CONTRACT_SHA256 = "5953b963a95d73056b8bd27341aad62200fecf9c434af3db6601ee978081dce4";
+const EXPECTED_MARKDOWN_SHA256 = "4cdc3a17728bb07100752ad841745a5ecf49a0aade0cd39af69bca899217e203";
+const EXPECTED_TOOL_CONTRACT_SHA256 = "7087e97e1be2f6a52138517d66169177aa08ca5017f69235af33e62603b54c9e";
 const EXPECTED_PAGE_COUNT = 55;
 const EXPECTED_GAP_COUNT = 68;
 const EXPECTED_REPLACEMENT_CHARACTER_COUNT = 434;
 const EXPECTED_ALPHA_COUNT = 49;
-const EXPECTED_MARKDOWN_BYTES = 183093;
+const EXPECTED_MARKDOWN_BYTES = 183927;
 const PAGE_SPAN = 10;
 
 function sha256(bytes) {
@@ -81,7 +81,7 @@ try {
     });
     const value = result.structuredContent;
     assert(!result.isError && value, `Installed conversion failed for pages ${startPage}-${endPage}`);
-    assert(value.renderer?.version === "1.13.0", "Installed Markdown renderer version differs");
+    assert(value.renderer?.version === "1.14.0", "Installed Markdown renderer version differs");
     assert(value.provenance?.layout?.parser_version === "5.4.624", "Installed PDF parser version differs");
     assert(value.provenance?.source?.sha256 === sourceSha256, "Installed conversion source identity differs");
     assert(value.provenance?.layout?.page_range?.start_page === startPage, "Installed conversion start page differs");

--- a/scripts/macos-claude-installed-smoke.mjs
+++ b/scripts/macos-claude-installed-smoke.mjs
@@ -29,7 +29,7 @@ const textFixture = path.join(fixtureDirectory, "synthetic-text-two-page.pdf");
 const rasterFixture = path.join(fixtureDirectory, "synthetic-raster-only.pdf");
 const mutationDirectory = path.join(fixtureDirectory, "mutation-output");
 const toolNames = [];
-const EXPECTED_TOOL_CONTRACT_SHA256 = "5953b963a95d73056b8bd27341aad62200fecf9c434af3db6601ee978081dce4";
+const EXPECTED_TOOL_CONTRACT_SHA256 = "7087e97e1be2f6a52138517d66169177aa08ca5017f69235af33e62603b54c9e";
 let toolContractSha256;
 let structuredToolCount;
 let markdownHash;

--- a/scripts/smoke-mcpb.mjs
+++ b/scripts/smoke-mcpb.mjs
@@ -150,7 +150,7 @@ async function main() {
       arguments: { pdf_path: fixturePath, max_markdown_bytes: 200000 },
     });
     if (markdown.isError
-      || markdown.structuredContent?.renderer?.version !== "1.13.0"
+      || markdown.structuredContent?.renderer?.version !== "1.14.0"
       || markdown.structuredContent?.markdown_bytes !== Buffer.byteLength(markdown.structuredContent?.markdown || "", "utf8")
       || markdown.structuredContent?.markdown_sha256 !== sha256(Buffer.from(markdown.structuredContent?.markdown || "", "utf8"))) {
       throw new Error("Packed convert_pdf_to_markdown contract smoke failed");

--- a/scripts/test-share-contract.mjs
+++ b/scripts/test-share-contract.mjs
@@ -840,7 +840,7 @@ async function main() {
       arguments: { pdf_path: fixturePath, max_markdown_bytes: 200000 },
     });
     if (markdown.isError
-      || markdown.structuredContent?.renderer?.version !== "1.13.0"
+      || markdown.structuredContent?.renderer?.version !== "1.14.0"
       || markdown.structuredContent?.markdown_bytes !== Buffer.byteLength(markdown.structuredContent?.markdown || "", "utf8")
       || markdown.structuredContent?.markdown_sha256 !== sha256(Buffer.from(markdown.structuredContent?.markdown || "", "utf8"))) {
       throw new Error("Share convert_pdf_to_markdown contract smoke failed");

--- a/server/markdown-conversion.js
+++ b/server/markdown-conversion.js
@@ -6,7 +6,7 @@ import {
 
 const RENDERER = Object.freeze({
   name: "pdf-tools.layout-markdown-renderer",
-  version: "1.13.0",
+  version: "1.14.0",
 });
 const SUPPORTED_LAYOUT_IR_VERSION = "1.4.0";
 
@@ -69,7 +69,7 @@ const GAP_CODES = new Set([
 ]);
 
 const LIMITATIONS = Object.freeze([
-  "Headings are emitted only from consistent enlarged font metrics, centered English-language source structure with section spacing, or left-aligned numbered research-paper structure with spacing plus either font contrast or exact small-caps geometry. Narrow vertical labels and ambiguous, very short, or unsupported heading styles remain body text.",
+  "Headings are emitted only from consistent enlarged font metrics, centered English-language source structure with section spacing, or numbered or lettered research-paper structure at an established body margin with spacing plus font, size, or exact small-caps evidence. Wrapped heading lines are joined only from matching font and height, a very small vertical gap, and bounded alignment. Narrow vertical labels and ambiguous, very short, or unsupported heading styles remain body text.",
   "A geometrically overlapping initial capital may be joined to its following uppercase word remainder. Line-end hyphens are preserved because source geometry cannot reliably distinguish a split word from an intentional compound. The source Extraction IR retains the original lines.",
   "A missing space after a separate source text item that is exactly the mathematical operator log is restored only in a short, compact left-to-right math run when a single-letter variable from a different source font resource follows on the same baseline with a small positive geometric gap and independent local math-layout evidence. A missing prose-to-variable space is restored only when a multiword prose item, a separate uppercase letter from a different source font resource, and continuing prose from the original prose font share one baseline with distinct positive boundary gaps, and the same letter/font pair occurs in a nearby compact equation on the same page and column. An inline single-digit stacked fraction is rendered only when consecutive same-font source items, explicit source whitespace, smaller exactly aligned numerator and denominator digits, ordinary prose on both sides, and exactly one thin matching solid-mask bar agree. A small version-pinned registry may recover a legacy Computer Modern Type-3 character only after an exact official-metric family match, exact target and two-witness glyph-program matches, and a complete operator/text sequence binding. General equations, scripts, other fraction bars, unregistered raster variants, and other damaged mathematical glyphs remain source reading-order text rather than being guessed.",
   "Lists are emitted only for literal bullet glyphs or decimal markers present in the source text.",
@@ -195,7 +195,7 @@ function headingTextEligible(value) {
 }
 
 function titleCaseHeading(value) {
-  const words = String(value).trim().match(/[\p{L}\p{N}]+/gu) ?? [];
+  const words = String(value).trim().match(/[\p{L}\p{N}]+(?:-[\p{L}\p{N}]+)*/gu) ?? [];
   if (words.length < 3 || words.length > 15) return false;
   const minorWords = new Set(["a", "an", "and", "as", "at", "by", "for", "in", "of", "on", "or", "the", "to"]);
   return words.every((word, index) => {
@@ -224,6 +224,17 @@ function hasSectionBreakBefore(page, evidence, index, bodyHeight) {
   return gap >= Math.max(line.height, bodyHeight) * 1.15;
 }
 
+function hasNumberedSectionBreakBefore(page, evidence, index, bodyHeight) {
+  const line = evidence[index].line;
+  if (index === 0) {
+    return Number.isFinite(page.geometry?.display_height)
+      && line.y >= page.geometry.display_height * 0.07;
+  }
+  const previous = evidence[index - 1].line;
+  const gap = line.y - (previous.y + previous.height);
+  return gap >= Math.max(line.height, bodyHeight) * 0.8;
+}
+
 function dominantBodyFont(page, bodyHeight) {
   const weights = new Map();
   for (const item of page.raw_items) {
@@ -236,13 +247,33 @@ function dominantBodyFont(page, bodyHeight) {
   return [...weights.entries()].sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]))[0]?.[0] ?? null;
 }
 
-function bodyLeftEdge(evidence, bodyHeight) {
+function bodyLeftAligned(evidence, bodyHeight, line) {
   const bodyLines = evidence.filter(({ line, height }) => (
     Number.isFinite(height)
     && Math.abs(height - bodyHeight) <= bodyHeight * 0.1
     && line.text.trim().length >= 20
   )).map(({ line }) => line.x).filter(Number.isFinite);
-  return bodyLines.length > 0 ? median(bodyLines) : null;
+  return Number.isFinite(line.x)
+    && bodyLines.filter(x => Math.abs(x - line.x) <= Math.max(4, bodyHeight)).length >= 3;
+}
+
+function lineIsBodyColumnCentered(page, evidence, bodyHeight, line) {
+  const pageWidth = page.geometry?.display_width;
+  if (!Number.isFinite(pageWidth)) return false;
+  const lineCenter = line.x + line.width / 2;
+  const sameHalf = candidate => (candidate.x + candidate.width / 2 < pageWidth / 2)
+    === (lineCenter < pageWidth / 2);
+  const prose = evidence.filter(({ line: candidate, height }) => (
+    Number.isFinite(height)
+    && Math.abs(height - bodyHeight) <= bodyHeight * 0.1
+    && candidate.width >= pageWidth * 0.25
+    && (candidate.text.match(/[\p{L}\p{N}]/gu) ?? []).length >= 20
+    && sameHalf(candidate)
+  )).map(({ line: candidate }) => candidate);
+  if (prose.length < 3) return false;
+  const columnCenter = (median(prose.map(candidate => candidate.x))
+    + median(prose.map(candidate => candidate.x + candidate.width))) / 2;
+  return Math.abs(lineCenter - columnCenter) <= Math.max(4, line.height);
 }
 
 function pageBodyHeight(page, evidence) {
@@ -291,22 +322,52 @@ function smallCapsNumberedHeadingEvidence(page, line, bodyHeight, headingWords) 
   return enlargedInitials || bodySizedInitials;
 }
 
-function numberedSectionHeadingLevel(page, evidence, index, bodyHeight, bodyFontName, bodyLeft) {
+function numberedSectionHeadingLevel(page, evidence, index, bodyHeight, bodyFontName) {
   const { line, height, consistentHeight, consistentFont, fontName } = evidence[index];
   const text = line.text.trim();
-  const match = text.match(/^(\d{1,3})(?:\.(\d{1,3}))?(?:\.(\d{1,3}))?\s+([\p{Lu}][^\n]{1,100})$/u);
+  const match = text.match(/^(?:(\d{1,3})(?:\.(\d{1,3}))?(?:\.(\d{1,3}))?|([A-Z])(?:\.(\d{1,3}))?)\s+([\p{Lu}][^\n]{1,100})$/u);
   const pageWidth = page.geometry?.display_width;
   const contrastingFontEvidence = consistentHeight && consistentFont && fontName && fontName !== bodyFontName
     && Number.isFinite(height) && height >= bodyHeight * 0.95 && height <= bodyHeight * 1.35;
+  const enlargedTextEvidence = consistentHeight && consistentFont
+    && Number.isFinite(height) && height >= bodyHeight * 1.08 && height <= bodyHeight * 1.35;
   const smallCapsEvidence = match
-    ? smallCapsNumberedHeadingEvidence(page, line, bodyHeight, match[4])
+    ? smallCapsNumberedHeadingEvidence(page, line, bodyHeight, match[6])
     : false;
   if (!match || !headingTextEligible(text) || /[.!?;:]$/u.test(text)
-    || (!contrastingFontEvidence && !smallCapsEvidence)
+    || (!contrastingFontEvidence && !enlargedTextEvidence && !smallCapsEvidence)
     || !Number.isFinite(pageWidth) || line.width < line.height * 2 || line.width > pageWidth * 0.7
-    || !Number.isFinite(bodyLeft) || Math.abs(line.x - bodyLeft) > Math.max(4, bodyHeight)
-    || !hasSectionBreakBefore(page, evidence, index, bodyHeight)) return null;
+    || !bodyLeftAligned(evidence, bodyHeight, line)
+    || !hasNumberedSectionBreakBefore(page, evidence, index, bodyHeight)) return null;
+  if (match[4] !== undefined) return match[5] === undefined ? 2 : 3;
   return match[3] === undefined ? (match[2] === undefined ? 2 : 3) : 4;
+}
+
+function wrappedResearchTitleLevel(page, evidence, index, bodyHeight, bodyFontName) {
+  const first = evidence[index];
+  if (!first.consistentHeight || !first.consistentFont || !first.fontName
+    || !Number.isFinite(first.height)
+    || first.height < bodyHeight * 1.08 || first.height > bodyHeight * 1.35
+    || (first.fontName === bodyFontName && first.height < bodyHeight * 1.15)
+    || !lineIsBodyColumnCentered(page, evidence, bodyHeight, first.line)
+    || !hasSectionBreakBefore(page, evidence, index, bodyHeight)
+    || /^(?:Figure|Table|Algorithm)\b/iu.test(first.line.text.trim())) return null;
+  let end = index;
+  while (end < evidence.length - 1 && end - index < 2) {
+    const current = evidence[end];
+    const next = evidence[end + 1];
+    const gap = next.line.y - (current.line.y + current.line.height);
+    if (!next.consistentHeight || !next.consistentFont
+      || next.fontName !== first.fontName
+      || !Number.isFinite(next.height)
+      || Math.abs(next.height - first.height) > first.height * 0.05
+      || gap < 0 || gap > Math.max(4, bodyHeight * 0.5)
+      || !lineIsBodyColumnCentered(page, evidence, bodyHeight, next.line)) break;
+    end += 1;
+  }
+  if (end === index || !hasBodyTextAfter(page, evidence, end, bodyHeight)) return null;
+  const text = evidence.slice(index, end + 1).map(item => item.line.text.trim()).join(" ");
+  return headingTextEligible(text) && titleCaseHeading(text) ? 2 : null;
 }
 
 function structuralHeadingLevel(page, evidence, index, bodyHeight) {
@@ -327,10 +388,11 @@ function structuralHeadingLevels(page, evidence, bodyHeight) {
     return level === null ? [] : [[line.id, level]];
   }));
   const bodyFontName = dominantBodyFont(page, bodyHeight);
-  const bodyLeft = bodyLeftEdge(evidence, bodyHeight);
   for (let index = 0; index < evidence.length; index += 1) {
-    const level = numberedSectionHeadingLevel(page, evidence, index, bodyHeight, bodyFontName, bodyLeft);
+    const level = numberedSectionHeadingLevel(page, evidence, index, bodyHeight, bodyFontName);
     if (level !== null) structural.set(evidence[index].line.id, level);
+    const wrappedLevel = wrappedResearchTitleLevel(page, evidence, index, bodyHeight, bodyFontName);
+    if (wrappedLevel !== null) structural.set(evidence[index].line.id, wrappedLevel);
   }
   if (page.page !== 1) return structural;
   const titleCandidates = evidence.filter(({ line, height }) => (
@@ -384,6 +446,31 @@ function headingLevels(page) {
     }
   }
   return combined;
+}
+
+function headingContinuationIds(page, headings) {
+  const evidence = lineFontEvidence(page);
+  const bodyHeight = pageBodyHeight(page, evidence);
+  const continuations = new Set();
+  for (let index = 0; index < evidence.length - 1; index += 1) {
+    const current = evidence[index];
+    const next = evidence[index + 1];
+    if ((!headings.has(current.line.id) && !continuations.has(current.line.id)) || headings.has(next.line.id)
+      || !current.consistentHeight || !next.consistentHeight
+      || !current.consistentFont || !next.consistentFont
+      || current.fontName !== next.fontName
+      || !Number.isFinite(current.height) || !Number.isFinite(next.height)
+      || Math.abs(current.height - next.height) > current.height * 0.05
+      || !headingTextEligible(next.line.text)) continue;
+    const gap = next.line.y - (current.line.y + current.line.height);
+    const aligned = (next.line.x >= current.line.x - Math.max(4, bodyHeight * 0.25)
+        && next.line.x - current.line.x <= bodyHeight * 3)
+      || (lineIsCentered(page, current.line) && lineIsCentered(page, next.line));
+    if (gap >= 0 && gap <= Math.max(4, bodyHeight * 0.5) && aligned) {
+      continuations.add(next.line.id);
+    }
+  }
+  return continuations;
 }
 
 /**
@@ -2035,12 +2122,30 @@ function joinParagraphContinuity(records) {
   return joined;
 }
 
+function joinHeadingContinuations(records) {
+  const joined = [];
+  for (const record of records) {
+    const previous = joined[joined.length - 1];
+    if (record.headingContinuation && previous?.headingLevel) {
+      joined[joined.length - 1] = {
+        ...previous,
+        text: `${previous.text} ${record.text}`,
+        sourceText: `${previous.sourceText} ${record.sourceText}`,
+      };
+    } else {
+      joined.push(record);
+    }
+  }
+  return joined;
+}
+
 function renderPage(page, {
   compact = false,
   pageBoundaryBefore = false,
   pageBoundaryAfter = false,
 } = {}) {
   const headings = headingLevels(page);
+  const headingContinuations = headingContinuationIds(page, headings);
   const analysis = segmentPageLines(page);
   const linkState = analyzePageLinks(page, analysis, headings);
   const unsafePage = analysis.tableReason !== null
@@ -2066,7 +2171,8 @@ function renderPage(page, {
         if (fractionPlan.skipped.has(line.id)) return [];
         const spans = linkState.spansByLine.get(line.id);
         const offsets = linkState.offsetsByLine.get(line.id);
-        if (spans && spans.length > 0 && offsets && !headings.get(line.id)) {
+        if (spans && spans.length > 0 && offsets && !headings.get(line.id)
+          && !headingContinuations.has(line.id)) {
           const linked = renderLinkedLine(line, offsets, spans);
           if (linked !== null) {
             return {
@@ -2099,10 +2205,12 @@ function renderPage(page, {
           normalizable: true,
           line,
           joinable: projectedText === null && !headings.get(line.id) && !rewritesLineStructure(line),
+          headingLevel: headings.get(line.id),
+          headingContinuation: headingContinuations.has(line.id),
         };
       });
   });
-  const entries = joinParagraphContinuity(records);
+  const entries = joinParagraphContinuity(joinHeadingContinuations(records));
   const normalized = compact
     ? normalizePlainLines(entries, { page: page.page, pageBoundaryBefore, pageBoundaryAfter })
     : { lines: entries.map(entry => entry.text), normalizations: emptyNormalizations() };

--- a/server/output-schemas.js
+++ b/server/output-schemas.js
@@ -878,7 +878,7 @@ export const TOOL_SUCCESS_OUTPUT_SCHEMAS = Object.freeze({
   convert_pdf_to_markdown: object({
     renderer: object({
       name: { const: "pdf-tools.layout-markdown-renderer" },
-      version: { const: "1.13.0" },
+      version: { const: "1.14.0" },
     }),
     conversion_status: enumString(["complete", "partial", "failed"]),
     markdown: string,

--- a/test/convert-pdf-to-markdown.test.js
+++ b/test/convert-pdf-to-markdown.test.js
@@ -305,7 +305,7 @@ describe("convert_pdf_to_markdown MCP tool", () => {
     expect(first.isError).not.toBe(true);
     expect(second.structuredContent).toEqual(first.structuredContent);
     expect(first.structuredContent).toMatchObject({
-      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.13.0" },
+      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.14.0" },
       conversion_status: "complete",
       saved_output: null,
       provenance: {

--- a/test/eval/markdown-bakeoff.test.js
+++ b/test/eval/markdown-bakeoff.test.js
@@ -64,7 +64,7 @@ async function handle(message) {
     const pageBoundaries = Array.from({ length: pageCount }, (_, index) => "<!-- PDF page " + (index + 1) + " -->");
     const markdown = pageBoundaries.join("\n\n") + "\n\nINV-1001 fixture evidence\n";
     const value = {
-      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.13.0" },
+      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.14.0" },
       conversion_status: "complete",
       markdown,
       markdown_sha256: digest(Buffer.from(markdown)),
@@ -146,7 +146,7 @@ function resultFor(binding) {
   const markdown = "<!-- PDF page 1 -->\n\nFixture text\n";
   return {
     structuredContent: {
-      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.13.0" },
+      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.14.0" },
       conversion_status: "complete",
       markdown,
       markdown_sha256: sha256(Buffer.from(markdown)),
@@ -234,7 +234,7 @@ describe("Markdown bakeoff renderer version binding", () => {
   });
 
   it("accepts the current renderer version and rejects all superseded ones", () => {
-    expect(validateMarkdownResult(resultFor("1.13.0"), binding).renderer.version).toBe("1.13.0");
+    expect(validateMarkdownResult(resultFor("1.14.0"), binding).renderer.version).toBe("1.14.0");
     for (const stale of ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.6.0", "1.7.0", "1.8.0", "1.9.0", "1.10.0", "1.11.0", "1.12.0"]) {
       expect(() => validateMarkdownResult(resultFor(stale), binding), stale)
         .toThrow(/Markdown result evidence is invalid/u);

--- a/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
+++ b/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
@@ -67,14 +67,14 @@
     {
       "role": "markdown_conversion_module",
       "path": "server/markdown-conversion.js",
-      "bytes": 104811,
-      "sha256": "1561a68998c77959ff8a9eec01562342818a7fc03025e5da1768d49285c1c810"
+      "bytes": 110148,
+      "sha256": "76b1256722119fd8f2f5c19b21039d274aa7375f392f02761b0d5df85af15240"
     },
     {
       "role": "output_schemas_module",
       "path": "server/output-schemas.js",
       "bytes": 48015,
-      "sha256": "de3be1f85f6524fd90504135fdee9b8c1daad54bd8d6800834307c3f192cf53a"
+      "sha256": "92a0bfa8258dec7340d1f97a149fdb466fbb6a1f31e41d4c65c70ed704bb0624"
     },
     {
       "role": "package_json",
@@ -113,7 +113,7 @@
       "sha256": "6e4429db62fcbe1dd73141d8c20a48b564d41f8bf8920d88775846995e1daf94"
     }
   ],
-  "validator_source_set_sha256": "0d738a919485a557246eb0eb61ca427b49feb8dbd0c88b750e877efc7524d7b2",
+  "validator_source_set_sha256": "1621ff2d8f9eae5ae702720a9fad85f4998586289c8e1d9415c426aecd451bef",
   "pdfjs_version": "5.4.624",
   "generation_contract": {
     "source_path": "source.pdf",

--- a/test/fixtures/eval/shannon/manifest.v1.json
+++ b/test/fixtures/eval/shannon/manifest.v1.json
@@ -22,7 +22,7 @@
     "pdf_tools": {
       "slot": "control.current_product.v0",
       "renderer_name": "pdf-tools.layout-markdown-renderer",
-      "renderer_version": "1.13.0",
+      "renderer_version": "1.14.0",
       "parser_name": "pdfjs-dist",
       "parser_version": "5.4.624"
     },

--- a/test/markdown-conversion.test.js
+++ b/test/markdown-conversion.test.js
@@ -364,7 +364,7 @@ describe("layout Markdown renderer", () => {
     // invocation, so any unreviewed serialized delta fails this regression.
     const serialized = JSON.stringify(pinnable);
     expect(createHash("sha256").update(serialized).digest("hex"))
-      .toBe("a0d64f0c2fbd9b39685a9e2ae1fff3af5a5ff7cba40c70411f0d3d4cc0986ab0");
+      .toBe("2018dbcf0869d5fdbd7beec2a1b4620363a0029d04f4bc380ec7c68a0f36d01f");
     const body = result.markdown.split("\n\n## Conversion gaps\n\n", 1)[0];
     expect(JSON.stringify({
       body,
@@ -372,7 +372,7 @@ describe("layout Markdown renderer", () => {
     })).toBe(NON_RECT_EXPECTED);
     expect(result.renderer).toEqual({
       name: "pdf-tools.layout-markdown-renderer",
-      version: "1.13.0",
+      version: "1.14.0",
     });
     expect(result.gaps[0].message).toMatch(/beyond reconstructed ruled or bounded solid-mask table grids/);
     expect(result.limitations.some(value => value.includes("clean ruled-rectangle grid evidence"))).toBe(true);
@@ -1101,6 +1101,83 @@ describe("layout Markdown renderer", () => {
     expect(result.markdown).toMatch(/^## 1 Introduction$/mu);
     expect(result.markdown).toMatch(/^### 3\.2 Attention$/mu);
     expect(result.markdown).toMatch(/^#### 3\.2\.1 Scaled Dot-Product Attention$/mu);
+  });
+
+  it("recognizes numbered headings at either established body margin in a two-column paper", async () => {
+    const body = (left, suffix) => [
+      textItem(`First ordinary body line in ${suffix}`, { top: 40, left, fontSize: 10 }),
+      textItem(`Second ordinary body line in ${suffix}`, { top: 55, left, fontSize: 10 }),
+      textItem(`Third ordinary body line in ${suffix}`, { top: 70, left, fontSize: 10 }),
+    ];
+    const layout = await validatedSyntheticLayout([{
+      items: [
+        ...body(108, "the left column"),
+        textItem("2 Related Work", { top: 110, left: 108, fontSize: 12, fontName: "f2" }),
+        textItem("Body beneath the left section heading", { top: 135, left: 108, fontSize: 10 }),
+        ...body(360, "the right column"),
+        textItem("4 Experiments", { top: 110, left: 360, fontSize: 12, fontName: "f2" }),
+        textItem("Body beneath the right section heading", { top: 135, left: 360, fontSize: 10 }),
+      ],
+    }]);
+    const result = renderPdfLayoutToMarkdown(layout, { includePageBoundaries: false });
+
+    expect(result.markdown).toMatch(/^## 2 Related Work$/mu);
+    expect(result.markdown).toMatch(/^## 4 Experiments$/mu);
+  });
+
+  it("recognizes lettered research-paper appendix headings", async () => {
+    const layout = await validatedSyntheticLayout([{
+      items: [
+        textItem("Opening ordinary body line establishes the font", { top: 40, left: 108, fontSize: 10 }),
+        textItem("Second ordinary body line establishes the margin", { top: 55, left: 108, fontSize: 10 }),
+        textItem("Third ordinary body line establishes the margin", { top: 70, left: 108, fontSize: 10 }),
+        textItem("A Additional Details", { top: 110, left: 108, fontSize: 12, fontName: "f2" }),
+        textItem("Body beneath the appendix heading continues", { top: 135, left: 108, fontSize: 10 }),
+        textItem("A.1 Pre-training Procedure", { top: 175, left: 108, fontSize: 10, fontName: "f2" }),
+        textItem("Body beneath the appendix subsection continues", { top: 200, left: 108, fontSize: 10 }),
+      ],
+    }]);
+    const result = renderPdfLayoutToMarkdown(layout, { includePageBoundaries: false });
+
+    expect(result.markdown).toMatch(/^## A Additional Details$/mu);
+    expect(result.markdown).toMatch(/^### A\.1 Pre-training Procedure$/mu);
+  });
+
+  it("joins visibly wrapped title and appendix heading lines", async () => {
+    const layout = await validatedSyntheticLayout([{
+      items: [
+        centeredTextItem("BERT: Pre-training of Bidirectional Transformers for", { top: 30, fontSize: 16, fontName: "f2" }),
+        centeredTextItem("Language Understanding", { top: 47, fontSize: 16, fontName: "f2" }),
+        centeredTextItem("Research Authors", { top: 70, fontSize: 8, fontName: "f3" }),
+        textItem("First ordinary body line establishes the font", { top: 90, left: 108, fontSize: 10 }),
+        textItem("Second ordinary body line establishes the margin", { top: 105, left: 108, fontSize: 10 }),
+        textItem("Third ordinary body line establishes the margin", { top: 120, left: 108, fontSize: 10 }),
+        textItem("A.4 Comparison of BERT, ELMo, and", { top: 160, left: 108, fontSize: 10, fontName: "f2" }),
+        textItem("OpenAI GPT", { top: 170, left: 108, fontSize: 10, fontName: "f2" }),
+        textItem("Body beneath the wrapped appendix heading", { top: 190, left: 108, fontSize: 10 }),
+      ],
+    }]);
+    const result = renderPdfLayoutToMarkdown(layout, { includePageBoundaries: false });
+
+    expect(result.markdown).toMatch(/^# BERT: Pre-training of Bidirectional Transformers for Language Understanding$/mu);
+    expect(result.markdown).toMatch(/^### A\.4 Comparison of BERT, ELMo, and OpenAI GPT$/mu);
+  });
+
+  it("recognizes a wrapped title centered within an established body column", async () => {
+    const layout = await validatedSyntheticLayout([{
+      items: [
+        positionedTextItem("First ordinary body line establishes this column", { top: 40, left: 72, width: 180, fontSize: 10, eol: true }),
+        positionedTextItem("Second ordinary body line establishes this column", { top: 55, left: 72, width: 180, fontSize: 10, eol: true }),
+        positionedTextItem("Third ordinary body line establishes this column", { top: 70, left: 72, width: 180, fontSize: 10, eol: true }),
+        positionedTextItem("Appendix for BERT: Pre-training of", { top: 110, left: 82, width: 160, fontSize: 12, fontName: "f2", eol: true }),
+        positionedTextItem("Deep Bidirectional Transformers for", { top: 122, left: 92, width: 140, fontSize: 12, fontName: "f2", eol: true }),
+        positionedTextItem("Language Understanding", { top: 134, left: 102, width: 120, fontSize: 12, fontName: "f2", eol: true }),
+        positionedTextItem("Body beneath the wrapped column title continues", { top: 160, left: 72, width: 180, fontSize: 10, eol: true }),
+      ],
+    }]);
+    const result = renderPdfLayoutToMarkdown(layout, { includePageBoundaries: false });
+
+    expect(result.markdown).toMatch(/^## Appendix for BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding$/mu);
   });
 
   it("recognizes numbered small-caps sections without relying on a different font resource", async () => {

--- a/test/mcp-contract.test.js
+++ b/test/mcp-contract.test.js
@@ -69,9 +69,11 @@ const EXAMPLE_PDF = path.join(REPO_ROOT, "example-fw9.pdf");
 // small-caps height relationship when heading initials match the body height.
 // 2026-08-04: Markdown renderer 1.13.0 uses wide prose to estimate body height
 // on chart-heavy pages and requires generic enlarged headings to lead text.
+// 2026-08-04: Markdown renderer 1.14.0 recognizes independently established
+// body margins in two-column papers, lettered appendices, and wrapped headings.
 // 2026-08-04: additive deterministic compare_pdfs contract with source-bound
 // evidence, exact whole-document limits, and typed channel coverage.
-const TOOL_CONTRACT_SHA256 = "5953b963a95d73056b8bd27341aad62200fecf9c434af3db6601ee978081dce4";
+const TOOL_CONTRACT_SHA256 = "7087e97e1be2f6a52138517d66169177aa08ca5017f69235af33e62603b54c9e";
 
 const CLOSED_READ = Object.freeze({
   readOnlyHint: true,

--- a/test/numbered-research-headings-live.test.js
+++ b/test/numbered-research-headings-live.test.js
@@ -9,8 +9,9 @@ import {
 
 const ATTENTION_SOURCE = process.env.PDF_TOOLS_ATTENTION_SOURCE;
 const ADAM_SOURCE = process.env.PDF_TOOLS_ADAM_SOURCE;
+const BERT_SOURCE = process.env.PDF_TOOLS_BERT_SOURCE;
 
-async function renderExternalPdf(sourcePath, expectedSha256) {
+async function renderExternalPdf(sourcePath, expectedSha256, pageCount = 15) {
   const sourceFile = await hashBoundedPdfFileSafely(sourcePath, 250 * 1024 * 1024, {
     assertPathAllowed: candidate => candidate,
   });
@@ -22,7 +23,8 @@ async function renderExternalPdf(sourcePath, expectedSha256) {
     size_bytes: sourceFile.sizeBytes,
   };
   const markdown = [];
-  for (const [startPage, endPage] of [[1, 5], [6, 10], [11, 15]]) {
+  for (let startPage = 1; startPage <= pageCount; startPage += 5) {
+    const endPage = Math.min(pageCount, startPage + 4);
     const response = await runPdfjsSubprocess(createPdfjsSubprocessRequest({
       operation: "extract_layout_for_markdown",
       source,
@@ -161,5 +163,48 @@ describe("external numbered research-paper headings", () => {
       "## 10 APPENDIX",
       "### 10.1 CONVERGENCE PROOF",
     ]);
+  }, 60_000);
+
+  it.runIf(Boolean(BERT_SOURCE))("recovers the complete BERT hierarchy across both columns and its appendices", async () => {
+    const markdown = await renderExternalPdf(
+      BERT_SOURCE,
+      "5692a5514787a8c6727b4ff3b726a3385798bc68e12138d1d4af83947e2acf6e",
+      16,
+    );
+    expect(contentHeadings(markdown)).toEqual([
+      "# BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding",
+      "## 1 Introduction",
+      "## 2 Related Work",
+      "### 2.1 Unsupervised Feature-based Approaches",
+      "### 2.2 Unsupervised Fine-tuning Approaches",
+      "### 2.3 Transfer Learning from Supervised Data",
+      "## 3 BERT",
+      "### 3.1 Pre-training BERT",
+      "### 3.2 Fine-tuning BERT",
+      "## 4 Experiments",
+      "### 4.1 GLUE",
+      "### 4.2 SQuAD v1.1",
+      "### 4.3 SQuAD v2.0",
+      "### 4.4 SWAG",
+      "## 5 Ablation Studies",
+      "### 5.1 Effect of Pre-training Tasks",
+      "### 5.2 Effect of Model Size",
+      "### 5.3 Feature-based Approach with BERT",
+      "## 6 Conclusion",
+      "## Appendix for “BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding”",
+      "## A Additional Details for BERT",
+      "### A.1 Illustration of the Pre-training Tasks",
+      "### A.2 Pre-training Procedure",
+      "### A.3 Fine-tuning Procedure",
+      "### A.4 Comparison of BERT, ELMo ,and OpenAI GPT",
+      "### A.5 Illustrations of Fine-tuning on Different Tasks",
+      "## B Detailed Experimental Setup",
+      "### B.1 Detailed Descriptions for the GLUE Benchmark Experiments.",
+      "## C Additional Ablation Studies",
+      "### C.1 Effect of Number of Training Steps",
+      "### C.2 Ablation for Different Masking Procedures",
+    ]);
+    expect(markdown).not.toMatch(/^#{1,6}\s+(?:arXiv:|Figure\s|Table\s|Next Sentence Prediction|No NSP:)/gmu);
+    expect(markdown).not.toContain("\uFFFD");
   }, 60_000);
 });


### PR DESCRIPTION
## What changed

- recognize research-paper headings at either independently established body margin on two-column pages
- recognize lettered appendix sections and their numbered subsections
- join visually wrapped title and section lines only with matching font, size, tight spacing, and bounded alignment
- bump the Markdown renderer contract to 1.14.0 and keep source/share runtimes byte-identical
- add a hash-locked live BERT paper test and update the maintained cross-paper evidence

## Why

The independent BERT trial exposed that the prior heading logic treated one median left edge as the page's body margin. On two-column papers, that caused most real headings in one column to be ignored. It also lacked a safe path for lettered appendices and visibly wrapped headings.

## Impact

The exact 16-page BERT source moves from 6/31 to 31/31 content headings with the correct hierarchy, including its centered three-line appendix title. The vertical arXiv label, figure/table labels, diagram text, and inline bold labels remain plain text. Attention remains 22/22 and Adam remains 17/17.

## Validation

- 167 passed, 6 optional skips across renderer, contracts, worker behavior, the refreshed extraction-integrity oracle, and the three hash-locked live research papers
- BERT: 31/31 content headings, 0 replacement characters, 0 explicit gaps
- reproducible share contract: 41 tools, 14 prompts, 112 SBOM components
- three complete 55-page Shannon runs are deterministic and content-identical to the prior candidate; only the renderer limitations disclosure changes
- installed-copy Shannon proof passes against the exact candidate runtime with the reviewed renderer/tool/output fingerprints
- source/share Markdown runtime and schema are byte-identical

This PR does not release, install, or contact Kepano.
