### PR TITLE
Stabilize escaped-child supervisor coverage

### DIFF
--- a/test/eval/docling-macos-supervisor.test.js
+++ b/test/eval/docling-macos-supervisor.test.js
@@ -339,6 +339,10 @@ describe.runIf(RUNS_ON_DARWIN)("native macOS structured-extraction supervisor", 
   });
 
   it("does not mistake an inaccessible child leaving the group for disappearance", async () => {
+    // The child can escape before the first process-group snapshot while still
+    // being discovered by the supervisor's separate child enumeration. The
+    // injected EPERM, fail-closed result, and surviving sentinel prove this
+    // path; the multiple-live-children test above pins the group count itself.
     const sentinel = path.join(root, "sampling-escape-eperm-sentinel");
     const result = await runFault(
       "sampling_escape_eperm",
@@ -353,7 +357,6 @@ describe.runIf(RUNS_ON_DARWIN)("native macOS structured-extraction supervisor", 
       controller_failure: "enumeration",
       observations: { original_process_group_empty: true },
     });
-    expect(result.evidence.observations.max_group_members).toBeGreaterThan(1);
     await waitForFile(sentinel, 2500);
   });
 


### PR DESCRIPTION
## Summary
- remove a timing-sensitive process-group count assertion from the escaped-child safety test
- retain the fail-closed EPERM result, escaped-child sentinel proof, and separate deterministic multi-child count coverage

## Verification
- focused macOS supervisor suite: 54/54 passed in five consecutive runs (270/270)
- full `npm run test:all`: 127 files passed, 4 skipped; 2007 tests passed, 85 skipped
- native suite: 62 passed, 9 skipped; aggregate exit 0