### PR TITLE
Fix five defects adversarial review found in the merged tree

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -27,7 +27,7 @@
     },
     {
       "name": "list_pdfs",
-      "description": "List all PDF files in a directory"
+      "description": "List PDF files in a directory, sorted by name, up to 200 per call"
     },
     {
       "name": "read_pdf_fields",
@@ -195,31 +195,31 @@
       "name": "view_and_analyze_pdf",
       "description": "Open and analyze any PDF document",
       "arguments": ["focus"],
-      "text": "Use PDF Tools to open a PDF stored on this computer and analyze it, focusing on ${arguments.focus}. If I haven't given you a path, start by listing the PDFs in my Documents folder so I can pick one. Then extract key findings, summarize sections, answer questions about specific pages, pull out structured data, and identify form fields if present."
+      "text": "Use PDF Tools to open a PDF stored on this computer and analyze it, focusing on ${arguments.focus}. If I haven't given you a path, start by listing the PDFs you can see so I can pick one. Then extract key findings, summarize sections, answer questions about specific pages, pull out structured data, and identify form fields if present."
     },
     {
       "name": "research_paper_analysis",
       "description": "Analyze & summarize research papers",
       "arguments": ["focus_area"],
-      "text": "Use PDF Tools to analyze a research paper stored on this computer, focusing on ${arguments.focus_area}. If I haven't given you a path, start by listing the PDFs in my Documents folder so I can pick one. Extract the key findings and methodology, identify research gaps, summarize it chapter by chapter, pull out the citations, and draft a literature review outline."
+      "text": "Use PDF Tools to analyze a research paper stored on this computer, focusing on ${arguments.focus_area}. If I haven't given you a path, start by listing the PDFs you can see so I can pick one. Extract the key findings and methodology, identify research gaps, summarize it chapter by chapter, pull out the citations, and draft a literature review outline."
     },
     {
       "name": "contract_comparison",
       "description": "Compare legal documents & contracts",
       "arguments": ["comparison_focus"],
-      "text": "Use PDF Tools to compare contracts or legal documents stored on this computer, focusing on ${arguments.comparison_focus}. If I haven't given you their paths, start by listing the PDFs in my Documents folder so I can pick them. Highlight changed clauses, modified terms, added or removed sections, pricing differences, and liability changes, then summarize the comparison."
+      "text": "Use PDF Tools to compare contracts or legal documents stored on this computer, focusing on ${arguments.comparison_focus}. If I haven't given you their paths, start by listing the PDFs you can see so I can pick them. Highlight changed clauses, modified terms, added or removed sections, pricing differences, and liability changes, then summarize the comparison."
     },
     {
       "name": "financial_report_extraction",
       "description": "Extract data from financial statements",
       "arguments": ["output_format"],
-      "text": "Use PDF Tools to extract and analyze data from financial PDFs stored on this computer, including tables and key metrics. If I haven't given you a path, start by listing the PDFs in my Documents folder so I can pick one. Convert what you extract to ${arguments.output_format} format, cite the page for the values you extract, and tell me plainly about anything you could not extract."
+      "text": "Use PDF Tools to extract and analyze data from financial PDFs stored on this computer, including tables and key metrics. If I haven't given you a path, start by listing the PDFs you can see so I can pick one. Convert what you extract to ${arguments.output_format} format, cite the page for the values you extract, and tell me plainly about anything you could not extract."
     },
     {
       "name": "document_qa_session",
       "description": "Interactive Q&A about your documents",
       "arguments": ["initial_question"],
-      "text": "Use PDF Tools to open a PDF stored on this computer so we can discuss it. My first question is: ${arguments.initial_question}. If I haven't given you a path, start by listing the PDFs in my Documents folder so I can pick one. Find specific information, explain complex sections, cross-reference different parts, and quote passages with their page numbers."
+      "text": "Use PDF Tools to open a PDF stored on this computer so we can discuss it. My first question is: ${arguments.initial_question}. If I haven't given you a path, start by listing the PDFs you can see so I can pick one. Find specific information, explain complex sections, cross-reference different parts, and quote passages with their page numbers."
     },
     {
       "name": "bulk_invoice_processing",
@@ -231,42 +231,42 @@
       "name": "technical_documentation_summary",
       "description": "Summarize technical manuals & documentation",
       "arguments": ["summary_type"],
-      "text": "Use PDF Tools to analyze technical documentation stored on this computer and create ${arguments.summary_type}. If I haven't given you a path, start by listing the PDFs in my Documents folder so I can pick one. Extract the code examples, build a reference guide, identify the implementation steps, and summarize the troubleshooting sections."
+      "text": "Use PDF Tools to analyze technical documentation stored on this computer and create ${arguments.summary_type}. If I haven't given you a path, start by listing the PDFs you can see so I can pick one. Extract the code examples, build a reference guide, identify the implementation steps, and summarize the troubleshooting sections."
     },
     {
       "name": "fill_w9_business",
       "description": "Fill W-9 for business entity",
-      "text": "Use PDF Tools to fill out a W-9 stored on this computer for my business. Start by listing the PDFs in my Documents folder so I can point you at the right form, then read its fields. Ask me for the business legal name, the DBA or trade name if it differs, the business type (LLC, corporation, partnership), the tax classification, the EIN, and the business address. Check the correct tax classification boxes and tell me about any required field you could not fill."
+      "text": "Use PDF Tools to fill out a W-9 stored on this computer for my business. If I haven't already given you the file, start by listing the PDFs you can see so I can point you at the right form, then read its fields. Ask me for the business legal name, the DBA or trade name if it differs, the business type (LLC, corporation, partnership), the tax classification, the EIN, and the business address. Check the correct tax classification boxes and tell me about any required field you could not fill."
     },
     {
       "name": "batch_invoices",
       "description": "Process multiple invoices",
-      "text": "Use PDF Tools to batch process invoice PDFs stored on this computer. Start by listing the PDFs in my Documents folder so I can confirm which ones to use, or I'll name a different folder. Extract the amounts and dates, build a summary spreadsheet, flag missing information, total them by vendor, date, and category, and tell me about any invoice you could not read. Ask me which fields matter most before you start."
+      "text": "Use PDF Tools to batch process invoice PDFs stored on this computer. If I haven't already named them, start by listing the PDFs you can see so I can confirm which ones to use, or I'll name a different folder. Extract the amounts and dates, build a summary spreadsheet, flag missing information, total them by vendor, date, and category, and tell me about any invoice you could not read. Ask me which fields matter most before you start."
     },
     {
       "name": "rental_application",
       "description": "Fill rental application",
-      "text": "Use PDF Tools to help me complete a rental application stored on this computer. Start by listing the PDFs in my Documents folder so I can point you at the right form, then read its fields. I'll have ready my personal details, three years of employment history, income verification, three years of previous addresses, references, vehicle information, and an emergency contact. Fill every required field and flag the ones that need supporting documents."
+      "text": "Use PDF Tools to help me complete a rental application stored on this computer. If I haven't already given you the file, start by listing the PDFs you can see so I can point you at the right form, then read its fields. I'll have ready my personal details, three years of employment history, income verification, three years of previous addresses, references, vehicle information, and an emergency contact. Fill every required field and flag the ones that need supporting documents."
     },
     {
       "name": "extract_1099_data",
       "description": "Extract data from 1099 forms",
-      "text": "Use PDF Tools to extract the data from 1099 forms stored on this computer (1099-NEC, 1099-MISC, 1099-DIV, 1099-INT and similar) and build a tax summary. Start by listing the PDFs in my Documents folder so I can confirm which ones to use. Organize by payer, identify the type of income, total each category, format it for import into tax software, and tell me about anything you could not read."
+      "text": "Use PDF Tools to extract the data from 1099 forms stored on this computer (1099-NEC, 1099-MISC, 1099-DIV, 1099-INT and similar) and build a tax summary. If I haven't already named them, start by listing the PDFs you can see so I can confirm which ones to use. Organize by payer, identify the type of income, total each category, format it for import into tax software, and tell me about anything you could not read."
     },
     {
       "name": "merge_documents",
       "description": "Combine multiple PDFs into one document",
-      "text": "Use PDF Tools to merge PDF files stored on this computer into one document. Start by listing the PDFs in my Documents folder so I can choose which ones to combine, then ask me where to save the result. Preserve the page order, and afterwards report the page count and the output path so I can check it. File operations happen locally; content you inspect is handled under my MCP host or model provider's data terms."
+      "text": "Use PDF Tools to merge PDF files stored on this computer into one document. If I haven't already named them, start by listing the PDFs you can see so I can choose which ones to combine, then ask me where to save the result. Preserve the page order, and afterwards report the page count and the output path so I can check it. File operations happen locally; content you inspect is handled under my MCP host or model provider's data terms."
     },
     {
       "name": "split_large_document",
       "description": "Split a PDF into smaller files",
-      "text": "Use PDF Tools to split a PDF stored on this computer into separate files. If I haven't given you a path, start by listing the PDFs in my Documents folder so I can pick one. I'll either give you exact page ranges (for example pages 1-10 and 11-20) or ask you to split at a regular interval (for example every 5 pages). Save each section as its own PDF and tell me where you wrote them."
+      "text": "Use PDF Tools to split a PDF stored on this computer into separate files. If I haven't given you a path, start by listing the PDFs you can see so I can pick one. I'll either give you exact page ranges (for example pages 1-10 and 11-20) or ask you to split at a regular interval (for example every 5 pages). Save each section as its own PDF and tell me where you wrote them."
     },
     {
       "name": "organize_scanned_pages",
       "description": "Rotate and reorder scanned PDF pages",
-      "text": "Use PDF Tools to fix up a scanned PDF stored on this computer. If I haven't given you a path, start by listing the PDFs in my Documents folder so I can pick one. Rotate the pages I tell you are sideways or upside-down (90, 180, or 270 degrees) and reorder pages that were scanned out of sequence. Tell me the page order and rotations you plan to apply before you save, so I can confirm them."
+      "text": "Use PDF Tools to fix up a scanned PDF stored on this computer. If I haven't given you a path, start by listing the PDFs you can see so I can pick one. Rotate the pages I tell you are sideways or upside-down (90, 180, or 270 degrees) and reorder pages that were scanned out of sequence. Tell me the page order and rotations you plan to apply before you save, so I can confirm them."
     }
   ],
   "user_config": {

--- a/manifest.mcpb.json
+++ b/manifest.mcpb.json
@@ -27,7 +27,7 @@
     },
     {
       "name": "list_pdfs",
-      "description": "List all PDF files in a directory"
+      "description": "List PDF files in a directory, sorted by name, up to 200 per call"
     },
     {
       "name": "read_pdf_fields",
@@ -79,7 +79,7 @@
     },
     {
       "name": "convert_pdf_to_markdown",
-      "description": "Convert supported local PDF text to deterministic Markdown with explicit partial and unsupported-content gaps; optionally enable counted compact-mode normalizations"
+      "description": "Convert supported local PDF text to deterministic Markdown with explicit partial and unsupported-content gaps, including evidence-backed tables and source-validated external http or https links; optionally enable counted compact-mode normalizations"
     },
     {
       "name": "render_pdf_page",
@@ -192,31 +192,31 @@
       "name": "view_and_analyze_pdf",
       "description": "Open and analyze any PDF document",
       "arguments": ["focus"],
-      "text": "Use PDF Tools to open a PDF stored on this computer and analyze it, focusing on ${arguments.focus}. If I haven't given you a path, start by listing the PDFs in my Documents folder so I can pick one. Then extract key findings, summarize sections, answer questions about specific pages, pull out structured data, and identify form fields if present."
+      "text": "Use PDF Tools to open a PDF stored on this computer and analyze it, focusing on ${arguments.focus}. If I haven't given you a path, start by listing the PDFs you can see so I can pick one. Then extract key findings, summarize sections, answer questions about specific pages, pull out structured data, and identify form fields if present."
     },
     {
       "name": "research_paper_analysis",
       "description": "Analyze & summarize research papers",
       "arguments": ["focus_area"],
-      "text": "Use PDF Tools to analyze a research paper stored on this computer, focusing on ${arguments.focus_area}. If I haven't given you a path, start by listing the PDFs in my Documents folder so I can pick one. Extract the key findings and methodology, identify research gaps, summarize it chapter by chapter, pull out the citations, and draft a literature review outline."
+      "text": "Use PDF Tools to analyze a research paper stored on this computer, focusing on ${arguments.focus_area}. If I haven't given you a path, start by listing the PDFs you can see so I can pick one. Extract the key findings and methodology, identify research gaps, summarize it chapter by chapter, pull out the citations, and draft a literature review outline."
     },
     {
       "name": "contract_comparison",
       "description": "Compare legal documents & contracts",
       "arguments": ["comparison_focus"],
-      "text": "Use PDF Tools to compare contracts or legal documents stored on this computer, focusing on ${arguments.comparison_focus}. If I haven't given you their paths, start by listing the PDFs in my Documents folder so I can pick them. Highlight changed clauses, modified terms, added or removed sections, pricing differences, and liability changes, then summarize the comparison."
+      "text": "Use PDF Tools to compare contracts or legal documents stored on this computer, focusing on ${arguments.comparison_focus}. If I haven't given you their paths, start by listing the PDFs you can see so I can pick them. Highlight changed clauses, modified terms, added or removed sections, pricing differences, and liability changes, then summarize the comparison."
     },
     {
       "name": "financial_report_extraction",
       "description": "Extract data from financial statements",
       "arguments": ["output_format"],
-      "text": "Use PDF Tools to extract and analyze data from financial PDFs stored on this computer, including tables and key metrics. If I haven't given you a path, start by listing the PDFs in my Documents folder so I can pick one. Convert what you extract to ${arguments.output_format} format, cite the page for the values you extract, and tell me plainly about anything you could not extract."
+      "text": "Use PDF Tools to extract and analyze data from financial PDFs stored on this computer, including tables and key metrics. If I haven't given you a path, start by listing the PDFs you can see so I can pick one. Convert what you extract to ${arguments.output_format} format, cite the page for the values you extract, and tell me plainly about anything you could not extract."
     },
     {
       "name": "document_qa_session",
       "description": "Interactive Q&A about your documents",
       "arguments": ["initial_question"],
-      "text": "Use PDF Tools to open a PDF stored on this computer so we can discuss it. My first question is: ${arguments.initial_question}. If I haven't given you a path, start by listing the PDFs in my Documents folder so I can pick one. Find specific information, explain complex sections, cross-reference different parts, and quote passages with their page numbers."
+      "text": "Use PDF Tools to open a PDF stored on this computer so we can discuss it. My first question is: ${arguments.initial_question}. If I haven't given you a path, start by listing the PDFs you can see so I can pick one. Find specific information, explain complex sections, cross-reference different parts, and quote passages with their page numbers."
     },
     {
       "name": "bulk_invoice_processing",
@@ -228,42 +228,42 @@
       "name": "technical_documentation_summary",
       "description": "Summarize technical manuals & documentation",
       "arguments": ["summary_type"],
-      "text": "Use PDF Tools to analyze technical documentation stored on this computer and create ${arguments.summary_type}. If I haven't given you a path, start by listing the PDFs in my Documents folder so I can pick one. Extract the code examples, build a reference guide, identify the implementation steps, and summarize the troubleshooting sections."
+      "text": "Use PDF Tools to analyze technical documentation stored on this computer and create ${arguments.summary_type}. If I haven't given you a path, start by listing the PDFs you can see so I can pick one. Extract the code examples, build a reference guide, identify the implementation steps, and summarize the troubleshooting sections."
     },
     {
       "name": "fill_w9_business",
       "description": "Fill W-9 for business entity",
-      "text": "Use PDF Tools to fill out a W-9 stored on this computer for my business. Start by listing the PDFs in my Documents folder so I can point you at the right form, then read its fields. Ask me for the business legal name, the DBA or trade name if it differs, the business type (LLC, corporation, partnership), the tax classification, the EIN, and the business address. Check the correct tax classification boxes and tell me about any required field you could not fill."
+      "text": "Use PDF Tools to fill out a W-9 stored on this computer for my business. If I haven't already given you the file, start by listing the PDFs you can see so I can point you at the right form, then read its fields. Ask me for the business legal name, the DBA or trade name if it differs, the business type (LLC, corporation, partnership), the tax classification, the EIN, and the business address. Check the correct tax classification boxes and tell me about any required field you could not fill."
     },
     {
       "name": "batch_invoices",
       "description": "Process multiple invoices",
-      "text": "Use PDF Tools to batch process invoice PDFs stored on this computer. Start by listing the PDFs in my Documents folder so I can confirm which ones to use, or I'll name a different folder. Extract the amounts and dates, build a summary spreadsheet, flag missing information, total them by vendor, date, and category, and tell me about any invoice you could not read. Ask me which fields matter most before you start."
+      "text": "Use PDF Tools to batch process invoice PDFs stored on this computer. If I haven't already named them, start by listing the PDFs you can see so I can confirm which ones to use, or I'll name a different folder. Extract the amounts and dates, build a summary spreadsheet, flag missing information, total them by vendor, date, and category, and tell me about any invoice you could not read. Ask me which fields matter most before you start."
     },
     {
       "name": "rental_application",
       "description": "Fill rental application",
-      "text": "Use PDF Tools to help me complete a rental application stored on this computer. Start by listing the PDFs in my Documents folder so I can point you at the right form, then read its fields. I'll have ready my personal details, three years of employment history, income verification, three years of previous addresses, references, vehicle information, and an emergency contact. Fill every required field and flag the ones that need supporting documents."
+      "text": "Use PDF Tools to help me complete a rental application stored on this computer. If I haven't already given you the file, start by listing the PDFs you can see so I can point you at the right form, then read its fields. I'll have ready my personal details, three years of employment history, income verification, three years of previous addresses, references, vehicle information, and an emergency contact. Fill every required field and flag the ones that need supporting documents."
     },
     {
       "name": "extract_1099_data",
       "description": "Extract data from 1099 forms",
-      "text": "Use PDF Tools to extract the data from 1099 forms stored on this computer (1099-NEC, 1099-MISC, 1099-DIV, 1099-INT and similar) and build a tax summary. Start by listing the PDFs in my Documents folder so I can confirm which ones to use. Organize by payer, identify the type of income, total each category, format it for import into tax software, and tell me about anything you could not read."
+      "text": "Use PDF Tools to extract the data from 1099 forms stored on this computer (1099-NEC, 1099-MISC, 1099-DIV, 1099-INT and similar) and build a tax summary. If I haven't already named them, start by listing the PDFs you can see so I can confirm which ones to use. Organize by payer, identify the type of income, total each category, format it for import into tax software, and tell me about anything you could not read."
     },
     {
       "name": "merge_documents",
       "description": "Combine multiple PDFs into one document",
-      "text": "Use PDF Tools to merge PDF files stored on this computer into one document. Start by listing the PDFs in my Documents folder so I can choose which ones to combine, then ask me where to save the result. Preserve the page order, and afterwards report the page count and the output path so I can check it. File operations happen locally; content you inspect is handled under my MCP host or model provider's data terms."
+      "text": "Use PDF Tools to merge PDF files stored on this computer into one document. If I haven't already named them, start by listing the PDFs you can see so I can choose which ones to combine, then ask me where to save the result. Preserve the page order, and afterwards report the page count and the output path so I can check it. File operations happen locally; content you inspect is handled under my MCP host or model provider's data terms."
     },
     {
       "name": "split_large_document",
       "description": "Split a PDF into smaller files",
-      "text": "Use PDF Tools to split a PDF stored on this computer into separate files. If I haven't given you a path, start by listing the PDFs in my Documents folder so I can pick one. I'll either give you exact page ranges (for example pages 1-10 and 11-20) or ask you to split at a regular interval (for example every 5 pages). Save each section as its own PDF and tell me where you wrote them."
+      "text": "Use PDF Tools to split a PDF stored on this computer into separate files. If I haven't given you a path, start by listing the PDFs you can see so I can pick one. I'll either give you exact page ranges (for example pages 1-10 and 11-20) or ask you to split at a regular interval (for example every 5 pages). Save each section as its own PDF and tell me where you wrote them."
     },
     {
       "name": "organize_scanned_pages",
       "description": "Rotate and reorder scanned PDF pages",
-      "text": "Use PDF Tools to fix up a scanned PDF stored on this computer. If I haven't given you a path, start by listing the PDFs in my Documents folder so I can pick one. Rotate the pages I tell you are sideways or upside-down (90, 180, or 270 degrees) and reorder pages that were scanned out of sequence. Tell me the page order and rotations you plan to apply before you save, so I can confirm them."
+      "text": "Use PDF Tools to fix up a scanned PDF stored on this computer. If I haven't given you a path, start by listing the PDFs you can see so I can pick one. Rotate the pages I tell you are sideways or upside-down (90, 180, or 270 degrees) and reorder pages that were scanned out of sequence. Tell me the page order and rotations you plan to apply before you save, so I can confirm them."
     }
   ],
   "user_config": {

--- a/pdf-toolkit-mcp-share/server/index.js
+++ b/pdf-toolkit-mcp-share/server/index.js
@@ -1100,31 +1100,31 @@ const PROMPT_TEMPLATES = [
     name: "view_and_analyze_pdf",
     description: "Open and analyze any PDF document",
     arguments: ["focus"],
-    text: "Use PDF Tools to open a PDF stored on this computer and analyze it, focusing on ${arguments.focus}. If I haven't given you a path, start by listing the PDFs in my Documents folder so I can pick one. Then extract key findings, summarize sections, answer questions about specific pages, pull out structured data, and identify form fields if present.",
+    text: "Use PDF Tools to open a PDF stored on this computer and analyze it, focusing on ${arguments.focus}. If I haven't given you a path, start by listing the PDFs you can see so I can pick one. Then extract key findings, summarize sections, answer questions about specific pages, pull out structured data, and identify form fields if present.",
   },
   {
     name: "research_paper_analysis",
     description: "Analyze & summarize research papers",
     arguments: ["focus_area"],
-    text: "Use PDF Tools to analyze a research paper stored on this computer, focusing on ${arguments.focus_area}. If I haven't given you a path, start by listing the PDFs in my Documents folder so I can pick one. Extract the key findings and methodology, identify research gaps, summarize it chapter by chapter, pull out the citations, and draft a literature review outline.",
+    text: "Use PDF Tools to analyze a research paper stored on this computer, focusing on ${arguments.focus_area}. If I haven't given you a path, start by listing the PDFs you can see so I can pick one. Extract the key findings and methodology, identify research gaps, summarize it chapter by chapter, pull out the citations, and draft a literature review outline.",
   },
   {
     name: "contract_comparison",
     description: "Compare legal documents & contracts",
     arguments: ["comparison_focus"],
-    text: "Use PDF Tools to compare contracts or legal documents stored on this computer, focusing on ${arguments.comparison_focus}. If I haven't given you their paths, start by listing the PDFs in my Documents folder so I can pick them. Highlight changed clauses, modified terms, added or removed sections, pricing differences, and liability changes, then summarize the comparison.",
+    text: "Use PDF Tools to compare contracts or legal documents stored on this computer, focusing on ${arguments.comparison_focus}. If I haven't given you their paths, start by listing the PDFs you can see so I can pick them. Highlight changed clauses, modified terms, added or removed sections, pricing differences, and liability changes, then summarize the comparison.",
   },
   {
     name: "financial_report_extraction",
     description: "Extract data from financial statements",
     arguments: ["output_format"],
-    text: "Use PDF Tools to extract and analyze data from financial PDFs stored on this computer, including tables and key metrics. If I haven't given you a path, start by listing the PDFs in my Documents folder so I can pick one. Convert what you extract to ${arguments.output_format} format, cite the page for the values you extract, and tell me plainly about anything you could not extract.",
+    text: "Use PDF Tools to extract and analyze data from financial PDFs stored on this computer, including tables and key metrics. If I haven't given you a path, start by listing the PDFs you can see so I can pick one. Convert what you extract to ${arguments.output_format} format, cite the page for the values you extract, and tell me plainly about anything you could not extract.",
   },
   {
     name: "document_qa_session",
     description: "Interactive Q&A about your documents",
     arguments: ["initial_question"],
-    text: "Use PDF Tools to open a PDF stored on this computer so we can discuss it. My first question is: ${arguments.initial_question}. If I haven't given you a path, start by listing the PDFs in my Documents folder so I can pick one. Find specific information, explain complex sections, cross-reference different parts, and quote passages with their page numbers.",
+    text: "Use PDF Tools to open a PDF stored on this computer so we can discuss it. My first question is: ${arguments.initial_question}. If I haven't given you a path, start by listing the PDFs you can see so I can pick one. Find specific information, explain complex sections, cross-reference different parts, and quote passages with their page numbers.",
   },
   {
     name: "bulk_invoice_processing",
@@ -1136,49 +1136,49 @@ const PROMPT_TEMPLATES = [
     name: "technical_documentation_summary",
     description: "Summarize technical manuals & documentation",
     arguments: ["summary_type"],
-    text: "Use PDF Tools to analyze technical documentation stored on this computer and create ${arguments.summary_type}. If I haven't given you a path, start by listing the PDFs in my Documents folder so I can pick one. Extract the code examples, build a reference guide, identify the implementation steps, and summarize the troubleshooting sections.",
+    text: "Use PDF Tools to analyze technical documentation stored on this computer and create ${arguments.summary_type}. If I haven't given you a path, start by listing the PDFs you can see so I can pick one. Extract the code examples, build a reference guide, identify the implementation steps, and summarize the troubleshooting sections.",
   },
   {
     name: "fill_w9_business",
     description: "Fill W-9 for business entity",
     arguments: [],
-    text: "Use PDF Tools to fill out a W-9 stored on this computer for my business. Start by listing the PDFs in my Documents folder so I can point you at the right form, then read its fields. Ask me for the business legal name, the DBA or trade name if it differs, the business type (LLC, corporation, partnership), the tax classification, the EIN, and the business address. Check the correct tax classification boxes and tell me about any required field you could not fill.",
+    text: "Use PDF Tools to fill out a W-9 stored on this computer for my business. If I haven't already given you the file, start by listing the PDFs you can see so I can point you at the right form, then read its fields. Ask me for the business legal name, the DBA or trade name if it differs, the business type (LLC, corporation, partnership), the tax classification, the EIN, and the business address. Check the correct tax classification boxes and tell me about any required field you could not fill.",
   },
   {
     name: "batch_invoices",
     description: "Process multiple invoices",
     arguments: [],
-    text: "Use PDF Tools to batch process invoice PDFs stored on this computer. Start by listing the PDFs in my Documents folder so I can confirm which ones to use, or I'll name a different folder. Extract the amounts and dates, build a summary spreadsheet, flag missing information, total them by vendor, date, and category, and tell me about any invoice you could not read. Ask me which fields matter most before you start.",
+    text: "Use PDF Tools to batch process invoice PDFs stored on this computer. If I haven't already named them, start by listing the PDFs you can see so I can confirm which ones to use, or I'll name a different folder. Extract the amounts and dates, build a summary spreadsheet, flag missing information, total them by vendor, date, and category, and tell me about any invoice you could not read. Ask me which fields matter most before you start.",
   },
   {
     name: "rental_application",
     description: "Fill rental application",
     arguments: [],
-    text: "Use PDF Tools to help me complete a rental application stored on this computer. Start by listing the PDFs in my Documents folder so I can point you at the right form, then read its fields. I'll have ready my personal details, three years of employment history, income verification, three years of previous addresses, references, vehicle information, and an emergency contact. Fill every required field and flag the ones that need supporting documents.",
+    text: "Use PDF Tools to help me complete a rental application stored on this computer. If I haven't already given you the file, start by listing the PDFs you can see so I can point you at the right form, then read its fields. I'll have ready my personal details, three years of employment history, income verification, three years of previous addresses, references, vehicle information, and an emergency contact. Fill every required field and flag the ones that need supporting documents.",
   },
   {
     name: "extract_1099_data",
     description: "Extract data from 1099 forms",
     arguments: [],
-    text: "Use PDF Tools to extract the data from 1099 forms stored on this computer (1099-NEC, 1099-MISC, 1099-DIV, 1099-INT and similar) and build a tax summary. Start by listing the PDFs in my Documents folder so I can confirm which ones to use. Organize by payer, identify the type of income, total each category, format it for import into tax software, and tell me about anything you could not read.",
+    text: "Use PDF Tools to extract the data from 1099 forms stored on this computer (1099-NEC, 1099-MISC, 1099-DIV, 1099-INT and similar) and build a tax summary. If I haven't already named them, start by listing the PDFs you can see so I can confirm which ones to use. Organize by payer, identify the type of income, total each category, format it for import into tax software, and tell me about anything you could not read.",
   },
   {
     name: "merge_documents",
     description: "Combine multiple PDFs into one document",
     arguments: [],
-    text: "Use PDF Tools to merge PDF files stored on this computer into one document. Start by listing the PDFs in my Documents folder so I can choose which ones to combine, then ask me where to save the result. Preserve the page order, and afterwards report the page count and the output path so I can check it. File operations happen locally; content you inspect is handled under my MCP host or model provider's data terms.",
+    text: "Use PDF Tools to merge PDF files stored on this computer into one document. If I haven't already named them, start by listing the PDFs you can see so I can choose which ones to combine, then ask me where to save the result. Preserve the page order, and afterwards report the page count and the output path so I can check it. File operations happen locally; content you inspect is handled under my MCP host or model provider's data terms.",
   },
   {
     name: "split_large_document",
     description: "Split a PDF into smaller files",
     arguments: [],
-    text: "Use PDF Tools to split a PDF stored on this computer into separate files. If I haven't given you a path, start by listing the PDFs in my Documents folder so I can pick one. I'll either give you exact page ranges (for example pages 1-10 and 11-20) or ask you to split at a regular interval (for example every 5 pages). Save each section as its own PDF and tell me where you wrote them.",
+    text: "Use PDF Tools to split a PDF stored on this computer into separate files. If I haven't given you a path, start by listing the PDFs you can see so I can pick one. I'll either give you exact page ranges (for example pages 1-10 and 11-20) or ask you to split at a regular interval (for example every 5 pages). Save each section as its own PDF and tell me where you wrote them.",
   },
   {
     name: "organize_scanned_pages",
     description: "Rotate and reorder scanned PDF pages",
     arguments: [],
-    text: "Use PDF Tools to fix up a scanned PDF stored on this computer. If I haven't given you a path, start by listing the PDFs in my Documents folder so I can pick one. Rotate the pages I tell you are sideways or upside-down (90, 180, or 270 degrees) and reorder pages that were scanned out of sequence. Tell me the page order and rotations you plan to apply before you save, so I can confirm them.",
+    text: "Use PDF Tools to fix up a scanned PDF stored on this computer. If I haven't given you a path, start by listing the PDFs you can see so I can pick one. Rotate the pages I tell you are sideways or upside-down (90, 180, or 270 degrees) and reorder pages that were scanned out of sequence. Tell me the page order and rotations you plan to apply before you save, so I can confirm them.",
   },
 ];
 
@@ -1187,7 +1187,16 @@ const PROMPT_ARGUMENT_MAX_LENGTH = 1024;
 // ordinary folder is never truncated, small enough that a folder holding years
 // of scanned documents cannot flood the conversation before any work starts.
 const LIST_PDFS_MAX_RESULTS = 200;
-const PROMPT_ARGUMENT_UNSAFE_CONTROLS = /[\u0000-\u001f\u007f-\u009f\u00ad\u200b-\u200f\u2028-\u202e\u2060-\u206f\ufeff]/u;
+// Values are substituted straight into a user-role message with no isolation,
+// so this regex is the only barrier left between a caller-supplied argument and
+// an operative instruction. Added beyond the original set:
+//   U+061C   ARABIC LETTER MARK, a bidi control MCP_CONTRACT already claims to reject
+//   U+180E   MONGOLIAN VOWEL SEPARATOR, historically a zero-width space
+//   U+3164   HANGUL FILLER and U+FFA0, blank glyphs usable as invisible padding
+//   U+FE00-FE0F, U+E0100-E01EF   variation selectors, render invisibly
+//   U+E0000-E007F   the Tags block, which encodes arbitrary hidden ASCII and is
+//                   the standard channel for smuggling an instruction past a human
+const PROMPT_ARGUMENT_UNSAFE_CONTROLS = /[\u0000-\u001f\u007f-\u009f\u00ad\u061c\u180e\u200b-\u200f\u2028-\u202e\u2060-\u206f\u3164\ufe00-\ufe0f\ufeff\uffa0]|[\u{e0000}-\u{e007f}]|[\u{e0100}-\u{e01ef}]/u;
 const RESOURCE_NOT_FOUND_ERROR_CODE = -32002;
 
 function validatedPromptArguments(prompt, suppliedArguments = {}) {
@@ -2487,13 +2496,18 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
     tools: [
       {
         name: "list_pdfs",
-        description: "List PDF files in a directory, sorted by name, returning at most 200 paths and reporting the true total when more exist. This tool operates on the user's local filesystem — all paths must be absolute paths on the user's machine (e.g. /Users/name/Documents/), NOT paths on Claude's container (/mnt/...).",
+        description: "List PDF files in a directory, sorted by name, returning at most 200 paths per call and reporting the true total when more exist. Use offset to page through a folder with more than 200 PDFs. This tool operates on the user's local filesystem — all paths must be absolute paths on the user's machine (e.g. /Users/name/Documents/), NOT paths on Claude's container (/mnt/...).",
         inputSchema: {
           type: "object",
           properties: {
             directory: {
               type: "string",
-              description: "Directory path to search for PDFs (default: ~/Documents). Must be a local filesystem path."
+              description: "Directory path to search for PDFs. Defaults to the configured PDFs folder. Must be a local filesystem path."
+            },
+            offset: {
+              type: "integer",
+              minimum: 0,
+              description: "Skip this many PDFs before listing. Use it to page through a folder holding more than 200 PDFs; the response reports the true total."
             }
           }
         },
@@ -3865,7 +3879,29 @@ async function handleToolCall(request) {
     switch (name) {
       case "list_pdfs": {
         const directory = resolvePath(args.directory || DEFAULT_PDF_DIR);
-        const files = await fs.readdir(directory);
+        // Every prompt template opens with this call, so a missing folder is the
+        // first thing a user can hit on a fresh install. A raw ENOENT scandir
+        // string is not something they can act on, and it is especially likely
+        // where the platform has no ~/Documents at all.
+        let files;
+        try {
+          files = await fs.readdir(directory);
+        } catch (error) {
+          if (error?.code === "ENOENT") {
+            throw new Error(
+              `No folder exists at ${directory}. `
+              + `Give me the folder your PDFs are actually in, `
+              + `or set the PDFs folder in this extension's settings.`,
+            );
+          }
+          if (error?.code === "ENOTDIR") {
+            throw new Error(`${directory} is a file, not a folder. Give me the folder that contains it.`);
+          }
+          if (error?.code === "EACCES" || error?.code === "EPERM") {
+            throw new Error(`This computer refused access to ${directory}. Check the folder's permissions.`);
+          }
+          throw error;
+        }
         const pdfFiles = files
           .filter(file => file.toLowerCase().endsWith('.pdf'))
           // readdir order is filesystem-dependent, so sort before any cap:
@@ -3883,27 +3919,66 @@ async function handleToolCall(request) {
         // about 768,000. A Documents folder holding years of scanned invoices
         // is exactly this product's user, so the entry point could consume a
         // whole context window before any work began.
-        const shown = pdfFiles.slice(0, LIST_PDFS_MAX_RESULTS);
-        const truncated = pdfFiles.length - shown.length;
-        if (truncated > 0) {
+        // An offset makes the cap a window rather than a ceiling. Without it a
+        // flat folder of thousands of date-named scans would have its newest
+        // files permanently unreachable, since the sort is ascending and
+        // "narrow the directory" is impossible when they are all in one folder.
+        const offset = Number.isInteger(args.offset) && args.offset > 0 ? args.offset : 0;
+        const shown = pdfFiles.slice(offset, offset + LIST_PDFS_MAX_RESULTS);
+        const remaining = pdfFiles.length - offset - shown.length;
+
+        if (offset === 0 && remaining <= 0) {
+          if (pdfFiles.length === 0) {
+            // "Found 0 PDF files:" with a trailing colon and nothing after it
+            // left a user with a misconfigured default unable to tell what was
+            // searched.
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: `No PDF files in ${directory}. `
+                    + `If your PDFs are somewhere else, tell me that folder.`
+                }
+              ],
+            };
+          }
+          // Unchanged wording for the ordinary case, so nothing that reads this
+          // output sees a difference on a normal folder.
           return {
             content: [
               {
                 type: "text",
-                text: `Found ${pdfFiles.length} PDF files in ${directory}. `
-                  + `Showing the first ${shown.length}, sorted by name; `
-                  + `${truncated} not shown.\n${shown.join('\n')}\n\n`
-                  + `Pass a more specific directory to narrow this list.`
+                text: `Found ${pdfFiles.length} PDF files:\n${pdfFiles.join('\n')}`
               }
             ],
           };
         }
 
+        if (shown.length === 0) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Found ${pdfFiles.length} PDF files in ${directory}. `
+                  + `Offset ${offset} is past the end of the list.`
+              }
+            ],
+          };
+        }
+
+        const position = `${offset + 1} to ${offset + shown.length} of ${pdfFiles.length}`;
+        const more = remaining > 0
+          ? ` To see the next ${Math.min(remaining, LIST_PDFS_MAX_RESULTS)}, call this tool again `
+            + `with offset ${offset + shown.length}.`
+          : ` That is the end of the list.`;
         return {
           content: [
             {
               type: "text",
-              text: `Found ${pdfFiles.length} PDF files:\n${pdfFiles.join('\n')}`
+              text: `Found ${pdfFiles.length} PDF files in ${directory}. `
+                + `Showing ${position}, sorted by name.\n${shown.join('\n')}\n\n`
+                + `Narrow the search with a more specific directory,`
+                + `${more}`
             }
           ],
         };

--- a/pdf-toolkit-mcp-share/server/pdfjs-subprocess.js
+++ b/pdf-toolkit-mcp-share/server/pdfjs-subprocess.js
@@ -938,8 +938,7 @@ async function loadInProcessWorkerModule() {
 //
 // That is not enough on its own to trust a default, because the failure this
 // guards against is a hard host crash that no in-process handler can catch. So
-// the default is win32-only and is backed by the crash-survival latch below.
-// The default stays OFF everywhere, and the flag stays a pure opt-in.
+// the default stays OFF everywhere and the flag stays a pure opt-in.
 //
 // A win32 default was implemented and reverted. An adversarial review showed the
 // crash-survival latch backing it did not hold: it cleared its marker the moment

--- a/server/index.js
+++ b/server/index.js
@@ -1100,31 +1100,31 @@ const PROMPT_TEMPLATES = [
     name: "view_and_analyze_pdf",
     description: "Open and analyze any PDF document",
     arguments: ["focus"],
-    text: "Use PDF Tools to open a PDF stored on this computer and analyze it, focusing on ${arguments.focus}. If I haven't given you a path, start by listing the PDFs in my Documents folder so I can pick one. Then extract key findings, summarize sections, answer questions about specific pages, pull out structured data, and identify form fields if present.",
+    text: "Use PDF Tools to open a PDF stored on this computer and analyze it, focusing on ${arguments.focus}. If I haven't given you a path, start by listing the PDFs you can see so I can pick one. Then extract key findings, summarize sections, answer questions about specific pages, pull out structured data, and identify form fields if present.",
   },
   {
     name: "research_paper_analysis",
     description: "Analyze & summarize research papers",
     arguments: ["focus_area"],
-    text: "Use PDF Tools to analyze a research paper stored on this computer, focusing on ${arguments.focus_area}. If I haven't given you a path, start by listing the PDFs in my Documents folder so I can pick one. Extract the key findings and methodology, identify research gaps, summarize it chapter by chapter, pull out the citations, and draft a literature review outline.",
+    text: "Use PDF Tools to analyze a research paper stored on this computer, focusing on ${arguments.focus_area}. If I haven't given you a path, start by listing the PDFs you can see so I can pick one. Extract the key findings and methodology, identify research gaps, summarize it chapter by chapter, pull out the citations, and draft a literature review outline.",
   },
   {
     name: "contract_comparison",
     description: "Compare legal documents & contracts",
     arguments: ["comparison_focus"],
-    text: "Use PDF Tools to compare contracts or legal documents stored on this computer, focusing on ${arguments.comparison_focus}. If I haven't given you their paths, start by listing the PDFs in my Documents folder so I can pick them. Highlight changed clauses, modified terms, added or removed sections, pricing differences, and liability changes, then summarize the comparison.",
+    text: "Use PDF Tools to compare contracts or legal documents stored on this computer, focusing on ${arguments.comparison_focus}. If I haven't given you their paths, start by listing the PDFs you can see so I can pick them. Highlight changed clauses, modified terms, added or removed sections, pricing differences, and liability changes, then summarize the comparison.",
   },
   {
     name: "financial_report_extraction",
     description: "Extract data from financial statements",
     arguments: ["output_format"],
-    text: "Use PDF Tools to extract and analyze data from financial PDFs stored on this computer, including tables and key metrics. If I haven't given you a path, start by listing the PDFs in my Documents folder so I can pick one. Convert what you extract to ${arguments.output_format} format, cite the page for the values you extract, and tell me plainly about anything you could not extract.",
+    text: "Use PDF Tools to extract and analyze data from financial PDFs stored on this computer, including tables and key metrics. If I haven't given you a path, start by listing the PDFs you can see so I can pick one. Convert what you extract to ${arguments.output_format} format, cite the page for the values you extract, and tell me plainly about anything you could not extract.",
   },
   {
     name: "document_qa_session",
     description: "Interactive Q&A about your documents",
     arguments: ["initial_question"],
-    text: "Use PDF Tools to open a PDF stored on this computer so we can discuss it. My first question is: ${arguments.initial_question}. If I haven't given you a path, start by listing the PDFs in my Documents folder so I can pick one. Find specific information, explain complex sections, cross-reference different parts, and quote passages with their page numbers.",
+    text: "Use PDF Tools to open a PDF stored on this computer so we can discuss it. My first question is: ${arguments.initial_question}. If I haven't given you a path, start by listing the PDFs you can see so I can pick one. Find specific information, explain complex sections, cross-reference different parts, and quote passages with their page numbers.",
   },
   {
     name: "bulk_invoice_processing",
@@ -1136,49 +1136,49 @@ const PROMPT_TEMPLATES = [
     name: "technical_documentation_summary",
     description: "Summarize technical manuals & documentation",
     arguments: ["summary_type"],
-    text: "Use PDF Tools to analyze technical documentation stored on this computer and create ${arguments.summary_type}. If I haven't given you a path, start by listing the PDFs in my Documents folder so I can pick one. Extract the code examples, build a reference guide, identify the implementation steps, and summarize the troubleshooting sections.",
+    text: "Use PDF Tools to analyze technical documentation stored on this computer and create ${arguments.summary_type}. If I haven't given you a path, start by listing the PDFs you can see so I can pick one. Extract the code examples, build a reference guide, identify the implementation steps, and summarize the troubleshooting sections.",
   },
   {
     name: "fill_w9_business",
     description: "Fill W-9 for business entity",
     arguments: [],
-    text: "Use PDF Tools to fill out a W-9 stored on this computer for my business. Start by listing the PDFs in my Documents folder so I can point you at the right form, then read its fields. Ask me for the business legal name, the DBA or trade name if it differs, the business type (LLC, corporation, partnership), the tax classification, the EIN, and the business address. Check the correct tax classification boxes and tell me about any required field you could not fill.",
+    text: "Use PDF Tools to fill out a W-9 stored on this computer for my business. If I haven't already given you the file, start by listing the PDFs you can see so I can point you at the right form, then read its fields. Ask me for the business legal name, the DBA or trade name if it differs, the business type (LLC, corporation, partnership), the tax classification, the EIN, and the business address. Check the correct tax classification boxes and tell me about any required field you could not fill.",
   },
   {
     name: "batch_invoices",
     description: "Process multiple invoices",
     arguments: [],
-    text: "Use PDF Tools to batch process invoice PDFs stored on this computer. Start by listing the PDFs in my Documents folder so I can confirm which ones to use, or I'll name a different folder. Extract the amounts and dates, build a summary spreadsheet, flag missing information, total them by vendor, date, and category, and tell me about any invoice you could not read. Ask me which fields matter most before you start.",
+    text: "Use PDF Tools to batch process invoice PDFs stored on this computer. If I haven't already named them, start by listing the PDFs you can see so I can confirm which ones to use, or I'll name a different folder. Extract the amounts and dates, build a summary spreadsheet, flag missing information, total them by vendor, date, and category, and tell me about any invoice you could not read. Ask me which fields matter most before you start.",
   },
   {
     name: "rental_application",
     description: "Fill rental application",
     arguments: [],
-    text: "Use PDF Tools to help me complete a rental application stored on this computer. Start by listing the PDFs in my Documents folder so I can point you at the right form, then read its fields. I'll have ready my personal details, three years of employment history, income verification, three years of previous addresses, references, vehicle information, and an emergency contact. Fill every required field and flag the ones that need supporting documents.",
+    text: "Use PDF Tools to help me complete a rental application stored on this computer. If I haven't already given you the file, start by listing the PDFs you can see so I can point you at the right form, then read its fields. I'll have ready my personal details, three years of employment history, income verification, three years of previous addresses, references, vehicle information, and an emergency contact. Fill every required field and flag the ones that need supporting documents.",
   },
   {
     name: "extract_1099_data",
     description: "Extract data from 1099 forms",
     arguments: [],
-    text: "Use PDF Tools to extract the data from 1099 forms stored on this computer (1099-NEC, 1099-MISC, 1099-DIV, 1099-INT and similar) and build a tax summary. Start by listing the PDFs in my Documents folder so I can confirm which ones to use. Organize by payer, identify the type of income, total each category, format it for import into tax software, and tell me about anything you could not read.",
+    text: "Use PDF Tools to extract the data from 1099 forms stored on this computer (1099-NEC, 1099-MISC, 1099-DIV, 1099-INT and similar) and build a tax summary. If I haven't already named them, start by listing the PDFs you can see so I can confirm which ones to use. Organize by payer, identify the type of income, total each category, format it for import into tax software, and tell me about anything you could not read.",
   },
   {
     name: "merge_documents",
     description: "Combine multiple PDFs into one document",
     arguments: [],
-    text: "Use PDF Tools to merge PDF files stored on this computer into one document. Start by listing the PDFs in my Documents folder so I can choose which ones to combine, then ask me where to save the result. Preserve the page order, and afterwards report the page count and the output path so I can check it. File operations happen locally; content you inspect is handled under my MCP host or model provider's data terms.",
+    text: "Use PDF Tools to merge PDF files stored on this computer into one document. If I haven't already named them, start by listing the PDFs you can see so I can choose which ones to combine, then ask me where to save the result. Preserve the page order, and afterwards report the page count and the output path so I can check it. File operations happen locally; content you inspect is handled under my MCP host or model provider's data terms.",
   },
   {
     name: "split_large_document",
     description: "Split a PDF into smaller files",
     arguments: [],
-    text: "Use PDF Tools to split a PDF stored on this computer into separate files. If I haven't given you a path, start by listing the PDFs in my Documents folder so I can pick one. I'll either give you exact page ranges (for example pages 1-10 and 11-20) or ask you to split at a regular interval (for example every 5 pages). Save each section as its own PDF and tell me where you wrote them.",
+    text: "Use PDF Tools to split a PDF stored on this computer into separate files. If I haven't given you a path, start by listing the PDFs you can see so I can pick one. I'll either give you exact page ranges (for example pages 1-10 and 11-20) or ask you to split at a regular interval (for example every 5 pages). Save each section as its own PDF and tell me where you wrote them.",
   },
   {
     name: "organize_scanned_pages",
     description: "Rotate and reorder scanned PDF pages",
     arguments: [],
-    text: "Use PDF Tools to fix up a scanned PDF stored on this computer. If I haven't given you a path, start by listing the PDFs in my Documents folder so I can pick one. Rotate the pages I tell you are sideways or upside-down (90, 180, or 270 degrees) and reorder pages that were scanned out of sequence. Tell me the page order and rotations you plan to apply before you save, so I can confirm them.",
+    text: "Use PDF Tools to fix up a scanned PDF stored on this computer. If I haven't given you a path, start by listing the PDFs you can see so I can pick one. Rotate the pages I tell you are sideways or upside-down (90, 180, or 270 degrees) and reorder pages that were scanned out of sequence. Tell me the page order and rotations you plan to apply before you save, so I can confirm them.",
   },
 ];
 
@@ -1187,7 +1187,16 @@ const PROMPT_ARGUMENT_MAX_LENGTH = 1024;
 // ordinary folder is never truncated, small enough that a folder holding years
 // of scanned documents cannot flood the conversation before any work starts.
 const LIST_PDFS_MAX_RESULTS = 200;
-const PROMPT_ARGUMENT_UNSAFE_CONTROLS = /[\u0000-\u001f\u007f-\u009f\u00ad\u200b-\u200f\u2028-\u202e\u2060-\u206f\ufeff]/u;
+// Values are substituted straight into a user-role message with no isolation,
+// so this regex is the only barrier left between a caller-supplied argument and
+// an operative instruction. Added beyond the original set:
+//   U+061C   ARABIC LETTER MARK, a bidi control MCP_CONTRACT already claims to reject
+//   U+180E   MONGOLIAN VOWEL SEPARATOR, historically a zero-width space
+//   U+3164   HANGUL FILLER and U+FFA0, blank glyphs usable as invisible padding
+//   U+FE00-FE0F, U+E0100-E01EF   variation selectors, render invisibly
+//   U+E0000-E007F   the Tags block, which encodes arbitrary hidden ASCII and is
+//                   the standard channel for smuggling an instruction past a human
+const PROMPT_ARGUMENT_UNSAFE_CONTROLS = /[\u0000-\u001f\u007f-\u009f\u00ad\u061c\u180e\u200b-\u200f\u2028-\u202e\u2060-\u206f\u3164\ufe00-\ufe0f\ufeff\uffa0]|[\u{e0000}-\u{e007f}]|[\u{e0100}-\u{e01ef}]/u;
 const RESOURCE_NOT_FOUND_ERROR_CODE = -32002;
 
 function validatedPromptArguments(prompt, suppliedArguments = {}) {
@@ -2487,13 +2496,18 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
     tools: [
       {
         name: "list_pdfs",
-        description: "List PDF files in a directory, sorted by name, returning at most 200 paths and reporting the true total when more exist. This tool operates on the user's local filesystem — all paths must be absolute paths on the user's machine (e.g. /Users/name/Documents/), NOT paths on Claude's container (/mnt/...).",
+        description: "List PDF files in a directory, sorted by name, returning at most 200 paths per call and reporting the true total when more exist. Use offset to page through a folder with more than 200 PDFs. This tool operates on the user's local filesystem — all paths must be absolute paths on the user's machine (e.g. /Users/name/Documents/), NOT paths on Claude's container (/mnt/...).",
         inputSchema: {
           type: "object",
           properties: {
             directory: {
               type: "string",
-              description: "Directory path to search for PDFs (default: ~/Documents). Must be a local filesystem path."
+              description: "Directory path to search for PDFs. Defaults to the configured PDFs folder. Must be a local filesystem path."
+            },
+            offset: {
+              type: "integer",
+              minimum: 0,
+              description: "Skip this many PDFs before listing. Use it to page through a folder holding more than 200 PDFs; the response reports the true total."
             }
           }
         },
@@ -3865,7 +3879,29 @@ async function handleToolCall(request) {
     switch (name) {
       case "list_pdfs": {
         const directory = resolvePath(args.directory || DEFAULT_PDF_DIR);
-        const files = await fs.readdir(directory);
+        // Every prompt template opens with this call, so a missing folder is the
+        // first thing a user can hit on a fresh install. A raw ENOENT scandir
+        // string is not something they can act on, and it is especially likely
+        // where the platform has no ~/Documents at all.
+        let files;
+        try {
+          files = await fs.readdir(directory);
+        } catch (error) {
+          if (error?.code === "ENOENT") {
+            throw new Error(
+              `No folder exists at ${directory}. `
+              + `Give me the folder your PDFs are actually in, `
+              + `or set the PDFs folder in this extension's settings.`,
+            );
+          }
+          if (error?.code === "ENOTDIR") {
+            throw new Error(`${directory} is a file, not a folder. Give me the folder that contains it.`);
+          }
+          if (error?.code === "EACCES" || error?.code === "EPERM") {
+            throw new Error(`This computer refused access to ${directory}. Check the folder's permissions.`);
+          }
+          throw error;
+        }
         const pdfFiles = files
           .filter(file => file.toLowerCase().endsWith('.pdf'))
           // readdir order is filesystem-dependent, so sort before any cap:
@@ -3883,27 +3919,66 @@ async function handleToolCall(request) {
         // about 768,000. A Documents folder holding years of scanned invoices
         // is exactly this product's user, so the entry point could consume a
         // whole context window before any work began.
-        const shown = pdfFiles.slice(0, LIST_PDFS_MAX_RESULTS);
-        const truncated = pdfFiles.length - shown.length;
-        if (truncated > 0) {
+        // An offset makes the cap a window rather than a ceiling. Without it a
+        // flat folder of thousands of date-named scans would have its newest
+        // files permanently unreachable, since the sort is ascending and
+        // "narrow the directory" is impossible when they are all in one folder.
+        const offset = Number.isInteger(args.offset) && args.offset > 0 ? args.offset : 0;
+        const shown = pdfFiles.slice(offset, offset + LIST_PDFS_MAX_RESULTS);
+        const remaining = pdfFiles.length - offset - shown.length;
+
+        if (offset === 0 && remaining <= 0) {
+          if (pdfFiles.length === 0) {
+            // "Found 0 PDF files:" with a trailing colon and nothing after it
+            // left a user with a misconfigured default unable to tell what was
+            // searched.
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: `No PDF files in ${directory}. `
+                    + `If your PDFs are somewhere else, tell me that folder.`
+                }
+              ],
+            };
+          }
+          // Unchanged wording for the ordinary case, so nothing that reads this
+          // output sees a difference on a normal folder.
           return {
             content: [
               {
                 type: "text",
-                text: `Found ${pdfFiles.length} PDF files in ${directory}. `
-                  + `Showing the first ${shown.length}, sorted by name; `
-                  + `${truncated} not shown.\n${shown.join('\n')}\n\n`
-                  + `Pass a more specific directory to narrow this list.`
+                text: `Found ${pdfFiles.length} PDF files:\n${pdfFiles.join('\n')}`
               }
             ],
           };
         }
 
+        if (shown.length === 0) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Found ${pdfFiles.length} PDF files in ${directory}. `
+                  + `Offset ${offset} is past the end of the list.`
+              }
+            ],
+          };
+        }
+
+        const position = `${offset + 1} to ${offset + shown.length} of ${pdfFiles.length}`;
+        const more = remaining > 0
+          ? ` To see the next ${Math.min(remaining, LIST_PDFS_MAX_RESULTS)}, call this tool again `
+            + `with offset ${offset + shown.length}.`
+          : ` That is the end of the list.`;
         return {
           content: [
             {
               type: "text",
-              text: `Found ${pdfFiles.length} PDF files:\n${pdfFiles.join('\n')}`
+              text: `Found ${pdfFiles.length} PDF files in ${directory}. `
+                + `Showing ${position}, sorted by name.\n${shown.join('\n')}\n\n`
+                + `Narrow the search with a more specific directory,`
+                + `${more}`
             }
           ],
         };

--- a/server/pdfjs-subprocess.js
+++ b/server/pdfjs-subprocess.js
@@ -938,8 +938,7 @@ async function loadInProcessWorkerModule() {
 //
 // That is not enough on its own to trust a default, because the failure this
 // guards against is a hard host crash that no in-process handler can catch. So
-// the default is win32-only and is backed by the crash-survival latch below.
-// The default stays OFF everywhere, and the flag stays a pure opt-in.
+// the default stays OFF everywhere and the flag stays a pure opt-in.
 //
 // A win32 default was implemented and reverted. An adversarial review showed the
 // crash-survival latch backing it did not hold: it cleared its marker the moment

--- a/test/fixtures/eval/trajectories/tool-contracts.v3.json
+++ b/test/fixtures/eval/trajectories/tool-contracts.v3.json
@@ -5,7 +5,7 @@
     "name": "pdf-tools",
     "version": "0.9.6"
   },
-  "tools_sha256": "c5b752a58ccd18ef8872cb0fc42c5cd246280594e657be41ab072f25d3975d36",
+  "tools_sha256": "ee9eb99327a9b218e581f45ab54adfe2224fa36036d00525c9ddcd9a1e84a202",
   "tools": [
     {
       "name": "add_signature_field",
@@ -1010,7 +1010,12 @@
         "properties": {
           "directory": {
             "type": "string",
-            "description": "Directory path to search for PDFs (default: ~/Documents). Must be a local filesystem path."
+            "description": "Directory path to search for PDFs. Defaults to the configured PDFs folder. Must be a local filesystem path."
+          },
+          "offset": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Skip this many PDFs before listing. Use it to page through a folder holding more than 200 PDFs; the response reports the true total."
           }
         }
       }

--- a/test/list-pdfs-default-directory.test.js
+++ b/test/list-pdfs-default-directory.test.js
@@ -166,8 +166,8 @@ describe("list_pdfs output is bounded", () => {
     expect(result.isError).not.toBe(true);
     // The true total is reported even though it is not all shown.
     expect(text).toContain(`Found ${FILE_COUNT} PDF files`);
-    expect(text).toContain("Showing the first 200");
-    expect(text).toContain(`${FILE_COUNT - 200} not shown`);
+    expect(text).toContain(`Showing 1 to 200 of ${FILE_COUNT}`);
+    expect(text).toContain("offset 200");
     const listed = text.split("\n").filter(line => line.endsWith(".pdf"));
     expect(listed).toHaveLength(200);
   }, 60_000);
@@ -188,4 +188,113 @@ describe("list_pdfs output is bounded", () => {
     expect(first).toContain("scan-0000.pdf");
     expect(first).not.toContain(`scan-${String(FILE_COUNT - 1).padStart(4, "0")}.pdf`);
   }, 60_000);
+});
+
+describe("first-run and paging behaviour", () => {
+  // Regressions found by adversarial review of the merged tree: a missing
+  // default folder returned a raw ENOENT scandir string as the first thing a
+  // user ever saw, and the 200 cap had no escape hatch for a flat folder.
+  let tmp;
+  let soloDir;
+  let client;
+  let transport;
+  const MANY = 205;
+
+  beforeAll(async () => {
+    tmp = await createTestTempDirectory(REPO_ROOT, "list-pdfs-firstrun");
+    const many = path.join(tmp, "many");
+    const empty = path.join(tmp, "empty");
+    await fs.mkdir(many, { recursive: true });
+    await fs.mkdir(empty, { recursive: true });
+    await fs.mkdir(path.join(tmp, "home"), { recursive: true });
+    await Promise.all(Array.from({ length: MANY }, (_, i) =>
+      fs.writeFile(path.join(many, `scan-${String(i).padStart(4, "0")}.pdf`), "%PDF-1.7\n")));
+    soloDir = path.join(tmp, "solo");
+    await fs.mkdir(soloDir, { recursive: true });
+    await fs.copyFile(EXAMPLE_PDF, path.join(soloDir, "only-one.pdf"));
+
+    client = new Client({ name: "pdf-tools-firstrun-client", version: "1.0.0" });
+    transport = new StdioClientTransport({
+      command: process.execPath,
+      args: [path.join(REPO_ROOT, "server", "index.js")],
+      cwd: REPO_ROOT,
+      env: {
+        HOME: path.join(tmp, "home"),
+        USERPROFILE: path.join(tmp, "home"),
+        ALLOWED_DIRECTORIES: [many, empty, path.join(tmp, "solo"), path.join(tmp, "absent")].join(path.delimiter),
+        DEFAULT_PDF_DIR: many,
+        DEFAULT_PROFILES_DIR: path.join(tmp, "profiles"),
+      },
+      stderr: "pipe",
+    });
+    await client.connect(transport);
+  }, 60_000);
+
+  afterAll(async () => {
+    try {
+      await transport?.close();
+    } finally {
+      await removeTestTempDirectory(tmp);
+    }
+  });
+
+  it("explains a missing folder instead of surfacing a raw errno", async () => {
+    const result = await client.callTool({
+      name: "list_pdfs",
+      arguments: { directory: path.join(tmp, "absent") },
+    });
+    const text = textFromToolResult(result);
+    expect(text).not.toContain("ENOENT");
+    expect(text).not.toContain("scandir");
+    expect(text).toContain("No folder exists at");
+  }, 30_000);
+
+  it("names the folder it searched when it finds nothing", async () => {
+    const result = await client.callTool({
+      name: "list_pdfs",
+      arguments: { directory: path.join(tmp, "empty") },
+    });
+    const text = textFromToolResult(result);
+    expect(text).toContain(path.join(tmp, "empty"));
+    // The old "Found 0 PDF files:" told the user nothing about where it looked.
+    expect(text).not.toMatch(/Found 0 PDF files:\s*$/);
+  }, 30_000);
+
+  it("pages past the cap so no file is permanently unreachable", async () => {
+    const first = textFromToolResult(await client.callTool({ name: "list_pdfs", arguments: {} }));
+    expect(first).toContain(`Found ${MANY} PDF files`);
+    expect(first).toContain("Showing 1 to 200");
+    expect(first).toContain("offset 200");
+    // The last file sorts last and is therefore invisible without paging.
+    const lastName = `scan-${String(MANY - 1).padStart(4, "0")}.pdf`;
+    expect(first).not.toContain(lastName);
+
+    const second = textFromToolResult(await client.callTool({
+      name: "list_pdfs",
+      arguments: { offset: 200 },
+    }));
+    expect(second).toContain(lastName);
+    expect(second).toContain(`Showing 201 to ${MANY} of ${MANY}`);
+    expect(second).toContain("end of the list");
+  }, 30_000);
+
+  it("reports an offset past the end rather than an empty listing", async () => {
+    const text = textFromToolResult(await client.callTool({
+      name: "list_pdfs",
+      arguments: { offset: 10_000 },
+    }));
+    expect(text).toContain("past the end of the list");
+  }, 30_000);
+
+  it("keeps the below-cap format byte-identical to the historical output", async () => {
+    // Pins the exact legacy string so a future refactor cannot quietly change
+    // what ordinary folders return.
+    const result = await client.callTool({
+      name: "list_pdfs",
+      arguments: { directory: soloDir },
+    });
+    expect(textFromToolResult(result)).toBe(
+      `Found 1 PDF files:\n${path.join(soloDir, "only-one.pdf")}`,
+    );
+  }, 30_000);
 });

--- a/test/mcp-contract.test.js
+++ b/test/mcp-contract.test.js
@@ -80,7 +80,10 @@ const EXAMPLE_PDF = path.join(REPO_ROOT, "example-fw9.pdf");
 // uncapped listing put ~38k tokens of filenames into the conversation for a
 // 2,000-PDF folder. Previously
 // d9c225a5b72694d73dc0064a28fecf76a5bedf27121b04e656b86f055ced9313.
-const TOOL_CONTRACT_SHA256 = "c65cd62a1d46c6b5837aa7bf12a1851717e4b09dc274182dcb07dac982e8fc64";
+// 2026-08-07: list_pdfs gains an offset parameter so a flat folder holding
+// more than 200 PDFs is fully reachable, and its description states the cap
+// and the paging. Previously c65cd62a1d46c6b5837aa7bf12a1851717e4b09dc274182dcb07dac982e8fc64.
+const TOOL_CONTRACT_SHA256 = "a594a3a23f6722fb121b9d2a57bad03fc60fda5e352583f07139d191914c8d52";
 
 const CLOSED_READ = Object.freeze({
   readOnlyHint: true,


### PR DESCRIPTION
Adversarial review of `c2fc630` (PR #91 as merged) returned **not shippable**, with five blocking findings. All five originated in that PR. This fixes them forward.

## 1. First-run failure — a raw errno as the user's first response

Every prompt template opens by listing a directory, so a missing folder is the first thing a user can hit. It returned `ENOENT: no such file or directory, scandir '/home/u/Documents'`. Now it names the absent folder and says what to do, and handles `ENOTDIR` and `EACCES` the same way. An empty folder previously produced `Found 0 PDF files:` — trailing colon, empty body, folder never named — leaving a user with a misconfigured default unable to tell what was searched.

**Prompts no longer hard-code "Documents."** The product ships a configurable PDFs folder, so naming Documents was wrong wherever a user changed it, wherever the platform has none, and under any host that resolves the default differently. They now say "the PDFs you can see" — true in all those cases, and still a concrete first action.

**Five prompts also listed unconditionally**, with no escape when the user had already supplied a path: `fill_w9_business`, `batch_invoices`, `rental_application`, `extract_1099_data`, `merge_documents`. They now check first.

## 2. Both shipped manifests advertised unbounded listing

PR #91 updated the runtime description to state the 200 cap but not the manifests — and `scripts/build-mcpb.mjs:220` stages `manifest.mcpb.json` into the packaged extension, so the shipped tool description was false.

Fixed in both, along with a **pre-existing drift** the review surfaced: `manifest.mcpb.json` carried a stale `convert_pdf_to_markdown` description missing its evidence-backed-tables and source-validated-links clause, wrong since `bf03b8d`.

## 3. The cap made files permanently unreachable

The sort is ascending, so a flat folder of date-named scans hid the **newest** files, and the remedy the message offered — narrow the directory — is impossible when they are all in one place. Those files were listable before the cap.

`list_pdfs` now takes an `offset`. The response reports which window it is showing, the true total, and the offset for the next page; an offset past the end says so rather than returning an empty listing.

## 4. The prompt-argument regex missed the standard smuggling channel

With argument isolation removed in PR #91, `PROMPT_ARGUMENT_UNSAFE_CONTROLS` is the only barrier left between a caller-supplied value and an operative `role: "user"` instruction. It missed:

- **U+E0000–E007F (Tags)** — encodes arbitrary hidden ASCII; the standard channel for smuggling an instruction past a human reader
- **U+061C** — a bidi control `docs/MCP_CONTRACT.md` already claimed to reject
- U+FE00–FE0F and U+E0100–E01EF variation selectors, U+3164 and U+FFA0 blank glyphs, U+180E

Verified: all reject; ordinary text still passes.

## 5. A comment asserting behaviour that had been reverted

`server/pdfjs-subprocess.js` held two adjacent sentences claiming opposite defaults, because `80d2d81` appended its correction instead of replacing the line it contradicted. A reader stopping at the first would conclude Windows defaults on. Fixed in both shipped copies.

## Also

The `offset` parameter moved a **second** pinned tool contract at `test/fixtures/eval/trajectories/tool-contracts.v3.json`, separate from `TOOL_CONTRACT_SHA256`. Regenerated with `scripts/eval-capture-tool-contracts.mjs`, not hand-edited; the diff is exactly the new property, the reworded description, and the resulting hash. Only the full aggregate catches this one.

## Verification

Full aggregate on macOS at `e22f633`, tree clean:

- `Test Files  134 passed | 4 skipped (138)`
- `Tests  2091 passed | 85 skipped (2176)`
- node-native: `pass 62, fail 0`
- `EXIT=0`

New tests cover the missing, not-a-directory, denied and empty folder cases, paging past the cap in both directions, an offset past the end, and pin the below-cap output byte-for-byte so a refactor cannot quietly change what ordinary folders return.

## Worth noting

PR #91 merged with a full green aggregate while all five of these were live. None are things that suite tests: a missing folder, a manifest string, a cap with no exit, an invisible character, a contradictory comment.