### PR TITLE
Derive the expected renderer policy from the platform in the render suite

### DIFF
--- a/test/render-pdf-page.test.js
+++ b/test/render-pdf-page.test.js
@@ -163,7 +163,11 @@ describe("render_pdf_page MCP tool", () => {
         size_bytes: sourceBytes.length,
       },
       raw_pixel_status: "available",
-      renderer_policy: "native_with_system_fallback",
+      // The system-renderer fallback is a macOS capability, so pdfjsRendererPolicy
+      // reports plain "native" everywhere else. The hardcoded darwin value failed
+      // on every non-darwin host; it stayed hidden because the aggregate gate runs
+      // on macOS.
+      renderer_policy: process.platform === "darwin" ? "native_with_system_fallback" : "native",
     });
     expect(result.structuredContent.png_sha256)
       .toBe(createHash("sha256").update(Buffer.from(image.data, "base64")).digest("hex"));


### PR DESCRIPTION
`test/render-pdf-page.test.js` hardcoded `renderer_policy: "native_with_system_fallback"`. That value is macOS-only by construction: `pdfjsRendererPolicy` returns plain `"native"` whenever `process.platform !== "darwin"`, because the system-renderer fallback is a macOS capability.

**The product was behaving correctly. The assertion was wrong.**

## This is currently red on master

It is not Windows-specific. At unfixed `master` the same failure reproduces on Linux x64: 1 failed / 14 passed / 7 skipped, identical to the Windows runner. Any non-darwin host running this suite fails today. It stayed invisible because the aggregate release gate runs on macOS, where the hardcoded value happens to be right.

## Evidence

- Windows render proof at unfixed candidate (run `31051118605`): **1 failed**, exactly `expected "native_with_system_fallback"` / `received "native"`.
- Windows render proof at this commit (run `31051499142`): **success**.
- Linux x64 local, unfixed: 1 failed / 14 passed / 7 skipped. With this change: **15 passed / 7 skipped**.

## Scope

Test-only, one file. Product behavior unchanged. The expectation now derives from the platform, matching the idiom this suite already uses for its darwin-gated system-fallback block.

The two sibling occurrences of the same string (`pdfjs-subprocess-boundary.test.js`, `pdfjs-worker-contract.test.js`) pass the policy as an explicit *input* rather than asserting a platform-derived *output*, so they are correct as written and deliberately untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)