### PR TITLE
Order run-binding cleanup after fixture readiness

### DIFF
--- a/test/eval/agent-workflow-run-binding.test.js
+++ b/test/eval/agent-workflow-run-binding.test.js
@@ -1087,6 +1087,7 @@ setInterval(() => {}, 1000);
     let caught = null;
     let parentPid = null;
     let grandchildPid = null;
+    let settledAt = null;
     const startedAt = Date.now();
     try {
       await Promise.race([
@@ -1110,6 +1111,7 @@ setInterval(() => {}, 1000);
     } catch (error) {
       caught = error;
     } finally {
+      settledAt = Date.now();
       if (watchdog !== null) clearTimeout(watchdog);
       const readFixturePid = async filename => {
         try {
@@ -1124,7 +1126,19 @@ setInterval(() => {}, 1000);
       parentPid = Number.isSafeInteger(reportedPid) && reportedPid > 0
         ? reportedPid
         : await readFixturePid(parentPidPath);
+      // The injected killProcess denies every real signal, so the fixture is
+      // still running once the runner gives up, and it records its grandchild
+      // pid on its own schedule rather than inside the runner's rejection
+      // budget. Wait for that observable readiness before the process group is
+      // killed below, otherwise a slow host lets the kill beat the write and
+      // the pid these assertions need is never recorded. The wait is bounded so
+      // a genuinely missing pid still fails instead of hanging.
       grandchildPid = await readFixturePid(grandchildPidPath);
+      const readinessDeadlineAt = Date.now() + 2_000;
+      while (grandchildPid === null && Date.now() < readinessDeadlineAt) {
+        await new Promise(resolve => setTimeout(resolve, 5));
+        grandchildPid = await readFixturePid(grandchildPidPath);
+      }
       if (parentPid !== null) {
         try {
           process.kill(-parentPid, "SIGKILL");
@@ -1152,7 +1166,10 @@ setInterval(() => {}, 1000);
         await new Promise(resolve => setTimeout(resolve, 10));
       }
     }
-    expect(Date.now() - startedAt).toBeLessThan(5_000);
+    // Bound the runner's own rejection, measured when the race settled, not the
+    // fixture teardown that follows it.
+    expect(settledAt).not.toBeNull();
+    expect(settledAt - startedAt).toBeLessThan(5_000);
     expect(caught).toMatchObject({
       code: "CODEX_PROCESS_TERMINATION_UNVERIFIABLE",
       process_result: {
@@ -1180,6 +1197,7 @@ setInterval(() => {}, 1000);
     });
     expect(parentPid).not.toBeNull();
     expect(grandchildPid).not.toBeNull();
+    expect(await fs.readFile(grandchildReadyPath, "utf8")).toBe("ready");
     for (const pid of [-parentPid, parentPid, grandchildPid]) {
       expect(() => process.kill(pid, 0)).toThrow(
         expect.objectContaining({ code: "ESRCH" }),


### PR DESCRIPTION
Repairs a self-inflicted race in `test/eval/agent-workflow-run-binding.test.js`. Test-only: one file, +19/−1. No product, runner, script, manifest, dependency, or packaging change.

## The defect

The test injects a `killProcess` that denies every real signal, so the fixture is still running once the runner gives up, and it records its grandchild pid on its own schedule rather than inside the runner's rejection budget. On a slow host the test's `SIGKILL` beats the fixture's `grandchild.pid` write, and the assertions fail with `grandchild PID unobserved` / `expected null not to be null`.

That is a spurious red that says nothing about the product, and it was observed for real on Silverbook during the 2026-07-31 durability rerun. Every `npm run test:all` — including release qualification runs — carries the risk until this lands.

## The repair

Wait for the fixture's observable readiness before killing the process group, bounded by a 2s deadline so a genuinely missing pid still fails rather than hanging. Also measures the runner's rejection budget from when the race actually settled, rather than from teardown that follows it.

## Evidence

- Independent review: **PASS / GO for integration**. These bytes are identical to the reviewed commit; nothing was re-derived or re-blessed.
- Focused file: **22/22 pass**.
- Slow-host differential under identical 600ms injection: parent `fcd481a` **fails 3/3** with the exact recorded failure, candidate **passes 3/3**.
- Stock `npm run test:all` at this exact commit on Silverbook: **exit 0**, 127 files passed / 4 skipped, **2,007 passed / 85 skipped / 0 failed**, native 62/0/9, tree clean after.
- The unpatched head `fcd481a` was run as a control and is itself green, so this is also an independent qualification of the current public head.

Branch parent is exactly `fcd481a`, the head of `master` at push time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)