### PR TITLE
Make Type-3 glyph recovery producer-independent, and bind a legacy TeX corpus that proves what it still cannot do

### DIFF
--- a/docs/evidence/legacy-tex-corpus-baseline-2026-08.md
+++ b/docs/evidence/legacy-tex-corpus-baseline-2026-08.md
@@ -1,0 +1,177 @@
+# Legacy dvips-era Type-3 corpus — failing baseline, 2026-08
+
+## Outcome
+
+**This is a failing baseline. Every recovery figure in it is zero, and every
+zero is a defect, not an intention.**
+
+The Computer Modern Type-3 recovery that works on Shannon's 1948 paper does
+not transfer. A study across 11 dvips-era PDFs and 560,754 Type-3 glyph
+occurrences matched 0 of 29 eligible occurrences against any registry digest.
+This document binds five of those PDFs as a pinned, measured corpus so the
+gap has an executable size instead of an anecdote, and so any later work has
+something it must visibly move.
+
+Four of the five are D. J. Bernstein papers from cr.yp.to, produced by
+`GNU Ghostscript 6.52`, which repacks glyph names to `/a0 /a1 /a2…`. On these
+`pdftotext` yields literal noise and PDF Tools recovers nothing — not one
+character, and not even a font family for three of the four. The fifth is an
+arXiv paper where the TeX character codes *are* preserved and 11 occurrences
+do carry an official Unicode mapping, and it still recovers nothing, which
+isolates the digest problem from the code-packing problem.
+
+Nothing in the recovery path was changed to produce this record. The corpus
+was measured through the shipped code exactly as it stands.
+
+## The corpus
+
+The documents are third-party and are deliberately **not** committed to this
+repository. They are fetched to a scratch directory and bound by digest.
+
+| Document | URL | SHA-256 | Producer | Creator |
+| --- | --- | --- | --- | --- |
+| `pippenger.pdf` | https://cr.yp.to/papers/pippenger.pdf | `ec45c2193abf5acfb5adaaf71c4b4f7b487d90b21f80b7b6d48fd51fd655ccae` | `GNU Ghostscript 6.52` | *(absent)* |
+| `nfscircuit.pdf` | https://cr.yp.to/papers/nfscircuit.pdf | `eee46391621b5d5d2de5de93e7c34217c5c8a6b2db517a682e52d6fb336f6f46` | `GNU Ghostscript 6.52` | *(absent)* |
+| `m3.pdf` | https://cr.yp.to/papers/m3.pdf | `988189c6600a24b242c39cd617ea13307e2c3f9880bbafd4914c33ae20be5fc5` | `GNU Ghostscript 6.52` | *(absent)* |
+| `sf.pdf` | https://cr.yp.to/papers/sf.pdf | `5a094ee9709d51817b1184e9c01e2e3acf9e3fdc0153a5d876c9cbb138cf34d9` | `GNU Ghostscript 6.52` | *(absent)* |
+| `astro-ph-9402001.pdf` | https://arxiv.org/pdf/astro-ph/9402001 | `eb0f80aea9c3c359e3826866a9c8128d41862937f5002dbd016a6f6adbbc0041` | `GPL Ghostscript GIT PRERELEASE 9.22` | `dvips 5.518` |
+
+## Measured baseline
+
+Occurrence and coverage figures come from `inspectType3GlyphEvidenceForPage`
+through `scripts/inventory-type3-glyphs.mjs`, the same census path
+`test/type3-glyph-inventory.test.js` already uses. Font figures are a
+document-level census of every Type-3 font dictionary reachable from a page's
+`/Resources /Font`, deduplicated by indirect reference, asked of the shipped
+`uniqueComputerModernFamily` resolver over its positive-width slots.
+
+| Metric | pippenger | nfscircuit | m3 | sf | astro-ph-9402001 |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Pages | 21 | 11 | 19 | 15 | 37 |
+| Bytes | 292,684 | 186,703 | 276,417 | 268,946 | 929,486 |
+| Type-3 fonts | 22 | 12 | 20 | 16 | 22 |
+| — admissible to the font linker | 19 | 10 | 18 | 15 | 4 |
+| — resolving a Computer Modern family | 0 | 0 | 0 | **1** | **10** |
+| Observed Type-3 occurrences | 78,175 | 40,704 | 92,502 | 74,271 | 100,114 |
+| Linked to a raw Type-3 font | 0 | 0 | 0 | 0 | 44 |
+| Omitted, unlinked | 78,175 | 40,704 | 92,502 | 74,271 | 100,070 |
+| Classified into a family | 0 | 0 | 0 | 0 | 12 |
+| Officially Unicode-mapped | 0 | 0 | 0 | 0 | 11 |
+| Matching a registry digest | 0 | 0 | 0 | 0 | 0 |
+| **Strictly recovered** | **0** | **0** | **0** | **0** | **0** |
+
+Corpus totals: 385,766 observed Type-3 glyph occurrences, 92 Type-3 fonts,
+44 linked occurrences, 11 officially Unicode-mapped occurrences, and **0
+recovered characters**. The single abstention reason reported for every
+document is `raw_type3_font_link_ambiguous_or_unavailable`.
+
+## Why nothing recovers
+
+The study named two causes. Measuring the corpus found a third that sits
+upstream of both, and the three stack.
+
+**1. A zero-width slot voids the whole font.** `rawType3Fonts` builds a font's
+width map with `if (width > 0) widths.set(code, width)`, dropping zero-width
+slots — correctly, since `metricScaleInterval` cannot fit a scale factor to an
+observed zero. But `linkedRawType3Font` then demands
+`raw.widths.get(code) === width` for *every* code the page actually drew,
+including the zero-width ones, where the lookup returns `undefined`. One drawn
+zero-width glyph therefore eliminates every candidate and abstains the entire
+font. Every Type-3 font in all four Ghostscript 6.52 papers — 22, 12, 20 and
+16 of them respectively — carries at least one zero-width slot. Replaying the
+linker over `pippenger.pdf` pages 1–5 with the shipped rule links 0 of 16
+font-page pairs; retaining the zero-width slots links 7. This is why 285,652
+occurrences across the four papers reach neither the family fingerprint nor
+any CharProc digest.
+
+**2. The family fingerprint does not survive repacking.** Of those same 7
+font-page pairs that would link, 0 resolve a Computer Modern family:
+`uniqueComputerModernFamily` matches `widths[code]` against TFM widths
+slot-for-slot, and Ghostscript 6.52 has repacked the codes. Fixing cause 1
+alone recovers nothing. Only one font in the whole Bernstein set — one in
+`sf.pdf` — fingerprints a family at all, and it still recovers nothing
+because its occurrences never link.
+
+**3. `/ToUnicode` presence excludes a font outright.** `rawType3Fonts` skips
+any Type-3 font carrying a `/ToUnicode`. In `astro-ph-9402001.pdf` 18 of 22
+fonts do, which is why only 4 fonts are admissible while 10 fingerprint a
+Computer Modern family, and why 100,070 of 100,114 occurrences are omitted.
+
+**4. The digest does not transfer even when everything else does.** The 44
+occurrences that do link in the arXiv paper produce 12 classified and 11
+officially Unicode-mapped occurrences — and 0 registry digest matches. The
+CharProc SHA-256 folds in PK resolution, producer operator idiom, and the
+per-glyph placement `cm` matrix, so a raster that is the same Computer Modern
+character hashes differently under a different producer. This is the cause the
+study named, isolated here from the other three.
+
+## Binding
+
+`test/legacy-tex-corpus-live.test.js` binds the corpus, following
+`test/shannon-type3-live.test.js`: environment-gated, source SHA-256 asserted
+before anything else, then an exact assertion on observed behaviour.
+
+- **Interface:** one directory variable, `PDF_TOOLS_LEGACY_CORPUS_DIR`, holding
+  all five documents under the fixed basenames in the table above. One
+  variable was chosen over five because five permit a partially configured
+  run — three set, two unset — which would characterize part of the corpus and
+  still report a pass. With one variable the suite is either fully skipped or
+  fully measured; once the directory is given, a missing or wrong-digest
+  document is a hard failure, never a skip. This was verified by pointing the
+  variable at a directory holding only one of the five: five tests failed with
+  `ENOENT` — the four absent documents and the corpus-level check — and none
+  was reported as skipped.
+- **Skips cleanly.** Unset, `npm test` reports the file as 1 skipped, 6 tests
+  skipped, and stays green without the corpus present.
+- **No hand-typed expectations.** Every recorded figure is the `measured`
+  object a real run printed, spliced back in unedited. A previous vacuous test
+  on this repository passed while both sides of its assertion were wrong.
+- **Empty-measurement guard.** Each document must report a positive page
+  count, at least one Type-3 font, and more than 10,000 observed occurrences
+  before any zero is accepted, so a broken harness cannot satisfy the baseline
+  by measuring nothing.
+- **Directional assertions.** Every recovery-shaped count is fenced from both
+  sides with its own message. A regression fails with "regressed below the
+  recorded baseline"; an improvement fails with "improved … update the
+  recorded baseline deliberately". Both directions were verified to fire by
+  temporarily perturbing a recorded figure.
+
+The suite needs no entry in `scripts/test-suite-classification.mjs`: it
+allocates no checkout-local scratch and so does not reach
+`test/helpers/temp-directory.js`, and it performs no computed dynamic import.
+Both inventories are derived from the import graph and re-checked by
+`test/test-runner-contract.test.js`, which passes unchanged.
+
+## Reproducing
+
+```bash
+mkdir -p /tmp/legacy-tex-corpus && cd /tmp/legacy-tex-corpus
+for paper in pippenger nfscircuit m3 sf; do
+  curl -sL -o "$paper.pdf" "https://cr.yp.to/papers/$paper.pdf"
+done
+curl -sL -o astro-ph-9402001.pdf https://arxiv.org/pdf/astro-ph/9402001
+shasum -a 256 *.pdf
+
+PDF_TOOLS_LEGACY_CORPUS_DIR=/tmp/legacy-tex-corpus \
+  npx vitest run test/legacy-tex-corpus-live.test.js
+```
+
+Observed: 1 file passed, 6 tests passed, 4.6s.
+
+Per-document census, outside the suite:
+
+```bash
+node scripts/inventory-type3-glyphs.mjs --source /tmp/legacy-tex-corpus/pippenger.pdf
+```
+
+## Known gaps
+
+- This is the gap. Zero recovered characters across 385,766 legacy Type-3
+  glyph occurrences is the tracked defect, and raising any figure in the
+  measured-baseline table is the work this record exists to measure.
+- No OCR engine is bundled, and none of the above depends on one. Every glyph
+  in this corpus is drawn by an embedded Type-3 font whose Computer Modern
+  identity is recoverable from metrics and raster bytes alone.
+- The corpus documents are not committed. The digests above are the only
+  binding; a re-fetch that produces different bytes must be treated as a
+  different document, not as a changed baseline.

--- a/docs/evidence/legacy-tex-corpus-baseline-2026-08.md
+++ b/docs/evidence/legacy-tex-corpus-baseline-2026-08.md
@@ -28,6 +28,16 @@ list, and its measured table and causal account were both left stale by those
 two changes. The table below and the section that follows it now match the
 shipped product. The headline has not moved: recovery is still zero.
 
+**Route status.** Both routes past this baseline have since been investigated
+to a conclusion and both are closed. Shape-to-family is ill-posed — recorded
+below under "The shape-keyed family identification dead end". Every
+metric-derived route is closed too, including the reconstruct-the-advance-from-
+the-spacer route that this document's obstacle 2 left open in principle: see
+`docs/evidence/legacy-tex-metric-routes-closed-2026-08.md`. Read that record
+before attempting anything on the four Ghostscript 6.52 papers. It does not
+soften the zeros here; it establishes that they are a property of what that
+producer emitted.
+
 ## The corpus
 
 The documents are third-party and are deliberately **not** committed to this
@@ -122,6 +132,17 @@ remain, and they are not the same obstacle for the two producers.
    renumbered codes. This is a safeguard doing its job, not a bug: a code with
    no advance is invisible to the fingerprint that qualified the family.
 
+   The obvious follow-up — recover each inked glyph's advance from the spacer
+   that follows it, then fingerprint as usual — was investigated and is closed.
+   The spacer carries an inter-glyph *displacement*, not an advance, and it is
+   not a function of the inked glyph: in one fourteen-glyph show operation of
+   `pippenger.pdf` the letter `t` takes displacements 33, 54, 29 and 30. Worse,
+   the font object being fingerprinted is not a TeX font at all but a glyph
+   cache page holding 171 / 168 / 168 / 164 inked glyphs, more than the 128
+   slots any Computer Modern font has, so no font-level identification of any
+   kind can work here. Full measurements in
+   `docs/evidence/legacy-tex-metric-routes-closed-2026-08.md`.
+
 3. *The rasters themselves do not match.* `astro-ph-9402001.pdf` is the clean
    case — codes preserved, 10 fonts fingerprinting a family, 11 occurrences
    officially Unicode-mapped — and it still matches 0 registry digests,
@@ -172,6 +193,12 @@ All four findings are measured on these exact documents.
   720 dpi — but they share exactly **one** shape with Shannon (600 dpi) and
   **none** with astro-ph (300 dpi), and that one shared shape is a 41x3 solid
   rectangle, a fraction rule rather than a character.
+
+With the metric routes closed as well, the only remaining theoretical route to
+the four Ghostscript 6.52 papers is an external labelled bitmap reference — a
+METAFONT run at each document's own mode and resolution — which no document
+here records and nothing in this repository can pin. That is the boundary of
+the problem, not planned work.
 
 ## Safeguards this corpus confirms are not what blocks it
 
@@ -255,13 +282,24 @@ node scripts/inventory-type3-glyphs.mjs --source /tmp/legacy-tex-corpus/pippenge
 
 - This is the gap. Zero recovered characters across 385,766 legacy Type-3
   glyph occurrences is the tracked defect, and raising any figure in the
-  measured-baseline table is the work this record exists to measure.
+  measured-baseline table is the work this record exists to measure. For the
+  four Ghostscript 6.52 papers that work now has no known route; that is a
+  finding about the producer, recorded in
+  `docs/evidence/legacy-tex-metric-routes-closed-2026-08.md`, and not a reason
+  to stop calling the zero a defect.
 - Linking is not recovery. 52,537 occurrences now link where none did, and
   that bought no characters. A future change that raises the linked count
   without raising the recovered count has not moved this baseline.
-- No OCR engine is bundled, and none of the above depends on one. Every glyph
-  in this corpus is drawn by an embedded Type-3 font whose Computer Modern
-  identity is recoverable from metrics and raster bytes alone.
+- No OCR engine is bundled, and none of the above depends on one. This was
+  once written here as "every glyph in this corpus is drawn by an embedded
+  Type-3 font whose Computer Modern identity is recoverable from metrics and
+  raster bytes alone." That is now known to be false for the four Ghostscript
+  6.52 papers, and it is the single most important correction to this record:
+  their Computer Modern identity is **not** derivable from the metrics and
+  structure their producer wrote into the file, by any route measured. See
+  `docs/evidence/legacy-tex-metric-routes-closed-2026-08.md`. It remains true
+  of `astro-ph-9402001.pdf`, whose codes and metrics are intact and whose only
+  obstacle is its 300 dpi rasters.
 - The corpus documents are not committed. The digests above are the only
   binding; a re-fetch that produces different bytes must be treated as a
   different document, not as a changed baseline.

--- a/docs/evidence/legacy-tex-corpus-baseline-2026-08.md
+++ b/docs/evidence/legacy-tex-corpus-baseline-2026-08.md
@@ -6,22 +6,27 @@
 zero is a defect, not an intention.**
 
 The Computer Modern Type-3 recovery that works on Shannon's 1948 paper does
-not transfer. A study across 11 dvips-era PDFs and 560,754 Type-3 glyph
-occurrences matched 0 of 29 eligible occurrences against any registry digest.
-This document binds five of those PDFs as a pinned, measured corpus so the
-gap has an executable size instead of an anecdote, and so any later work has
-something it must visibly move.
+not transfer. Five dvips-era PDFs carrying 385,766 Type-3 glyph occurrences
+recover **0 characters**. This document binds them as a pinned, measured
+corpus so the gap has an executable size instead of an anecdote, and so any
+later work has something it must visibly move.
 
 Four of the five are D. J. Bernstein papers from cr.yp.to, produced by
 `GNU Ghostscript 6.52`, which repacks glyph names to `/a0 /a1 /a2…`. On these
 `pdftotext` yields literal noise and PDF Tools recovers nothing — not one
-character, and not even a font family for three of the four. The fifth is an
-arXiv paper where the TeX character codes *are* preserved and 11 occurrences
-do carry an official Unicode mapping, and it still recovers nothing, which
-isolates the digest problem from the code-packing problem.
+character, and only one Computer Modern family across all four. The fifth is
+an arXiv paper where the TeX character codes *are* preserved and 11
+occurrences do carry an official Unicode mapping, and it still recovers
+nothing, which isolates the shape problem from the code-packing problem.
 
-Nothing in the recovery path was changed to produce this record. The corpus
-was measured through the shipped code exactly as it stands.
+Nothing in the recovery path was weakened to produce this record. The corpus
+is measured through the shipped code exactly as it stands.
+
+**Revision note.** The first version of this document was written before the
+linker fix and before the recovery key was moved off the CharProc operator
+list, and its measured table and causal account were both left stale by those
+two changes. The table below and the section that follows it now match the
+shipped product. The headline has not moved: recovery is still zero.
 
 ## The corpus
 
@@ -45,6 +50,10 @@ document-level census of every Type-3 font dictionary reachable from a page's
 `/Resources /Font`, deduplicated by indirect reference, asked of the shipped
 `uniqueComputerModernFamily` resolver over its positive-width slots.
 
+Every figure below is the `measured` object a real run printed, and is the
+same object `test/legacy-tex-corpus-live.test.js` asserts. Nothing here is
+typed by hand on both sides of an assertion.
+
 | Metric | pippenger | nfscircuit | m3 | sf | astro-ph-9402001 |
 | --- | ---: | ---: | ---: | ---: | ---: |
 | Pages | 21 | 11 | 19 | 15 | 37 |
@@ -53,57 +62,131 @@ document-level census of every Type-3 font dictionary reachable from a page's
 | — admissible to the font linker | 19 | 10 | 18 | 15 | 4 |
 | — resolving a Computer Modern family | 0 | 0 | 0 | **1** | **10** |
 | Observed Type-3 occurrences | 78,175 | 40,704 | 92,502 | 74,271 | 100,114 |
-| Linked to a raw Type-3 font | 0 | 0 | 0 | 0 | 44 |
-| Omitted, unlinked | 78,175 | 40,704 | 92,502 | 74,271 | 100,070 |
-| Classified into a family | 0 | 0 | 0 | 0 | 12 |
-| Officially Unicode-mapped | 0 | 0 | 0 | 0 | 11 |
+| Linked to a raw Type-3 font | **5,440** | **7,484** | **17,335** | **22,234** | 44 |
+| Omitted, unlinked | 72,735 | 33,220 | 75,167 | 52,037 | 100,070 |
+| Classified into a family | 0 | 0 | 0 | **10** | 12 |
+| Officially Unicode-mapped | 0 | 0 | 0 | **2** | 11 |
 | Matching a registry digest | 0 | 0 | 0 | 0 | 0 |
 | **Strictly recovered** | **0** | **0** | **0** | **0** | **0** |
 
 Corpus totals: 385,766 observed Type-3 glyph occurrences, 92 Type-3 fonts,
-44 linked occurrences, 11 officially Unicode-mapped occurrences, and **0
-recovered characters**. The single abstention reason reported for every
+52,537 linked occurrences, 22 classified, 13 officially Unicode-mapped, and
+**0 recovered characters**. The single abstention reason reported for every
 document is `raw_type3_font_link_ambiguous_or_unavailable`.
 
 ## Why nothing recovers
 
-The study named two causes. Measuring the corpus found a third that sits
-upstream of both, and the three stack.
+Two of the three original causes have been removed, and the table above
+records what removing them bought. Neither bought a single character.
 
-**1. A zero-width slot voids the whole font.** `rawType3Fonts` builds a font's
-width map with `if (width > 0) widths.set(code, width)`, dropping zero-width
-slots — correctly, since `metricScaleInterval` cannot fit a scale factor to an
-observed zero. But `linkedRawType3Font` then demands
-`raw.widths.get(code) === width` for *every* code the page actually drew,
-including the zero-width ones, where the lookup returns `undefined`. One drawn
-zero-width glyph therefore eliminates every candidate and abstains the entire
-font. Every Type-3 font in all four Ghostscript 6.52 papers — 22, 12, 20 and
-16 of them respectively — carries at least one zero-width slot. Replaying the
-linker over `pippenger.pdf` pages 1–5 with the shipped rule links 0 of 16
-font-page pairs; retaining the zero-width slots links 7. This is why 285,652
-occurrences across the four papers reach neither the family fingerprint nor
-any CharProc digest.
+**Fixed: a zero-width slot no longer voids the whole font.** `rawType3Fonts`
+used to build one width map with `if (width > 0) widths.set(code, width)`,
+and `linkedRawType3Font` then demanded `raw.widths.get(code) === width` for
+every code the page drew — including the zero-width ones, where the lookup
+returned `undefined`. One drawn zero-width glyph eliminated every candidate
+and abstained the entire font, and every Type-3 font in all four Ghostscript
+6.52 papers declares at least one zero-width slot. There are now two width
+views: `widths` keeps every declared slot for the linker, because a declared
+zero is a fact about the font, and `metricWidths` keeps only the positive
+slots for the TFM fingerprint, because `metricScaleInterval` cannot fit a
+scale to an observed zero. The four papers went from 0 linked occurrences to
+5,440 / 7,484 / 17,335 / 22,234.
 
-**2. The family fingerprint does not survive repacking.** Of those same 7
-font-page pairs that would link, 0 resolve a Computer Modern family:
-`uniqueComputerModernFamily` matches `widths[code]` against TFM widths
-slot-for-slot, and Ghostscript 6.52 has repacked the codes. Fixing cause 1
-alone recovers nothing. Only one font in the whole Bernstein set — one in
-`sf.pdf` — fingerprints a family at all, and it still recovers nothing
-because its occurrences never link.
+**Fixed: the key no longer folds in the producer's idiom.** The recovery key
+used to be the CharProc operator list, which carries the producer's operator
+idiom and the per-glyph placement `cm`. It is now the decoded image mask's
+stored sample grid, cropped to its ink, so the same raster keys identically
+across toolchains. This is what let `sf` classify 10 occurrences and
+officially name 2.
 
-**3. `/ToUnicode` presence excludes a font outright.** `rawType3Fonts` skips
-any Type-3 font carrying a `/ToUnicode`. In `astro-ph-9402001.pdf` 18 of 22
-fonts do, which is why only 4 fonts are admissible while 10 fingerprint a
-Computer Modern family, and why 100,070 of 100,114 occurrences are omitted.
+**Still open, and why every figure above is still zero.** Three obstacles
+remain, and they are not the same obstacle for the two producers.
 
-**4. The digest does not transfer even when everything else does.** The 44
-occurrences that do link in the arXiv paper produce 12 classified and 11
-officially Unicode-mapped occurrences — and 0 registry digest matches. The
-CharProc SHA-256 folds in PK resolution, producer operator idiom, and the
-per-glyph placement `cm` matrix, so a raster that is the same Computer Modern
-character hashes differently under a different producer. This is the cause the
-study named, isolated here from the other three.
+1. *Family resolution does not survive glyph repacking.*
+   `uniqueComputerModernFamily` matches declared widths against TFM widths
+   slot for slot, and Ghostscript 6.52 has renumbered the codes. Across the
+   four Bernstein papers exactly one font — in `sf.pdf` — fingerprints a
+   family at all, off just two spacer advances, and the two occurrences it
+   officially names mean nothing. Only the missing shape match keeps that
+   coincidence out of the output.
+
+2. *Positive-width pinning rejects the Bernstein papers by construction.*
+   Ghostscript 6.52 splits every character into two Type-3 glyphs: an inked
+   glyph declaring `0 0 llx lly urx ury d1` with advance zero, and a separate
+   ink-free advance glyph declaring `w 0 0 0 0 0 d1`. Read straight out of the
+   bytes the split is total — 584 / 457 / 537 / 530 inked CharProcs, every one
+   of them zero advance, against 98 / 99 / 102 / 106 advance-only CharProcs,
+   no exceptions. The inked codes and the positive-width codes are disjoint
+   sets, so a recovered code can never be an inked code in these four
+   documents, and the family fingerprint can only ever see spacer advances at
+   renumbered codes. This is a safeguard doing its job, not a bug: a code with
+   no advance is invisible to the fingerprint that qualified the family.
+
+3. *The rasters themselves do not match.* `astro-ph-9402001.pdf` is the clean
+   case — codes preserved, 10 fonts fingerprinting a family, 11 occurrences
+   officially Unicode-mapped — and it still matches 0 registry digests,
+   because it rasterised Computer Modern at its own PK resolution (300 dpi
+   against Shannon's 600) and no enrolled shape is that shape. Its remaining
+   18 of 22 fonts carry their own `/ToUnicode` and are deliberately left to
+   PDF.js, which is why only 4 fonts are admissible to the linker while 10
+   fingerprint a family. Those 18 are not discarded: they stay in the page's
+   link-uniqueness pool as competitors, so a font matching both them and a
+   recoverable font is reported ambiguous rather than resolved in favour of
+   recovery.
+
+## The shape-keyed family identification dead end
+
+Identifying the family from matched glyph *shapes*, rather than from
+`widths[code]`, was the obvious way past obstacle 1. It was investigated and
+measured to be a dead end. Recorded here so it is not attempted again blind.
+All four findings are measured on these exact documents.
+
+- **There is no bitmap reference to match against.** The pinned official CTAN
+  `cm/ps-type3` fonts are cubic-Bézier *outline* programs: all 41 glyph
+  programs of the labeled reference fixture take the exact-operator evidence
+  lane and none takes the image-mask lane. `cm/mf.zip` is METAFONT source, and
+  turning it into the PK rasters these documents carry needs a METAFONT run at
+  a mode and resolution no document here records.
+- **Bridging outline to bitmap is never exact, and no threshold separates
+  right from wrong.** Rasterising the official CTAN outline for cmmi alpha
+  across 225,225 combinations of resolution (60–110 px/em in 0.05 steps),
+  alpha threshold and sub-pixel offset reproduced the Shannon reviewed alpha
+  raster's ink box 241 times and its bits **zero** times; the closest was 72
+  of 1,748 pixels wrong, 4.1%. Scored against three Shannon rasters of known
+  identity over every reference slot that could reproduce the target's ink
+  box, the correct slot's best agreement was 4.3% wrong for alpha, 2.1% for
+  omega and 14.5% for sigma, while the best *wrong* slot reached 20.1% for
+  alpha and 24.5% for sigma. A threshold would have to admit 14.5% and reject
+  20.1% — a 1.4x window, already that narrow against a reference holding 41 of
+  Computer Modern's roughly 9,600 (font, slot) pairs. Widening the reference
+  can only close it further.
+- **An exact matcher would still not determine a family.** One digest in the
+  shipped registry already stands at two different (family, slot) pairs: the
+  same bitmap is `cmmi-pk-raster-period-2df559-v1` (math-italic slot 58, ".")
+  and `cmsy-pk-raster-centered-dot-33077f-v1` (math-symbol slot 1, "⋅"). Shape
+  identifies a code only once the family is known, which is the direction the
+  shipped matcher already runs in and the opposite of the direction proposed.
+- **There is no cross-document anchor either.** The mask key is genuinely
+  producer-independent — the four cr.yp.to papers share 387 to 440 of their
+  451 to 581 distinct inked shapes with each other, being one PK library at
+  720 dpi — but they share exactly **one** shape with Shannon (600 dpi) and
+  **none** with astro-ph (300 dpi), and that one shared shape is a 41x3 solid
+  rectangle, a fraction rule rather than a character.
+
+## Safeguards this corpus confirms are not what blocks it
+
+Recording these so a later attempt does not spend effort loosening a rule
+that is not in its way. Each was measured against the corpus:
+
+- **Per-font paint orientation.** A font whose mask-lane glyphs disagree on
+  their CharProc-local determinant sign gets no grid keys. All 92 embedded
+  Type-3 fonts of this corpus are unanimous, as are all 24 of Shannon's, so
+  this rule refuses nothing here. See
+  `docs/evidence/type3-reflected-paint-2026-08.md`.
+- **Shape-code injectivity.** No corpus document reaches a registry digest at
+  all, so no match is lost to a shape standing at two enrolled codes.
+- **The `/ToUnicode` deferral.** Removing it would not recover astro-ph: the
+  18 deferred fonts fail on rasters, not on eligibility.
 
 ## Binding
 
@@ -135,6 +218,10 @@ before anything else, then an exact assertion on observed behaviour.
   recorded baseline"; an improvement fails with "improved … update the
   recorded baseline deliberately". Both directions were verified to fire by
   temporarily perturbing a recorded figure.
+- **Linker regression fence.** The corpus-level test additionally asserts that
+  each Ghostscript 6.52 paper still links a positive number of occurrences, so
+  the zero-width linker fix cannot silently regress back to the 0/0/0/0 state
+  this document originally recorded.
 
 The suite needs no entry in `scripts/test-suite-classification.mjs`: it
 allocates no checkout-local scratch and so does not reach
@@ -156,7 +243,7 @@ PDF_TOOLS_LEGACY_CORPUS_DIR=/tmp/legacy-tex-corpus \
   npx vitest run test/legacy-tex-corpus-live.test.js
 ```
 
-Observed: 1 file passed, 6 tests passed, 4.6s.
+Observed: 1 file passed, 6 tests passed.
 
 Per-document census, outside the suite:
 
@@ -169,6 +256,9 @@ node scripts/inventory-type3-glyphs.mjs --source /tmp/legacy-tex-corpus/pippenge
 - This is the gap. Zero recovered characters across 385,766 legacy Type-3
   glyph occurrences is the tracked defect, and raising any figure in the
   measured-baseline table is the work this record exists to measure.
+- Linking is not recovery. 52,537 occurrences now link where none did, and
+  that bought no characters. A future change that raises the linked count
+  without raising the recovered count has not moved this baseline.
 - No OCR engine is bundled, and none of the above depends on one. Every glyph
   in this corpus is drawn by an embedded Type-3 font whose Computer Modern
   identity is recoverable from metrics and raster bytes alone.

--- a/docs/evidence/legacy-tex-metric-routes-closed-2026-08.md
+++ b/docs/evidence/legacy-tex-metric-routes-closed-2026-08.md
@@ -1,0 +1,252 @@
+# Legacy dvips-era Type-3 corpus — every metric route closed, 2026-08
+
+## Outcome
+
+**Recovery on the four GNU Ghostscript 6.52 papers is zero and stays zero.
+This record does not excuse that. It records why the remaining route was
+closed, so the next attempt spends its effort somewhere it can work.**
+
+`docs/evidence/legacy-tex-corpus-baseline-2026-08.md` bound the failing
+baseline and closed one of the two routes past it: identifying a Computer
+Modern family from matched glyph *shapes* is ill-posed, because there is no
+labelled bitmap reference to match against and shape does not determine a
+family even when the match is exact.
+
+The other route was metric. `uniqueComputerModernFamily` identifies a family by
+fitting one scale factor to a font's declared `/Widths`, and Ghostscript 6.52
+declares zero for every inked code. If the per-character advance could be
+recovered from somewhere else in the file — from the spacer glyph that follows
+each inked one — the shipped fingerprint would work unchanged on renumbered
+codes. That is the hypothesis this investigation tested, and it is wrong in
+three independent ways, the third of which is not about advances at all.
+
+Combined with the shape finding, **all metric-derived routes to these four
+documents are closed.** This is a property of what the producer emitted, not a
+limit on effort: the information the fingerprint needs is not in the file in
+any form, at any tolerance, under any statistic. It is not a claim about
+legacy Type-3 documents generally — the fifth corpus document, the arXiv
+paper, preserves its TeX codes and fails for an entirely different reason
+(its rasters, at 300 dpi, match no enrolled shape), and nothing here applies
+to it.
+
+## What was measured, and against what
+
+- Corpus: the same five pinned documents as the baseline record, verified by
+  SHA-256 before measurement. The four in scope are `pippenger.pdf`,
+  `nfscircuit.pdf`, `m3.pdf` and `sf.pdf`, all `GNU Ghostscript 6.52`.
+- Metrics: `CM_TFM_METRICS` from `server/type3-cm-reference.js`, the same
+  pinned CTAN TFM table the shipped resolver uses, and
+  `uniqueComputerModernFamily` from `server/layout-extraction.js` itself.
+- Displacements are read out of the page content streams directly: for each
+  inked code, the `wx` of the spacer that immediately follows it in the same
+  show operation, or, where the inked glyph ends the operation and the
+  operation stands alone between two moves, the `tx` of the following `Td`
+  minus the spacers already consumed.
+
+## 1. The spacer does not carry a per-character advance
+
+The hypothesis was that Ghostscript 6.52 displaces the advance onto the
+ink-free spacer glyph, so that `spacer.wx` is the missing `/Widths` entry for
+the inked glyph before it. It is not. The spacer carries an inter-glyph
+**displacement** — advance plus interword space plus kern plus grid rounding —
+and that is not a function of the inked glyph.
+
+**Most inked glyphs have no spacer to ask.** Of the inked occurrences, only
+53.0% (pippenger), 77.4% (nfscircuit), 59.1% (m3) and 51.3% (sf) are followed
+by a spacer at all. The rest end their show operation, where the displacement
+has already been folded into the following `Td`: 30.1 / 20.0 / 28.2 / 46.6%
+of inked occurrences are run-final. In pippenger the single commonest shape of
+show operation is one inked glyph and nothing else — **7,725 of 15,010 show
+operations, 51.5%** — so for over half the operations in the document there is
+no spacer in the operation to attribute anything to.
+
+**Where a spacer does follow, it is not stable per character.** The map from
+inked code to spacer code is many-to-many. In pippenger, of the 333 inked
+codes that ever take a spacer partner, **222 take more than one spacer code**;
+in nfscircuit 238 of 323, m3 238 of 334, sf 214 of 317. Read the other way,
+one spacer serves many different inked codes: 168 / 170 / 198 / 183 spacer
+codes across the four documents serve more than one. Across every inked code
+with any displacement data at all — 432 / 357 / 420 / 388 codes — only
+109 / 98 / 101 / 103 are single-valued, and the *most common* displacement for
+a code accounts for just 43.7 / 46.0 / 46.2 / 46.8% of that code's
+observations. There is no modal value to take as "the" advance.
+
+**Ground truth confirms it directly.** Page 1 of `pippenger.pdf` opens with a
+readable roman line and a bold title, both drawn by font `9 0 R`, which lets
+each drawn code be labelled by eye. One show operation on that page holds
+fourteen inked glyphs, and the letter `t` (code 7) appears in it four times
+with four different displacements — **33, 54, 29 and 30**. In the same
+fourteen-glyph operation, `.` (code 8), `I` (code 10) and `w` (code 12) are
+each followed by a spacer of exactly **51**, and 51 is the only displacement
+either `.` or `I` is ever observed with anywhere in the document: they happen
+to occur only before a word space, so what was measured is the word space, not
+the letter.
+
+A quantity that changes four times for one letter inside one line, and that
+reports the same number for a period, a capital I and a `w`, is not a
+character advance. This is the mechanism, and it is why every attempt below
+fails: the file records where the next glyph goes, not how wide this one is.
+
+## 2. The decisive independent test
+
+Two blockers stand between these documents and the shipped fingerprint: the
+advance is not recoverable (§1), and the codes are renumbered so even a correct
+advance sits at the wrong slot. The test grants a *perfect* solution to both at
+once.
+
+The fifteen ground-truth roman characters read off page 1 were placed at their
+true OT1 slots and given their best-case reconstructed advances. Against the
+whole pinned `CM_TFM_METRICS` table:
+
+| Tolerance | ±0.5 | ±1 | ±2 | ±3 | ±5 | ±8 | ±12 |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| Metrics fitting, min statistic | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
+| Metrics fitting, mode statistic | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
+
+Zero, everywhere, out to **24 times the shipped ±0.5 tolerance**. The same is
+true of the fifteen ground-truth bold characters out to ±5; at ±8 thirty
+metrics fit at once and at ±12 forty-four do, which is no identification at
+all. Dropping the three characters that were only ever seen before a word
+space admits 25 metrics at ±2 under the min statistic — obtained by discarding
+evidence and widening fourfold, and still not unique.
+
+The reason is visible in the per-character implied scale. Against `cmr10`, the
+fifteen characters imply anything from **66.6 px/em** (`n`) to **183.6 px/em**
+(`.`); against `cmr7`, 58.6 to 157.7. A single font cannot be drawn at two
+scales at once, so no scale exists, so no metric fits. This is not a tolerance
+that needs loosening. There is no signal to loosen toward.
+
+## 3. The category error
+
+This is the deepest finding, and it is the one that would have defeated the
+other two even if they had gone the other way.
+
+**Ghostscript 6.52 does not emit one Type-3 font per TeX font. It emits glyph
+cache pages.** Every one of the four documents contains exactly one Type-3 font
+— object `9 0 R` in all four — carrying **171 / 168 / 168 / 164** inked
+glyphs. Every Computer Modern font has at most 128 slots. A font with 171
+inked glyphs is not a Computer Modern font that has been renumbered; it is a
+bucket into which several of them have been poured.
+
+In pippenger's `9 0 R`, code 10 is the small roman `I` (mask 21x41) and code 49
+is the large bold `I` (mask 39x69). Same letter, two design sizes and two
+weights, one font object. The question the fingerprint asks — *what family is
+this font?* — has no answer for these objects, and neither would the shape
+question, and neither would any question posed at font level. No font-level
+identification of any kind can work for this producer.
+
+That is why §1 and §2 are not fixable by a better statistic. They are
+measurements of a font that is not a font.
+
+## 4. What a width-pinned prediction would actually have said
+
+One candidate looked stable enough to be worth carrying to the end. `m3.pdf`'s
+font `408 0 R` is the only object in the corpus that resolves a single family
+under all three reconstruction statistics — min, mode and max — landing on
+`computer-modern-math-italic`, and uniquely on `cmmi7` under min. Six other
+fonts resolve under exactly one statistic and dissolve under the others.
+
+Its fitted scale is **103.99 px/em**, which at this corpus's 720 dpi places a
+**7 pt metric at 10.40 pt** — the first sign that the fit is a coincidence
+rather than an identification. Seven of its codes are pinned to exactly one
+`cmmi7` slot at the shipped ±0.5:
+
+| Code | Advance | Mask | Ink band (glyph space, baseline ≈ 72) | Predicted `cmmi7` slot |
+| ---: | ---: | --- | --- | --- |
+| 0 | 38 | 31x48 | −10 … 38 | `l` |
+| 12 | 79 | 74x71 | 4 … 75 | `psi` |
+| 24 | 82 | 43x46 | 28 … 74 | `L` |
+| 29 | 42 | 35x50 | 38 … 88 | `i` |
+| 35 | 78 | 52x46 | 28 … 74 | `varphi` |
+| 37 | 86 | 45x46 | 28 … 74 | `w` |
+| 42 | 113 | 47x65 | 28 … 93 | `M` |
+
+Rendered, they are not those characters:
+
+- Code 24, pinned to a capital `L`, is a 43x46 mask sitting entirely between
+  the x-height line and the baseline. It has no ascender. A capital cannot be
+  an x-height box.
+- Code 0, pinned to `l`, draws entirely **above** the baseline, in the band
+  −10 to 38, in a font whose ordinary glyphs all reach down to about 72. It is
+  a superscript raster, not a letter.
+- Code 42, pinned to `M`, is 47 px wide against its own 113-unit advance, a
+  0.42 ink-to-advance ratio, and it descends 21 units below the baseline.
+  The genuine bold `M` in pippenger's `9 0 R` draws 102 px against a 109-unit
+  advance — 0.94 — and has no descender.
+- Code 29, pinned to `i`, sits 16 units lower than the font's own baseline
+  band: a subscript.
+
+The line this font actually helps draw, on page 4 of `m3.pdf`, is
+
+```text
+4x² + 1x³ + 5x⁴ + 9x⁵ ∈ R[x] → R[x][y]/(x²−y)
+```
+
+and it is drawn by **five different Type-3 fonts** (`408 0 R`, `304 0 R`,
+`9 0 R`, `382 0 R`, `266 0 R`) — one per raster size the cache happened to
+need, which is exactly the cache-page structure of §3. `408 0 R` is the
+superscript-and-subscript bucket. Had the metric route been shipped, this is
+the one place in the corpus it would have produced output, and the output would
+have been `L`, `M`, `i`, `w`, `l`, `psi` and `varphi` in place of digits and
+exponents.
+
+The shipped pipeline abstains here. That abstention is correct, and this
+section is the evidence that it is correct rather than merely cautious.
+
+## What is left
+
+Nothing derived from metrics. Shape does not determine a family
+(`legacy-tex-corpus-baseline-2026-08.md`), width does not survive the
+producer's split and renumbering (§1, §2), and the font object these documents
+present is not the unit either question is asked about (§3).
+
+The only remaining theoretical route is an **external labelled bitmap
+reference**: a METAFONT run for each Computer Modern font at each document's
+own mode and resolution, producing PK rasters whose bits can be compared
+directly against the embedded image masks. That is unavailable and
+unpinnable — no document in the corpus records the mode or the exact
+resolution its rasters were built at, the toolchain that built them is not
+pinned by anything in the file, and the repository has no METAFONT engine and
+no reproducible way to pin one. It is recorded as the boundary of the problem,
+not as planned work.
+
+The honest summary is that these four documents are not recoverable by this
+pipeline, and no measurement performed here suggests a way that they could
+become recoverable. The corpus stays bound as a failing baseline, and any
+future change that moves it must move `strict_recovery_count` in
+`test/legacy-tex-corpus-live.test.js`, not the count of things that link.
+
+## Reproducing
+
+Measurement scripts are not committed; they read the corpus and the shipped
+`server/` exports and print the figures above.
+
+```bash
+# Corpus fetched and digest-verified as in legacy-tex-corpus-baseline-2026-08.md.
+node adv/a-inventory.mjs    # inked vs spacer CharProcs, all zero-advance
+node adv/a-pairing.mjs      # ink→spacer pairing, run-final share, many-to-many map
+node adv/b-advances.mjs     # per-code displacement multiplicity and modal share
+node adv/b-family.mjs       # per-font family fit under min and mode
+node adv/c-groundtruth.mjs  # labelled page-1 characters, per-character implied scale
+node adv/e-final.mjs        # slot-indexed fit at ±0.5…±12; the >128-glyph fact
+node adv/f-falsepos.mjs     # fonts resolving under some statistic; 408 0 R located
+node adv/g-pin.mjs          # 408 0 R unique width pins vs rendered masks
+node adv/h-check.mjs        # lone-inked-glyph show operations; the 't' line
+```
+
+Every figure in this record was re-run and reproduced before it was written
+down. The five corpus documents hashed to the digests pinned in
+`legacy-tex-corpus-baseline-2026-08.md`.
+
+## Known gaps
+
+- Recovery on these four documents is **0** and this record does not change
+  it. It changes only what a future attempt should not spend time on.
+- The finding is specific to GNU Ghostscript 6.52 style glyph-cache output. It
+  says nothing about dvips-era Type-3 documents in general, and it does not
+  apply to `astro-ph-9402001.pdf`, which preserves its TeX codes, fingerprints
+  ten fonts correctly, and fails on rasters instead.
+- No OCR engine is bundled, and nothing above depends on one. The claim is
+  narrower than "these documents cannot be read": it is that their Computer
+  Modern *identity* is not derivable from the metrics and structure the
+  producer wrote into the file.

--- a/docs/evidence/type3-reflected-paint-2026-08.md
+++ b/docs/evidence/type3-reflected-paint-2026-08.md
@@ -1,0 +1,203 @@
+# Reflected Type-3 paint — defect, fix and measurement, 2026-08
+
+## The defect
+
+Moving the Type-3 recovery key onto the stored image-mask grid made it
+producer-independent, which is what it exists to be. It also made it blind to
+reflection, and in Computer Modern reflection is usually a **different
+enrolled character**, not a different view of the same one.
+
+**16 of the shipped registry digests — eight mirror pairs — are the exact
+horizontal mirror of another shipped digest.** They are the parenthesis and
+bracket pairs of the two enrolled cmex fonts: five pairs in one, three in the
+other. Each pair honestly stores two separate rasters, one the mirror of the
+other, and each recovers correctly. But a CharProc that stores the `]` raster
+and paints it reflected paints a `[`, and the stored grid alone cannot tell
+those two apart.
+
+Measured, not assumed: the registry holds 71 entries over 69 distinct primary
+digests, 68 of which the reference document resolves to an actual grid. Every
+one of those 68 grids was mirrored horizontally, vertically and by 180° and
+the result looked back up in the registry. Horizontal mirroring hit another
+registry digest 16 times; 180° rotation hit the same 16, these glyphs being
+vertically symmetric; vertical mirroring hit nothing. An earlier review note
+put this at 32 by counting each digest once per transform that hits — the
+figure is 16 digests.
+
+### Reproduced on the reference document
+
+Edited exactly one number in `shannon-entropy.pdf`: the CharProc of CMEX code
+3 (`]`, glyph `/#2303` of font `23 0 R`). Mask bytes left byte-identical; only
+the x scale of the glyph's own placement `cm` negated, with the matching
+translation so the reflected ink lands in the same box.
+
+```
+17 0 0 98 1.1 -95.1 cm     →     -17 0 0 98 18.1 -95.1 cm
+```
+
+A control document was built the same way — same decompression, same
+re-encode, same object rewrite — with the `cm` left alone, so the measurement
+separates the mutation from the repackaging.
+
+| Strict recoveries, all 55 pages | pristine | control (re-encoded, upright) | mutated (reflected) |
+| --- | ---: | ---: | ---: |
+| master `241a8dd` | 1,864 | 1,864 | **1,853** |
+| this branch, before the fix | 1,872 | 1,872 | **1,872** |
+| this branch, after the fix | 1,872 | 1,872 | **1,775** |
+
+Master abstains on the tampered glyph: `cmex-pk-raster-big-right-bracket-a23d3c-v1`
+goes from 11 occurrences to 0, because master's key was the CharProc operator
+list and the edited `cm` is inside it. The grid-keyed branch **kept emitting
+`]` eleven times for ink that now paints `[`, and reported no gap.** That is
+the regression.
+
+## What was rejected, and why
+
+Two fixes were considered first and are recorded here so they are not retried.
+
+- **Fold the CharProc-local determinant sign into the key.** Producer-
+  dependent, and therefore a reintroduction of the exact defect the grid key
+  removed. Shannon carries its flip in `FontMatrix [1 0 0 -1]` and every one
+  of its 24 Type-3 fonts composes to sign −1; other dvips-era producers leave
+  the FontMatrix upright and come out uniformly +1. The same painted glyph
+  would key two ways.
+- **Abstain whenever one font holds two enrolled codes that are mirrors of
+  each other.** Kills every legitimate Shannon parenthesis and bracket
+  recovery, where each code honestly stores its own raster.
+
+**Shape-code injectivity does not catch this**, and both the previous
+docstring at the canonical-mask helper and the commit message of *"Key Type-3
+recovery on the stored grid, not a painted orientation"* asserted that it
+does. Both were wrong. Injectivity asks whether one shape stands at two
+enrolled codes of one font. The reflected glyph stands at one code holding one
+raster; its mirror image lives at a *different* code holding a different,
+genuinely mirrored raster. Both codes are injective and both recover, one of
+them as the wrong character. The docstring has been corrected in place; this
+record is the correction for the commit message, which is already in history.
+
+## The fix: per-font paint orientation
+
+`type3FontPaintOrientation(font, ops)` returns the single sign of the
+CharProc-local determinant — FontMatrix composed with the glyph's own `cm` —
+that every mask-lane glyph of one embedded font agrees on, or `null` when the
+font has no such agreement. The mask lane then requires a glyph's own sign to
+equal its font's. A glyph that disagrees with its siblings is reflected
+relative to them and falls to the placement-bearing operator digest, which is
+domain-separated from every mask-keyed registry entry and so recovers nothing.
+
+Three properties make this admissible where the rejected options were not.
+
+1. **It is producer-independent.** The sign is only ever compared between two
+   glyphs of the same embedded font. No absolute convention is asserted, so
+   the dvipdfmx-shaped and Ghostscript-shaped documents that split the y-flip
+   differently are unaffected — each is internally unanimous at its own sign.
+   Verified on the two-producer fixture pair: one document unanimous at −1,
+   the other unanimous at +1, identical keys.
+2. **It requires unanimity, not a majority.** A majority is a vote an
+   adversary wins by flipping more glyphs, and most legacy fonts here carry
+   one to four mask glyphs, where a majority is not defined. A font that
+   disagrees with itself has no convention to normalise against and gets no
+   grid keys at all.
+3. **It is deterministic and page-independent.** PDF.js builds
+   `charProcOperatorList` eagerly from the whole `/CharProcs` dictionary when
+   the font is loaded, not lazily per drawn glyph, so the answer is a property
+   of the font rather than of which page was extracted first. Confirmed
+   against the pinned pdfjs-dist 5.4.624 source.
+
+## Measurement
+
+**No real font mixes signs.** Census of the CharProc-local determinant sign of
+every mask-lane glyph, per embedded font:
+
+| Document | Type-3 fonts | unanimous | mixed | font sign |
+| --- | ---: | ---: | ---: | --- |
+| `shannon-entropy.pdf` | 24 | 24 | **0** | all −1 |
+| `astro-ph-9402001.pdf` | 22 | 22 | **0** | all −1 |
+| `m3.pdf` | 20 | 20 | **0** | all +1 |
+| `nfscircuit.pdf` | 12 | 12 | **0** | all +1 |
+| `pippenger.pdf` | 22 | 22 | **0** | all +1 |
+| `sf.pdf` | 16 | 16 | **0** | all +1 |
+| two-producer fixture, dvipdfmx idiom | 1 | 1 | 0 | +1 |
+| two-producer fixture, Ghostscript idiom | 1 | 1 | 0 | −1 |
+
+116 embedded Type-3 fonts across the reference document and the full legacy
+corpus; not one is mixed. Both signs occur across documents, which is why the
+absolute sign cannot be keyed on and the intra-font comparison can.
+
+Mirroring the single CMEX `cm` above makes exactly one font mixed — `g_d0_f10`,
+1 glyph at +1 against 15 at −1 — and no other.
+
+**Effect on real output: none.**
+
+- Shannon strict recovery is **1,872**, with a per-registry-id map identical
+  to the pre-fix branch, checked key by key.
+- Legacy corpus recovery is **0**, unchanged, with its baseline untouched.
+- The layout occurrence oracle regenerates with every measured case
+  byte-identical; only its provenance block moves, recording the new
+  `server/layout-extraction.js` digest.
+
+**Effect on the attack.** The tampered font abstains entirely: 1,872 → 1,775.
+The eleven wrong `]` characters are gone, and so are the other 86 recoveries
+from the font that was tampered with — a font with no internal paint
+convention is not trusted for any of its glyphs.
+
+## Accepted residual
+
+This does not detect a document in which **every** glyph of a font is
+reflected. Such a font is internally unanimous and is indistinguishable from
+an honest font by a different producer, which is precisely the ambiguity the
+producer-independent key accepts by design; a whole-font flip is also a
+different rendered document, not a targeted substitution of one character. A
+targeted substitution — one glyph reflected among upright siblings — is what
+the registry-mirror structure makes exploitable, and that is what is now
+refused.
+
+## Binding
+
+`test/read-pdf-layout.test.js`, describe *"one font, one glyph reflected
+relative to its siblings"*. Two PDFs are built from the same eight mask bytes
+in a two-glyph Type-3 font, differing only in whether the second glyph's `cm`
+is reflected.
+
+- *"keys both glyphs on the grid when the font agrees with itself"* — the
+  unanimous font resolves a sign, both glyphs reach the mask lane, and the two
+  identical grids key identically. This is the producer-independent behaviour,
+  asserted so the fix cannot be over-applied.
+- *"refuses the grid key to a whole font that disagrees with itself"* — first
+  asserts that the reflected glyph, keyed on its **own** sign, still collides
+  exactly with the upright glyph's key. That is the defect, reproduced inside
+  the test, so the test cannot pass vacuously. It then asserts the font
+  resolves no orientation and that neither glyph is grid-keyed.
+
+Both were verified to go red by deleting the safeguard, in each of its two
+halves independently:
+
+| Deletion | Result |
+| --- | --- |
+| Mask lane stops consulting `fontPaintOrientation` | 1 failed |
+| `type3FontPaintOrientation` stops requiring unanimity | 1 failed |
+
+## Reproducing
+
+The safeguard's own tests need nothing external:
+
+```bash
+npx vitest run test/read-pdf-layout.test.js -t "reflected relative"
+```
+
+The reference-document measurement needs the licensed source and the
+mutation, which is a one-line edit to a single CharProc stream: decompress
+`shannon-entropy.pdf`, find the CharProc named `/#2303` in the `/CharProcs` of
+font `23 0 R`, replace its `17 0 0 98 1.1 -95.1 cm` with
+`-17 0 0 98 18.1 -95.1 cm`, leave every byte after `ID` untouched, and rewrite
+the stream uncompressed with a corrected `/Length`. Then:
+
+```bash
+PDF_TOOLS_SHANNON_SOURCE=/path/to/shannon-entropy.pdf \
+  npx vitest run test/shannon-type3-live.test.js
+```
+
+Recovery counts for the mutated document are read off
+`extract_layout_for_markdown` over pages 1-55, summing `glyph_recoveries` per
+`registry_id`, which is the same traversal `test/shannon-type3-live.test.js`
+performs.

--- a/pdf-toolkit-mcp-share/server/layout-extraction.js
+++ b/pdf-toolkit-mcp-share/server/layout-extraction.js
@@ -9,7 +9,7 @@ import {
 } from "./type3-cm-reference.js";
 
 const IR_NAME = "pdf-tools.extraction-ir";
-const IR_VERSION = "1.4.0";
+const IR_VERSION = "1.5.0";
 /*
  * IR_VERSION pin sweep (all must remain aligned):
  * - server/layout-extraction.js: IR_VERSION and EXTRACTION_IR_IDENTITY
@@ -17,7 +17,14 @@ const IR_VERSION = "1.4.0";
  * - server/markdown-conversion.js: supported layout identity
  * - test/read-pdf-layout.test.js, test/convert-pdf-to-markdown.test.js,
  *   test/mcp-contract.test.js, and test/pdfjs-worker-contract.test.js
- * - pdf-toolkit-mcp-share/server/layout-extraction.js and output-schemas.js
+ * - scripts/smoke-mcpb.mjs and scripts/test-share-contract.mjs
+ * - pdf-toolkit-mcp-share/server/layout-extraction.js, markdown-conversion.js,
+ *   and output-schemas.js
+ *
+ * 1.5.0: the Type-3 glyph evidence key is the stored image-mask sample grid.
+ * The published digests under glyph_sha256 and witness_glyph_sha256 all
+ * changed, and those two fields plus glyph_evidence_version replaced the
+ * charproc-named fields of 1.4.0.
  */
 const INTERNAL_SOURCE_REPLAY = Symbol("pdf-layout-internal-source-replay");
 const INTERNAL_MARKDOWN_PROJECTION = Symbol("pdf-layout-internal-markdown-projection");
@@ -59,13 +66,16 @@ const MAX_PAINTED_RECTANGLES = 500;
 /*
  * Type-3 glyph evidence keys.
  *
- * v2 keys a legacy bitmap glyph on its decoded image mask instead of on the
- * CharProc operator list. The operator list folds in the producer's idiom, the
- * inline-image filter it chose, and the per-glyph placement matrix, none of
- * which are properties of the glyph: two documents carrying a pixel-identical
- * Computer Modern raster hashed differently under v1 and now hash the same.
- * Non-mask glyph programs keep the exact operator digest under a separate
- * domain tag, so the two lanes can never satisfy each other's registry entries.
+ * v2 keys a legacy bitmap glyph on the stored samples of its decoded image
+ * mask instead of on the CharProc operator list. The operator list folds in the
+ * producer's idiom, the inline-image filter it chose, and the per-glyph
+ * placement matrix, none of which are properties of the glyph: two documents
+ * carrying a pixel-identical Computer Modern raster hashed differently under v1
+ * and now hash the same. No matrix takes part in the key, because the matrices
+ * that decide painted orientation are not all reachable from inside a CharProc
+ * and keying on the reachable half is what made v1 producer-dependent. Non-mask
+ * glyph programs keep the exact operator digest under a separate domain tag, so
+ * the two lanes can never satisfy each other's registry entries.
  */
 const TYPE3_GLYPH_EVIDENCE_VERSION = "pdfjs-type3-glyph-evidence-v2";
 const TYPE3_MASK_EVIDENCE_DOMAIN = "type3-glyph-image-mask-v1";
@@ -86,11 +96,11 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 11,
     source_unicode: "\u000b",
     target_unicode: "α",
-    glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093",
+    glyph_sha256: "55bb60d8560069c0650380cf09cdd023866ca4b91bb92b2fe4b45a056da1bf47",
     allow_collapsed_whitespace: true,
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 25, glyph_sha256: "751c36c470d1f0292b9d39de8cfec243d0e1e4ca3b2a2648676a8048cdf75322" }),
-      Object.freeze({ original_char_code: 26, glyph_sha256: "ff3b8028f135ce4dbf41a3e3fa8415f54615e9c3e7253d13e9070a71679ccebc" }),
+      Object.freeze({ original_char_code: 25, glyph_sha256: "9554966ab58edc060791bd02f04513a8da4a749f80a943d2daa3460a393fee7f" }),
+      Object.freeze({ original_char_code: 26, glyph_sha256: "eaa7d3cbe50f3ec7903d72addc77f88a471c1dfdc2fd9eb02ce0fbf800068507" }),
     ]),
   }),
   Object.freeze({
@@ -102,8 +112,8 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     target_unicode: ".",
     glyph_sha256: "2ed87b069c99482d0823c085da9c199582e6e4b51172a2b360d9b6652066e3ae",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 59, glyph_sha256: "65e5727a8eb6528fe7013fcf6f2522e93c65ee868f0315850cefd2992e5b7e5b" }),
-      Object.freeze({ original_char_code: 61, glyph_sha256: "2406e228edd78d0d53cc29b48a3154626a47c6fda6b01450cf2c1155cd6b81f7" }),
+      Object.freeze({ original_char_code: 59, glyph_sha256: "b06ab15c9fa4160e3448e0d4cf7e0c6aa1ff13b5dd01ab1406df95d77c279a53" }),
+      Object.freeze({ original_char_code: 61, glyph_sha256: "44505b10d5f364c73f92f52606205ba2fa27a7f96d4dc41c8ba311cc2bc3ffe3" }),
     ]),
   }),
   Object.freeze({
@@ -113,10 +123,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 59,
     source_unicode: ";",
     target_unicode: ",",
-    glyph_sha256: "65e5727a8eb6528fe7013fcf6f2522e93c65ee868f0315850cefd2992e5b7e5b",
+    glyph_sha256: "b06ab15c9fa4160e3448e0d4cf7e0c6aa1ff13b5dd01ab1406df95d77c279a53",
     witnesses: Object.freeze([
       Object.freeze({ original_char_code: 58, glyph_sha256: "2ed87b069c99482d0823c085da9c199582e6e4b51172a2b360d9b6652066e3ae" }),
-      Object.freeze({ original_char_code: 61, glyph_sha256: "2406e228edd78d0d53cc29b48a3154626a47c6fda6b01450cf2c1155cd6b81f7" }),
+      Object.freeze({ original_char_code: 61, glyph_sha256: "44505b10d5f364c73f92f52606205ba2fa27a7f96d4dc41c8ba311cc2bc3ffe3" }),
     ]),
   }),
   Object.freeze({
@@ -126,10 +136,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 25,
     source_unicode: "\u0019",
     target_unicode: "π",
-    glyph_sha256: "751c36c470d1f0292b9d39de8cfec243d0e1e4ca3b2a2648676a8048cdf75322",
+    glyph_sha256: "9554966ab58edc060791bd02f04513a8da4a749f80a943d2daa3460a393fee7f",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
-      Object.freeze({ original_char_code: 26, glyph_sha256: "ff3b8028f135ce4dbf41a3e3fa8415f54615e9c3e7253d13e9070a71679ccebc" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "55bb60d8560069c0650380cf09cdd023866ca4b91bb92b2fe4b45a056da1bf47" }),
+      Object.freeze({ original_char_code: 26, glyph_sha256: "eaa7d3cbe50f3ec7903d72addc77f88a471c1dfdc2fd9eb02ce0fbf800068507" }),
     ]),
   }),
   Object.freeze({
@@ -139,10 +149,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 26,
     source_unicode: "\u001a",
     target_unicode: "ρ",
-    glyph_sha256: "ff3b8028f135ce4dbf41a3e3fa8415f54615e9c3e7253d13e9070a71679ccebc",
+    glyph_sha256: "eaa7d3cbe50f3ec7903d72addc77f88a471c1dfdc2fd9eb02ce0fbf800068507",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
-      Object.freeze({ original_char_code: 25, glyph_sha256: "751c36c470d1f0292b9d39de8cfec243d0e1e4ca3b2a2648676a8048cdf75322" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "55bb60d8560069c0650380cf09cdd023866ca4b91bb92b2fe4b45a056da1bf47" }),
+      Object.freeze({ original_char_code: 25, glyph_sha256: "9554966ab58edc060791bd02f04513a8da4a749f80a943d2daa3460a393fee7f" }),
     ]),
   }),
   Object.freeze({
@@ -152,10 +162,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 33,
     source_unicode: "!",
     target_unicode: "ω",
-    glyph_sha256: "4c740569ca05e182025cfeb2d99d35f6c2655f7674b919fe2f145a33ff4ffdd1",
+    glyph_sha256: "d88e2217762ec495c847bbc7535cfa5a3b083590190c185788dfd69929affa24",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
-      Object.freeze({ original_char_code: 25, glyph_sha256: "751c36c470d1f0292b9d39de8cfec243d0e1e4ca3b2a2648676a8048cdf75322" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "55bb60d8560069c0650380cf09cdd023866ca4b91bb92b2fe4b45a056da1bf47" }),
+      Object.freeze({ original_char_code: 25, glyph_sha256: "9554966ab58edc060791bd02f04513a8da4a749f80a943d2daa3460a393fee7f" }),
     ]),
   }),
   Object.freeze({
@@ -165,10 +175,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 61,
     source_unicode: "=",
     target_unicode: "/",
-    glyph_sha256: "2406e228edd78d0d53cc29b48a3154626a47c6fda6b01450cf2c1155cd6b81f7",
+    glyph_sha256: "44505b10d5f364c73f92f52606205ba2fa27a7f96d4dc41c8ba311cc2bc3ffe3",
     witnesses: Object.freeze([
       Object.freeze({ original_char_code: 58, glyph_sha256: "2ed87b069c99482d0823c085da9c199582e6e4b51172a2b360d9b6652066e3ae" }),
-      Object.freeze({ original_char_code: 59, glyph_sha256: "65e5727a8eb6528fe7013fcf6f2522e93c65ee868f0315850cefd2992e5b7e5b" }),
+      Object.freeze({ original_char_code: 59, glyph_sha256: "b06ab15c9fa4160e3448e0d4cf7e0c6aa1ff13b5dd01ab1406df95d77c279a53" }),
     ]),
   }),
   Object.freeze({
@@ -180,8 +190,8 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     target_unicode: "−",
     glyph_sha256: "68b4a1e125aa58ed3e798029190dbf4e2f3937030f921cd995cf7c8ad2f2eedc",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 21, glyph_sha256: "d2622641d0fa27eba18c91fd6333cfad66cbc23918a88854242d2f0f4c6ca968" }),
-      Object.freeze({ original_char_code: 112, glyph_sha256: "f57899424fb6b62d3a54288b4fb0f41a9edc7b8e17bbd41f0a1e1fac6b743196" }),
+      Object.freeze({ original_char_code: 21, glyph_sha256: "520751dc437215219c1269212ade701dc57b1484416b9bad9ef3da2806bb53e9" }),
+      Object.freeze({ original_char_code: 112, glyph_sha256: "0ecbc7bd327017ee4719d7fa1e0b097bdd7b06557f8a39e11aa7c10a8a408218" }),
     ]),
   }),
   Object.freeze({
@@ -191,10 +201,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 21,
     source_unicode: "\u0015",
     target_unicode: "≥",
-    glyph_sha256: "d2622641d0fa27eba18c91fd6333cfad66cbc23918a88854242d2f0f4c6ca968",
+    glyph_sha256: "520751dc437215219c1269212ade701dc57b1484416b9bad9ef3da2806bb53e9",
     witnesses: Object.freeze([
       Object.freeze({ original_char_code: 0, glyph_sha256: "68b4a1e125aa58ed3e798029190dbf4e2f3937030f921cd995cf7c8ad2f2eedc" }),
-      Object.freeze({ original_char_code: 112, glyph_sha256: "f57899424fb6b62d3a54288b4fb0f41a9edc7b8e17bbd41f0a1e1fac6b743196" }),
+      Object.freeze({ original_char_code: 112, glyph_sha256: "0ecbc7bd327017ee4719d7fa1e0b097bdd7b06557f8a39e11aa7c10a8a408218" }),
     ]),
   }),
   Object.freeze({
@@ -204,10 +214,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 112,
     source_unicode: "p",
     target_unicode: "√",
-    glyph_sha256: "f57899424fb6b62d3a54288b4fb0f41a9edc7b8e17bbd41f0a1e1fac6b743196",
+    glyph_sha256: "0ecbc7bd327017ee4719d7fa1e0b097bdd7b06557f8a39e11aa7c10a8a408218",
     witnesses: Object.freeze([
       Object.freeze({ original_char_code: 0, glyph_sha256: "68b4a1e125aa58ed3e798029190dbf4e2f3937030f921cd995cf7c8ad2f2eedc" }),
-      Object.freeze({ original_char_code: 21, glyph_sha256: "d2622641d0fa27eba18c91fd6333cfad66cbc23918a88854242d2f0f4c6ca968" }),
+      Object.freeze({ original_char_code: 21, glyph_sha256: "520751dc437215219c1269212ade701dc57b1484416b9bad9ef3da2806bb53e9" }),
     ]),
   }),
   Object.freeze({
@@ -217,10 +227,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 33,
     source_unicode: "!",
     target_unicode: "ω",
-    glyph_sha256: "ce4f89e61b842053344c92603d0588263e0118e0321411ae3f798b2f39445fe2",
+    glyph_sha256: "776ec8ccac079e545eeadd4abc00c0384bfd5f8ffe976e754d832ca527aba9f3",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, glyph_sha256: "e9705ccd52613dd5c8dcbff8618f9d825f88b29a9ddcedc01532fd7ba217385f" }),
-      Object.freeze({ original_char_code: 25, glyph_sha256: "fa64dc2c1de162435601ca8107e3a5027cc9dd3ca9d0aaa6998e5736c3f9564a" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "a8e84e0d932585f5ea43e57c1c6aa2ddc349dbf9c95f25dde63d953281094aed" }),
+      Object.freeze({ original_char_code: 25, glyph_sha256: "8844ed36948e6f388a823fa06d5165b38e5c00b68d0a9196c4875d3a5ed4147c" }),
     ]),
   }),
   Object.freeze({
@@ -232,8 +242,8 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     target_unicode: ".",
     glyph_sha256: "8520f46225db90fbb8c41a8ffe4ced238a45f80f3dd74acf4d9b12ec29598513",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 59, glyph_sha256: "67bc7d266ae458bb1c5cf497d1de03ccbc4b85d03457ef2a54e7aa9e91b2ef6a" }),
-      Object.freeze({ original_char_code: 61, glyph_sha256: "7604ca52d40535d2c7205e425d56cb07e19c388dc6ff5806ffe87cc9d811c025" }),
+      Object.freeze({ original_char_code: 59, glyph_sha256: "76bea2467b789bea3b7bf4585d0bea146aa54cf04448d992013837d2febb8ab7" }),
+      Object.freeze({ original_char_code: 61, glyph_sha256: "6564b30a30b414b35c8f5c892e3d63ece09a101e911109fac83f4bff95dc04b5" }),
     ]),
   }),
   Object.freeze({
@@ -243,10 +253,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 61,
     source_unicode: "=",
     target_unicode: "/",
-    glyph_sha256: "7604ca52d40535d2c7205e425d56cb07e19c388dc6ff5806ffe87cc9d811c025",
+    glyph_sha256: "6564b30a30b414b35c8f5c892e3d63ece09a101e911109fac83f4bff95dc04b5",
     witnesses: Object.freeze([
       Object.freeze({ original_char_code: 58, glyph_sha256: "8520f46225db90fbb8c41a8ffe4ced238a45f80f3dd74acf4d9b12ec29598513" }),
-      Object.freeze({ original_char_code: 59, glyph_sha256: "67bc7d266ae458bb1c5cf497d1de03ccbc4b85d03457ef2a54e7aa9e91b2ef6a" }),
+      Object.freeze({ original_char_code: 59, glyph_sha256: "76bea2467b789bea3b7bf4585d0bea146aa54cf04448d992013837d2febb8ab7" }),
     ]),
   }),
   Object.freeze({
@@ -256,10 +266,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 59,
     source_unicode: ";",
     target_unicode: ",",
-    glyph_sha256: "67bc7d266ae458bb1c5cf497d1de03ccbc4b85d03457ef2a54e7aa9e91b2ef6a",
+    glyph_sha256: "76bea2467b789bea3b7bf4585d0bea146aa54cf04448d992013837d2febb8ab7",
     witnesses: Object.freeze([
       Object.freeze({ original_char_code: 58, glyph_sha256: "8520f46225db90fbb8c41a8ffe4ced238a45f80f3dd74acf4d9b12ec29598513" }),
-      Object.freeze({ original_char_code: 61, glyph_sha256: "7604ca52d40535d2c7205e425d56cb07e19c388dc6ff5806ffe87cc9d811c025" }),
+      Object.freeze({ original_char_code: 61, glyph_sha256: "6564b30a30b414b35c8f5c892e3d63ece09a101e911109fac83f4bff95dc04b5" }),
     ]),
   }),
   Object.freeze({
@@ -271,7 +281,7 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     target_unicode: "−",
     glyph_sha256: "ed5df416bb312c2b49ed8936f226016a28e9a09fa52aba56281dd6a8a5430d19",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 6, glyph_sha256: "4734e344eca1f8f73183a34504c1068146b425815a2a8ef6aa00a18dfd45d9a2" }),
+      Object.freeze({ original_char_code: 6, glyph_sha256: "4dd026f859f9674351763f1eec5d88e6ef486555ea12f8eb6a433b1a95238a19" }),
       Object.freeze({ original_char_code: 33, glyph_sha256: "a818ff8e95ae122382e0f0198e875400f4cc07ef1115dbe936ad5dd37933c4d4" }),
     ]),
   }),
@@ -284,8 +294,8 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     target_unicode: "−",
     glyph_sha256: "3f6fdf2abc68f5693f9ea7cdec4d94214a57fb953fb66c747b86dd1f6293d807",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 21, glyph_sha256: "73a2cec4aa27d5042b9f4275179fbf2bb7b99413537597ede0537b7f19c8384c" }),
-      Object.freeze({ original_char_code: 112, glyph_sha256: "f15e035b5867fbee9918125e49566e00b94dcd8422649079c87207e94f7a9e63" }),
+      Object.freeze({ original_char_code: 21, glyph_sha256: "cf5071eb6c006bc80cf9399c28dc00f7e12d8e7f090942de46cb06d404481dd6" }),
+      Object.freeze({ original_char_code: 112, glyph_sha256: "da5345f465509486a66762b6cf8918a3ba5c937f4ca8c7bc4657f4f905d0b4be" }),
     ]),
   }),
   Object.freeze({
@@ -310,8 +320,8 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     target_unicode: ".",
     glyph_sha256: "8520f46225db90fbb8c41a8ffe4ced238a45f80f3dd74acf4d9b12ec29598513",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 59, glyph_sha256: "5363832452620aa888b74219c2a632d1e58a27060bffb1cf6392bf5b2fad8316" }),
-      Object.freeze({ original_char_code: 61, glyph_sha256: "f1c63f92441a1dc720dac5d5d39e38da21d397d81e32c4a87a5bfa34c50b8f8d" }),
+      Object.freeze({ original_char_code: 59, glyph_sha256: "be90d1c78149ab81005db5ce23c2ad819399c82bc16bdc7b41de5a3e3a2ee494" }),
+      Object.freeze({ original_char_code: 61, glyph_sha256: "7102f7980d961e8217c684332b9fe84a9a9f31290153ccf1ee784ffb16527665" }),
     ]),
   }),
   Object.freeze({
@@ -321,10 +331,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 59,
     source_unicode: ";",
     target_unicode: ",",
-    glyph_sha256: "5363832452620aa888b74219c2a632d1e58a27060bffb1cf6392bf5b2fad8316",
+    glyph_sha256: "be90d1c78149ab81005db5ce23c2ad819399c82bc16bdc7b41de5a3e3a2ee494",
     witnesses: Object.freeze([
       Object.freeze({ original_char_code: 58, glyph_sha256: "8520f46225db90fbb8c41a8ffe4ced238a45f80f3dd74acf4d9b12ec29598513" }),
-      Object.freeze({ original_char_code: 61, glyph_sha256: "f1c63f92441a1dc720dac5d5d39e38da21d397d81e32c4a87a5bfa34c50b8f8d" }),
+      Object.freeze({ original_char_code: 61, glyph_sha256: "7102f7980d961e8217c684332b9fe84a9a9f31290153ccf1ee784ffb16527665" }),
     ]),
   }),
   Object.freeze({
@@ -334,10 +344,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 61,
     source_unicode: "=",
     target_unicode: "/",
-    glyph_sha256: "f1c63f92441a1dc720dac5d5d39e38da21d397d81e32c4a87a5bfa34c50b8f8d",
+    glyph_sha256: "7102f7980d961e8217c684332b9fe84a9a9f31290153ccf1ee784ffb16527665",
     witnesses: Object.freeze([
       Object.freeze({ original_char_code: 58, glyph_sha256: "8520f46225db90fbb8c41a8ffe4ced238a45f80f3dd74acf4d9b12ec29598513" }),
-      Object.freeze({ original_char_code: 59, glyph_sha256: "5363832452620aa888b74219c2a632d1e58a27060bffb1cf6392bf5b2fad8316" }),
+      Object.freeze({ original_char_code: 59, glyph_sha256: "be90d1c78149ab81005db5ce23c2ad819399c82bc16bdc7b41de5a3e3a2ee494" }),
     ]),
   }),
   Object.freeze({
@@ -347,11 +357,11 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 11,
     source_unicode: "\u000b",
     target_unicode: "α",
-    glyph_sha256: "6092e20a2f8a4925449780db726c4912ccee956a094589d3cb63ede3b5d7383b",
+    glyph_sha256: "afd53079aef8914177830dd32a4751df81d06ef083e4d1a0fc641896dc827fb4",
     allow_collapsed_whitespace: true,
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 25, glyph_sha256: "38b7cc2fac5858dfd6acc1c7936eb874900c61299c8758edc607cb91cbd68b39" }),
-      Object.freeze({ original_char_code: 26, glyph_sha256: "8271aed349c3127895bf7d96b57c83fd62b03cc6c9c9428e600a58b269899365" }),
+      Object.freeze({ original_char_code: 25, glyph_sha256: "ef3b94ad4d1be76d84c62c89da120449668fd9b47cd120922110a9a7977c45f0" }),
+      Object.freeze({ original_char_code: 26, glyph_sha256: "a98c60dd17ef1c118bbdd5ae57e81f7a5cc843450fa650017b64372445a3a5a4" }),
     ]),
   }),
   Object.freeze({
@@ -361,10 +371,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 25,
     source_unicode: "\u0019",
     target_unicode: "π",
-    glyph_sha256: "38b7cc2fac5858dfd6acc1c7936eb874900c61299c8758edc607cb91cbd68b39",
+    glyph_sha256: "ef3b94ad4d1be76d84c62c89da120449668fd9b47cd120922110a9a7977c45f0",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, glyph_sha256: "6092e20a2f8a4925449780db726c4912ccee956a094589d3cb63ede3b5d7383b" }),
-      Object.freeze({ original_char_code: 26, glyph_sha256: "8271aed349c3127895bf7d96b57c83fd62b03cc6c9c9428e600a58b269899365" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "afd53079aef8914177830dd32a4751df81d06ef083e4d1a0fc641896dc827fb4" }),
+      Object.freeze({ original_char_code: 26, glyph_sha256: "a98c60dd17ef1c118bbdd5ae57e81f7a5cc843450fa650017b64372445a3a5a4" }),
     ]),
   }),
   Object.freeze({
@@ -374,10 +384,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 26,
     source_unicode: "\u001a",
     target_unicode: "ρ",
-    glyph_sha256: "8271aed349c3127895bf7d96b57c83fd62b03cc6c9c9428e600a58b269899365",
+    glyph_sha256: "a98c60dd17ef1c118bbdd5ae57e81f7a5cc843450fa650017b64372445a3a5a4",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, glyph_sha256: "6092e20a2f8a4925449780db726c4912ccee956a094589d3cb63ede3b5d7383b" }),
-      Object.freeze({ original_char_code: 25, glyph_sha256: "38b7cc2fac5858dfd6acc1c7936eb874900c61299c8758edc607cb91cbd68b39" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "afd53079aef8914177830dd32a4751df81d06ef083e4d1a0fc641896dc827fb4" }),
+      Object.freeze({ original_char_code: 25, glyph_sha256: "ef3b94ad4d1be76d84c62c89da120449668fd9b47cd120922110a9a7977c45f0" }),
     ]),
   }),
   Object.freeze({
@@ -387,11 +397,11 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 11,
     source_unicode: "\u000b",
     target_unicode: "α",
-    glyph_sha256: "e9705ccd52613dd5c8dcbff8618f9d825f88b29a9ddcedc01532fd7ba217385f",
+    glyph_sha256: "a8e84e0d932585f5ea43e57c1c6aa2ddc349dbf9c95f25dde63d953281094aed",
     allow_collapsed_whitespace: true,
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 25, glyph_sha256: "fa64dc2c1de162435601ca8107e3a5027cc9dd3ca9d0aaa6998e5736c3f9564a" }),
-      Object.freeze({ original_char_code: 26, glyph_sha256: "509f130688569e2b0b333a102fcaee164efdc687a94db9d7a40c928009129431" }),
+      Object.freeze({ original_char_code: 25, glyph_sha256: "8844ed36948e6f388a823fa06d5165b38e5c00b68d0a9196c4875d3a5ed4147c" }),
+      Object.freeze({ original_char_code: 26, glyph_sha256: "4cbdb66a4c77a8d3544a862526cbf6918a1575df24ee425489fd4266aeaf0f2d" }),
     ]),
   }),
   Object.freeze({
@@ -401,10 +411,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 25,
     source_unicode: "\u0019",
     target_unicode: "π",
-    glyph_sha256: "fa64dc2c1de162435601ca8107e3a5027cc9dd3ca9d0aaa6998e5736c3f9564a",
+    glyph_sha256: "8844ed36948e6f388a823fa06d5165b38e5c00b68d0a9196c4875d3a5ed4147c",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, glyph_sha256: "e9705ccd52613dd5c8dcbff8618f9d825f88b29a9ddcedc01532fd7ba217385f" }),
-      Object.freeze({ original_char_code: 26, glyph_sha256: "509f130688569e2b0b333a102fcaee164efdc687a94db9d7a40c928009129431" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "a8e84e0d932585f5ea43e57c1c6aa2ddc349dbf9c95f25dde63d953281094aed" }),
+      Object.freeze({ original_char_code: 26, glyph_sha256: "4cbdb66a4c77a8d3544a862526cbf6918a1575df24ee425489fd4266aeaf0f2d" }),
     ]),
   }),
   Object.freeze({
@@ -414,10 +424,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 26,
     source_unicode: "\u001a",
     target_unicode: "ρ",
-    glyph_sha256: "509f130688569e2b0b333a102fcaee164efdc687a94db9d7a40c928009129431",
+    glyph_sha256: "4cbdb66a4c77a8d3544a862526cbf6918a1575df24ee425489fd4266aeaf0f2d",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, glyph_sha256: "e9705ccd52613dd5c8dcbff8618f9d825f88b29a9ddcedc01532fd7ba217385f" }),
-      Object.freeze({ original_char_code: 25, glyph_sha256: "fa64dc2c1de162435601ca8107e3a5027cc9dd3ca9d0aaa6998e5736c3f9564a" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "a8e84e0d932585f5ea43e57c1c6aa2ddc349dbf9c95f25dde63d953281094aed" }),
+      Object.freeze({ original_char_code: 25, glyph_sha256: "8844ed36948e6f388a823fa06d5165b38e5c00b68d0a9196c4875d3a5ed4147c" }),
     ]),
   }),
   Object.freeze({
@@ -427,10 +437,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 21,
     source_unicode: "\u0015",
     target_unicode: "≥",
-    glyph_sha256: "73a2cec4aa27d5042b9f4275179fbf2bb7b99413537597ede0537b7f19c8384c",
+    glyph_sha256: "cf5071eb6c006bc80cf9399c28dc00f7e12d8e7f090942de46cb06d404481dd6",
     witnesses: Object.freeze([
       Object.freeze({ original_char_code: 0, glyph_sha256: "3f6fdf2abc68f5693f9ea7cdec4d94214a57fb953fb66c747b86dd1f6293d807" }),
-      Object.freeze({ original_char_code: 112, glyph_sha256: "f15e035b5867fbee9918125e49566e00b94dcd8422649079c87207e94f7a9e63" }),
+      Object.freeze({ original_char_code: 112, glyph_sha256: "da5345f465509486a66762b6cf8918a3ba5c937f4ca8c7bc4657f4f905d0b4be" }),
     ]),
   }),
   Object.freeze({
@@ -440,10 +450,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 112,
     source_unicode: "p",
     target_unicode: "√",
-    glyph_sha256: "f15e035b5867fbee9918125e49566e00b94dcd8422649079c87207e94f7a9e63",
+    glyph_sha256: "da5345f465509486a66762b6cf8918a3ba5c937f4ca8c7bc4657f4f905d0b4be",
     witnesses: Object.freeze([
       Object.freeze({ original_char_code: 0, glyph_sha256: "3f6fdf2abc68f5693f9ea7cdec4d94214a57fb953fb66c747b86dd1f6293d807" }),
-      Object.freeze({ original_char_code: 21, glyph_sha256: "73a2cec4aa27d5042b9f4275179fbf2bb7b99413537597ede0537b7f19c8384c" }),
+      Object.freeze({ original_char_code: 21, glyph_sha256: "cf5071eb6c006bc80cf9399c28dc00f7e12d8e7f090942de46cb06d404481dd6" }),
     ]),
   }),
   Object.freeze({
@@ -456,7 +466,7 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     glyph_sha256: "2ed87b069c99482d0823c085da9c199582e6e4b51172a2b360d9b6652066e3ae",
     witnesses: Object.freeze([
       Object.freeze({ original_char_code: 0, glyph_sha256: "68b4a1e125aa58ed3e798029190dbf4e2f3937030f921cd995cf7c8ad2f2eedc" }),
-      Object.freeze({ original_char_code: 6, glyph_sha256: "009835b7eda7745c9e2e167ce0ed1b5e4ff9063af4c92280dffab3213f07e395" }),
+      Object.freeze({ original_char_code: 6, glyph_sha256: "f7b39315fb585e4066816ab2d3d3d07e1b1d79bb9a30fdae7fbf5588d2873906" }),
     ]),
   }),
   Object.freeze({
@@ -466,7 +476,7 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 20,
     source_unicode: "\u0014",
     target_unicode: "≤",
-    glyph_sha256: "b7694606e91a2a5ad7ad6b16032289f5f4bcca7d7528ef93759e39908c68d8c4",
+    glyph_sha256: "1f5c8de996c9b3c20c6503052f62d18022e4b97537957d565a0b3668c3c4918d",
     witnesses: Object.freeze([
       Object.freeze({ original_char_code: 0, glyph_sha256: "68b4a1e125aa58ed3e798029190dbf4e2f3937030f921cd995cf7c8ad2f2eedc" }),
       Object.freeze({ original_char_code: 1, glyph_sha256: "2ed87b069c99482d0823c085da9c199582e6e4b51172a2b360d9b6652066e3ae" }),
@@ -479,10 +489,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 48,
     source_unicode: "0",
     target_unicode: "′",
-    glyph_sha256: "a24e8c43c1c680cc6c2a676adb046c59ca00ebe5116ed583b37f3b1d6a39cc66",
+    glyph_sha256: "70c2850ba731163e1e74c60f354ca5407181fd97b75b500deba6e92fe068f6ea",
     witnesses: Object.freeze([
       Object.freeze({ original_char_code: 0, glyph_sha256: "ed5df416bb312c2b49ed8936f226016a28e9a09fa52aba56281dd6a8a5430d19" }),
-      Object.freeze({ original_char_code: 6, glyph_sha256: "4734e344eca1f8f73183a34504c1068146b425815a2a8ef6aa00a18dfd45d9a2" }),
+      Object.freeze({ original_char_code: 6, glyph_sha256: "4dd026f859f9674351763f1eec5d88e6ef486555ea12f8eb6a433b1a95238a19" }),
     ]),
   }),
   Object.freeze({
@@ -713,10 +723,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 1,
     source_unicode: "\u0001",
     target_unicode: "Δ",
-    glyph_sha256: "30552b3ff5ae9fae4095b2a791d73b448221a488c7b6ede9ddfb6852f474a052",
+    glyph_sha256: "d3461f539f11089075b8a98c57a23114902418575458cb92fad483e950129164",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
-      Object.freeze({ original_char_code: 14, glyph_sha256: "8d55a727feda11508e29c3b5c500d64dc58ce7b6fdb3d9776ef1e0d2df7888a3" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "55bb60d8560069c0650380cf09cdd023866ca4b91bb92b2fe4b45a056da1bf47" }),
+      Object.freeze({ original_char_code: 14, glyph_sha256: "b2f587826f470886f73db237c0dcc326ea588e176bee087052b5ee7fec6e4cd6" }),
     ]),
   }),
   Object.freeze({
@@ -726,10 +736,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 14,
     source_unicode: "\u000e",
     target_unicode: "δ",
-    glyph_sha256: "8d55a727feda11508e29c3b5c500d64dc58ce7b6fdb3d9776ef1e0d2df7888a3",
+    glyph_sha256: "b2f587826f470886f73db237c0dcc326ea588e176bee087052b5ee7fec6e4cd6",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 1, glyph_sha256: "30552b3ff5ae9fae4095b2a791d73b448221a488c7b6ede9ddfb6852f474a052" }),
-      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "d3461f539f11089075b8a98c57a23114902418575458cb92fad483e950129164" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "55bb60d8560069c0650380cf09cdd023866ca4b91bb92b2fe4b45a056da1bf47" }),
     ]),
   }),
   Object.freeze({
@@ -739,10 +749,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 14,
     source_unicode: "\u000e",
     target_unicode: "δ",
-    glyph_sha256: "40e6d476435323a686a4ef5f02ac43f6b6b5e3612887c18105b82575e76e2e9b",
+    glyph_sha256: "e8cb8e148c83465beb80f9a888fecb2b5b9a0e4625701b97cc149ffc893ed1ed",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, glyph_sha256: "6092e20a2f8a4925449780db726c4912ccee956a094589d3cb63ede3b5d7383b" }),
-      Object.freeze({ original_char_code: 15, glyph_sha256: "8692c50f6e5d1605e52e3d414ad4c285a583d11bcfff2f7a3be93bee06117de5" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "afd53079aef8914177830dd32a4751df81d06ef083e4d1a0fc641896dc827fb4" }),
+      Object.freeze({ original_char_code: 15, glyph_sha256: "cb992b6a906e74dce8a20f585dc7c3befd47b7f99356f6e0acfeff69b324a367" }),
     ]),
   }),
   Object.freeze({
@@ -752,10 +762,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 15,
     source_unicode: "\u000f",
     target_unicode: "ϵ",
-    glyph_sha256: "da7780d95a5aea753d5de0f042903c2e96618c719283db449cd0476c5e74a6a4",
+    glyph_sha256: "c05d44175c21bf871787e49b7e44630f1424dec624ed460442d05060a67283df",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 1, glyph_sha256: "30552b3ff5ae9fae4095b2a791d73b448221a488c7b6ede9ddfb6852f474a052" }),
-      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "d3461f539f11089075b8a98c57a23114902418575458cb92fad483e950129164" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "55bb60d8560069c0650380cf09cdd023866ca4b91bb92b2fe4b45a056da1bf47" }),
     ]),
   }),
   Object.freeze({
@@ -765,10 +775,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 15,
     source_unicode: "\u000f",
     target_unicode: "ϵ",
-    glyph_sha256: "8692c50f6e5d1605e52e3d414ad4c285a583d11bcfff2f7a3be93bee06117de5",
+    glyph_sha256: "cb992b6a906e74dce8a20f585dc7c3befd47b7f99356f6e0acfeff69b324a367",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, glyph_sha256: "6092e20a2f8a4925449780db726c4912ccee956a094589d3cb63ede3b5d7383b" }),
-      Object.freeze({ original_char_code: 14, glyph_sha256: "40e6d476435323a686a4ef5f02ac43f6b6b5e3612887c18105b82575e76e2e9b" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "afd53079aef8914177830dd32a4751df81d06ef083e4d1a0fc641896dc827fb4" }),
+      Object.freeze({ original_char_code: 14, glyph_sha256: "e8cb8e148c83465beb80f9a888fecb2b5b9a0e4625701b97cc149ffc893ed1ed" }),
     ]),
   }),
   Object.freeze({
@@ -778,10 +788,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 17,
     source_unicode: "\u0011",
     target_unicode: "η",
-    glyph_sha256: "8a211c038232f3e28545e3d2f4a42ebd349a8cc27e45bc0a6775b4cd105cfb9c",
+    glyph_sha256: "9d63d43c9de79f2045762af5a19d73f86c29c9dfbbb96ca3913f7a7d3fe83255",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, glyph_sha256: "6092e20a2f8a4925449780db726c4912ccee956a094589d3cb63ede3b5d7383b" }),
-      Object.freeze({ original_char_code: 14, glyph_sha256: "40e6d476435323a686a4ef5f02ac43f6b6b5e3612887c18105b82575e76e2e9b" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "afd53079aef8914177830dd32a4751df81d06ef083e4d1a0fc641896dc827fb4" }),
+      Object.freeze({ original_char_code: 14, glyph_sha256: "e8cb8e148c83465beb80f9a888fecb2b5b9a0e4625701b97cc149ffc893ed1ed" }),
     ]),
   }),
   Object.freeze({
@@ -791,10 +801,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 18,
     source_unicode: "\u0012",
     target_unicode: "θ",
-    glyph_sha256: "1687afb884c912cf4555cef231572f37ac3eabe87344bc993fc3880d5eabdd2a",
+    glyph_sha256: "2f363c697c4ee84b7785dc606f0b38c93d8f4d63ea076784943858eae5c58859",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, glyph_sha256: "6092e20a2f8a4925449780db726c4912ccee956a094589d3cb63ede3b5d7383b" }),
-      Object.freeze({ original_char_code: 14, glyph_sha256: "40e6d476435323a686a4ef5f02ac43f6b6b5e3612887c18105b82575e76e2e9b" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "afd53079aef8914177830dd32a4751df81d06ef083e4d1a0fc641896dc827fb4" }),
+      Object.freeze({ original_char_code: 14, glyph_sha256: "e8cb8e148c83465beb80f9a888fecb2b5b9a0e4625701b97cc149ffc893ed1ed" }),
     ]),
   }),
   Object.freeze({
@@ -804,10 +814,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 21,
     source_unicode: "\u0015",
     target_unicode: "λ",
-    glyph_sha256: "bdf1508d236990157b905ae312c6daf9452a27e2e15f0d239e174047d700327f",
+    glyph_sha256: "41831967f0efef3f08cc7cdc544673323d526955d54eb70a02c0759c7fd4a2ff",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 1, glyph_sha256: "30552b3ff5ae9fae4095b2a791d73b448221a488c7b6ede9ddfb6852f474a052" }),
-      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "d3461f539f11089075b8a98c57a23114902418575458cb92fad483e950129164" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "55bb60d8560069c0650380cf09cdd023866ca4b91bb92b2fe4b45a056da1bf47" }),
     ]),
   }),
   Object.freeze({
@@ -817,10 +827,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 21,
     source_unicode: "\u0015",
     target_unicode: "λ",
-    glyph_sha256: "50a0ec752f73c00a5126d9e2ac8c9d3b97058ebd24e08570f18a994cad8702bd",
+    glyph_sha256: "75980da7a10a36beb8fccf4970e9295c03fe44be69bf167dacfdead776e5163f",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, glyph_sha256: "6092e20a2f8a4925449780db726c4912ccee956a094589d3cb63ede3b5d7383b" }),
-      Object.freeze({ original_char_code: 14, glyph_sha256: "40e6d476435323a686a4ef5f02ac43f6b6b5e3612887c18105b82575e76e2e9b" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "afd53079aef8914177830dd32a4751df81d06ef083e4d1a0fc641896dc827fb4" }),
+      Object.freeze({ original_char_code: 14, glyph_sha256: "e8cb8e148c83465beb80f9a888fecb2b5b9a0e4625701b97cc149ffc893ed1ed" }),
     ]),
   }),
   Object.freeze({
@@ -830,10 +840,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 22,
     source_unicode: "\u0016",
     target_unicode: "μ",
-    glyph_sha256: "58753b33f3d1d72955b0f1ef1777c5455c5ba37588f5fd88a0271ddcc0f46a75",
+    glyph_sha256: "9bb6e58efa558b61d35a7d6c83ee5d6404c734858f689177a6527efe04065404",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 1, glyph_sha256: "30552b3ff5ae9fae4095b2a791d73b448221a488c7b6ede9ddfb6852f474a052" }),
-      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "d3461f539f11089075b8a98c57a23114902418575458cb92fad483e950129164" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "55bb60d8560069c0650380cf09cdd023866ca4b91bb92b2fe4b45a056da1bf47" }),
     ]),
   }),
   Object.freeze({
@@ -843,10 +853,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 23,
     source_unicode: "\u0017",
     target_unicode: "ν",
-    glyph_sha256: "d56aaf7b101a1a8f54fb062c3176637576fc6d46c262c250b1082d5c606853c7",
+    glyph_sha256: "6f42ddf03199aeb21b3487177b315979b4afafe5f3a499805c49bf5bd46d719e",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 1, glyph_sha256: "30552b3ff5ae9fae4095b2a791d73b448221a488c7b6ede9ddfb6852f474a052" }),
-      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "d3461f539f11089075b8a98c57a23114902418575458cb92fad483e950129164" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "55bb60d8560069c0650380cf09cdd023866ca4b91bb92b2fe4b45a056da1bf47" }),
     ]),
   }),
   Object.freeze({
@@ -856,10 +866,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 27,
     source_unicode: "\u001b",
     target_unicode: "σ",
-    glyph_sha256: "c9a619efc5cd6a08c8ca09b92aca0d61391929ca7846322b4baf0d3f38edc5d8",
+    glyph_sha256: "06ec7ab10994040dc4927dbc3da9884ebf14f0da502e9240cdaec07d1443998d",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, glyph_sha256: "6092e20a2f8a4925449780db726c4912ccee956a094589d3cb63ede3b5d7383b" }),
-      Object.freeze({ original_char_code: 14, glyph_sha256: "40e6d476435323a686a4ef5f02ac43f6b6b5e3612887c18105b82575e76e2e9b" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "afd53079aef8914177830dd32a4751df81d06ef083e4d1a0fc641896dc827fb4" }),
+      Object.freeze({ original_char_code: 14, glyph_sha256: "e8cb8e148c83465beb80f9a888fecb2b5b9a0e4625701b97cc149ffc893ed1ed" }),
     ]),
   }),
   Object.freeze({
@@ -869,10 +879,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 28,
     source_unicode: "\u001c",
     target_unicode: "τ",
-    glyph_sha256: "10338ccd15eb973844cbbc07005a82aa702020cd2910adb162e71870fc67f82a",
+    glyph_sha256: "c01bf46eb9a8d19c7fb57d94905839c2fc2ba40450c736e8996ccd72948fa4ab",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 1, glyph_sha256: "30552b3ff5ae9fae4095b2a791d73b448221a488c7b6ede9ddfb6852f474a052" }),
-      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "d3461f539f11089075b8a98c57a23114902418575458cb92fad483e950129164" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "55bb60d8560069c0650380cf09cdd023866ca4b91bb92b2fe4b45a056da1bf47" }),
     ]),
   }),
   Object.freeze({
@@ -882,10 +892,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 39,
     source_unicode: "'",
     target_unicode: "φ",
-    glyph_sha256: "4231ef8441ffbc9e7bc7693f3ec28d2de301d0edc6f9df6f69968a95af266e97",
+    glyph_sha256: "31ddaca9be2bbf03dd58481b7516a3447a4ce89938ce2d99067b37805e08debd",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 1, glyph_sha256: "30552b3ff5ae9fae4095b2a791d73b448221a488c7b6ede9ddfb6852f474a052" }),
-      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "d3461f539f11089075b8a98c57a23114902418575458cb92fad483e950129164" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "55bb60d8560069c0650380cf09cdd023866ca4b91bb92b2fe4b45a056da1bf47" }),
     ]),
   }),
   Object.freeze({
@@ -895,10 +905,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 82,
     source_unicode: "R",
     target_unicode: "∫",
-    glyph_sha256: "58d503ac1ab67ecadd8e1ec07991a8338ddd452f5c3069dcba0ebe52e42fb3ee",
+    glyph_sha256: "362d48887daf303c09269e0fbc69db2338f062ce758cd9e242d3306f9f0c1952",
     complete_font_enrollment: Object.freeze([82, 90]),
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 90, glyph_sha256: "063d12bd3f8fba24a0375a5da378e3a0acb6195c42f91625ea0798dba6545ed7" }),
+      Object.freeze({ original_char_code: 90, glyph_sha256: "e5844045853943e3424dc224e60ba1217a509b2cc8e20f67a3504b141ed3c9c9" }),
     ]),
   }),
   Object.freeze({
@@ -908,10 +918,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 90,
     source_unicode: "Z",
     target_unicode: "∫",
-    glyph_sha256: "063d12bd3f8fba24a0375a5da378e3a0acb6195c42f91625ea0798dba6545ed7",
+    glyph_sha256: "e5844045853943e3424dc224e60ba1217a509b2cc8e20f67a3504b141ed3c9c9",
     complete_font_enrollment: Object.freeze([82, 90]),
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 82, glyph_sha256: "58d503ac1ab67ecadd8e1ec07991a8338ddd452f5c3069dcba0ebe52e42fb3ee" }),
+      Object.freeze({ original_char_code: 82, glyph_sha256: "362d48887daf303c09269e0fbc69db2338f062ce758cd9e242d3306f9f0c1952" }),
     ]),
   }),
   Object.freeze({
@@ -921,7 +931,7 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 6,
     source_unicode: "\u0006",
     target_unicode: "±",
-    glyph_sha256: "4734e344eca1f8f73183a34504c1068146b425815a2a8ef6aa00a18dfd45d9a2",
+    glyph_sha256: "4dd026f859f9674351763f1eec5d88e6ef486555ea12f8eb6a433b1a95238a19",
     witnesses: Object.freeze([
       Object.freeze({ original_char_code: 0, glyph_sha256: "ed5df416bb312c2b49ed8936f226016a28e9a09fa52aba56281dd6a8a5430d19" }),
       Object.freeze({ original_char_code: 33, glyph_sha256: "a818ff8e95ae122382e0f0198e875400f4cc07ef1115dbe936ad5dd37933c4d4" }),
@@ -950,7 +960,7 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     glyph_sha256: "a818ff8e95ae122382e0f0198e875400f4cc07ef1115dbe936ad5dd37933c4d4",
     witnesses: Object.freeze([
       Object.freeze({ original_char_code: 0, glyph_sha256: "ed5df416bb312c2b49ed8936f226016a28e9a09fa52aba56281dd6a8a5430d19" }),
-      Object.freeze({ original_char_code: 6, glyph_sha256: "4734e344eca1f8f73183a34504c1068146b425815a2a8ef6aa00a18dfd45d9a2" }),
+      Object.freeze({ original_char_code: 6, glyph_sha256: "4dd026f859f9674351763f1eec5d88e6ef486555ea12f8eb6a433b1a95238a19" }),
     ]),
   }),
   Object.freeze({
@@ -960,10 +970,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 17,
     source_unicode: "\u0011",
     target_unicode: "η",
-    glyph_sha256: "712ac34ba1c3de89b2c233171e58eaa55e54ebcb0d4cec1609a788fa90eef047",
+    glyph_sha256: "b92c6fb549abb85d45c5ef490227e3accba0f512901b57fb72079a7232ed51fe",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
-      Object.freeze({ original_char_code: 25, glyph_sha256: "751c36c470d1f0292b9d39de8cfec243d0e1e4ca3b2a2648676a8048cdf75322" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "55bb60d8560069c0650380cf09cdd023866ca4b91bb92b2fe4b45a056da1bf47" }),
+      Object.freeze({ original_char_code: 25, glyph_sha256: "9554966ab58edc060791bd02f04513a8da4a749f80a943d2daa3460a393fee7f" }),
     ]),
   }),
   Object.freeze({
@@ -973,10 +983,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 18,
     source_unicode: "\u0012",
     target_unicode: "θ",
-    glyph_sha256: "38d2baa791ebd167d9d328153bd4cabcb722c833e759315f3a398537e0f57e03",
+    glyph_sha256: "23102a1771564bb5329a4dbceb26cb3c92ee878dc907664891121ffd96cd4924",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
-      Object.freeze({ original_char_code: 25, glyph_sha256: "751c36c470d1f0292b9d39de8cfec243d0e1e4ca3b2a2648676a8048cdf75322" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "55bb60d8560069c0650380cf09cdd023866ca4b91bb92b2fe4b45a056da1bf47" }),
+      Object.freeze({ original_char_code: 25, glyph_sha256: "9554966ab58edc060791bd02f04513a8da4a749f80a943d2daa3460a393fee7f" }),
     ]),
   }),
   Object.freeze({
@@ -986,10 +996,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 27,
     source_unicode: "\u001b",
     target_unicode: "σ",
-    glyph_sha256: "de609d12d1935bc3ff128046fa3c5f4330689ded53c9fc7a179a0b7c368f9f9a",
+    glyph_sha256: "dfba03d4b605f4ae62fd08d5829cc2e26549f0f40d2d2b9a11adf2db1046a10a",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
-      Object.freeze({ original_char_code: 25, glyph_sha256: "751c36c470d1f0292b9d39de8cfec243d0e1e4ca3b2a2648676a8048cdf75322" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "55bb60d8560069c0650380cf09cdd023866ca4b91bb92b2fe4b45a056da1bf47" }),
+      Object.freeze({ original_char_code: 25, glyph_sha256: "9554966ab58edc060791bd02f04513a8da4a749f80a943d2daa3460a393fee7f" }),
     ]),
   }),
   Object.freeze({
@@ -999,10 +1009,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 6,
     source_unicode: "\u0006",
     target_unicode: "±",
-    glyph_sha256: "009835b7eda7745c9e2e167ce0ed1b5e4ff9063af4c92280dffab3213f07e395",
+    glyph_sha256: "f7b39315fb585e4066816ab2d3d3d07e1b1d79bb9a30fdae7fbf5588d2873906",
     witnesses: Object.freeze([
       Object.freeze({ original_char_code: 0, glyph_sha256: "68b4a1e125aa58ed3e798029190dbf4e2f3937030f921cd995cf7c8ad2f2eedc" }),
-      Object.freeze({ original_char_code: 21, glyph_sha256: "d2622641d0fa27eba18c91fd6333cfad66cbc23918a88854242d2f0f4c6ca968" }),
+      Object.freeze({ original_char_code: 21, glyph_sha256: "520751dc437215219c1269212ade701dc57b1484416b9bad9ef3da2806bb53e9" }),
     ]),
   }),
 ]);
@@ -1157,13 +1167,26 @@ function type3GlyphImageMask(charProc, fontMatrix, ops) {
   if (!Number.isInteger(width) || !Number.isInteger(height) || width <= 0 || height <= 0) return null;
   if (width * height > MAX_TYPE3_GLYPH_MASK_PIXELS) return null;
   if (path.length > MAX_TYPE3_GLYPH_MASK_PATH_NODES) return null;
-  // Only an axis-aligned, non-degenerate placement has an unambiguous mirror
-  // decomposition; a rotated or skewed glyph program is left unrecognized.
+  // Exactly what this checks: the CharProc-local matrix, meaning the font's
+  // FontMatrix composed with the `cm` chain written inside this one glyph
+  // program. Exactly what it does NOT check, and cannot: the text matrix and
+  // the graphics CTM in force at the `Tj` that draws the glyph. Those are set
+  // by the page content stream outside the CharProc and are invisible here, so
+  // nothing below is a statement about the orientation the glyph is finally
+  // painted in.
+  //
+  // That gap is deliberate rather than tolerated. The key is the stored sample
+  // grid, which no matrix anywhere can alter, so painted orientation is not an
+  // input to it. This check survives only to hold the mask lane to the plain
+  // axis-aligned, non-degenerate scale-or-reflection bitmap idiom every
+  // enrolled entry was qualified on: a glyph program that rotates, shears, or
+  // collapses its own bitmap is a different construction and is keyed by the
+  // exact operator digest instead of by this lane.
   if (Math.abs(transform[1]) > 1e-9 || Math.abs(transform[2]) > 1e-9) return null;
   if (!(Math.abs(transform[0]) > 0) || !(Math.abs(transform[3]) > 0)) return null;
   const bits = fillAxisAlignedLatticePath(path, width, height);
   if (!bits) return null;
-  return { width, height, bits, mirror_x: transform[0] < 0, mirror_y: transform[3] < 0 };
+  return { width, height, bits };
 }
 
 function fillAxisAlignedLatticePath(path, width, height) {
@@ -1200,8 +1223,8 @@ function fillAxisAlignedLatticePath(path, width, height) {
     if (index + 1 >= path.length) return null;
     const x = lattice(path[index], width);
     // PDF.js emits the traced outline y-up in the unit square, so unit y 1 is
-    // image row 0. Reading it back as a row index keeps the grid in the
-    // stored sample order and leaves orientation to the canonical step.
+    // image row 0. Reading it back as a row index recovers the grid in the
+    // stored sample order, which is the order the key is taken in.
     const y = lattice(1 - path[index + 1], height);
     index += 2;
     if (x === null || y === null) return null;
@@ -1233,14 +1256,34 @@ function fillAxisAlignedLatticePath(path, width, height) {
 }
 
 /**
- * The producer-independent form of a decoded mask: mirrored back into the
- * orientation it is actually painted in, then cropped to its own ink. What is
- * deliberately dropped is everything a second producer would have chosen
- * differently for the same glyph — the placement matrix, the blank padding
- * around the ink, and the operator idiom that carried them.
+ * The producer-independent form of a decoded mask: the stored sample grid,
+ * cropped to its own ink.
+ *
+ * The grid as stored is the canonical form on purpose. It is the one thing in
+ * a Type-3 bitmap glyph that is a property of the glyph and of nothing else:
+ * every matrix that could reorient it — the CharProc's own `cm`, the font's
+ * FontMatrix, the text matrix, the page CTM — is chosen by the producer or by
+ * the page that draws the character, and only the first two are even reachable
+ * from inside a CharProc. Normalizing to painted orientation would therefore
+ * mean keying partly on data this function cannot see, and did: an earlier
+ * revision folded in `sign(FontMatrix x cm)` and gave two documents different
+ * keys for a pixel-identical comma.
+ *
+ * The accepted consequence is that a glyph painted rotated or reflected keys
+ * the same as the upright one. That is the correct answer for text set at an
+ * angle, which is still the same character. Where it could be wrong is a font
+ * that reuses one bitmap for two characters by reflecting it — the classic
+ * matched-parenthesis trick — and that case is already refused by the
+ * shape-code injectivity rule below: one shape standing at two enrolled codes
+ * of a font is ambiguous evidence and recovers nothing.
+ *
+ * Also deliberately dropped: the blank padding around the ink and the operator
+ * idiom that carried the samples. An inkless mask has no shape to key at all
+ * and is rejected here rather than collapsing every blank glyph of every font
+ * onto one digest.
  */
 function canonicalType3MaskBits(mask) {
-  const { width, height, bits, mirror_x: mirrorX, mirror_y: mirrorY } = mask;
+  const { width, height, bits } = mask;
   let top = height;
   let bottom = -1;
   let left = width;
@@ -1248,26 +1291,20 @@ function canonicalType3MaskBits(mask) {
   for (let row = 0; row < height; row += 1) {
     for (let column = 0; column < width; column += 1) {
       if (!bits[row * width + column]) continue;
-      const visualRow = mirrorY ? height - 1 - row : row;
-      const visualColumn = mirrorX ? width - 1 - column : column;
-      if (visualRow < top) top = visualRow;
-      if (visualRow > bottom) bottom = visualRow;
-      if (visualColumn < left) left = visualColumn;
-      if (visualColumn > right) right = visualColumn;
+      if (row < top) top = row;
+      if (row > bottom) bottom = row;
+      if (column < left) left = column;
+      if (column > right) right = column;
     }
   }
-  if (bottom < 0) return { width: 0, height: 0, packed: Buffer.alloc(0) };
+  if (bottom < 0) return null;
   const inkWidth = right - left + 1;
   const inkHeight = bottom - top + 1;
   const stride = (inkWidth + 7) >> 3;
   const packed = Buffer.alloc(stride * inkHeight);
   for (let row = 0; row < inkHeight; row += 1) {
     for (let column = 0; column < inkWidth; column += 1) {
-      const visualRow = top + row;
-      const visualColumn = left + column;
-      const sourceRow = mirrorY ? height - 1 - visualRow : visualRow;
-      const sourceColumn = mirrorX ? width - 1 - visualColumn : visualColumn;
-      if (bits[sourceRow * width + sourceColumn]) packed[row * stride + (column >> 3)] |= 128 >> (column & 7);
+      if (bits[(top + row) * width + left + column]) packed[row * stride + (column >> 3)] |= 128 >> (column & 7);
     }
   }
   return { width: inkWidth, height: inkHeight, packed };
@@ -1276,24 +1313,25 @@ function canonicalType3MaskBits(mask) {
 /**
  * The recovery key for one Type-3 glyph program.
  *
- * A glyph whose body is a single decoded image mask is keyed on the mask
- * itself, so the same Computer Modern raster keys identically no matter which
- * dvips-era toolchain packed it, which filter it was compressed with, or where
- * the producer placed it inside the glyph box. Anything else — an outline
- * CharProc, a multi-object program, a rotated placement — falls back to the
- * exact canonicalized operator digest, which is narrower but never wrong. The
- * two lanes are domain-separated, so a mask digest can never satisfy an
- * operator-keyed registry entry or the reverse.
+ * A glyph whose body is a single decoded image mask carrying ink is keyed on
+ * the stored mask grid, so the same Computer Modern raster keys identically no
+ * matter which dvips-era toolchain packed it, which filter it was compressed
+ * with, or where and which way round the producer placed it inside the glyph
+ * box. Anything else — an outline CharProc, a multi-object program, a glyph
+ * program that rotates or shears its own bitmap, an inkless mask with no shape
+ * to key — falls back to the exact canonicalized operator digest, which is
+ * narrower but never wrong. The two lanes are domain-separated, so a mask
+ * digest can never satisfy an operator-keyed registry entry or the reverse.
  */
 export function type3GlyphEvidenceSha256(charProc, fontMatrix, ops) {
   const mask = type3GlyphImageMask(charProc, fontMatrix, ops);
-  if (!mask) {
+  const canonical = mask ? canonicalType3MaskBits(mask) : null;
+  if (!canonical) {
     const operators = type3CharProcSha256(charProc);
     return operators === null
       ? null
       : createHash("sha256").update(`${TYPE3_CHARPROC_EVIDENCE_DOMAIN}:${operators}`).digest("hex");
   }
-  const canonical = canonicalType3MaskBits(mask);
   return createHash("sha256")
     .update(`${TYPE3_MASK_EVIDENCE_DOMAIN}:${canonical.width}x${canonical.height}:`)
     .update(canonical.packed)
@@ -1737,9 +1775,19 @@ function linkedRawType3Font(fontId, fontTokens, rawFonts) {
 
 /*
  * One glyph program is looked up once per registry entry that names it and
- * again for the enrolled-shape index, so the decode is memoized on the PDF.js
- * CharProc object itself. PDF.js caches Type-3 font objects per document, so
- * the same object comes back on every page the font is used on.
+ * again for the enrolled-shape index, so the decode is memoized. PDF.js caches
+ * Type-3 font objects per document, so the same font object comes back on
+ * every page the font is used on.
+ *
+ * The cache is keyed on the font and then the glyph id, not on the CharProc
+ * object alone, because the digest is a function of all three of the
+ * arguments below and only the CharProc is an object identity. A font owns
+ * exactly one FontMatrix and one CharProc for a given glyph id, so keying on
+ * the pair covers both; keying on a CharProc that two fonts happened to share
+ * would not, since the two fonts can declare different FontMatrix values and
+ * the matrix decides whether the mask lane is admissible at all. `ops` is the
+ * operator table of the single pinned PDF.js build loaded in this process and
+ * is therefore constant for the cache's lifetime.
  */
 const type3GlyphEvidenceCache = new WeakMap();
 
@@ -1748,10 +1796,15 @@ function type3GlyphEvidenceForCode(font, rawFont, code, ops) {
   if (typeof glyphId !== "string") return null;
   const charProc = font?.charProcOperatorList?.[glyphId];
   if (!charProc || typeof charProc !== "object") return null;
-  const cached = type3GlyphEvidenceCache.get(charProc);
+  let byGlyphId = type3GlyphEvidenceCache.get(font);
+  if (byGlyphId === undefined) {
+    byGlyphId = new Map();
+    type3GlyphEvidenceCache.set(font, byGlyphId);
+  }
+  const cached = byGlyphId.get(glyphId);
   if (cached !== undefined) return cached;
   const digest = type3GlyphEvidenceSha256(charProc, font?.fontMatrix, ops);
-  type3GlyphEvidenceCache.set(charProc, digest);
+  byGlyphId.set(glyphId, digest);
   return digest;
 }
 

--- a/pdf-toolkit-mcp-share/server/layout-extraction.js
+++ b/pdf-toolkit-mcp-share/server/layout-extraction.js
@@ -56,10 +56,27 @@ const RAW_PAGE_SPACE = Object.freeze({
   stage: "before_user_unit_and_page_rotation",
 });
 const MAX_PAINTED_RECTANGLES = 500;
-const TYPE3_GLYPH_CANONICALIZER_VERSION = "pdfjs-charproc-json-v1";
+/*
+ * Type-3 glyph evidence keys.
+ *
+ * v2 keys a legacy bitmap glyph on its decoded image mask instead of on the
+ * CharProc operator list. The operator list folds in the producer's idiom, the
+ * inline-image filter it chose, and the per-glyph placement matrix, none of
+ * which are properties of the glyph: two documents carrying a pixel-identical
+ * Computer Modern raster hashed differently under v1 and now hash the same.
+ * Non-mask glyph programs keep the exact operator digest under a separate
+ * domain tag, so the two lanes can never satisfy each other's registry entries.
+ */
+const TYPE3_GLYPH_EVIDENCE_VERSION = "pdfjs-type3-glyph-evidence-v2";
+const TYPE3_MASK_EVIDENCE_DOMAIN = "type3-glyph-image-mask-v1";
+const TYPE3_CHARPROC_EVIDENCE_DOMAIN = "pdfjs-charproc-json-v1";
 const MAX_TYPE3_GLYPH_CANONICAL_NODES = 100000;
 const MAX_TYPE3_GLYPH_CANONICAL_DEPTH = 32;
 const MAX_TYPE3_GLYPH_CANONICAL_BYTES = 250000;
+// PDF.js refuses to trace a mask wider or taller than 1000 samples, so a
+// larger grid can never arrive here; the area bound caps the working buffer.
+const MAX_TYPE3_GLYPH_MASK_PIXELS = 1_000_000;
+const MAX_TYPE3_GLYPH_MASK_PATH_NODES = 60_000;
 
 const TYPE3_RECOVERY_REGISTRY = Object.freeze([
   Object.freeze({
@@ -69,11 +86,11 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 11,
     source_unicode: "\u000b",
     target_unicode: "α",
-    charproc_sha256: "e688a83f98433c841694f990aabafe5245cfc9320f584d7f70da706f0eeba259",
+    glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093",
     allow_collapsed_whitespace: true,
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 25, charproc_sha256: "780b04fa47830ca782211b86dbedfe0adec0445bdf94d538bfe7adde08ed9445" }),
-      Object.freeze({ original_char_code: 26, charproc_sha256: "1500df39391626d02f9e98132f991f71899612069298e52340e12fb65590836f" }),
+      Object.freeze({ original_char_code: 25, glyph_sha256: "751c36c470d1f0292b9d39de8cfec243d0e1e4ca3b2a2648676a8048cdf75322" }),
+      Object.freeze({ original_char_code: 26, glyph_sha256: "ff3b8028f135ce4dbf41a3e3fa8415f54615e9c3e7253d13e9070a71679ccebc" }),
     ]),
   }),
   Object.freeze({
@@ -83,10 +100,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 58,
     source_unicode: ":",
     target_unicode: ".",
-    charproc_sha256: "2df559091df37cc5da5c1ce3e05eebc1075c4c041b83d96a1904d2c2f21edab0",
+    glyph_sha256: "2ed87b069c99482d0823c085da9c199582e6e4b51172a2b360d9b6652066e3ae",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 59, charproc_sha256: "42b5ebf435945b75e1dc1bc271bfbb4aa2dc02b8adc93cd26b4bb64dec9fde8a" }),
-      Object.freeze({ original_char_code: 61, charproc_sha256: "55447dde50a97970297d189788eb154c675c41e6d2eca2836949aefadd0b1780" }),
+      Object.freeze({ original_char_code: 59, glyph_sha256: "65e5727a8eb6528fe7013fcf6f2522e93c65ee868f0315850cefd2992e5b7e5b" }),
+      Object.freeze({ original_char_code: 61, glyph_sha256: "2406e228edd78d0d53cc29b48a3154626a47c6fda6b01450cf2c1155cd6b81f7" }),
     ]),
   }),
   Object.freeze({
@@ -96,10 +113,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 59,
     source_unicode: ";",
     target_unicode: ",",
-    charproc_sha256: "42b5ebf435945b75e1dc1bc271bfbb4aa2dc02b8adc93cd26b4bb64dec9fde8a",
+    glyph_sha256: "65e5727a8eb6528fe7013fcf6f2522e93c65ee868f0315850cefd2992e5b7e5b",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 58, charproc_sha256: "2df559091df37cc5da5c1ce3e05eebc1075c4c041b83d96a1904d2c2f21edab0" }),
-      Object.freeze({ original_char_code: 61, charproc_sha256: "55447dde50a97970297d189788eb154c675c41e6d2eca2836949aefadd0b1780" }),
+      Object.freeze({ original_char_code: 58, glyph_sha256: "2ed87b069c99482d0823c085da9c199582e6e4b51172a2b360d9b6652066e3ae" }),
+      Object.freeze({ original_char_code: 61, glyph_sha256: "2406e228edd78d0d53cc29b48a3154626a47c6fda6b01450cf2c1155cd6b81f7" }),
     ]),
   }),
   Object.freeze({
@@ -109,10 +126,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 25,
     source_unicode: "\u0019",
     target_unicode: "π",
-    charproc_sha256: "780b04fa47830ca782211b86dbedfe0adec0445bdf94d538bfe7adde08ed9445",
+    glyph_sha256: "751c36c470d1f0292b9d39de8cfec243d0e1e4ca3b2a2648676a8048cdf75322",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, charproc_sha256: "e688a83f98433c841694f990aabafe5245cfc9320f584d7f70da706f0eeba259" }),
-      Object.freeze({ original_char_code: 26, charproc_sha256: "1500df39391626d02f9e98132f991f71899612069298e52340e12fb65590836f" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
+      Object.freeze({ original_char_code: 26, glyph_sha256: "ff3b8028f135ce4dbf41a3e3fa8415f54615e9c3e7253d13e9070a71679ccebc" }),
     ]),
   }),
   Object.freeze({
@@ -122,10 +139,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 26,
     source_unicode: "\u001a",
     target_unicode: "ρ",
-    charproc_sha256: "1500df39391626d02f9e98132f991f71899612069298e52340e12fb65590836f",
+    glyph_sha256: "ff3b8028f135ce4dbf41a3e3fa8415f54615e9c3e7253d13e9070a71679ccebc",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, charproc_sha256: "e688a83f98433c841694f990aabafe5245cfc9320f584d7f70da706f0eeba259" }),
-      Object.freeze({ original_char_code: 25, charproc_sha256: "780b04fa47830ca782211b86dbedfe0adec0445bdf94d538bfe7adde08ed9445" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
+      Object.freeze({ original_char_code: 25, glyph_sha256: "751c36c470d1f0292b9d39de8cfec243d0e1e4ca3b2a2648676a8048cdf75322" }),
     ]),
   }),
   Object.freeze({
@@ -135,10 +152,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 33,
     source_unicode: "!",
     target_unicode: "ω",
-    charproc_sha256: "81b41121b5e19a2aebd37331ab3584fe08221ca1afcda83f4ce8b76997177074",
+    glyph_sha256: "4c740569ca05e182025cfeb2d99d35f6c2655f7674b919fe2f145a33ff4ffdd1",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, charproc_sha256: "e688a83f98433c841694f990aabafe5245cfc9320f584d7f70da706f0eeba259" }),
-      Object.freeze({ original_char_code: 25, charproc_sha256: "780b04fa47830ca782211b86dbedfe0adec0445bdf94d538bfe7adde08ed9445" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
+      Object.freeze({ original_char_code: 25, glyph_sha256: "751c36c470d1f0292b9d39de8cfec243d0e1e4ca3b2a2648676a8048cdf75322" }),
     ]),
   }),
   Object.freeze({
@@ -148,10 +165,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 61,
     source_unicode: "=",
     target_unicode: "/",
-    charproc_sha256: "55447dde50a97970297d189788eb154c675c41e6d2eca2836949aefadd0b1780",
+    glyph_sha256: "2406e228edd78d0d53cc29b48a3154626a47c6fda6b01450cf2c1155cd6b81f7",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 58, charproc_sha256: "2df559091df37cc5da5c1ce3e05eebc1075c4c041b83d96a1904d2c2f21edab0" }),
-      Object.freeze({ original_char_code: 59, charproc_sha256: "42b5ebf435945b75e1dc1bc271bfbb4aa2dc02b8adc93cd26b4bb64dec9fde8a" }),
+      Object.freeze({ original_char_code: 58, glyph_sha256: "2ed87b069c99482d0823c085da9c199582e6e4b51172a2b360d9b6652066e3ae" }),
+      Object.freeze({ original_char_code: 59, glyph_sha256: "65e5727a8eb6528fe7013fcf6f2522e93c65ee868f0315850cefd2992e5b7e5b" }),
     ]),
   }),
   Object.freeze({
@@ -161,10 +178,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 0,
     source_unicode: "\u0000",
     target_unicode: "−",
-    charproc_sha256: "fb1f6bf10138511bcefade47467b3e2f9ae691ab3dab097914be1f0f66305470",
+    glyph_sha256: "68b4a1e125aa58ed3e798029190dbf4e2f3937030f921cd995cf7c8ad2f2eedc",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 21, charproc_sha256: "05b4a9d88c1df64b3ac339ae6bb7ed82383b93bb08512842452db43453a28970" }),
-      Object.freeze({ original_char_code: 112, charproc_sha256: "772f491fc17e6bb3bc37c17ace6be704244ab121c7180d59319726e0af4b0efc" }),
+      Object.freeze({ original_char_code: 21, glyph_sha256: "d2622641d0fa27eba18c91fd6333cfad66cbc23918a88854242d2f0f4c6ca968" }),
+      Object.freeze({ original_char_code: 112, glyph_sha256: "f57899424fb6b62d3a54288b4fb0f41a9edc7b8e17bbd41f0a1e1fac6b743196" }),
     ]),
   }),
   Object.freeze({
@@ -174,10 +191,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 21,
     source_unicode: "\u0015",
     target_unicode: "≥",
-    charproc_sha256: "05b4a9d88c1df64b3ac339ae6bb7ed82383b93bb08512842452db43453a28970",
+    glyph_sha256: "d2622641d0fa27eba18c91fd6333cfad66cbc23918a88854242d2f0f4c6ca968",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 0, charproc_sha256: "fb1f6bf10138511bcefade47467b3e2f9ae691ab3dab097914be1f0f66305470" }),
-      Object.freeze({ original_char_code: 112, charproc_sha256: "772f491fc17e6bb3bc37c17ace6be704244ab121c7180d59319726e0af4b0efc" }),
+      Object.freeze({ original_char_code: 0, glyph_sha256: "68b4a1e125aa58ed3e798029190dbf4e2f3937030f921cd995cf7c8ad2f2eedc" }),
+      Object.freeze({ original_char_code: 112, glyph_sha256: "f57899424fb6b62d3a54288b4fb0f41a9edc7b8e17bbd41f0a1e1fac6b743196" }),
     ]),
   }),
   Object.freeze({
@@ -187,10 +204,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 112,
     source_unicode: "p",
     target_unicode: "√",
-    charproc_sha256: "772f491fc17e6bb3bc37c17ace6be704244ab121c7180d59319726e0af4b0efc",
+    glyph_sha256: "f57899424fb6b62d3a54288b4fb0f41a9edc7b8e17bbd41f0a1e1fac6b743196",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 0, charproc_sha256: "fb1f6bf10138511bcefade47467b3e2f9ae691ab3dab097914be1f0f66305470" }),
-      Object.freeze({ original_char_code: 21, charproc_sha256: "05b4a9d88c1df64b3ac339ae6bb7ed82383b93bb08512842452db43453a28970" }),
+      Object.freeze({ original_char_code: 0, glyph_sha256: "68b4a1e125aa58ed3e798029190dbf4e2f3937030f921cd995cf7c8ad2f2eedc" }),
+      Object.freeze({ original_char_code: 21, glyph_sha256: "d2622641d0fa27eba18c91fd6333cfad66cbc23918a88854242d2f0f4c6ca968" }),
     ]),
   }),
   Object.freeze({
@@ -200,10 +217,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 33,
     source_unicode: "!",
     target_unicode: "ω",
-    charproc_sha256: "0ebf4d75e5bdb232683c871c77579bc14887f9aaa397a3c8334c220ec09af0d9",
+    glyph_sha256: "ce4f89e61b842053344c92603d0588263e0118e0321411ae3f798b2f39445fe2",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, charproc_sha256: "c3d175e547d650cd0382115f3caed3b08d39f61827d10b26aad43eac6b6c4fa1" }),
-      Object.freeze({ original_char_code: 25, charproc_sha256: "994283a40dea8e4890f7216ef046a865f34ef7100cc1055de62d1eba7daf8fe2" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "e9705ccd52613dd5c8dcbff8618f9d825f88b29a9ddcedc01532fd7ba217385f" }),
+      Object.freeze({ original_char_code: 25, glyph_sha256: "fa64dc2c1de162435601ca8107e3a5027cc9dd3ca9d0aaa6998e5736c3f9564a" }),
     ]),
   }),
   Object.freeze({
@@ -213,10 +230,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 58,
     source_unicode: ":",
     target_unicode: ".",
-    charproc_sha256: "cdf3cbb1bd7626495858ebacb74816ba82ac139458edf75c6d737f6b121b65fe",
+    glyph_sha256: "8520f46225db90fbb8c41a8ffe4ced238a45f80f3dd74acf4d9b12ec29598513",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 59, charproc_sha256: "7c69e2ebf2eec772599fae11d278adcc3c88472af6279f9801865628040d981b" }),
-      Object.freeze({ original_char_code: 61, charproc_sha256: "dfa9c162caf4e99dafd16ca5d87e90f89d44c29312a2675e89aa789c5355d63e" }),
+      Object.freeze({ original_char_code: 59, glyph_sha256: "67bc7d266ae458bb1c5cf497d1de03ccbc4b85d03457ef2a54e7aa9e91b2ef6a" }),
+      Object.freeze({ original_char_code: 61, glyph_sha256: "7604ca52d40535d2c7205e425d56cb07e19c388dc6ff5806ffe87cc9d811c025" }),
     ]),
   }),
   Object.freeze({
@@ -226,10 +243,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 61,
     source_unicode: "=",
     target_unicode: "/",
-    charproc_sha256: "dfa9c162caf4e99dafd16ca5d87e90f89d44c29312a2675e89aa789c5355d63e",
+    glyph_sha256: "7604ca52d40535d2c7205e425d56cb07e19c388dc6ff5806ffe87cc9d811c025",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 58, charproc_sha256: "cdf3cbb1bd7626495858ebacb74816ba82ac139458edf75c6d737f6b121b65fe" }),
-      Object.freeze({ original_char_code: 59, charproc_sha256: "7c69e2ebf2eec772599fae11d278adcc3c88472af6279f9801865628040d981b" }),
+      Object.freeze({ original_char_code: 58, glyph_sha256: "8520f46225db90fbb8c41a8ffe4ced238a45f80f3dd74acf4d9b12ec29598513" }),
+      Object.freeze({ original_char_code: 59, glyph_sha256: "67bc7d266ae458bb1c5cf497d1de03ccbc4b85d03457ef2a54e7aa9e91b2ef6a" }),
     ]),
   }),
   Object.freeze({
@@ -239,10 +256,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 59,
     source_unicode: ";",
     target_unicode: ",",
-    charproc_sha256: "7c69e2ebf2eec772599fae11d278adcc3c88472af6279f9801865628040d981b",
+    glyph_sha256: "67bc7d266ae458bb1c5cf497d1de03ccbc4b85d03457ef2a54e7aa9e91b2ef6a",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 58, charproc_sha256: "cdf3cbb1bd7626495858ebacb74816ba82ac139458edf75c6d737f6b121b65fe" }),
-      Object.freeze({ original_char_code: 61, charproc_sha256: "dfa9c162caf4e99dafd16ca5d87e90f89d44c29312a2675e89aa789c5355d63e" }),
+      Object.freeze({ original_char_code: 58, glyph_sha256: "8520f46225db90fbb8c41a8ffe4ced238a45f80f3dd74acf4d9b12ec29598513" }),
+      Object.freeze({ original_char_code: 61, glyph_sha256: "7604ca52d40535d2c7205e425d56cb07e19c388dc6ff5806ffe87cc9d811c025" }),
     ]),
   }),
   Object.freeze({
@@ -252,10 +269,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 0,
     source_unicode: "\u0000",
     target_unicode: "−",
-    charproc_sha256: "0c8b34a3281f9e8e91b2d955f952a50d187cd06c432be27c015b78570e645e9d",
+    glyph_sha256: "ed5df416bb312c2b49ed8936f226016a28e9a09fa52aba56281dd6a8a5430d19",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 6, charproc_sha256: "b68b24c69a8802a7e57a1cabaa7c1153a0a305e5d29ba308b78d60c16a5464b7" }),
-      Object.freeze({ original_char_code: 33, charproc_sha256: "6ff1e08b5364a8ce02ac2390691fdfb1f2e532bd0a1dac95d01a155bbce482fc" }),
+      Object.freeze({ original_char_code: 6, glyph_sha256: "4734e344eca1f8f73183a34504c1068146b425815a2a8ef6aa00a18dfd45d9a2" }),
+      Object.freeze({ original_char_code: 33, glyph_sha256: "a818ff8e95ae122382e0f0198e875400f4cc07ef1115dbe936ad5dd37933c4d4" }),
     ]),
   }),
   Object.freeze({
@@ -265,10 +282,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 0,
     source_unicode: "\u0000",
     target_unicode: "−",
-    charproc_sha256: "b32276d22e1dd4133c20888ade044d27e59f2cbdfca0901c3b9d46006ed7dee9",
+    glyph_sha256: "3f6fdf2abc68f5693f9ea7cdec4d94214a57fb953fb66c747b86dd1f6293d807",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 21, charproc_sha256: "b57ae2e4cf2525371916a1a4bcf0c55165b9230b1038f2d5451cdbbad5a51dcc" }),
-      Object.freeze({ original_char_code: 112, charproc_sha256: "0c8ca6c662e9ca24f90a61f53206ea0719476473861471a1b04bf489b3cc37a3" }),
+      Object.freeze({ original_char_code: 21, glyph_sha256: "73a2cec4aa27d5042b9f4275179fbf2bb7b99413537597ede0537b7f19c8384c" }),
+      Object.freeze({ original_char_code: 112, glyph_sha256: "f15e035b5867fbee9918125e49566e00b94dcd8422649079c87207e94f7a9e63" }),
     ]),
   }),
   Object.freeze({
@@ -278,10 +295,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 0,
     source_unicode: "\u0000",
     target_unicode: "−",
-    charproc_sha256: "f56714c48094acb5e3fdb76a62fcce203b4ed0bc60ec49f57fba5bf6ee80d91a",
+    glyph_sha256: "183f30cb001ea6b5047c6f806e3a27fd095bcdde1470f7b1f351dba8ea94282e",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 21, charproc_sha256: "b6986c1595532ddd51fad9d8148c404111da8cb112c272d66f1d0c4acaa86395" }),
-      Object.freeze({ original_char_code: 112, charproc_sha256: "7d178f8e3e6ebbba7a97d5476fa81d88528b89b45fecae79124d7b497cb69973" }),
+      Object.freeze({ original_char_code: 21, glyph_sha256: "f9b735aa52a672962391a234ed5e79f5c30635d6ce2ea998f103ba616e39dbdf" }),
+      Object.freeze({ original_char_code: 112, glyph_sha256: "5dd2e8e832e3ed95c353d14854c6441e9f3ea10c1ff66466ba7b15cbf59546d7" }),
     ]),
   }),
   Object.freeze({
@@ -291,10 +308,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 58,
     source_unicode: ":",
     target_unicode: ".",
-    charproc_sha256: "bd8a8b68f402b7ae4df615c7fbd63e42decccc4f2dcf2cb6f56e871328466c67",
+    glyph_sha256: "8520f46225db90fbb8c41a8ffe4ced238a45f80f3dd74acf4d9b12ec29598513",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 59, charproc_sha256: "dec7c435ea1bb5cad4fb9020f992cfd9aa1c087e3b9dd144cbbe7f27f939e0f5" }),
-      Object.freeze({ original_char_code: 61, charproc_sha256: "f5b035495791c897c3fdc5a86f0d8290cdd67dee1a20a33ad40663b4636eb773" }),
+      Object.freeze({ original_char_code: 59, glyph_sha256: "5363832452620aa888b74219c2a632d1e58a27060bffb1cf6392bf5b2fad8316" }),
+      Object.freeze({ original_char_code: 61, glyph_sha256: "f1c63f92441a1dc720dac5d5d39e38da21d397d81e32c4a87a5bfa34c50b8f8d" }),
     ]),
   }),
   Object.freeze({
@@ -304,10 +321,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 59,
     source_unicode: ";",
     target_unicode: ",",
-    charproc_sha256: "dec7c435ea1bb5cad4fb9020f992cfd9aa1c087e3b9dd144cbbe7f27f939e0f5",
+    glyph_sha256: "5363832452620aa888b74219c2a632d1e58a27060bffb1cf6392bf5b2fad8316",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 58, charproc_sha256: "bd8a8b68f402b7ae4df615c7fbd63e42decccc4f2dcf2cb6f56e871328466c67" }),
-      Object.freeze({ original_char_code: 61, charproc_sha256: "f5b035495791c897c3fdc5a86f0d8290cdd67dee1a20a33ad40663b4636eb773" }),
+      Object.freeze({ original_char_code: 58, glyph_sha256: "8520f46225db90fbb8c41a8ffe4ced238a45f80f3dd74acf4d9b12ec29598513" }),
+      Object.freeze({ original_char_code: 61, glyph_sha256: "f1c63f92441a1dc720dac5d5d39e38da21d397d81e32c4a87a5bfa34c50b8f8d" }),
     ]),
   }),
   Object.freeze({
@@ -317,10 +334,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 61,
     source_unicode: "=",
     target_unicode: "/",
-    charproc_sha256: "f5b035495791c897c3fdc5a86f0d8290cdd67dee1a20a33ad40663b4636eb773",
+    glyph_sha256: "f1c63f92441a1dc720dac5d5d39e38da21d397d81e32c4a87a5bfa34c50b8f8d",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 58, charproc_sha256: "bd8a8b68f402b7ae4df615c7fbd63e42decccc4f2dcf2cb6f56e871328466c67" }),
-      Object.freeze({ original_char_code: 59, charproc_sha256: "dec7c435ea1bb5cad4fb9020f992cfd9aa1c087e3b9dd144cbbe7f27f939e0f5" }),
+      Object.freeze({ original_char_code: 58, glyph_sha256: "8520f46225db90fbb8c41a8ffe4ced238a45f80f3dd74acf4d9b12ec29598513" }),
+      Object.freeze({ original_char_code: 59, glyph_sha256: "5363832452620aa888b74219c2a632d1e58a27060bffb1cf6392bf5b2fad8316" }),
     ]),
   }),
   Object.freeze({
@@ -330,11 +347,11 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 11,
     source_unicode: "\u000b",
     target_unicode: "α",
-    charproc_sha256: "bab8aeb78893a19704c95538c54764abaae0cfe9d84812825f718e7687432f63",
+    glyph_sha256: "6092e20a2f8a4925449780db726c4912ccee956a094589d3cb63ede3b5d7383b",
     allow_collapsed_whitespace: true,
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 25, charproc_sha256: "3d439e1c736c51e1c18e75219c43d953b6f2c3ab588f50ceeb69f5567343492c" }),
-      Object.freeze({ original_char_code: 26, charproc_sha256: "fa4a3dbc3f77e082142e29cc43e4e21aaf61fcf6ddbaefae24f1767caaea34b8" }),
+      Object.freeze({ original_char_code: 25, glyph_sha256: "38b7cc2fac5858dfd6acc1c7936eb874900c61299c8758edc607cb91cbd68b39" }),
+      Object.freeze({ original_char_code: 26, glyph_sha256: "8271aed349c3127895bf7d96b57c83fd62b03cc6c9c9428e600a58b269899365" }),
     ]),
   }),
   Object.freeze({
@@ -344,10 +361,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 25,
     source_unicode: "\u0019",
     target_unicode: "π",
-    charproc_sha256: "3d439e1c736c51e1c18e75219c43d953b6f2c3ab588f50ceeb69f5567343492c",
+    glyph_sha256: "38b7cc2fac5858dfd6acc1c7936eb874900c61299c8758edc607cb91cbd68b39",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, charproc_sha256: "bab8aeb78893a19704c95538c54764abaae0cfe9d84812825f718e7687432f63" }),
-      Object.freeze({ original_char_code: 26, charproc_sha256: "fa4a3dbc3f77e082142e29cc43e4e21aaf61fcf6ddbaefae24f1767caaea34b8" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "6092e20a2f8a4925449780db726c4912ccee956a094589d3cb63ede3b5d7383b" }),
+      Object.freeze({ original_char_code: 26, glyph_sha256: "8271aed349c3127895bf7d96b57c83fd62b03cc6c9c9428e600a58b269899365" }),
     ]),
   }),
   Object.freeze({
@@ -357,10 +374,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 26,
     source_unicode: "\u001a",
     target_unicode: "ρ",
-    charproc_sha256: "fa4a3dbc3f77e082142e29cc43e4e21aaf61fcf6ddbaefae24f1767caaea34b8",
+    glyph_sha256: "8271aed349c3127895bf7d96b57c83fd62b03cc6c9c9428e600a58b269899365",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, charproc_sha256: "bab8aeb78893a19704c95538c54764abaae0cfe9d84812825f718e7687432f63" }),
-      Object.freeze({ original_char_code: 25, charproc_sha256: "3d439e1c736c51e1c18e75219c43d953b6f2c3ab588f50ceeb69f5567343492c" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "6092e20a2f8a4925449780db726c4912ccee956a094589d3cb63ede3b5d7383b" }),
+      Object.freeze({ original_char_code: 25, glyph_sha256: "38b7cc2fac5858dfd6acc1c7936eb874900c61299c8758edc607cb91cbd68b39" }),
     ]),
   }),
   Object.freeze({
@@ -370,11 +387,11 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 11,
     source_unicode: "\u000b",
     target_unicode: "α",
-    charproc_sha256: "c3d175e547d650cd0382115f3caed3b08d39f61827d10b26aad43eac6b6c4fa1",
+    glyph_sha256: "e9705ccd52613dd5c8dcbff8618f9d825f88b29a9ddcedc01532fd7ba217385f",
     allow_collapsed_whitespace: true,
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 25, charproc_sha256: "994283a40dea8e4890f7216ef046a865f34ef7100cc1055de62d1eba7daf8fe2" }),
-      Object.freeze({ original_char_code: 26, charproc_sha256: "ee4042a5a8e974c4bbcb77535105c9244e68a6d9c79181107ffab0fce453bfe0" }),
+      Object.freeze({ original_char_code: 25, glyph_sha256: "fa64dc2c1de162435601ca8107e3a5027cc9dd3ca9d0aaa6998e5736c3f9564a" }),
+      Object.freeze({ original_char_code: 26, glyph_sha256: "509f130688569e2b0b333a102fcaee164efdc687a94db9d7a40c928009129431" }),
     ]),
   }),
   Object.freeze({
@@ -384,10 +401,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 25,
     source_unicode: "\u0019",
     target_unicode: "π",
-    charproc_sha256: "994283a40dea8e4890f7216ef046a865f34ef7100cc1055de62d1eba7daf8fe2",
+    glyph_sha256: "fa64dc2c1de162435601ca8107e3a5027cc9dd3ca9d0aaa6998e5736c3f9564a",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, charproc_sha256: "c3d175e547d650cd0382115f3caed3b08d39f61827d10b26aad43eac6b6c4fa1" }),
-      Object.freeze({ original_char_code: 26, charproc_sha256: "ee4042a5a8e974c4bbcb77535105c9244e68a6d9c79181107ffab0fce453bfe0" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "e9705ccd52613dd5c8dcbff8618f9d825f88b29a9ddcedc01532fd7ba217385f" }),
+      Object.freeze({ original_char_code: 26, glyph_sha256: "509f130688569e2b0b333a102fcaee164efdc687a94db9d7a40c928009129431" }),
     ]),
   }),
   Object.freeze({
@@ -397,10 +414,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 26,
     source_unicode: "\u001a",
     target_unicode: "ρ",
-    charproc_sha256: "ee4042a5a8e974c4bbcb77535105c9244e68a6d9c79181107ffab0fce453bfe0",
+    glyph_sha256: "509f130688569e2b0b333a102fcaee164efdc687a94db9d7a40c928009129431",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, charproc_sha256: "c3d175e547d650cd0382115f3caed3b08d39f61827d10b26aad43eac6b6c4fa1" }),
-      Object.freeze({ original_char_code: 25, charproc_sha256: "994283a40dea8e4890f7216ef046a865f34ef7100cc1055de62d1eba7daf8fe2" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "e9705ccd52613dd5c8dcbff8618f9d825f88b29a9ddcedc01532fd7ba217385f" }),
+      Object.freeze({ original_char_code: 25, glyph_sha256: "fa64dc2c1de162435601ca8107e3a5027cc9dd3ca9d0aaa6998e5736c3f9564a" }),
     ]),
   }),
   Object.freeze({
@@ -410,10 +427,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 21,
     source_unicode: "\u0015",
     target_unicode: "≥",
-    charproc_sha256: "b57ae2e4cf2525371916a1a4bcf0c55165b9230b1038f2d5451cdbbad5a51dcc",
+    glyph_sha256: "73a2cec4aa27d5042b9f4275179fbf2bb7b99413537597ede0537b7f19c8384c",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 0, charproc_sha256: "b32276d22e1dd4133c20888ade044d27e59f2cbdfca0901c3b9d46006ed7dee9" }),
-      Object.freeze({ original_char_code: 112, charproc_sha256: "0c8ca6c662e9ca24f90a61f53206ea0719476473861471a1b04bf489b3cc37a3" }),
+      Object.freeze({ original_char_code: 0, glyph_sha256: "3f6fdf2abc68f5693f9ea7cdec4d94214a57fb953fb66c747b86dd1f6293d807" }),
+      Object.freeze({ original_char_code: 112, glyph_sha256: "f15e035b5867fbee9918125e49566e00b94dcd8422649079c87207e94f7a9e63" }),
     ]),
   }),
   Object.freeze({
@@ -423,10 +440,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 112,
     source_unicode: "p",
     target_unicode: "√",
-    charproc_sha256: "0c8ca6c662e9ca24f90a61f53206ea0719476473861471a1b04bf489b3cc37a3",
+    glyph_sha256: "f15e035b5867fbee9918125e49566e00b94dcd8422649079c87207e94f7a9e63",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 0, charproc_sha256: "b32276d22e1dd4133c20888ade044d27e59f2cbdfca0901c3b9d46006ed7dee9" }),
-      Object.freeze({ original_char_code: 21, charproc_sha256: "b57ae2e4cf2525371916a1a4bcf0c55165b9230b1038f2d5451cdbbad5a51dcc" }),
+      Object.freeze({ original_char_code: 0, glyph_sha256: "3f6fdf2abc68f5693f9ea7cdec4d94214a57fb953fb66c747b86dd1f6293d807" }),
+      Object.freeze({ original_char_code: 21, glyph_sha256: "73a2cec4aa27d5042b9f4275179fbf2bb7b99413537597ede0537b7f19c8384c" }),
     ]),
   }),
   Object.freeze({
@@ -436,10 +453,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 1,
     source_unicode: "\u0001",
     target_unicode: "⋅",
-    charproc_sha256: "33077f6f9b7f5c5631bd3cb7bbfc79b4da1fbd929b23f6e08e55c90566608c7a",
+    glyph_sha256: "2ed87b069c99482d0823c085da9c199582e6e4b51172a2b360d9b6652066e3ae",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 0, charproc_sha256: "fb1f6bf10138511bcefade47467b3e2f9ae691ab3dab097914be1f0f66305470" }),
-      Object.freeze({ original_char_code: 6, charproc_sha256: "4dedb5543e5ab5817e06920d50b7983b3febaf06c22feeb83bdbb3d8449e2c3c" }),
+      Object.freeze({ original_char_code: 0, glyph_sha256: "68b4a1e125aa58ed3e798029190dbf4e2f3937030f921cd995cf7c8ad2f2eedc" }),
+      Object.freeze({ original_char_code: 6, glyph_sha256: "009835b7eda7745c9e2e167ce0ed1b5e4ff9063af4c92280dffab3213f07e395" }),
     ]),
   }),
   Object.freeze({
@@ -449,10 +466,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 20,
     source_unicode: "\u0014",
     target_unicode: "≤",
-    charproc_sha256: "90da52fa2f67a6d3b82a7866614b7539c4e5454d2585dd223db8cb2428c6ce18",
+    glyph_sha256: "b7694606e91a2a5ad7ad6b16032289f5f4bcca7d7528ef93759e39908c68d8c4",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 0, charproc_sha256: "fb1f6bf10138511bcefade47467b3e2f9ae691ab3dab097914be1f0f66305470" }),
-      Object.freeze({ original_char_code: 1, charproc_sha256: "33077f6f9b7f5c5631bd3cb7bbfc79b4da1fbd929b23f6e08e55c90566608c7a" }),
+      Object.freeze({ original_char_code: 0, glyph_sha256: "68b4a1e125aa58ed3e798029190dbf4e2f3937030f921cd995cf7c8ad2f2eedc" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "2ed87b069c99482d0823c085da9c199582e6e4b51172a2b360d9b6652066e3ae" }),
     ]),
   }),
   Object.freeze({
@@ -462,10 +479,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 48,
     source_unicode: "0",
     target_unicode: "′",
-    charproc_sha256: "35220701523f8641fb0364aa66642008d3fcc04067a7a3c6b73cc2fd8b117c0c",
+    glyph_sha256: "a24e8c43c1c680cc6c2a676adb046c59ca00ebe5116ed583b37f3b1d6a39cc66",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 0, charproc_sha256: "0c8b34a3281f9e8e91b2d955f952a50d187cd06c432be27c015b78570e645e9d" }),
-      Object.freeze({ original_char_code: 6, charproc_sha256: "b68b24c69a8802a7e57a1cabaa7c1153a0a305e5d29ba308b78d60c16a5464b7" }),
+      Object.freeze({ original_char_code: 0, glyph_sha256: "ed5df416bb312c2b49ed8936f226016a28e9a09fa52aba56281dd6a8a5430d19" }),
+      Object.freeze({ original_char_code: 6, glyph_sha256: "4734e344eca1f8f73183a34504c1068146b425815a2a8ef6aa00a18dfd45d9a2" }),
     ]),
   }),
   Object.freeze({
@@ -475,10 +492,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 106,
     source_unicode: "j",
     target_unicode: "|",
-    charproc_sha256: "6ab8a73ddd4d36b2c52a405228bde08114d463329384ad6605d5c9d5095385d0",
+    glyph_sha256: "6b5b24f359788e9c53ad35f6de00ff0cdf7637eb8cb1b6efb124d96ba54c071f",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 0, charproc_sha256: "fb1f6bf10138511bcefade47467b3e2f9ae691ab3dab097914be1f0f66305470" }),
-      Object.freeze({ original_char_code: 1, charproc_sha256: "33077f6f9b7f5c5631bd3cb7bbfc79b4da1fbd929b23f6e08e55c90566608c7a" }),
+      Object.freeze({ original_char_code: 0, glyph_sha256: "68b4a1e125aa58ed3e798029190dbf4e2f3937030f921cd995cf7c8ad2f2eedc" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "2ed87b069c99482d0823c085da9c199582e6e4b51172a2b360d9b6652066e3ae" }),
     ]),
   }),
   Object.freeze({
@@ -488,10 +505,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 0,
     source_unicode: "\u0000",
     target_unicode: "(",
-    charproc_sha256: "eeae0f8c005ab72ff0fc77dda2d45be6bcca4359a98f882a1d33bf25619a6ae1",
+    glyph_sha256: "db8987d9df1b673b7c30dca2e284cf446998ad64b8a0a7a50c607cb3a08de761",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 1, charproc_sha256: "9a0788d07694db3951c5f1b847f8d50beb1e82e0dd877cf3d75ad2b9f0de0876" }),
-      Object.freeze({ original_char_code: 2, charproc_sha256: "add929da8d3840d8390cdbc6ad2746f411a6318e7c71cf97d789cac0dd24a693" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "a06c1a0819e09411d527d1313e0c91e68f2985038930a9bead785d1d62372154" }),
+      Object.freeze({ original_char_code: 2, glyph_sha256: "de6ca507791bcb2a932347364bab4103b89d0cc312119d313878eb3b904f66f6" }),
     ]),
   }),
   Object.freeze({
@@ -501,10 +518,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 1,
     source_unicode: "\u0001",
     target_unicode: ")",
-    charproc_sha256: "9a0788d07694db3951c5f1b847f8d50beb1e82e0dd877cf3d75ad2b9f0de0876",
+    glyph_sha256: "a06c1a0819e09411d527d1313e0c91e68f2985038930a9bead785d1d62372154",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 0, charproc_sha256: "eeae0f8c005ab72ff0fc77dda2d45be6bcca4359a98f882a1d33bf25619a6ae1" }),
-      Object.freeze({ original_char_code: 2, charproc_sha256: "add929da8d3840d8390cdbc6ad2746f411a6318e7c71cf97d789cac0dd24a693" }),
+      Object.freeze({ original_char_code: 0, glyph_sha256: "db8987d9df1b673b7c30dca2e284cf446998ad64b8a0a7a50c607cb3a08de761" }),
+      Object.freeze({ original_char_code: 2, glyph_sha256: "de6ca507791bcb2a932347364bab4103b89d0cc312119d313878eb3b904f66f6" }),
     ]),
   }),
   Object.freeze({
@@ -514,10 +531,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 2,
     source_unicode: "\u0002",
     target_unicode: "[",
-    charproc_sha256: "add929da8d3840d8390cdbc6ad2746f411a6318e7c71cf97d789cac0dd24a693",
+    glyph_sha256: "de6ca507791bcb2a932347364bab4103b89d0cc312119d313878eb3b904f66f6",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 0, charproc_sha256: "eeae0f8c005ab72ff0fc77dda2d45be6bcca4359a98f882a1d33bf25619a6ae1" }),
-      Object.freeze({ original_char_code: 1, charproc_sha256: "9a0788d07694db3951c5f1b847f8d50beb1e82e0dd877cf3d75ad2b9f0de0876" }),
+      Object.freeze({ original_char_code: 0, glyph_sha256: "db8987d9df1b673b7c30dca2e284cf446998ad64b8a0a7a50c607cb3a08de761" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "a06c1a0819e09411d527d1313e0c91e68f2985038930a9bead785d1d62372154" }),
     ]),
   }),
   Object.freeze({
@@ -527,10 +544,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 2,
     source_unicode: "\u0002",
     target_unicode: "[",
-    charproc_sha256: "24e2fb74862685748e4dda1996a1664497a46fb66fc842633cd13686f974cf80",
+    glyph_sha256: "6b0a15286d5c6eab2ff6a3ec1ae3f10b2bda4a2a502190a441875d1307a089ca",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 3, charproc_sha256: "2810f1eec224c30a86c790b2b990953f0b54f28f9a32a035649784962b075cb5" }),
-      Object.freeze({ original_char_code: 16, charproc_sha256: "e0188ef949df660ee321f0379d85dcde82054590708f27c0398434fbcbb9bbc3" }),
+      Object.freeze({ original_char_code: 3, glyph_sha256: "f760c316d37754edd56178f58f7935789b7cfec19a577e3de751f3437e258583" }),
+      Object.freeze({ original_char_code: 16, glyph_sha256: "dd4cc29a14d2086fc3affe1d8c0bed29b1dc1b29df911950c6b5320e347dfebc" }),
     ]),
   }),
   Object.freeze({
@@ -540,10 +557,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 3,
     source_unicode: "\u0003",
     target_unicode: "]",
-    charproc_sha256: "a23d3c42be14fa95a5745ed7c8bfecb7c1f575dccfc7dcb9a64f0a7523ef914f",
+    glyph_sha256: "1ea7f7dfe19ac962ae5a1408a4ebdb91046dd499d108474b0d830235a07921d9",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 0, charproc_sha256: "eeae0f8c005ab72ff0fc77dda2d45be6bcca4359a98f882a1d33bf25619a6ae1" }),
-      Object.freeze({ original_char_code: 1, charproc_sha256: "9a0788d07694db3951c5f1b847f8d50beb1e82e0dd877cf3d75ad2b9f0de0876" }),
+      Object.freeze({ original_char_code: 0, glyph_sha256: "db8987d9df1b673b7c30dca2e284cf446998ad64b8a0a7a50c607cb3a08de761" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "a06c1a0819e09411d527d1313e0c91e68f2985038930a9bead785d1d62372154" }),
     ]),
   }),
   Object.freeze({
@@ -553,10 +570,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 3,
     source_unicode: "\u0003",
     target_unicode: "]",
-    charproc_sha256: "2810f1eec224c30a86c790b2b990953f0b54f28f9a32a035649784962b075cb5",
+    glyph_sha256: "f760c316d37754edd56178f58f7935789b7cfec19a577e3de751f3437e258583",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 2, charproc_sha256: "24e2fb74862685748e4dda1996a1664497a46fb66fc842633cd13686f974cf80" }),
-      Object.freeze({ original_char_code: 16, charproc_sha256: "e0188ef949df660ee321f0379d85dcde82054590708f27c0398434fbcbb9bbc3" }),
+      Object.freeze({ original_char_code: 2, glyph_sha256: "6b0a15286d5c6eab2ff6a3ec1ae3f10b2bda4a2a502190a441875d1307a089ca" }),
+      Object.freeze({ original_char_code: 16, glyph_sha256: "dd4cc29a14d2086fc3affe1d8c0bed29b1dc1b29df911950c6b5320e347dfebc" }),
     ]),
   }),
   Object.freeze({
@@ -566,10 +583,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 16,
     source_unicode: "\u0010",
     target_unicode: "(",
-    charproc_sha256: "1784beab0bd30a40b0e4476f38975039ae3ab074f725b3a8b8ac7801e8c7b0c5",
+    glyph_sha256: "6e514ff075120591b98740dcd095c9f73ec09f5483c8705f75b7cc0e89178e31",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 0, charproc_sha256: "eeae0f8c005ab72ff0fc77dda2d45be6bcca4359a98f882a1d33bf25619a6ae1" }),
-      Object.freeze({ original_char_code: 1, charproc_sha256: "9a0788d07694db3951c5f1b847f8d50beb1e82e0dd877cf3d75ad2b9f0de0876" }),
+      Object.freeze({ original_char_code: 0, glyph_sha256: "db8987d9df1b673b7c30dca2e284cf446998ad64b8a0a7a50c607cb3a08de761" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "a06c1a0819e09411d527d1313e0c91e68f2985038930a9bead785d1d62372154" }),
     ]),
   }),
   Object.freeze({
@@ -579,10 +596,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 16,
     source_unicode: "\u0010",
     target_unicode: "(",
-    charproc_sha256: "e0188ef949df660ee321f0379d85dcde82054590708f27c0398434fbcbb9bbc3",
+    glyph_sha256: "dd4cc29a14d2086fc3affe1d8c0bed29b1dc1b29df911950c6b5320e347dfebc",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 2, charproc_sha256: "24e2fb74862685748e4dda1996a1664497a46fb66fc842633cd13686f974cf80" }),
-      Object.freeze({ original_char_code: 3, charproc_sha256: "2810f1eec224c30a86c790b2b990953f0b54f28f9a32a035649784962b075cb5" }),
+      Object.freeze({ original_char_code: 2, glyph_sha256: "6b0a15286d5c6eab2ff6a3ec1ae3f10b2bda4a2a502190a441875d1307a089ca" }),
+      Object.freeze({ original_char_code: 3, glyph_sha256: "f760c316d37754edd56178f58f7935789b7cfec19a577e3de751f3437e258583" }),
     ]),
   }),
   Object.freeze({
@@ -592,10 +609,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 17,
     source_unicode: "\u0011",
     target_unicode: ")",
-    charproc_sha256: "fd720e62a2ff88280ae62f59a9c3c75c64ff57767f5f6c2136e400abf6a06a4a",
+    glyph_sha256: "4a24a711ec6fb485ffd8a893be44c48f0a9b91450c50219fd94176ff32938b15",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 0, charproc_sha256: "eeae0f8c005ab72ff0fc77dda2d45be6bcca4359a98f882a1d33bf25619a6ae1" }),
-      Object.freeze({ original_char_code: 1, charproc_sha256: "9a0788d07694db3951c5f1b847f8d50beb1e82e0dd877cf3d75ad2b9f0de0876" }),
+      Object.freeze({ original_char_code: 0, glyph_sha256: "db8987d9df1b673b7c30dca2e284cf446998ad64b8a0a7a50c607cb3a08de761" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "a06c1a0819e09411d527d1313e0c91e68f2985038930a9bead785d1d62372154" }),
     ]),
   }),
   Object.freeze({
@@ -605,10 +622,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 17,
     source_unicode: "\u0011",
     target_unicode: ")",
-    charproc_sha256: "741b0e1ccef4470e9fc1446144de647f95d3f064c8ee0a30e932a6f0f21d5c36",
+    glyph_sha256: "c62e5e3a49164445ab07b6786922a5d8cd5d6806bc687aab4027a7b834f30381",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 2, charproc_sha256: "24e2fb74862685748e4dda1996a1664497a46fb66fc842633cd13686f974cf80" }),
-      Object.freeze({ original_char_code: 3, charproc_sha256: "2810f1eec224c30a86c790b2b990953f0b54f28f9a32a035649784962b075cb5" }),
+      Object.freeze({ original_char_code: 2, glyph_sha256: "6b0a15286d5c6eab2ff6a3ec1ae3f10b2bda4a2a502190a441875d1307a089ca" }),
+      Object.freeze({ original_char_code: 3, glyph_sha256: "f760c316d37754edd56178f58f7935789b7cfec19a577e3de751f3437e258583" }),
     ]),
   }),
   Object.freeze({
@@ -618,10 +635,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 18,
     source_unicode: "\u0012",
     target_unicode: "(",
-    charproc_sha256: "d0c76fc6c61d5272b91e030c99f55649bd7a738dd57be5e5987505e317d79489",
+    glyph_sha256: "2ea0b479a269492539f17c9eeb24b9836e2c337ac091081b66ec7267d67a6cbe",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 0, charproc_sha256: "eeae0f8c005ab72ff0fc77dda2d45be6bcca4359a98f882a1d33bf25619a6ae1" }),
-      Object.freeze({ original_char_code: 1, charproc_sha256: "9a0788d07694db3951c5f1b847f8d50beb1e82e0dd877cf3d75ad2b9f0de0876" }),
+      Object.freeze({ original_char_code: 0, glyph_sha256: "db8987d9df1b673b7c30dca2e284cf446998ad64b8a0a7a50c607cb3a08de761" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "a06c1a0819e09411d527d1313e0c91e68f2985038930a9bead785d1d62372154" }),
     ]),
   }),
   Object.freeze({
@@ -631,10 +648,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 19,
     source_unicode: "\u0013",
     target_unicode: ")",
-    charproc_sha256: "4787f4b191732cff06605637446e648294d85d36ddbe811db3be7d3790eddd21",
+    glyph_sha256: "30ce6ba7dc248d84d411a6050c735dc52420bbfc2e127330da96bb3876fdc176",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 0, charproc_sha256: "eeae0f8c005ab72ff0fc77dda2d45be6bcca4359a98f882a1d33bf25619a6ae1" }),
-      Object.freeze({ original_char_code: 1, charproc_sha256: "9a0788d07694db3951c5f1b847f8d50beb1e82e0dd877cf3d75ad2b9f0de0876" }),
+      Object.freeze({ original_char_code: 0, glyph_sha256: "db8987d9df1b673b7c30dca2e284cf446998ad64b8a0a7a50c607cb3a08de761" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "a06c1a0819e09411d527d1313e0c91e68f2985038930a9bead785d1d62372154" }),
     ]),
   }),
   Object.freeze({
@@ -644,10 +661,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 20,
     source_unicode: "\u0014",
     target_unicode: "[",
-    charproc_sha256: "2daf02b5e930be4e4d4cf68cb0d7fadd5f3e44238cc34e7308dd3bf39fbcf372",
+    glyph_sha256: "d7bb229a762f6389b264ecc8182d96463512edd9d15641adcddd80da1d62864a",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 0, charproc_sha256: "eeae0f8c005ab72ff0fc77dda2d45be6bcca4359a98f882a1d33bf25619a6ae1" }),
-      Object.freeze({ original_char_code: 1, charproc_sha256: "9a0788d07694db3951c5f1b847f8d50beb1e82e0dd877cf3d75ad2b9f0de0876" }),
+      Object.freeze({ original_char_code: 0, glyph_sha256: "db8987d9df1b673b7c30dca2e284cf446998ad64b8a0a7a50c607cb3a08de761" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "a06c1a0819e09411d527d1313e0c91e68f2985038930a9bead785d1d62372154" }),
     ]),
   }),
   Object.freeze({
@@ -657,10 +674,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 20,
     source_unicode: "\u0014",
     target_unicode: "[",
-    charproc_sha256: "42ccb43e7b055f57391032b7a14079d777e45451ccb5d28b5d7ed2cbff51ea3a",
+    glyph_sha256: "5d63c680f912fa771991bec647d6024bbffc00377ef7515cd5eb4a063ac6fb30",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 2, charproc_sha256: "24e2fb74862685748e4dda1996a1664497a46fb66fc842633cd13686f974cf80" }),
-      Object.freeze({ original_char_code: 3, charproc_sha256: "2810f1eec224c30a86c790b2b990953f0b54f28f9a32a035649784962b075cb5" }),
+      Object.freeze({ original_char_code: 2, glyph_sha256: "6b0a15286d5c6eab2ff6a3ec1ae3f10b2bda4a2a502190a441875d1307a089ca" }),
+      Object.freeze({ original_char_code: 3, glyph_sha256: "f760c316d37754edd56178f58f7935789b7cfec19a577e3de751f3437e258583" }),
     ]),
   }),
   Object.freeze({
@@ -670,10 +687,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 21,
     source_unicode: "\u0015",
     target_unicode: "]",
-    charproc_sha256: "50dd658a682af9da1e5f9e3ed106d7de7cd6f7b1df172736fe38b3a21469e225",
+    glyph_sha256: "c041f94f074b2255945dfb7dd0a115ae7ce4a97002147ca315fa7647362120a0",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 0, charproc_sha256: "eeae0f8c005ab72ff0fc77dda2d45be6bcca4359a98f882a1d33bf25619a6ae1" }),
-      Object.freeze({ original_char_code: 1, charproc_sha256: "9a0788d07694db3951c5f1b847f8d50beb1e82e0dd877cf3d75ad2b9f0de0876" }),
+      Object.freeze({ original_char_code: 0, glyph_sha256: "db8987d9df1b673b7c30dca2e284cf446998ad64b8a0a7a50c607cb3a08de761" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "a06c1a0819e09411d527d1313e0c91e68f2985038930a9bead785d1d62372154" }),
     ]),
   }),
   Object.freeze({
@@ -683,10 +700,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 21,
     source_unicode: "\u0015",
     target_unicode: "]",
-    charproc_sha256: "ebfd69f0be341fbb00596c55ae708eeccc641b0174b4972f377f14ad33d35649",
+    glyph_sha256: "5aac802aecbaec1d9ed686ae4ddc1bb6c8bce048462620ec5582b95c0299661d",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 2, charproc_sha256: "24e2fb74862685748e4dda1996a1664497a46fb66fc842633cd13686f974cf80" }),
-      Object.freeze({ original_char_code: 3, charproc_sha256: "2810f1eec224c30a86c790b2b990953f0b54f28f9a32a035649784962b075cb5" }),
+      Object.freeze({ original_char_code: 2, glyph_sha256: "6b0a15286d5c6eab2ff6a3ec1ae3f10b2bda4a2a502190a441875d1307a089ca" }),
+      Object.freeze({ original_char_code: 3, glyph_sha256: "f760c316d37754edd56178f58f7935789b7cfec19a577e3de751f3437e258583" }),
     ]),
   }),
   Object.freeze({
@@ -696,10 +713,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 1,
     source_unicode: "\u0001",
     target_unicode: "Δ",
-    charproc_sha256: "762215421d47ca10bd29483ca69c105402ef88b6c80b7c4b1072e10a81fc14cc",
+    glyph_sha256: "30552b3ff5ae9fae4095b2a791d73b448221a488c7b6ede9ddfb6852f474a052",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, charproc_sha256: "e688a83f98433c841694f990aabafe5245cfc9320f584d7f70da706f0eeba259" }),
-      Object.freeze({ original_char_code: 14, charproc_sha256: "a5a76e73ff8dec163f779ae9cbcb92f18349e41fb4ce34f2e6a443c5aff1ef56" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
+      Object.freeze({ original_char_code: 14, glyph_sha256: "8d55a727feda11508e29c3b5c500d64dc58ce7b6fdb3d9776ef1e0d2df7888a3" }),
     ]),
   }),
   Object.freeze({
@@ -709,10 +726,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 14,
     source_unicode: "\u000e",
     target_unicode: "δ",
-    charproc_sha256: "a5a76e73ff8dec163f779ae9cbcb92f18349e41fb4ce34f2e6a443c5aff1ef56",
+    glyph_sha256: "8d55a727feda11508e29c3b5c500d64dc58ce7b6fdb3d9776ef1e0d2df7888a3",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 1, charproc_sha256: "762215421d47ca10bd29483ca69c105402ef88b6c80b7c4b1072e10a81fc14cc" }),
-      Object.freeze({ original_char_code: 11, charproc_sha256: "e688a83f98433c841694f990aabafe5245cfc9320f584d7f70da706f0eeba259" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "30552b3ff5ae9fae4095b2a791d73b448221a488c7b6ede9ddfb6852f474a052" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
     ]),
   }),
   Object.freeze({
@@ -722,10 +739,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 14,
     source_unicode: "\u000e",
     target_unicode: "δ",
-    charproc_sha256: "b41124da800ba2c4ed342b553c9433dc8b0eaf4e6228dab9901d6f9cd4e4449d",
+    glyph_sha256: "40e6d476435323a686a4ef5f02ac43f6b6b5e3612887c18105b82575e76e2e9b",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, charproc_sha256: "bab8aeb78893a19704c95538c54764abaae0cfe9d84812825f718e7687432f63" }),
-      Object.freeze({ original_char_code: 15, charproc_sha256: "7c62980ea7b423af3bfd7f14a2b5efa95b4dd23f611c1a013ef7b7fd57cefb51" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "6092e20a2f8a4925449780db726c4912ccee956a094589d3cb63ede3b5d7383b" }),
+      Object.freeze({ original_char_code: 15, glyph_sha256: "8692c50f6e5d1605e52e3d414ad4c285a583d11bcfff2f7a3be93bee06117de5" }),
     ]),
   }),
   Object.freeze({
@@ -735,10 +752,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 15,
     source_unicode: "\u000f",
     target_unicode: "ϵ",
-    charproc_sha256: "376b93ca5b31fec7270e1c4ea1425de0c60c37146b03f2c5f9de6b979209462a",
+    glyph_sha256: "da7780d95a5aea753d5de0f042903c2e96618c719283db449cd0476c5e74a6a4",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 1, charproc_sha256: "762215421d47ca10bd29483ca69c105402ef88b6c80b7c4b1072e10a81fc14cc" }),
-      Object.freeze({ original_char_code: 11, charproc_sha256: "e688a83f98433c841694f990aabafe5245cfc9320f584d7f70da706f0eeba259" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "30552b3ff5ae9fae4095b2a791d73b448221a488c7b6ede9ddfb6852f474a052" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
     ]),
   }),
   Object.freeze({
@@ -748,10 +765,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 15,
     source_unicode: "\u000f",
     target_unicode: "ϵ",
-    charproc_sha256: "7c62980ea7b423af3bfd7f14a2b5efa95b4dd23f611c1a013ef7b7fd57cefb51",
+    glyph_sha256: "8692c50f6e5d1605e52e3d414ad4c285a583d11bcfff2f7a3be93bee06117de5",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, charproc_sha256: "bab8aeb78893a19704c95538c54764abaae0cfe9d84812825f718e7687432f63" }),
-      Object.freeze({ original_char_code: 14, charproc_sha256: "b41124da800ba2c4ed342b553c9433dc8b0eaf4e6228dab9901d6f9cd4e4449d" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "6092e20a2f8a4925449780db726c4912ccee956a094589d3cb63ede3b5d7383b" }),
+      Object.freeze({ original_char_code: 14, glyph_sha256: "40e6d476435323a686a4ef5f02ac43f6b6b5e3612887c18105b82575e76e2e9b" }),
     ]),
   }),
   Object.freeze({
@@ -761,10 +778,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 17,
     source_unicode: "\u0011",
     target_unicode: "η",
-    charproc_sha256: "a19a510f4227807eab4664f0736e8e6258fe26dcc46d7ac8d0c7a378691237cf",
+    glyph_sha256: "8a211c038232f3e28545e3d2f4a42ebd349a8cc27e45bc0a6775b4cd105cfb9c",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, charproc_sha256: "bab8aeb78893a19704c95538c54764abaae0cfe9d84812825f718e7687432f63" }),
-      Object.freeze({ original_char_code: 14, charproc_sha256: "b41124da800ba2c4ed342b553c9433dc8b0eaf4e6228dab9901d6f9cd4e4449d" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "6092e20a2f8a4925449780db726c4912ccee956a094589d3cb63ede3b5d7383b" }),
+      Object.freeze({ original_char_code: 14, glyph_sha256: "40e6d476435323a686a4ef5f02ac43f6b6b5e3612887c18105b82575e76e2e9b" }),
     ]),
   }),
   Object.freeze({
@@ -774,10 +791,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 18,
     source_unicode: "\u0012",
     target_unicode: "θ",
-    charproc_sha256: "700332af231f58b628cd690de8f32a0604206fdbfd85a5a9fe18846044fda42b",
+    glyph_sha256: "1687afb884c912cf4555cef231572f37ac3eabe87344bc993fc3880d5eabdd2a",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, charproc_sha256: "bab8aeb78893a19704c95538c54764abaae0cfe9d84812825f718e7687432f63" }),
-      Object.freeze({ original_char_code: 14, charproc_sha256: "b41124da800ba2c4ed342b553c9433dc8b0eaf4e6228dab9901d6f9cd4e4449d" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "6092e20a2f8a4925449780db726c4912ccee956a094589d3cb63ede3b5d7383b" }),
+      Object.freeze({ original_char_code: 14, glyph_sha256: "40e6d476435323a686a4ef5f02ac43f6b6b5e3612887c18105b82575e76e2e9b" }),
     ]),
   }),
   Object.freeze({
@@ -787,10 +804,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 21,
     source_unicode: "\u0015",
     target_unicode: "λ",
-    charproc_sha256: "25c0ac6215a1b5e1a1df1a3d643e7465f92f6708d5ba8030eefe30c4378cb3a2",
+    glyph_sha256: "bdf1508d236990157b905ae312c6daf9452a27e2e15f0d239e174047d700327f",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 1, charproc_sha256: "762215421d47ca10bd29483ca69c105402ef88b6c80b7c4b1072e10a81fc14cc" }),
-      Object.freeze({ original_char_code: 11, charproc_sha256: "e688a83f98433c841694f990aabafe5245cfc9320f584d7f70da706f0eeba259" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "30552b3ff5ae9fae4095b2a791d73b448221a488c7b6ede9ddfb6852f474a052" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
     ]),
   }),
   Object.freeze({
@@ -800,10 +817,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 21,
     source_unicode: "\u0015",
     target_unicode: "λ",
-    charproc_sha256: "2023b726a9e1f2d0e2d551201dec4d7c14bca4a7fd3367e17b2e8d1421a573f5",
+    glyph_sha256: "50a0ec752f73c00a5126d9e2ac8c9d3b97058ebd24e08570f18a994cad8702bd",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, charproc_sha256: "bab8aeb78893a19704c95538c54764abaae0cfe9d84812825f718e7687432f63" }),
-      Object.freeze({ original_char_code: 14, charproc_sha256: "b41124da800ba2c4ed342b553c9433dc8b0eaf4e6228dab9901d6f9cd4e4449d" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "6092e20a2f8a4925449780db726c4912ccee956a094589d3cb63ede3b5d7383b" }),
+      Object.freeze({ original_char_code: 14, glyph_sha256: "40e6d476435323a686a4ef5f02ac43f6b6b5e3612887c18105b82575e76e2e9b" }),
     ]),
   }),
   Object.freeze({
@@ -813,10 +830,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 22,
     source_unicode: "\u0016",
     target_unicode: "μ",
-    charproc_sha256: "2c7d9c60cea80cf491a5990df64a392b80506682bd8732664129d36f2f51cdb6",
+    glyph_sha256: "58753b33f3d1d72955b0f1ef1777c5455c5ba37588f5fd88a0271ddcc0f46a75",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 1, charproc_sha256: "762215421d47ca10bd29483ca69c105402ef88b6c80b7c4b1072e10a81fc14cc" }),
-      Object.freeze({ original_char_code: 11, charproc_sha256: "e688a83f98433c841694f990aabafe5245cfc9320f584d7f70da706f0eeba259" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "30552b3ff5ae9fae4095b2a791d73b448221a488c7b6ede9ddfb6852f474a052" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
     ]),
   }),
   Object.freeze({
@@ -826,10 +843,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 23,
     source_unicode: "\u0017",
     target_unicode: "ν",
-    charproc_sha256: "f463297f1a37674d79d82c72d69f9b7c2c0fcbe71a450af43b9876cba82e91b2",
+    glyph_sha256: "d56aaf7b101a1a8f54fb062c3176637576fc6d46c262c250b1082d5c606853c7",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 1, charproc_sha256: "762215421d47ca10bd29483ca69c105402ef88b6c80b7c4b1072e10a81fc14cc" }),
-      Object.freeze({ original_char_code: 11, charproc_sha256: "e688a83f98433c841694f990aabafe5245cfc9320f584d7f70da706f0eeba259" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "30552b3ff5ae9fae4095b2a791d73b448221a488c7b6ede9ddfb6852f474a052" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
     ]),
   }),
   Object.freeze({
@@ -839,10 +856,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 27,
     source_unicode: "\u001b",
     target_unicode: "σ",
-    charproc_sha256: "94bd43b8371d7d511c5adbbce53cb99f894fc15e2ba084ddd5bddb00a65ca02a",
+    glyph_sha256: "c9a619efc5cd6a08c8ca09b92aca0d61391929ca7846322b4baf0d3f38edc5d8",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, charproc_sha256: "bab8aeb78893a19704c95538c54764abaae0cfe9d84812825f718e7687432f63" }),
-      Object.freeze({ original_char_code: 14, charproc_sha256: "b41124da800ba2c4ed342b553c9433dc8b0eaf4e6228dab9901d6f9cd4e4449d" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "6092e20a2f8a4925449780db726c4912ccee956a094589d3cb63ede3b5d7383b" }),
+      Object.freeze({ original_char_code: 14, glyph_sha256: "40e6d476435323a686a4ef5f02ac43f6b6b5e3612887c18105b82575e76e2e9b" }),
     ]),
   }),
   Object.freeze({
@@ -852,10 +869,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 28,
     source_unicode: "\u001c",
     target_unicode: "τ",
-    charproc_sha256: "53992a8aa4b2134eee16941856f5e38adf6181e4c5f80354097626905cbf69a7",
+    glyph_sha256: "10338ccd15eb973844cbbc07005a82aa702020cd2910adb162e71870fc67f82a",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 1, charproc_sha256: "762215421d47ca10bd29483ca69c105402ef88b6c80b7c4b1072e10a81fc14cc" }),
-      Object.freeze({ original_char_code: 11, charproc_sha256: "e688a83f98433c841694f990aabafe5245cfc9320f584d7f70da706f0eeba259" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "30552b3ff5ae9fae4095b2a791d73b448221a488c7b6ede9ddfb6852f474a052" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
     ]),
   }),
   Object.freeze({
@@ -865,10 +882,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 39,
     source_unicode: "'",
     target_unicode: "φ",
-    charproc_sha256: "117a85afcd9bbddb35a7be9228c55001a0cc97e38df0402f2e8817ea96b33d2e",
+    glyph_sha256: "4231ef8441ffbc9e7bc7693f3ec28d2de301d0edc6f9df6f69968a95af266e97",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 1, charproc_sha256: "762215421d47ca10bd29483ca69c105402ef88b6c80b7c4b1072e10a81fc14cc" }),
-      Object.freeze({ original_char_code: 11, charproc_sha256: "e688a83f98433c841694f990aabafe5245cfc9320f584d7f70da706f0eeba259" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "30552b3ff5ae9fae4095b2a791d73b448221a488c7b6ede9ddfb6852f474a052" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
     ]),
   }),
   Object.freeze({
@@ -878,10 +895,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 82,
     source_unicode: "R",
     target_unicode: "∫",
-    charproc_sha256: "e5fa9eb07a6e6807fb2ef29b805950074c1095fec2dbdc857ba9f46e4fbaaf77",
+    glyph_sha256: "58d503ac1ab67ecadd8e1ec07991a8338ddd452f5c3069dcba0ebe52e42fb3ee",
     complete_font_enrollment: Object.freeze([82, 90]),
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 90, charproc_sha256: "4a183facdfcc364d036490de4893001dd292baad2d6a9e22cff0d81d92b6bf5b" }),
+      Object.freeze({ original_char_code: 90, glyph_sha256: "063d12bd3f8fba24a0375a5da378e3a0acb6195c42f91625ea0798dba6545ed7" }),
     ]),
   }),
   Object.freeze({
@@ -891,10 +908,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 90,
     source_unicode: "Z",
     target_unicode: "∫",
-    charproc_sha256: "4a183facdfcc364d036490de4893001dd292baad2d6a9e22cff0d81d92b6bf5b",
+    glyph_sha256: "063d12bd3f8fba24a0375a5da378e3a0acb6195c42f91625ea0798dba6545ed7",
     complete_font_enrollment: Object.freeze([82, 90]),
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 82, charproc_sha256: "e5fa9eb07a6e6807fb2ef29b805950074c1095fec2dbdc857ba9f46e4fbaaf77" }),
+      Object.freeze({ original_char_code: 82, glyph_sha256: "58d503ac1ab67ecadd8e1ec07991a8338ddd452f5c3069dcba0ebe52e42fb3ee" }),
     ]),
   }),
   Object.freeze({
@@ -904,10 +921,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 6,
     source_unicode: "\u0006",
     target_unicode: "±",
-    charproc_sha256: "b68b24c69a8802a7e57a1cabaa7c1153a0a305e5d29ba308b78d60c16a5464b7",
+    glyph_sha256: "4734e344eca1f8f73183a34504c1068146b425815a2a8ef6aa00a18dfd45d9a2",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 0, charproc_sha256: "0c8b34a3281f9e8e91b2d955f952a50d187cd06c432be27c015b78570e645e9d" }),
-      Object.freeze({ original_char_code: 33, charproc_sha256: "6ff1e08b5364a8ce02ac2390691fdfb1f2e532bd0a1dac95d01a155bbce482fc" }),
+      Object.freeze({ original_char_code: 0, glyph_sha256: "ed5df416bb312c2b49ed8936f226016a28e9a09fa52aba56281dd6a8a5430d19" }),
+      Object.freeze({ original_char_code: 33, glyph_sha256: "a818ff8e95ae122382e0f0198e875400f4cc07ef1115dbe936ad5dd37933c4d4" }),
     ]),
   }),
   Object.freeze({
@@ -917,10 +934,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 33,
     source_unicode: "!",
     target_unicode: "→",
-    charproc_sha256: "7d300b0750eccc0a4a46dc4308474d519a19002749ea7ed11bdba2daeaaf4776",
+    glyph_sha256: "3efef4ea645a3cd8776d728305dd613116e17b74b006570e8cc6fd8a4b1dbb4b",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 0, charproc_sha256: "fb1f6bf10138511bcefade47467b3e2f9ae691ab3dab097914be1f0f66305470" }),
-      Object.freeze({ original_char_code: 1, charproc_sha256: "33077f6f9b7f5c5631bd3cb7bbfc79b4da1fbd929b23f6e08e55c90566608c7a" }),
+      Object.freeze({ original_char_code: 0, glyph_sha256: "68b4a1e125aa58ed3e798029190dbf4e2f3937030f921cd995cf7c8ad2f2eedc" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "2ed87b069c99482d0823c085da9c199582e6e4b51172a2b360d9b6652066e3ae" }),
     ]),
   }),
   Object.freeze({
@@ -930,10 +947,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 33,
     source_unicode: "!",
     target_unicode: "→",
-    charproc_sha256: "6ff1e08b5364a8ce02ac2390691fdfb1f2e532bd0a1dac95d01a155bbce482fc",
+    glyph_sha256: "a818ff8e95ae122382e0f0198e875400f4cc07ef1115dbe936ad5dd37933c4d4",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 0, charproc_sha256: "0c8b34a3281f9e8e91b2d955f952a50d187cd06c432be27c015b78570e645e9d" }),
-      Object.freeze({ original_char_code: 6, charproc_sha256: "b68b24c69a8802a7e57a1cabaa7c1153a0a305e5d29ba308b78d60c16a5464b7" }),
+      Object.freeze({ original_char_code: 0, glyph_sha256: "ed5df416bb312c2b49ed8936f226016a28e9a09fa52aba56281dd6a8a5430d19" }),
+      Object.freeze({ original_char_code: 6, glyph_sha256: "4734e344eca1f8f73183a34504c1068146b425815a2a8ef6aa00a18dfd45d9a2" }),
     ]),
   }),
   Object.freeze({
@@ -943,10 +960,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 17,
     source_unicode: "\u0011",
     target_unicode: "η",
-    charproc_sha256: "2fd7e5e9b50a6e5116b22bf8cc472eaaeccdc66b09680cbc8a67a9f10544f8da",
+    glyph_sha256: "712ac34ba1c3de89b2c233171e58eaa55e54ebcb0d4cec1609a788fa90eef047",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, charproc_sha256: "e688a83f98433c841694f990aabafe5245cfc9320f584d7f70da706f0eeba259" }),
-      Object.freeze({ original_char_code: 25, charproc_sha256: "780b04fa47830ca782211b86dbedfe0adec0445bdf94d538bfe7adde08ed9445" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
+      Object.freeze({ original_char_code: 25, glyph_sha256: "751c36c470d1f0292b9d39de8cfec243d0e1e4ca3b2a2648676a8048cdf75322" }),
     ]),
   }),
   Object.freeze({
@@ -956,10 +973,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 18,
     source_unicode: "\u0012",
     target_unicode: "θ",
-    charproc_sha256: "194bccf1b8ad8839f03bf6ebb90cf67cc7c97c8e386f21189d59900109299e58",
+    glyph_sha256: "38d2baa791ebd167d9d328153bd4cabcb722c833e759315f3a398537e0f57e03",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, charproc_sha256: "e688a83f98433c841694f990aabafe5245cfc9320f584d7f70da706f0eeba259" }),
-      Object.freeze({ original_char_code: 25, charproc_sha256: "780b04fa47830ca782211b86dbedfe0adec0445bdf94d538bfe7adde08ed9445" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
+      Object.freeze({ original_char_code: 25, glyph_sha256: "751c36c470d1f0292b9d39de8cfec243d0e1e4ca3b2a2648676a8048cdf75322" }),
     ]),
   }),
   Object.freeze({
@@ -969,10 +986,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 27,
     source_unicode: "\u001b",
     target_unicode: "σ",
-    charproc_sha256: "dae3aa06efc876bfa8242e02ad384046ce039fca3ff87523faab17bce15a75de",
+    glyph_sha256: "de609d12d1935bc3ff128046fa3c5f4330689ded53c9fc7a179a0b7c368f9f9a",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, charproc_sha256: "e688a83f98433c841694f990aabafe5245cfc9320f584d7f70da706f0eeba259" }),
-      Object.freeze({ original_char_code: 25, charproc_sha256: "780b04fa47830ca782211b86dbedfe0adec0445bdf94d538bfe7adde08ed9445" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
+      Object.freeze({ original_char_code: 25, glyph_sha256: "751c36c470d1f0292b9d39de8cfec243d0e1e4ca3b2a2648676a8048cdf75322" }),
     ]),
   }),
   Object.freeze({
@@ -982,10 +999,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 6,
     source_unicode: "\u0006",
     target_unicode: "±",
-    charproc_sha256: "4dedb5543e5ab5817e06920d50b7983b3febaf06c22feeb83bdbb3d8449e2c3c",
+    glyph_sha256: "009835b7eda7745c9e2e167ce0ed1b5e4ff9063af4c92280dffab3213f07e395",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 0, charproc_sha256: "fb1f6bf10138511bcefade47467b3e2f9ae691ab3dab097914be1f0f66305470" }),
-      Object.freeze({ original_char_code: 21, charproc_sha256: "05b4a9d88c1df64b3ac339ae6bb7ed82383b93bb08512842452db43453a28970" }),
+      Object.freeze({ original_char_code: 0, glyph_sha256: "68b4a1e125aa58ed3e798029190dbf4e2f3937030f921cd995cf7c8ad2f2eedc" }),
+      Object.freeze({ original_char_code: 21, glyph_sha256: "d2622641d0fa27eba18c91fd6333cfad66cbc23918a88854242d2f0f4c6ca968" }),
     ]),
   }),
 ]);
@@ -1075,6 +1092,214 @@ export function type3CharProcSha256(charProc) {
   }
 }
 
+function multiplyType3Transform(outer, inner) {
+  return [
+    outer[0] * inner[0] + outer[2] * inner[1],
+    outer[1] * inner[0] + outer[3] * inner[1],
+    outer[0] * inner[2] + outer[2] * inner[3],
+    outer[1] * inner[2] + outer[3] * inner[3],
+    outer[0] * inner[4] + outer[2] * inner[5] + outer[4],
+    outer[1] * inner[4] + outer[3] * inner[5] + outer[5],
+  ];
+}
+
+/**
+ * Rebuilds the decoded 1-bit image-mask grid from the outline PDF.js compiles
+ * for a Type-3 bitmap glyph.
+ *
+ * PDF.js does not hand out the decoded mask samples: for a Type-3 glyph whose
+ * body is a single inline image mask it decodes the samples (applying /Decode,
+ * /BlackIs1 and any CCITT or Flate filter), traces the painted pixels, and
+ * emits one `rawFillPath` whose vertices sit exactly on the pixel lattice,
+ * expressed in the unit square as `x / width` and `1 - row / height`. Every
+ * edge is therefore axis-parallel and integral, and filling that outline with
+ * the non-zero rule recovers the painted samples exactly. Verified bit for bit
+ * against the 123 distinct inline masks of the Shannon reference document,
+ * decoded independently straight out of the CharProcs streams.
+ */
+function type3GlyphImageMask(charProc, fontMatrix, ops) {
+  if (!charProc || !Array.isArray(charProc.fnArray) || !Array.isArray(charProc.argsArray)) return null;
+  if (!Array.isArray(fontMatrix) || fontMatrix.length !== 6 || !fontMatrix.every(Number.isFinite)) return null;
+  if (![ops?.save, ops?.restore, ops?.transform, ops?.constructPath, ops?.rawFillPath,
+    ops?.setCharWidthAndBounds].every(Number.isFinite)) return null;
+  let current = [...fontMatrix];
+  const stack = [];
+  let painted = null;
+  for (let index = 0; index < charProc.fnArray.length; index += 1) {
+    const operation = charProc.fnArray[index];
+    const args = charProc.argsArray[index];
+    if (operation === ops.save) {
+      if (stack.length > MAX_TYPE3_GLYPH_CANONICAL_DEPTH) return null;
+      stack.push([...current]);
+    } else if (operation === ops.restore) {
+      if (stack.length === 0) return null;
+      current = stack.pop();
+    } else if (operation === ops.transform) {
+      if (!Array.isArray(args) || args.length !== 6 || !args.every(Number.isFinite)) return null;
+      current = multiplyType3Transform(current, args);
+    } else if (operation === ops.setCharWidthAndBounds) {
+      // Declares the glyph's advance and bounds. It paints nothing, and its
+      // numbers are exactly the producer-specific placement this key drops.
+    } else if (operation === ops.constructPath) {
+      // A second painted object means this is not a plain single-mask glyph.
+      if (painted || args?.[0] !== ops.rawFillPath) return null;
+      painted = { path: args?.[1]?.[0], box: args?.[2], transform: current };
+    } else {
+      return null;
+    }
+  }
+  if (!painted) return null;
+  const { path, box, transform } = painted;
+  if (!ArrayBuffer.isView(path) || !ArrayBuffer.isView(box) || box.length !== 4) return null;
+  if (box[0] !== 0 || box[1] !== 0) return null;
+  const width = box[2];
+  const height = box[3];
+  if (!Number.isInteger(width) || !Number.isInteger(height) || width <= 0 || height <= 0) return null;
+  if (width * height > MAX_TYPE3_GLYPH_MASK_PIXELS) return null;
+  if (path.length > MAX_TYPE3_GLYPH_MASK_PATH_NODES) return null;
+  // Only an axis-aligned, non-degenerate placement has an unambiguous mirror
+  // decomposition; a rotated or skewed glyph program is left unrecognized.
+  if (Math.abs(transform[1]) > 1e-9 || Math.abs(transform[2]) > 1e-9) return null;
+  if (!(Math.abs(transform[0]) > 0) || !(Math.abs(transform[3]) > 0)) return null;
+  const bits = fillAxisAlignedLatticePath(path, width, height);
+  if (!bits) return null;
+  return { width, height, bits, mirror_x: transform[0] < 0, mirror_y: transform[3] < 0 };
+}
+
+function fillAxisAlignedLatticePath(path, width, height) {
+  const crossings = Array.from({ length: height }, () => []);
+  const lattice = (value, extent) => {
+    const scaled = value * extent;
+    const rounded = Math.round(scaled);
+    if (!Number.isFinite(scaled) || Math.abs(scaled - rounded) > 1e-3) return null;
+    return rounded < 0 || rounded > extent ? null : rounded;
+  };
+  const addEdge = (fromX, fromY, toX, toY) => {
+    if (fromX !== toX) return fromY === toY;
+    const direction = toY > fromY ? 1 : -1;
+    for (let row = Math.min(fromY, toY); row < Math.max(fromY, toY); row += 1) {
+      crossings[row].push([fromX, direction]);
+    }
+    return true;
+  };
+  let startX = 0;
+  let startY = 0;
+  let cursorX = 0;
+  let cursorY = 0;
+  let open = false;
+  for (let index = 0; index < path.length;) {
+    const operation = path[index];
+    index += 1;
+    if (operation !== DRAW_OPS.moveTo && operation !== DRAW_OPS.lineTo && operation !== DRAW_OPS.closePath) return null;
+    if (operation === DRAW_OPS.closePath) {
+      if (open && !addEdge(cursorX, cursorY, startX, startY)) return null;
+      cursorX = startX;
+      cursorY = startY;
+      continue;
+    }
+    if (index + 1 >= path.length) return null;
+    const x = lattice(path[index], width);
+    // PDF.js emits the traced outline y-up in the unit square, so unit y 1 is
+    // image row 0. Reading it back as a row index keeps the grid in the
+    // stored sample order and leaves orientation to the canonical step.
+    const y = lattice(1 - path[index + 1], height);
+    index += 2;
+    if (x === null || y === null) return null;
+    if (operation === DRAW_OPS.moveTo) {
+      if (open && !addEdge(cursorX, cursorY, startX, startY)) return null;
+      startX = x;
+      startY = y;
+      open = true;
+    } else if (!open || !addEdge(cursorX, cursorY, x, y)) {
+      return null;
+    }
+    cursorX = x;
+    cursorY = y;
+  }
+  if (open && !addEdge(cursorX, cursorY, startX, startY)) return null;
+  const bits = new Uint8Array(width * height);
+  for (let row = 0; row < height; row += 1) {
+    const edges = crossings[row].sort((left, right) => left[0] - right[0]);
+    let winding = 0;
+    let previous = 0;
+    for (const [x, direction] of edges) {
+      if (winding !== 0) bits.fill(1, row * width + previous, row * width + x);
+      winding += direction;
+      previous = x;
+    }
+    if (winding !== 0) return null;
+  }
+  return bits;
+}
+
+/**
+ * The producer-independent form of a decoded mask: mirrored back into the
+ * orientation it is actually painted in, then cropped to its own ink. What is
+ * deliberately dropped is everything a second producer would have chosen
+ * differently for the same glyph — the placement matrix, the blank padding
+ * around the ink, and the operator idiom that carried them.
+ */
+function canonicalType3MaskBits(mask) {
+  const { width, height, bits, mirror_x: mirrorX, mirror_y: mirrorY } = mask;
+  let top = height;
+  let bottom = -1;
+  let left = width;
+  let right = -1;
+  for (let row = 0; row < height; row += 1) {
+    for (let column = 0; column < width; column += 1) {
+      if (!bits[row * width + column]) continue;
+      const visualRow = mirrorY ? height - 1 - row : row;
+      const visualColumn = mirrorX ? width - 1 - column : column;
+      if (visualRow < top) top = visualRow;
+      if (visualRow > bottom) bottom = visualRow;
+      if (visualColumn < left) left = visualColumn;
+      if (visualColumn > right) right = visualColumn;
+    }
+  }
+  if (bottom < 0) return { width: 0, height: 0, packed: Buffer.alloc(0) };
+  const inkWidth = right - left + 1;
+  const inkHeight = bottom - top + 1;
+  const stride = (inkWidth + 7) >> 3;
+  const packed = Buffer.alloc(stride * inkHeight);
+  for (let row = 0; row < inkHeight; row += 1) {
+    for (let column = 0; column < inkWidth; column += 1) {
+      const visualRow = top + row;
+      const visualColumn = left + column;
+      const sourceRow = mirrorY ? height - 1 - visualRow : visualRow;
+      const sourceColumn = mirrorX ? width - 1 - visualColumn : visualColumn;
+      if (bits[sourceRow * width + sourceColumn]) packed[row * stride + (column >> 3)] |= 128 >> (column & 7);
+    }
+  }
+  return { width: inkWidth, height: inkHeight, packed };
+}
+
+/**
+ * The recovery key for one Type-3 glyph program.
+ *
+ * A glyph whose body is a single decoded image mask is keyed on the mask
+ * itself, so the same Computer Modern raster keys identically no matter which
+ * dvips-era toolchain packed it, which filter it was compressed with, or where
+ * the producer placed it inside the glyph box. Anything else — an outline
+ * CharProc, a multi-object program, a rotated placement — falls back to the
+ * exact canonicalized operator digest, which is narrower but never wrong. The
+ * two lanes are domain-separated, so a mask digest can never satisfy an
+ * operator-keyed registry entry or the reverse.
+ */
+export function type3GlyphEvidenceSha256(charProc, fontMatrix, ops) {
+  const mask = type3GlyphImageMask(charProc, fontMatrix, ops);
+  if (!mask) {
+    const operators = type3CharProcSha256(charProc);
+    return operators === null
+      ? null
+      : createHash("sha256").update(`${TYPE3_CHARPROC_EVIDENCE_DOMAIN}:${operators}`).digest("hex");
+  }
+  const canonical = canonicalType3MaskBits(mask);
+  return createHash("sha256")
+    .update(`${TYPE3_MASK_EVIDENCE_DOMAIN}:${canonical.width}x${canonical.height}:`)
+    .update(canonical.packed)
+    .digest("hex");
+}
+
 function fontEncodingDifferences(font, context) {
   const encoding = context.lookup(font.get(PDFName.of("Encoding")), PDFDict);
   const differences = encoding?.lookup(PDFName.of("Differences"), PDFArray);
@@ -1105,14 +1330,41 @@ function rawType3Fonts(pdfLibPage) {
     for (const [, reference] of fonts.entries()) {
       const font = context.lookup(reference, PDFDict);
       if (font?.get(PDFName.of("Subtype"))?.toString() !== "/Type3") continue;
-      if (font.has(PDFName.of("ToUnicode"))) continue;
+      /*
+       * A font carrying its own /ToUnicode is deliberately left alone: PDF.js
+       * already maps those glyphs, and overriding a valid producer-supplied
+       * mapping would be a regression, not a recovery. It is still parsed and
+       * kept here as a *competitor*, so that a page whose glyphs match both it
+       * and a recoverable font is reported as ambiguous instead of silently
+       * linking to the recoverable one. Retaining zero-width slots made many
+       * more link attempts succeed, so the pool they have to be unique against
+       * has to be the whole page, not just the recoverable part of it.
+       */
+      const recoverable = !font.has(PDFName.of("ToUnicode"));
       const first = font.lookup(PDFName.of("FirstChar"), PDFNumber)?.asNumber();
       const last = font.lookup(PDFName.of("LastChar"), PDFNumber)?.asNumber();
       const widthsArray = font.lookup(PDFName.of("Widths"), PDFArray);
       const codeToGlyph = fontEncodingDifferences(font, context);
       if (!Number.isSafeInteger(first) || !Number.isSafeInteger(last) || !widthsArray || !codeToGlyph) continue;
-      if (first < 0 || last > 127 || last < first || widthsArray.size() !== last - first + 1) continue;
+      if (first < 0 || last < first || widthsArray.size() !== last - first + 1) continue;
+      /*
+       * Two separate width views, because the two consumers need opposite
+       * things from a declared zero.
+       *
+       * `widths` keeps every declared slot, zeros included. It is the linker's
+       * evidence: a drawn glyph whose declared width is 0 is a fact about the
+       * font, and dropping it turned the linker's `widths.get(code) === width`
+       * test into `undefined === 0`, so a single legitimately zero-width drawn
+       * glyph voided an otherwise perfect font match.
+       *
+       * `metricWidths` keeps only the positive slots, because that is what a
+       * TFM scale can actually be fitted to: `metricScaleInterval` divides by
+       * the reference width and an observed 0 pins the scale into
+       * (-0.5/ref, +0.5/ref), which no real scale satisfies. Feeding zeros to
+       * the family fingerprint would abolish family resolution outright.
+       */
       const widths = new Map();
+      const metricWidths = new Map();
       let valid = true;
       for (let code = first; code <= last; code += 1) {
         const width = widthsArray.lookup(code - first, PDFNumber)?.asNumber();
@@ -1120,9 +1372,20 @@ function rawType3Fonts(pdfLibPage) {
           valid = false;
           break;
         }
-        if (width > 0) widths.set(code, width);
+        widths.set(code, width);
+        if (width > 0) metricWidths.set(code, width);
       }
-      if (valid && widths.size > 0) records.push({ widths, codeToGlyph });
+      if (!valid) continue;
+      // The official Computer Modern encodings only reach code 127, so a font
+      // declaring higher codes cannot be one of them and can only ever be a
+      // competitor. Same for a font with no positive width at all: nothing can
+      // fingerprint its family.
+      records.push({
+        widths,
+        metricWidths,
+        codeToGlyph,
+        recoverable: recoverable && last <= 127 && metricWidths.size > 0,
+      });
     }
     return records;
   } catch {
@@ -1468,14 +1731,78 @@ function linkedRawType3Font(fontId, fontTokens, rawFonts) {
   }
   const candidates = rawFonts.filter(raw => [...observed].every(([code, width]) => raw.widths.get(code) === width)
     && [...glyphIds].every(([code, glyphId]) => raw.codeToGlyph.get(code) === glyphId));
-  if (candidates.length !== 1) return null;
+  if (candidates.length !== 1 || !candidates[0].recoverable) return null;
   return candidates[0];
 }
 
-function charProcDigestForCode(font, rawFont, code) {
+/*
+ * One glyph program is looked up once per registry entry that names it and
+ * again for the enrolled-shape index, so the decode is memoized on the PDF.js
+ * CharProc object itself. PDF.js caches Type-3 font objects per document, so
+ * the same object comes back on every page the font is used on.
+ */
+const type3GlyphEvidenceCache = new WeakMap();
+
+function type3GlyphEvidenceForCode(font, rawFont, code, ops) {
   const glyphId = rawFont.codeToGlyph.get(code);
   if (typeof glyphId !== "string") return null;
-  return type3CharProcSha256(font?.charProcOperatorList?.[glyphId]);
+  const charProc = font?.charProcOperatorList?.[glyphId];
+  if (!charProc || typeof charProc !== "object") return null;
+  const cached = type3GlyphEvidenceCache.get(charProc);
+  if (cached !== undefined) return cached;
+  const digest = type3GlyphEvidenceSha256(charProc, font?.fontMatrix, ops);
+  type3GlyphEvidenceCache.set(charProc, digest);
+  return digest;
+}
+
+/**
+ * Every officially enrolled code of `family` that this font actually draws,
+ * mapped to its glyph evidence digest.
+ */
+function enrolledGlyphEvidence(font, rawFont, family, ops) {
+  const byCode = new Map();
+  for (const key of Object.keys(CM_CODEPOINTS[family] ?? {})) {
+    const code = Number(key);
+    const digest = type3GlyphEvidenceForCode(font, rawFont, code, ops);
+    if (digest !== null) byCode.set(code, digest);
+  }
+  return byCode;
+}
+
+/**
+ * Corroboration the shape key has to earn back.
+ *
+ * Keying on the decoded mask deliberately discards the placement matrix, and
+ * placement is real evidence: a Computer Modern period and a Computer Modern
+ * centred dot at the same design size are the *same* nine-by-nine blob, told
+ * apart only by how high above the baseline the producer put it. Under the old
+ * CharProc key that difference was inside the digest. It is no longer, so the
+ * matcher requires instead that the shape identify the code on its own within
+ * the font it came from: a digest that appears at two enrolled codes of the
+ * same font is ambiguous evidence and recovers nothing.
+ */
+function evidenceIdentifiesCode(enrolled, code, digest) {
+  if (digest === null || enrolled.get(code) !== digest) return false;
+  let seen = 0;
+  for (const candidate of enrolled.values()) {
+    if (candidate === digest) seen += 1;
+    if (seen > 1) return false;
+  }
+  return seen === 1;
+}
+
+/**
+ * The second thing the matcher has to earn back, this time for Block A.
+ *
+ * Retaining zero-width slots is what lets a legacy font link at all, but it
+ * also means a drawn glyph can now reach the registry with no advance width
+ * behind it, and a zero advance is invisible to the TFM fingerprint that
+ * qualifies the family. A recovered code must therefore carry a positive
+ * declared width — which, being positive, is one of the widths
+ * `uniqueComputerModernFamily` had to fit to the family's own metrics.
+ */
+function metricPinnedCode(rawFont, code) {
+  return rawFont.metricWidths.has(code);
 }
 
 /**
@@ -1484,14 +1811,36 @@ function charProcDigestForCode(font, rawFont, code) {
  * single-witness entry relies on this so that its reduced corroboration is
  * still the whole of the evidence its font can offer.
  */
-function fontMatchesCompleteEnrollment(font, rawFont, family, declaredCodes) {
+function fontMatchesCompleteEnrollment(enrolled, family, declaredCodes) {
   const declared = new Set(declaredCodes);
   for (const key of Object.keys(CM_CODEPOINTS[family] ?? {})) {
     const code = Number(key);
-    const present = charProcDigestForCode(font, rawFont, code) !== null;
-    if (present !== declared.has(code)) return false;
+    if (enrolled.has(code) !== declared.has(code)) return false;
   }
   return true;
+}
+
+/**
+ * Registry entries whose whole evidence the font satisfies. A code matched by
+ * more than one entry is reported as such and recovers nothing: two entries
+ * disagreeing about one glyph is exactly the ambiguity this pipeline abstains
+ * on, and it is newly reachable now that the key no longer separates entries
+ * by their producer's placement.
+ */
+function matchingRegistryEntries(enrolled, rawFont, family) {
+  const byCode = new Map();
+  for (const registry of TYPE3_RECOVERY_REGISTRY) {
+    if (registry.family !== family) continue;
+    if (!metricPinnedCode(rawFont, registry.original_char_code)) continue;
+    if (!evidenceIdentifiesCode(enrolled, registry.original_char_code, registry.glyph_sha256)) continue;
+    if (registry.witnesses.some(witness => !metricPinnedCode(rawFont, witness.original_char_code)
+      || !evidenceIdentifiesCode(enrolled, witness.original_char_code, witness.glyph_sha256))) continue;
+    if (registry.complete_font_enrollment
+      && !fontMatchesCompleteEnrollment(enrolled, family, registry.complete_font_enrollment)) continue;
+    if (!byCode.has(registry.original_char_code)) byCode.set(registry.original_char_code, []);
+    byCode.get(registry.original_char_code).push(registry);
+  }
+  return [...byCode.values()].filter(entries => entries.length === 1).map(entries => entries[0]);
 }
 
 function collectType3GlyphRecoveries({ textContent, operators, pdfjsPage, pdfLibPage, pdfjsLib }) {
@@ -1521,15 +1870,11 @@ function collectType3GlyphRecoveries({ textContent, operators, pdfjsPage, pdfLib
     if (!font) continue;
     const rawFont = linkedRawType3Font(fontId, fontTokens, rawFonts);
     if (!rawFont) continue;
-    const family = uniqueComputerModernFamily(rawFont.widths);
+    const family = uniqueComputerModernFamily(rawFont.metricWidths);
     if (!family || family.startsWith("unsupported:")) continue;
-    for (const registry of TYPE3_RECOVERY_REGISTRY.filter(entry => entry.family === family)) {
-      const targetDigest = charProcDigestForCode(font, rawFont, registry.original_char_code);
-      if (targetDigest !== registry.charproc_sha256) continue;
-      const witnessDigests = registry.witnesses.map(witness => charProcDigestForCode(font, rawFont, witness.original_char_code));
-      if (witnessDigests.some((digest, index) => digest !== registry.witnesses[index].charproc_sha256)) continue;
-      if (registry.complete_font_enrollment
-        && !fontMatchesCompleteEnrollment(font, rawFont, family, registry.complete_font_enrollment)) continue;
+    const enrolled = enrolledGlyphEvidence(font, rawFont, family, pdfjsLib?.OPS ?? {});
+    for (const registry of matchingRegistryEntries(enrolled, rawFont, family)) {
+      const witnessDigests = registry.witnesses.map(witness => witness.glyph_sha256);
       for (const token of fontTokens) {
         const glyph = token.glyph;
         if (glyph.originalCharCode !== registry.original_char_code || glyph.unicode !== registry.source_unicode) continue;
@@ -1555,10 +1900,10 @@ function collectType3GlyphRecoveries({ textContent, operators, pdfjsPage, pdfLib
           source_font_id: fontId,
           registry_id: registry.id,
           qualification: registry.qualification,
-          charproc_sha256: registry.charproc_sha256,
-          witness_charproc_sha256: witnessDigests,
+          glyph_sha256: registry.glyph_sha256,
+          witness_glyph_sha256: witnessDigests,
           tfm_reference_version: CM_TFM_REFERENCE_VERSION,
-          canonicalizer_version: TYPE3_GLYPH_CANONICALIZER_VERSION,
+          glyph_evidence_version: TYPE3_GLYPH_EVIDENCE_VERSION,
         });
       }
     }
@@ -1644,34 +1989,37 @@ export function inspectType3GlyphEvidenceForPage({ textContent, operators, pdfjs
       omissions.push({ font_id: fontId, reason: "raw_type3_font_link_ambiguous_or_unavailable", scope: "type3_glyph", count: fontTokens.length });
       continue;
     }
-    const family = uniqueComputerModernFamily(rawFont.widths);
+    const family = uniqueComputerModernFamily(rawFont.metricWidths);
     const official = family ? CM_CODEPOINTS[family] : null;
     const witnessCodes = family ? CM_WITNESS_CODEPOINTS[family] : null;
-    const mappedCodeCharprocSha256 = official ? Object.fromEntries([...new Set([
+    const mappedCodeGlyphSha256 = official ? Object.fromEntries([...new Set([
       ...Object.keys(official),
       ...Object.keys(witnessCodes ?? {}),
     ])]
       .map(Number)
       .sort((left, right) => left - right)
-      .map(code => [code, charProcDigestForCode(font, rawFont, code)])) : {};
+      .map(code => [code, type3GlyphEvidenceForCode(font, rawFont, code, ops)])) : {};
+    const enrolled = family ? enrolledGlyphEvidence(font, rawFont, family, ops) : new Map();
+    const matchedByCode = new Map();
+    if (family) {
+      for (const entry of matchingRegistryEntries(enrolled, rawFont, family)) {
+        matchedByCode.set(entry.original_char_code, entry);
+      }
+    }
     for (const token of fontTokens) {
       const code = token.glyph.originalCharCode;
       if (!Number.isSafeInteger(code)) {
         omissions.push({ font_id: fontId, reason: "original_char_code_unavailable", scope: "type3_glyph", count: 1 });
         continue;
       }
-      const digest = charProcDigestForCode(font, rawFont, code);
-      if (!digest) omissions.push({ font_id: fontId, reason: "charproc_digest_unavailable", scope: "glyph_evidence", count: 1 });
-      const registryEvidenceMatchIds = TYPE3_RECOVERY_REGISTRY.filter(entry => entry.family === family
-        && entry.original_char_code === code
-        && entry.source_unicode === token.glyph.unicode
-        && entry.target_unicode === official?.[code]
-        && entry.charproc_sha256 === digest
-        && entry.witnesses.every(witness => mappedCodeCharprocSha256[witness.original_char_code] === witness.charproc_sha256)
-        && (!entry.complete_font_enrollment
-          || fontMatchesCompleteEnrollment(font, rawFont, family, entry.complete_font_enrollment)))
-        .map(entry => entry.id)
-        .sort();
+      const digest = type3GlyphEvidenceForCode(font, rawFont, code, ops);
+      if (!digest) omissions.push({ font_id: fontId, reason: "glyph_evidence_unavailable", scope: "glyph_evidence", count: 1 });
+      const matched = matchedByCode.get(code) ?? null;
+      const registryEvidenceMatchIds = matched
+        && matched.source_unicode === token.glyph.unicode
+        && matched.target_unicode === official?.[code]
+        ? [matched.id]
+        : [];
       occurrences.push({
         family,
         family_status: !family
@@ -1682,13 +2030,13 @@ export function inspectType3GlyphEvidenceForPage({ textContent, operators, pdfjs
         original_char_code: code,
         source_unicode: typeof token.glyph.unicode === "string" ? token.glyph.unicode : "",
         intended_unicode: official?.[code] ?? null,
-        charproc_sha256: digest,
-        mapped_code_charproc_sha256: mappedCodeCharprocSha256,
+        glyph_sha256: digest,
+        mapped_code_glyph_sha256: mappedCodeGlyphSha256,
         registry_evidence_match_ids: registryEvidenceMatchIds,
         operator_index: token.operator_index,
         glyph_index: token.glyph_index,
         tfm_reference_version: CM_TFM_REFERENCE_VERSION,
-        canonicalizer_version: TYPE3_GLYPH_CANONICALIZER_VERSION,
+        glyph_evidence_version: TYPE3_GLYPH_EVIDENCE_VERSION,
       });
     }
   }
@@ -3166,10 +3514,10 @@ export function validatePdfLayoutSemantics(payload, {
             && recovery.original_char_code === registry.original_char_code
             && recovery.operator_unicode === registry.source_unicode
             && recovery.target_unicode === registry.target_unicode
-            && recovery.charproc_sha256 === registry.charproc_sha256
-            && sameJson(recovery.witness_charproc_sha256, registry.witnesses.map(witness => witness.charproc_sha256))
+            && recovery.glyph_sha256 === registry.glyph_sha256
+            && sameJson(recovery.witness_glyph_sha256, registry.witnesses.map(witness => witness.glyph_sha256))
             && recovery.tfm_reference_version === CM_TFM_REFERENCE_VERSION
-            && recovery.canonicalizer_version === TYPE3_GLYPH_CANONICALIZER_VERSION,
+            && recovery.glyph_evidence_version === TYPE3_GLYPH_EVIDENCE_VERSION,
           `item ${item.id} glyph-recovery registry evidence is invalid`);
           const exactScalarBinding = recovery.binding_kind === "exact_text_scalar"
             && recovery.source_unicode === recovery.operator_unicode
@@ -3853,10 +4201,10 @@ export async function validatePdfLayoutSourceEvidence(payload, {
             font_name: expectedFontName,
             registry_id: recovery.registry_id,
             qualification: recovery.qualification,
-            charproc_sha256: recovery.charproc_sha256,
-            witness_charproc_sha256: recovery.witness_charproc_sha256,
+            glyph_sha256: recovery.glyph_sha256,
+            witness_glyph_sha256: recovery.witness_glyph_sha256,
             tfm_reference_version: recovery.tfm_reference_version,
-            canonicalizer_version: recovery.canonicalizer_version,
+            glyph_evidence_version: recovery.glyph_evidence_version,
           }));
           const comparisons = [
             ["text", outputItem.text, expectedText],
@@ -4224,10 +4572,10 @@ export async function extractPdfLayout({
           font_name: publicFontName,
           registry_id: recovery.registry_id,
           qualification: recovery.qualification,
-          charproc_sha256: recovery.charproc_sha256,
-          witness_charproc_sha256: recovery.witness_charproc_sha256,
+          glyph_sha256: recovery.glyph_sha256,
+          witness_glyph_sha256: recovery.witness_glyph_sha256,
           tfm_reference_version: recovery.tfm_reference_version,
-          canonicalizer_version: recovery.canonicalizer_version,
+          glyph_evidence_version: recovery.glyph_evidence_version,
         }));
         if (!geometryItem.valid) {
           invalidGeometry = true;

--- a/pdf-toolkit-mcp-share/server/layout-extraction.js
+++ b/pdf-toolkit-mcp-share/server/layout-extraction.js
@@ -1172,21 +1172,23 @@ function type3GlyphImageMask(charProc, fontMatrix, ops) {
   // program. Exactly what it does NOT check, and cannot: the text matrix and
   // the graphics CTM in force at the `Tj` that draws the glyph. Those are set
   // by the page content stream outside the CharProc and are invisible here, so
-  // nothing below is a statement about the orientation the glyph is finally
-  // painted in.
+  // the absolute orientation the glyph is finally painted in is not knowable
+  // from a CharProc, and nothing here claims to know it.
   //
-  // That gap is deliberate rather than tolerated. The key is the stored sample
-  // grid, which no matrix anywhere can alter, so painted orientation is not an
-  // input to it. This check survives only to hold the mask lane to the plain
-  // axis-aligned, non-degenerate scale-or-reflection bitmap idiom every
-  // enrolled entry was qualified on: a glyph program that rotates, shears, or
-  // collapses its own bitmap is a different construction and is keyed by the
-  // exact operator digest instead of by this lane.
+  // Two things come out of the matrix. First, admissibility: the mask lane is
+  // held to the plain axis-aligned, non-degenerate scale-or-reflection bitmap
+  // idiom every enrolled entry was qualified on, so a glyph program that
+  // rotates, shears, or collapses its own bitmap is a different construction
+  // and is keyed by the exact operator digest instead. Second, the sign of the
+  // CharProc-local determinant, which is not part of the key — it is
+  // producer-dependent in absolute terms — but is comparable between two
+  // glyphs of the same font. `type3FontPaintOrientation` uses it for exactly
+  // that and nothing else.
   if (Math.abs(transform[1]) > 1e-9 || Math.abs(transform[2]) > 1e-9) return null;
   if (!(Math.abs(transform[0]) > 0) || !(Math.abs(transform[3]) > 0)) return null;
   const bits = fillAxisAlignedLatticePath(path, width, height);
   if (!bits) return null;
-  return { width, height, bits };
+  return { width, height, bits, paint_orientation: Math.sign(transform[0] * transform[3]) };
 }
 
 function fillAxisAlignedLatticePath(path, width, height) {
@@ -1271,11 +1273,26 @@ function fillAxisAlignedLatticePath(path, width, height) {
  *
  * The accepted consequence is that a glyph painted rotated or reflected keys
  * the same as the upright one. That is the correct answer for text set at an
- * angle, which is still the same character. Where it could be wrong is a font
- * that reuses one bitmap for two characters by reflecting it — the classic
- * matched-parenthesis trick — and that case is already refused by the
- * shape-code injectivity rule below: one shape standing at two enrolled codes
- * of a font is ambiguous evidence and recovers nothing.
+ * angle, which is still the same character. Where it is wrong is a reflection
+ * that turns the shape into a *different* enrolled character, and Computer
+ * Modern has those: 16 of the shipped registry digests — eight mirror pairs,
+ * the parenthesis and bracket pairs of the two enrolled cmex fonts — are the
+ * exact horizontal mirror of another shipped digest. Measured, by mirroring
+ * every registry grid the reference document resolves and looking the result
+ * back up. A CharProc holding the stored raster of `]` but painting it
+ * reflected paints `[`, and the grid alone cannot tell the two apart.
+ *
+ * Shape-code injectivity does not refuse that case, and an earlier revision of
+ * this comment wrongly claimed it did. Injectivity asks whether one shape
+ * stands at two enrolled codes of the font. The reflected glyph stands at one
+ * code holding one raster; its mirror image lives at a different code holding
+ * a different, genuinely mirrored raster. Both codes are injective and both
+ * recover, one of them as the wrong character. Demonstrated on the Shannon
+ * reference document by negating the x scale of a single CMEX CharProc `cm`
+ * while leaving its mask bytes byte-identical.
+ *
+ * What refuses it is `type3FontPaintOrientation`: reflection relative to the
+ * font's own siblings is detectable without knowing any absolute orientation.
  *
  * Also deliberately dropped: the blank padding around the ink and the operator
  * idiom that carried the samples. An inkless mask has no shape to key at all
@@ -1322,10 +1339,20 @@ function canonicalType3MaskBits(mask) {
  * to key — falls back to the exact canonicalized operator digest, which is
  * narrower but never wrong. The two lanes are domain-separated, so a mask
  * digest can never satisfy an operator-keyed registry entry or the reverse.
+ *
+ * `fontPaintOrientation` is the one sign every mask-lane glyph of this font
+ * agrees on, from `type3FontPaintOrientation`, and is required for the mask
+ * lane rather than optional: a caller with no font-wide answer gets the
+ * operator lane, which is the safe direction. A glyph whose own CharProc-local
+ * determinant sign disagrees with its siblings is reflected relative to them
+ * and is refused the grid key.
  */
-export function type3GlyphEvidenceSha256(charProc, fontMatrix, ops) {
+export function type3GlyphEvidenceSha256(charProc, fontMatrix, ops, fontPaintOrientation) {
   const mask = type3GlyphImageMask(charProc, fontMatrix, ops);
-  const canonical = mask ? canonicalType3MaskBits(mask) : null;
+  const oriented = mask !== null
+    && (fontPaintOrientation === 1 || fontPaintOrientation === -1)
+    && mask.paint_orientation === fontPaintOrientation;
+  const canonical = oriented ? canonicalType3MaskBits(mask) : null;
   if (!canonical) {
     const operators = type3CharProcSha256(charProc);
     return operators === null
@@ -1791,6 +1818,69 @@ function linkedRawType3Font(fontId, fontTokens, rawFonts) {
  */
 const type3GlyphEvidenceCache = new WeakMap();
 
+const type3FontPaintOrientationCache = new WeakMap();
+
+/**
+ * The single paint convention every mask-lane glyph of one embedded font
+ * agrees on, as `1` or `-1`, or `null` when the font has none.
+ *
+ * The grid key deliberately discards orientation, which is right — the stored
+ * samples are the glyph and the matrices around them are the producer. But it
+ * leaves reflection unpoliced, and in Computer Modern reflection is not a
+ * harmless re-orientation of the same character: mirroring the `]` raster
+ * paints a `[`, and both are separately enrolled. So orientation has to be
+ * checked somewhere, and the only place it can be checked honestly is between
+ * glyphs of one font.
+ *
+ * The comparison is the sign of the CharProc-local determinant — FontMatrix
+ * composed with the glyph's own `cm`. That sign is meaningless in absolute
+ * terms, because producers split the flip differently: the Shannon reference
+ * document carries it in `FontMatrix [1 0 0 -1]` and gives every glyph of
+ * every one of its 24 Type-3 fonts sign -1, while other dvips-era producers
+ * leave FontMatrix upright and come out uniformly +1. Keying on it, or
+ * demanding a particular value of it, would make the same painted glyph key
+ * two ways — the exact producer dependence the grid key exists to remove.
+ * Comparing it *within* one font asks a different and answerable question: a
+ * font sets all of its bitmaps the same way round, so a glyph whose sign
+ * differs from its siblings is reflected relative to them, whatever absolute
+ * convention the producer chose.
+ *
+ * Unanimity, not a majority, because a majority is a vote an adversary can
+ * win by flipping more glyphs, and because most legacy fonts here carry one to
+ * four mask glyphs, where a majority is not defined. A font that disagrees
+ * with itself has no convention to normalize against and gets no grid keys at
+ * all; every glyph falls to the operator digest and abstains.
+ *
+ * Measured, not assumed: all 24 embedded Type-3 fonts of the Shannon
+ * reference document and all 92 of the five legacy TeX corpus documents are
+ * unanimous, and none of the 116 is mixed. Mirroring one CMEX CharProc `cm`
+ * makes exactly its own font mixed and nothing else.
+ *
+ * The scan covers every entry of `charProcOperatorList`, which PDF.js builds
+ * eagerly from the whole /CharProcs dictionary when the font is loaded rather
+ * than lazily per drawn glyph, so the answer is a property of the font and not
+ * of which page happened to be extracted first.
+ */
+export function type3FontPaintOrientation(font, ops) {
+  const cached = type3FontPaintOrientationCache.get(font);
+  if (cached !== undefined) return cached;
+  const charProcs = font?.charProcOperatorList;
+  let orientation = null;
+  if (charProcs && typeof charProcs === "object") {
+    for (const glyphId of Object.keys(charProcs)) {
+      const mask = type3GlyphImageMask(charProcs[glyphId], font?.fontMatrix, ops);
+      if (mask === null) continue;
+      if (orientation === null) orientation = mask.paint_orientation;
+      else if (orientation !== mask.paint_orientation) {
+        orientation = null;
+        break;
+      }
+    }
+  }
+  type3FontPaintOrientationCache.set(font, orientation);
+  return orientation;
+}
+
 function type3GlyphEvidenceForCode(font, rawFont, code, ops) {
   const glyphId = rawFont.codeToGlyph.get(code);
   if (typeof glyphId !== "string") return null;
@@ -1803,7 +1893,7 @@ function type3GlyphEvidenceForCode(font, rawFont, code, ops) {
   }
   const cached = byGlyphId.get(glyphId);
   if (cached !== undefined) return cached;
-  const digest = type3GlyphEvidenceSha256(charProc, font?.fontMatrix, ops);
+  const digest = type3GlyphEvidenceSha256(charProc, font?.fontMatrix, ops, type3FontPaintOrientation(font, ops));
   byGlyphId.set(glyphId, digest);
   return digest;
 }

--- a/pdf-toolkit-mcp-share/server/markdown-conversion.js
+++ b/pdf-toolkit-mcp-share/server/markdown-conversion.js
@@ -8,7 +8,7 @@ const RENDERER = Object.freeze({
   name: "pdf-tools.layout-markdown-renderer",
   version: "1.14.0",
 });
-const SUPPORTED_LAYOUT_IR_VERSION = "1.4.0";
+const SUPPORTED_LAYOUT_IR_VERSION = "1.5.0";
 
 // Bounded geometric table inference. A run of adjacent lines is treated as a
 // table only when every row fills every detected column, so ragged or

--- a/pdf-toolkit-mcp-share/server/output-schemas.js
+++ b/pdf-toolkit-mcp-share/server/output-schemas.js
@@ -653,10 +653,10 @@ const layoutGlyphRecovery = object({
   font_name: nullable(string),
   registry_id: string,
   qualification: string,
-  charproc_sha256: string,
-  witness_charproc_sha256: stringArray,
+  glyph_sha256: string,
+  witness_glyph_sha256: stringArray,
   tfm_reference_version: string,
-  canonicalizer_version: string,
+  glyph_evidence_version: string,
 });
 const layoutRawItemProperties = {
   id: string,

--- a/pdf-toolkit-mcp-share/server/output-schemas.js
+++ b/pdf-toolkit-mcp-share/server/output-schemas.js
@@ -886,7 +886,7 @@ export const TOOL_SUCCESS_OUTPUT_SCHEMAS = Object.freeze({
     truncated: boolean,
   }),
   read_pdf_layout: object({
-    ir: object({ name: { const: "pdf-tools.extraction-ir" }, version: { const: "1.4.0" } }),
+    ir: object({ name: { const: "pdf-tools.extraction-ir" }, version: { const: "1.5.0" } }),
     parser: object({ name: { const: "pdfjs-dist" }, version: { const: "5.4.624" } }),
     source: object({
       pdf_path: string,
@@ -898,7 +898,7 @@ export const TOOL_SUCCESS_OUTPUT_SCHEMAS = Object.freeze({
       kind: { const: "source_parser_ir_options" },
       source_sha256: { type: "string", pattern: "^[a-f0-9]{64}$" },
       parser_version: { const: "5.4.624" },
-      ir_version: { const: "1.4.0" },
+      ir_version: { const: "1.5.0" },
       requested_start_page: integer,
       requested_end_page: integer,
       max_items: integer,
@@ -952,7 +952,7 @@ export const TOOL_SUCCESS_OUTPUT_SCHEMAS = Object.freeze({
       }),
       layout: object({
         name: { const: "pdf-tools.extraction-ir" },
-        version: { const: "1.4.0" },
+        version: { const: "1.5.0" },
         parser_name: { const: "pdfjs-dist" },
         parser_version: { const: "5.4.624" },
         page_range: object({

--- a/scripts/inventory-type3-glyphs.mjs
+++ b/scripts/inventory-type3-glyphs.mjs
@@ -91,8 +91,8 @@ async function main() {
         occurrence.original_char_code,
         occurrence.source_unicode,
         occurrence.intended_unicode,
-        occurrence.charproc_sha256,
-        occurrence.mapped_code_charproc_sha256,
+        occurrence.glyph_sha256,
+        occurrence.mapped_code_glyph_sha256,
         occurrence.registry_evidence_match_ids,
       ]);
       if (!groups.has(key)) groups.set(key, { ...occurrence, count: 0, pages: new Set(), locations_by_page: {} });
@@ -110,18 +110,18 @@ async function main() {
       source_unicode_codepoints: scalarLabel(group.source_unicode),
       intended_unicode: group.intended_unicode,
       intended_unicode_codepoints: scalarLabel(group.intended_unicode),
-      charproc_sha256: group.charproc_sha256,
-      mapped_code_charproc_sha256: group.mapped_code_charproc_sha256,
+      glyph_sha256: group.glyph_sha256,
+      mapped_code_glyph_sha256: group.mapped_code_glyph_sha256,
       registry_evidence_match_ids: group.registry_evidence_match_ids,
       count: group.count,
       pages: [...group.pages].sort((left, right) => left - right),
       locations_by_page: group.locations_by_page,
       tfm_reference_version: group.tfm_reference_version,
-      canonicalizer_version: group.canonicalizer_version,
+      glyph_evidence_version: group.glyph_evidence_version,
     })).sort((left, right) => right.count - left.count
       || String(left.family).localeCompare(String(right.family))
       || left.original_char_code - right.original_char_code
-      || String(left.charproc_sha256).localeCompare(String(right.charproc_sha256)));
+      || String(left.glyph_sha256).localeCompare(String(right.glyph_sha256)));
     const abstentionGroups = new Map();
     for (const abstention of abstentions) {
       const key = canonicalJson([abstention.reason, abstention.family ?? null]);

--- a/scripts/macos-claude-installed-smoke.mjs
+++ b/scripts/macos-claude-installed-smoke.mjs
@@ -29,7 +29,7 @@ const textFixture = path.join(fixtureDirectory, "synthetic-text-two-page.pdf");
 const rasterFixture = path.join(fixtureDirectory, "synthetic-raster-only.pdf");
 const mutationDirectory = path.join(fixtureDirectory, "mutation-output");
 const toolNames = [];
-const EXPECTED_TOOL_CONTRACT_SHA256 = "d9c225a5b72694d73dc0064a28fecf76a5bedf27121b04e656b86f055ced9313";
+const EXPECTED_TOOL_CONTRACT_SHA256 = "dafeaf19570eece1bb3901f883ea456216b7f46ea6872b80a9eb205c24b9e45f";
 const ACCESSIBILITY_CONCLUSION_KEYS = Object.freeze([
   "certification",
   "document_accessibility",

--- a/scripts/macos-claude-installed-smoke.mjs
+++ b/scripts/macos-claude-installed-smoke.mjs
@@ -29,7 +29,7 @@ const textFixture = path.join(fixtureDirectory, "synthetic-text-two-page.pdf");
 const rasterFixture = path.join(fixtureDirectory, "synthetic-raster-only.pdf");
 const mutationDirectory = path.join(fixtureDirectory, "mutation-output");
 const toolNames = [];
-const EXPECTED_TOOL_CONTRACT_SHA256 = "dafeaf19570eece1bb3901f883ea456216b7f46ea6872b80a9eb205c24b9e45f";
+const EXPECTED_TOOL_CONTRACT_SHA256 = "b980fc09c3b9c886f01e08b82fe67df569e5cafa5471dd4c3e549ac6d8e26fc0";
 const ACCESSIBILITY_CONCLUSION_KEYS = Object.freeze([
   "certification",
   "document_accessibility",

--- a/scripts/smoke-mcpb.mjs
+++ b/scripts/smoke-mcpb.mjs
@@ -218,7 +218,7 @@ async function main() {
       arguments: { pdf_path: fixturePath, max_output_characters: 200000 },
     });
     if (layout.isError
-      || layout.structuredContent?.ir?.version !== "1.4.0"
+      || layout.structuredContent?.ir?.version !== "1.5.0"
       || layout.structuredContent?.source?.size_bytes !== statSync(fixturePath).size) {
       throw new Error("Packed read_pdf_layout contract smoke failed");
     }

--- a/scripts/test-share-contract.mjs
+++ b/scripts/test-share-contract.mjs
@@ -832,7 +832,7 @@ async function main() {
       arguments: { pdf_path: fixturePath, max_output_characters: 200000 },
     });
     if (layout.isError
-      || layout.structuredContent?.ir?.version !== "1.4.0"
+      || layout.structuredContent?.ir?.version !== "1.5.0"
       || layout.structuredContent?.source?.size_bytes !== statSync(fixturePath).size) {
       throw new Error("Share read_pdf_layout contract smoke failed");
     }

--- a/server/layout-extraction.js
+++ b/server/layout-extraction.js
@@ -9,7 +9,7 @@ import {
 } from "./type3-cm-reference.js";
 
 const IR_NAME = "pdf-tools.extraction-ir";
-const IR_VERSION = "1.4.0";
+const IR_VERSION = "1.5.0";
 /*
  * IR_VERSION pin sweep (all must remain aligned):
  * - server/layout-extraction.js: IR_VERSION and EXTRACTION_IR_IDENTITY
@@ -17,7 +17,14 @@ const IR_VERSION = "1.4.0";
  * - server/markdown-conversion.js: supported layout identity
  * - test/read-pdf-layout.test.js, test/convert-pdf-to-markdown.test.js,
  *   test/mcp-contract.test.js, and test/pdfjs-worker-contract.test.js
- * - pdf-toolkit-mcp-share/server/layout-extraction.js and output-schemas.js
+ * - scripts/smoke-mcpb.mjs and scripts/test-share-contract.mjs
+ * - pdf-toolkit-mcp-share/server/layout-extraction.js, markdown-conversion.js,
+ *   and output-schemas.js
+ *
+ * 1.5.0: the Type-3 glyph evidence key is the stored image-mask sample grid.
+ * The published digests under glyph_sha256 and witness_glyph_sha256 all
+ * changed, and those two fields plus glyph_evidence_version replaced the
+ * charproc-named fields of 1.4.0.
  */
 const INTERNAL_SOURCE_REPLAY = Symbol("pdf-layout-internal-source-replay");
 const INTERNAL_MARKDOWN_PROJECTION = Symbol("pdf-layout-internal-markdown-projection");
@@ -59,13 +66,16 @@ const MAX_PAINTED_RECTANGLES = 500;
 /*
  * Type-3 glyph evidence keys.
  *
- * v2 keys a legacy bitmap glyph on its decoded image mask instead of on the
- * CharProc operator list. The operator list folds in the producer's idiom, the
- * inline-image filter it chose, and the per-glyph placement matrix, none of
- * which are properties of the glyph: two documents carrying a pixel-identical
- * Computer Modern raster hashed differently under v1 and now hash the same.
- * Non-mask glyph programs keep the exact operator digest under a separate
- * domain tag, so the two lanes can never satisfy each other's registry entries.
+ * v2 keys a legacy bitmap glyph on the stored samples of its decoded image
+ * mask instead of on the CharProc operator list. The operator list folds in the
+ * producer's idiom, the inline-image filter it chose, and the per-glyph
+ * placement matrix, none of which are properties of the glyph: two documents
+ * carrying a pixel-identical Computer Modern raster hashed differently under v1
+ * and now hash the same. No matrix takes part in the key, because the matrices
+ * that decide painted orientation are not all reachable from inside a CharProc
+ * and keying on the reachable half is what made v1 producer-dependent. Non-mask
+ * glyph programs keep the exact operator digest under a separate domain tag, so
+ * the two lanes can never satisfy each other's registry entries.
  */
 const TYPE3_GLYPH_EVIDENCE_VERSION = "pdfjs-type3-glyph-evidence-v2";
 const TYPE3_MASK_EVIDENCE_DOMAIN = "type3-glyph-image-mask-v1";
@@ -86,11 +96,11 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 11,
     source_unicode: "\u000b",
     target_unicode: "α",
-    glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093",
+    glyph_sha256: "55bb60d8560069c0650380cf09cdd023866ca4b91bb92b2fe4b45a056da1bf47",
     allow_collapsed_whitespace: true,
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 25, glyph_sha256: "751c36c470d1f0292b9d39de8cfec243d0e1e4ca3b2a2648676a8048cdf75322" }),
-      Object.freeze({ original_char_code: 26, glyph_sha256: "ff3b8028f135ce4dbf41a3e3fa8415f54615e9c3e7253d13e9070a71679ccebc" }),
+      Object.freeze({ original_char_code: 25, glyph_sha256: "9554966ab58edc060791bd02f04513a8da4a749f80a943d2daa3460a393fee7f" }),
+      Object.freeze({ original_char_code: 26, glyph_sha256: "eaa7d3cbe50f3ec7903d72addc77f88a471c1dfdc2fd9eb02ce0fbf800068507" }),
     ]),
   }),
   Object.freeze({
@@ -102,8 +112,8 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     target_unicode: ".",
     glyph_sha256: "2ed87b069c99482d0823c085da9c199582e6e4b51172a2b360d9b6652066e3ae",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 59, glyph_sha256: "65e5727a8eb6528fe7013fcf6f2522e93c65ee868f0315850cefd2992e5b7e5b" }),
-      Object.freeze({ original_char_code: 61, glyph_sha256: "2406e228edd78d0d53cc29b48a3154626a47c6fda6b01450cf2c1155cd6b81f7" }),
+      Object.freeze({ original_char_code: 59, glyph_sha256: "b06ab15c9fa4160e3448e0d4cf7e0c6aa1ff13b5dd01ab1406df95d77c279a53" }),
+      Object.freeze({ original_char_code: 61, glyph_sha256: "44505b10d5f364c73f92f52606205ba2fa27a7f96d4dc41c8ba311cc2bc3ffe3" }),
     ]),
   }),
   Object.freeze({
@@ -113,10 +123,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 59,
     source_unicode: ";",
     target_unicode: ",",
-    glyph_sha256: "65e5727a8eb6528fe7013fcf6f2522e93c65ee868f0315850cefd2992e5b7e5b",
+    glyph_sha256: "b06ab15c9fa4160e3448e0d4cf7e0c6aa1ff13b5dd01ab1406df95d77c279a53",
     witnesses: Object.freeze([
       Object.freeze({ original_char_code: 58, glyph_sha256: "2ed87b069c99482d0823c085da9c199582e6e4b51172a2b360d9b6652066e3ae" }),
-      Object.freeze({ original_char_code: 61, glyph_sha256: "2406e228edd78d0d53cc29b48a3154626a47c6fda6b01450cf2c1155cd6b81f7" }),
+      Object.freeze({ original_char_code: 61, glyph_sha256: "44505b10d5f364c73f92f52606205ba2fa27a7f96d4dc41c8ba311cc2bc3ffe3" }),
     ]),
   }),
   Object.freeze({
@@ -126,10 +136,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 25,
     source_unicode: "\u0019",
     target_unicode: "π",
-    glyph_sha256: "751c36c470d1f0292b9d39de8cfec243d0e1e4ca3b2a2648676a8048cdf75322",
+    glyph_sha256: "9554966ab58edc060791bd02f04513a8da4a749f80a943d2daa3460a393fee7f",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
-      Object.freeze({ original_char_code: 26, glyph_sha256: "ff3b8028f135ce4dbf41a3e3fa8415f54615e9c3e7253d13e9070a71679ccebc" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "55bb60d8560069c0650380cf09cdd023866ca4b91bb92b2fe4b45a056da1bf47" }),
+      Object.freeze({ original_char_code: 26, glyph_sha256: "eaa7d3cbe50f3ec7903d72addc77f88a471c1dfdc2fd9eb02ce0fbf800068507" }),
     ]),
   }),
   Object.freeze({
@@ -139,10 +149,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 26,
     source_unicode: "\u001a",
     target_unicode: "ρ",
-    glyph_sha256: "ff3b8028f135ce4dbf41a3e3fa8415f54615e9c3e7253d13e9070a71679ccebc",
+    glyph_sha256: "eaa7d3cbe50f3ec7903d72addc77f88a471c1dfdc2fd9eb02ce0fbf800068507",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
-      Object.freeze({ original_char_code: 25, glyph_sha256: "751c36c470d1f0292b9d39de8cfec243d0e1e4ca3b2a2648676a8048cdf75322" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "55bb60d8560069c0650380cf09cdd023866ca4b91bb92b2fe4b45a056da1bf47" }),
+      Object.freeze({ original_char_code: 25, glyph_sha256: "9554966ab58edc060791bd02f04513a8da4a749f80a943d2daa3460a393fee7f" }),
     ]),
   }),
   Object.freeze({
@@ -152,10 +162,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 33,
     source_unicode: "!",
     target_unicode: "ω",
-    glyph_sha256: "4c740569ca05e182025cfeb2d99d35f6c2655f7674b919fe2f145a33ff4ffdd1",
+    glyph_sha256: "d88e2217762ec495c847bbc7535cfa5a3b083590190c185788dfd69929affa24",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
-      Object.freeze({ original_char_code: 25, glyph_sha256: "751c36c470d1f0292b9d39de8cfec243d0e1e4ca3b2a2648676a8048cdf75322" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "55bb60d8560069c0650380cf09cdd023866ca4b91bb92b2fe4b45a056da1bf47" }),
+      Object.freeze({ original_char_code: 25, glyph_sha256: "9554966ab58edc060791bd02f04513a8da4a749f80a943d2daa3460a393fee7f" }),
     ]),
   }),
   Object.freeze({
@@ -165,10 +175,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 61,
     source_unicode: "=",
     target_unicode: "/",
-    glyph_sha256: "2406e228edd78d0d53cc29b48a3154626a47c6fda6b01450cf2c1155cd6b81f7",
+    glyph_sha256: "44505b10d5f364c73f92f52606205ba2fa27a7f96d4dc41c8ba311cc2bc3ffe3",
     witnesses: Object.freeze([
       Object.freeze({ original_char_code: 58, glyph_sha256: "2ed87b069c99482d0823c085da9c199582e6e4b51172a2b360d9b6652066e3ae" }),
-      Object.freeze({ original_char_code: 59, glyph_sha256: "65e5727a8eb6528fe7013fcf6f2522e93c65ee868f0315850cefd2992e5b7e5b" }),
+      Object.freeze({ original_char_code: 59, glyph_sha256: "b06ab15c9fa4160e3448e0d4cf7e0c6aa1ff13b5dd01ab1406df95d77c279a53" }),
     ]),
   }),
   Object.freeze({
@@ -180,8 +190,8 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     target_unicode: "−",
     glyph_sha256: "68b4a1e125aa58ed3e798029190dbf4e2f3937030f921cd995cf7c8ad2f2eedc",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 21, glyph_sha256: "d2622641d0fa27eba18c91fd6333cfad66cbc23918a88854242d2f0f4c6ca968" }),
-      Object.freeze({ original_char_code: 112, glyph_sha256: "f57899424fb6b62d3a54288b4fb0f41a9edc7b8e17bbd41f0a1e1fac6b743196" }),
+      Object.freeze({ original_char_code: 21, glyph_sha256: "520751dc437215219c1269212ade701dc57b1484416b9bad9ef3da2806bb53e9" }),
+      Object.freeze({ original_char_code: 112, glyph_sha256: "0ecbc7bd327017ee4719d7fa1e0b097bdd7b06557f8a39e11aa7c10a8a408218" }),
     ]),
   }),
   Object.freeze({
@@ -191,10 +201,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 21,
     source_unicode: "\u0015",
     target_unicode: "≥",
-    glyph_sha256: "d2622641d0fa27eba18c91fd6333cfad66cbc23918a88854242d2f0f4c6ca968",
+    glyph_sha256: "520751dc437215219c1269212ade701dc57b1484416b9bad9ef3da2806bb53e9",
     witnesses: Object.freeze([
       Object.freeze({ original_char_code: 0, glyph_sha256: "68b4a1e125aa58ed3e798029190dbf4e2f3937030f921cd995cf7c8ad2f2eedc" }),
-      Object.freeze({ original_char_code: 112, glyph_sha256: "f57899424fb6b62d3a54288b4fb0f41a9edc7b8e17bbd41f0a1e1fac6b743196" }),
+      Object.freeze({ original_char_code: 112, glyph_sha256: "0ecbc7bd327017ee4719d7fa1e0b097bdd7b06557f8a39e11aa7c10a8a408218" }),
     ]),
   }),
   Object.freeze({
@@ -204,10 +214,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 112,
     source_unicode: "p",
     target_unicode: "√",
-    glyph_sha256: "f57899424fb6b62d3a54288b4fb0f41a9edc7b8e17bbd41f0a1e1fac6b743196",
+    glyph_sha256: "0ecbc7bd327017ee4719d7fa1e0b097bdd7b06557f8a39e11aa7c10a8a408218",
     witnesses: Object.freeze([
       Object.freeze({ original_char_code: 0, glyph_sha256: "68b4a1e125aa58ed3e798029190dbf4e2f3937030f921cd995cf7c8ad2f2eedc" }),
-      Object.freeze({ original_char_code: 21, glyph_sha256: "d2622641d0fa27eba18c91fd6333cfad66cbc23918a88854242d2f0f4c6ca968" }),
+      Object.freeze({ original_char_code: 21, glyph_sha256: "520751dc437215219c1269212ade701dc57b1484416b9bad9ef3da2806bb53e9" }),
     ]),
   }),
   Object.freeze({
@@ -217,10 +227,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 33,
     source_unicode: "!",
     target_unicode: "ω",
-    glyph_sha256: "ce4f89e61b842053344c92603d0588263e0118e0321411ae3f798b2f39445fe2",
+    glyph_sha256: "776ec8ccac079e545eeadd4abc00c0384bfd5f8ffe976e754d832ca527aba9f3",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, glyph_sha256: "e9705ccd52613dd5c8dcbff8618f9d825f88b29a9ddcedc01532fd7ba217385f" }),
-      Object.freeze({ original_char_code: 25, glyph_sha256: "fa64dc2c1de162435601ca8107e3a5027cc9dd3ca9d0aaa6998e5736c3f9564a" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "a8e84e0d932585f5ea43e57c1c6aa2ddc349dbf9c95f25dde63d953281094aed" }),
+      Object.freeze({ original_char_code: 25, glyph_sha256: "8844ed36948e6f388a823fa06d5165b38e5c00b68d0a9196c4875d3a5ed4147c" }),
     ]),
   }),
   Object.freeze({
@@ -232,8 +242,8 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     target_unicode: ".",
     glyph_sha256: "8520f46225db90fbb8c41a8ffe4ced238a45f80f3dd74acf4d9b12ec29598513",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 59, glyph_sha256: "67bc7d266ae458bb1c5cf497d1de03ccbc4b85d03457ef2a54e7aa9e91b2ef6a" }),
-      Object.freeze({ original_char_code: 61, glyph_sha256: "7604ca52d40535d2c7205e425d56cb07e19c388dc6ff5806ffe87cc9d811c025" }),
+      Object.freeze({ original_char_code: 59, glyph_sha256: "76bea2467b789bea3b7bf4585d0bea146aa54cf04448d992013837d2febb8ab7" }),
+      Object.freeze({ original_char_code: 61, glyph_sha256: "6564b30a30b414b35c8f5c892e3d63ece09a101e911109fac83f4bff95dc04b5" }),
     ]),
   }),
   Object.freeze({
@@ -243,10 +253,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 61,
     source_unicode: "=",
     target_unicode: "/",
-    glyph_sha256: "7604ca52d40535d2c7205e425d56cb07e19c388dc6ff5806ffe87cc9d811c025",
+    glyph_sha256: "6564b30a30b414b35c8f5c892e3d63ece09a101e911109fac83f4bff95dc04b5",
     witnesses: Object.freeze([
       Object.freeze({ original_char_code: 58, glyph_sha256: "8520f46225db90fbb8c41a8ffe4ced238a45f80f3dd74acf4d9b12ec29598513" }),
-      Object.freeze({ original_char_code: 59, glyph_sha256: "67bc7d266ae458bb1c5cf497d1de03ccbc4b85d03457ef2a54e7aa9e91b2ef6a" }),
+      Object.freeze({ original_char_code: 59, glyph_sha256: "76bea2467b789bea3b7bf4585d0bea146aa54cf04448d992013837d2febb8ab7" }),
     ]),
   }),
   Object.freeze({
@@ -256,10 +266,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 59,
     source_unicode: ";",
     target_unicode: ",",
-    glyph_sha256: "67bc7d266ae458bb1c5cf497d1de03ccbc4b85d03457ef2a54e7aa9e91b2ef6a",
+    glyph_sha256: "76bea2467b789bea3b7bf4585d0bea146aa54cf04448d992013837d2febb8ab7",
     witnesses: Object.freeze([
       Object.freeze({ original_char_code: 58, glyph_sha256: "8520f46225db90fbb8c41a8ffe4ced238a45f80f3dd74acf4d9b12ec29598513" }),
-      Object.freeze({ original_char_code: 61, glyph_sha256: "7604ca52d40535d2c7205e425d56cb07e19c388dc6ff5806ffe87cc9d811c025" }),
+      Object.freeze({ original_char_code: 61, glyph_sha256: "6564b30a30b414b35c8f5c892e3d63ece09a101e911109fac83f4bff95dc04b5" }),
     ]),
   }),
   Object.freeze({
@@ -271,7 +281,7 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     target_unicode: "−",
     glyph_sha256: "ed5df416bb312c2b49ed8936f226016a28e9a09fa52aba56281dd6a8a5430d19",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 6, glyph_sha256: "4734e344eca1f8f73183a34504c1068146b425815a2a8ef6aa00a18dfd45d9a2" }),
+      Object.freeze({ original_char_code: 6, glyph_sha256: "4dd026f859f9674351763f1eec5d88e6ef486555ea12f8eb6a433b1a95238a19" }),
       Object.freeze({ original_char_code: 33, glyph_sha256: "a818ff8e95ae122382e0f0198e875400f4cc07ef1115dbe936ad5dd37933c4d4" }),
     ]),
   }),
@@ -284,8 +294,8 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     target_unicode: "−",
     glyph_sha256: "3f6fdf2abc68f5693f9ea7cdec4d94214a57fb953fb66c747b86dd1f6293d807",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 21, glyph_sha256: "73a2cec4aa27d5042b9f4275179fbf2bb7b99413537597ede0537b7f19c8384c" }),
-      Object.freeze({ original_char_code: 112, glyph_sha256: "f15e035b5867fbee9918125e49566e00b94dcd8422649079c87207e94f7a9e63" }),
+      Object.freeze({ original_char_code: 21, glyph_sha256: "cf5071eb6c006bc80cf9399c28dc00f7e12d8e7f090942de46cb06d404481dd6" }),
+      Object.freeze({ original_char_code: 112, glyph_sha256: "da5345f465509486a66762b6cf8918a3ba5c937f4ca8c7bc4657f4f905d0b4be" }),
     ]),
   }),
   Object.freeze({
@@ -310,8 +320,8 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     target_unicode: ".",
     glyph_sha256: "8520f46225db90fbb8c41a8ffe4ced238a45f80f3dd74acf4d9b12ec29598513",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 59, glyph_sha256: "5363832452620aa888b74219c2a632d1e58a27060bffb1cf6392bf5b2fad8316" }),
-      Object.freeze({ original_char_code: 61, glyph_sha256: "f1c63f92441a1dc720dac5d5d39e38da21d397d81e32c4a87a5bfa34c50b8f8d" }),
+      Object.freeze({ original_char_code: 59, glyph_sha256: "be90d1c78149ab81005db5ce23c2ad819399c82bc16bdc7b41de5a3e3a2ee494" }),
+      Object.freeze({ original_char_code: 61, glyph_sha256: "7102f7980d961e8217c684332b9fe84a9a9f31290153ccf1ee784ffb16527665" }),
     ]),
   }),
   Object.freeze({
@@ -321,10 +331,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 59,
     source_unicode: ";",
     target_unicode: ",",
-    glyph_sha256: "5363832452620aa888b74219c2a632d1e58a27060bffb1cf6392bf5b2fad8316",
+    glyph_sha256: "be90d1c78149ab81005db5ce23c2ad819399c82bc16bdc7b41de5a3e3a2ee494",
     witnesses: Object.freeze([
       Object.freeze({ original_char_code: 58, glyph_sha256: "8520f46225db90fbb8c41a8ffe4ced238a45f80f3dd74acf4d9b12ec29598513" }),
-      Object.freeze({ original_char_code: 61, glyph_sha256: "f1c63f92441a1dc720dac5d5d39e38da21d397d81e32c4a87a5bfa34c50b8f8d" }),
+      Object.freeze({ original_char_code: 61, glyph_sha256: "7102f7980d961e8217c684332b9fe84a9a9f31290153ccf1ee784ffb16527665" }),
     ]),
   }),
   Object.freeze({
@@ -334,10 +344,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 61,
     source_unicode: "=",
     target_unicode: "/",
-    glyph_sha256: "f1c63f92441a1dc720dac5d5d39e38da21d397d81e32c4a87a5bfa34c50b8f8d",
+    glyph_sha256: "7102f7980d961e8217c684332b9fe84a9a9f31290153ccf1ee784ffb16527665",
     witnesses: Object.freeze([
       Object.freeze({ original_char_code: 58, glyph_sha256: "8520f46225db90fbb8c41a8ffe4ced238a45f80f3dd74acf4d9b12ec29598513" }),
-      Object.freeze({ original_char_code: 59, glyph_sha256: "5363832452620aa888b74219c2a632d1e58a27060bffb1cf6392bf5b2fad8316" }),
+      Object.freeze({ original_char_code: 59, glyph_sha256: "be90d1c78149ab81005db5ce23c2ad819399c82bc16bdc7b41de5a3e3a2ee494" }),
     ]),
   }),
   Object.freeze({
@@ -347,11 +357,11 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 11,
     source_unicode: "\u000b",
     target_unicode: "α",
-    glyph_sha256: "6092e20a2f8a4925449780db726c4912ccee956a094589d3cb63ede3b5d7383b",
+    glyph_sha256: "afd53079aef8914177830dd32a4751df81d06ef083e4d1a0fc641896dc827fb4",
     allow_collapsed_whitespace: true,
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 25, glyph_sha256: "38b7cc2fac5858dfd6acc1c7936eb874900c61299c8758edc607cb91cbd68b39" }),
-      Object.freeze({ original_char_code: 26, glyph_sha256: "8271aed349c3127895bf7d96b57c83fd62b03cc6c9c9428e600a58b269899365" }),
+      Object.freeze({ original_char_code: 25, glyph_sha256: "ef3b94ad4d1be76d84c62c89da120449668fd9b47cd120922110a9a7977c45f0" }),
+      Object.freeze({ original_char_code: 26, glyph_sha256: "a98c60dd17ef1c118bbdd5ae57e81f7a5cc843450fa650017b64372445a3a5a4" }),
     ]),
   }),
   Object.freeze({
@@ -361,10 +371,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 25,
     source_unicode: "\u0019",
     target_unicode: "π",
-    glyph_sha256: "38b7cc2fac5858dfd6acc1c7936eb874900c61299c8758edc607cb91cbd68b39",
+    glyph_sha256: "ef3b94ad4d1be76d84c62c89da120449668fd9b47cd120922110a9a7977c45f0",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, glyph_sha256: "6092e20a2f8a4925449780db726c4912ccee956a094589d3cb63ede3b5d7383b" }),
-      Object.freeze({ original_char_code: 26, glyph_sha256: "8271aed349c3127895bf7d96b57c83fd62b03cc6c9c9428e600a58b269899365" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "afd53079aef8914177830dd32a4751df81d06ef083e4d1a0fc641896dc827fb4" }),
+      Object.freeze({ original_char_code: 26, glyph_sha256: "a98c60dd17ef1c118bbdd5ae57e81f7a5cc843450fa650017b64372445a3a5a4" }),
     ]),
   }),
   Object.freeze({
@@ -374,10 +384,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 26,
     source_unicode: "\u001a",
     target_unicode: "ρ",
-    glyph_sha256: "8271aed349c3127895bf7d96b57c83fd62b03cc6c9c9428e600a58b269899365",
+    glyph_sha256: "a98c60dd17ef1c118bbdd5ae57e81f7a5cc843450fa650017b64372445a3a5a4",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, glyph_sha256: "6092e20a2f8a4925449780db726c4912ccee956a094589d3cb63ede3b5d7383b" }),
-      Object.freeze({ original_char_code: 25, glyph_sha256: "38b7cc2fac5858dfd6acc1c7936eb874900c61299c8758edc607cb91cbd68b39" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "afd53079aef8914177830dd32a4751df81d06ef083e4d1a0fc641896dc827fb4" }),
+      Object.freeze({ original_char_code: 25, glyph_sha256: "ef3b94ad4d1be76d84c62c89da120449668fd9b47cd120922110a9a7977c45f0" }),
     ]),
   }),
   Object.freeze({
@@ -387,11 +397,11 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 11,
     source_unicode: "\u000b",
     target_unicode: "α",
-    glyph_sha256: "e9705ccd52613dd5c8dcbff8618f9d825f88b29a9ddcedc01532fd7ba217385f",
+    glyph_sha256: "a8e84e0d932585f5ea43e57c1c6aa2ddc349dbf9c95f25dde63d953281094aed",
     allow_collapsed_whitespace: true,
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 25, glyph_sha256: "fa64dc2c1de162435601ca8107e3a5027cc9dd3ca9d0aaa6998e5736c3f9564a" }),
-      Object.freeze({ original_char_code: 26, glyph_sha256: "509f130688569e2b0b333a102fcaee164efdc687a94db9d7a40c928009129431" }),
+      Object.freeze({ original_char_code: 25, glyph_sha256: "8844ed36948e6f388a823fa06d5165b38e5c00b68d0a9196c4875d3a5ed4147c" }),
+      Object.freeze({ original_char_code: 26, glyph_sha256: "4cbdb66a4c77a8d3544a862526cbf6918a1575df24ee425489fd4266aeaf0f2d" }),
     ]),
   }),
   Object.freeze({
@@ -401,10 +411,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 25,
     source_unicode: "\u0019",
     target_unicode: "π",
-    glyph_sha256: "fa64dc2c1de162435601ca8107e3a5027cc9dd3ca9d0aaa6998e5736c3f9564a",
+    glyph_sha256: "8844ed36948e6f388a823fa06d5165b38e5c00b68d0a9196c4875d3a5ed4147c",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, glyph_sha256: "e9705ccd52613dd5c8dcbff8618f9d825f88b29a9ddcedc01532fd7ba217385f" }),
-      Object.freeze({ original_char_code: 26, glyph_sha256: "509f130688569e2b0b333a102fcaee164efdc687a94db9d7a40c928009129431" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "a8e84e0d932585f5ea43e57c1c6aa2ddc349dbf9c95f25dde63d953281094aed" }),
+      Object.freeze({ original_char_code: 26, glyph_sha256: "4cbdb66a4c77a8d3544a862526cbf6918a1575df24ee425489fd4266aeaf0f2d" }),
     ]),
   }),
   Object.freeze({
@@ -414,10 +424,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 26,
     source_unicode: "\u001a",
     target_unicode: "ρ",
-    glyph_sha256: "509f130688569e2b0b333a102fcaee164efdc687a94db9d7a40c928009129431",
+    glyph_sha256: "4cbdb66a4c77a8d3544a862526cbf6918a1575df24ee425489fd4266aeaf0f2d",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, glyph_sha256: "e9705ccd52613dd5c8dcbff8618f9d825f88b29a9ddcedc01532fd7ba217385f" }),
-      Object.freeze({ original_char_code: 25, glyph_sha256: "fa64dc2c1de162435601ca8107e3a5027cc9dd3ca9d0aaa6998e5736c3f9564a" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "a8e84e0d932585f5ea43e57c1c6aa2ddc349dbf9c95f25dde63d953281094aed" }),
+      Object.freeze({ original_char_code: 25, glyph_sha256: "8844ed36948e6f388a823fa06d5165b38e5c00b68d0a9196c4875d3a5ed4147c" }),
     ]),
   }),
   Object.freeze({
@@ -427,10 +437,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 21,
     source_unicode: "\u0015",
     target_unicode: "≥",
-    glyph_sha256: "73a2cec4aa27d5042b9f4275179fbf2bb7b99413537597ede0537b7f19c8384c",
+    glyph_sha256: "cf5071eb6c006bc80cf9399c28dc00f7e12d8e7f090942de46cb06d404481dd6",
     witnesses: Object.freeze([
       Object.freeze({ original_char_code: 0, glyph_sha256: "3f6fdf2abc68f5693f9ea7cdec4d94214a57fb953fb66c747b86dd1f6293d807" }),
-      Object.freeze({ original_char_code: 112, glyph_sha256: "f15e035b5867fbee9918125e49566e00b94dcd8422649079c87207e94f7a9e63" }),
+      Object.freeze({ original_char_code: 112, glyph_sha256: "da5345f465509486a66762b6cf8918a3ba5c937f4ca8c7bc4657f4f905d0b4be" }),
     ]),
   }),
   Object.freeze({
@@ -440,10 +450,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 112,
     source_unicode: "p",
     target_unicode: "√",
-    glyph_sha256: "f15e035b5867fbee9918125e49566e00b94dcd8422649079c87207e94f7a9e63",
+    glyph_sha256: "da5345f465509486a66762b6cf8918a3ba5c937f4ca8c7bc4657f4f905d0b4be",
     witnesses: Object.freeze([
       Object.freeze({ original_char_code: 0, glyph_sha256: "3f6fdf2abc68f5693f9ea7cdec4d94214a57fb953fb66c747b86dd1f6293d807" }),
-      Object.freeze({ original_char_code: 21, glyph_sha256: "73a2cec4aa27d5042b9f4275179fbf2bb7b99413537597ede0537b7f19c8384c" }),
+      Object.freeze({ original_char_code: 21, glyph_sha256: "cf5071eb6c006bc80cf9399c28dc00f7e12d8e7f090942de46cb06d404481dd6" }),
     ]),
   }),
   Object.freeze({
@@ -456,7 +466,7 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     glyph_sha256: "2ed87b069c99482d0823c085da9c199582e6e4b51172a2b360d9b6652066e3ae",
     witnesses: Object.freeze([
       Object.freeze({ original_char_code: 0, glyph_sha256: "68b4a1e125aa58ed3e798029190dbf4e2f3937030f921cd995cf7c8ad2f2eedc" }),
-      Object.freeze({ original_char_code: 6, glyph_sha256: "009835b7eda7745c9e2e167ce0ed1b5e4ff9063af4c92280dffab3213f07e395" }),
+      Object.freeze({ original_char_code: 6, glyph_sha256: "f7b39315fb585e4066816ab2d3d3d07e1b1d79bb9a30fdae7fbf5588d2873906" }),
     ]),
   }),
   Object.freeze({
@@ -466,7 +476,7 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 20,
     source_unicode: "\u0014",
     target_unicode: "≤",
-    glyph_sha256: "b7694606e91a2a5ad7ad6b16032289f5f4bcca7d7528ef93759e39908c68d8c4",
+    glyph_sha256: "1f5c8de996c9b3c20c6503052f62d18022e4b97537957d565a0b3668c3c4918d",
     witnesses: Object.freeze([
       Object.freeze({ original_char_code: 0, glyph_sha256: "68b4a1e125aa58ed3e798029190dbf4e2f3937030f921cd995cf7c8ad2f2eedc" }),
       Object.freeze({ original_char_code: 1, glyph_sha256: "2ed87b069c99482d0823c085da9c199582e6e4b51172a2b360d9b6652066e3ae" }),
@@ -479,10 +489,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 48,
     source_unicode: "0",
     target_unicode: "′",
-    glyph_sha256: "a24e8c43c1c680cc6c2a676adb046c59ca00ebe5116ed583b37f3b1d6a39cc66",
+    glyph_sha256: "70c2850ba731163e1e74c60f354ca5407181fd97b75b500deba6e92fe068f6ea",
     witnesses: Object.freeze([
       Object.freeze({ original_char_code: 0, glyph_sha256: "ed5df416bb312c2b49ed8936f226016a28e9a09fa52aba56281dd6a8a5430d19" }),
-      Object.freeze({ original_char_code: 6, glyph_sha256: "4734e344eca1f8f73183a34504c1068146b425815a2a8ef6aa00a18dfd45d9a2" }),
+      Object.freeze({ original_char_code: 6, glyph_sha256: "4dd026f859f9674351763f1eec5d88e6ef486555ea12f8eb6a433b1a95238a19" }),
     ]),
   }),
   Object.freeze({
@@ -713,10 +723,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 1,
     source_unicode: "\u0001",
     target_unicode: "Δ",
-    glyph_sha256: "30552b3ff5ae9fae4095b2a791d73b448221a488c7b6ede9ddfb6852f474a052",
+    glyph_sha256: "d3461f539f11089075b8a98c57a23114902418575458cb92fad483e950129164",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
-      Object.freeze({ original_char_code: 14, glyph_sha256: "8d55a727feda11508e29c3b5c500d64dc58ce7b6fdb3d9776ef1e0d2df7888a3" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "55bb60d8560069c0650380cf09cdd023866ca4b91bb92b2fe4b45a056da1bf47" }),
+      Object.freeze({ original_char_code: 14, glyph_sha256: "b2f587826f470886f73db237c0dcc326ea588e176bee087052b5ee7fec6e4cd6" }),
     ]),
   }),
   Object.freeze({
@@ -726,10 +736,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 14,
     source_unicode: "\u000e",
     target_unicode: "δ",
-    glyph_sha256: "8d55a727feda11508e29c3b5c500d64dc58ce7b6fdb3d9776ef1e0d2df7888a3",
+    glyph_sha256: "b2f587826f470886f73db237c0dcc326ea588e176bee087052b5ee7fec6e4cd6",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 1, glyph_sha256: "30552b3ff5ae9fae4095b2a791d73b448221a488c7b6ede9ddfb6852f474a052" }),
-      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "d3461f539f11089075b8a98c57a23114902418575458cb92fad483e950129164" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "55bb60d8560069c0650380cf09cdd023866ca4b91bb92b2fe4b45a056da1bf47" }),
     ]),
   }),
   Object.freeze({
@@ -739,10 +749,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 14,
     source_unicode: "\u000e",
     target_unicode: "δ",
-    glyph_sha256: "40e6d476435323a686a4ef5f02ac43f6b6b5e3612887c18105b82575e76e2e9b",
+    glyph_sha256: "e8cb8e148c83465beb80f9a888fecb2b5b9a0e4625701b97cc149ffc893ed1ed",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, glyph_sha256: "6092e20a2f8a4925449780db726c4912ccee956a094589d3cb63ede3b5d7383b" }),
-      Object.freeze({ original_char_code: 15, glyph_sha256: "8692c50f6e5d1605e52e3d414ad4c285a583d11bcfff2f7a3be93bee06117de5" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "afd53079aef8914177830dd32a4751df81d06ef083e4d1a0fc641896dc827fb4" }),
+      Object.freeze({ original_char_code: 15, glyph_sha256: "cb992b6a906e74dce8a20f585dc7c3befd47b7f99356f6e0acfeff69b324a367" }),
     ]),
   }),
   Object.freeze({
@@ -752,10 +762,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 15,
     source_unicode: "\u000f",
     target_unicode: "ϵ",
-    glyph_sha256: "da7780d95a5aea753d5de0f042903c2e96618c719283db449cd0476c5e74a6a4",
+    glyph_sha256: "c05d44175c21bf871787e49b7e44630f1424dec624ed460442d05060a67283df",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 1, glyph_sha256: "30552b3ff5ae9fae4095b2a791d73b448221a488c7b6ede9ddfb6852f474a052" }),
-      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "d3461f539f11089075b8a98c57a23114902418575458cb92fad483e950129164" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "55bb60d8560069c0650380cf09cdd023866ca4b91bb92b2fe4b45a056da1bf47" }),
     ]),
   }),
   Object.freeze({
@@ -765,10 +775,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 15,
     source_unicode: "\u000f",
     target_unicode: "ϵ",
-    glyph_sha256: "8692c50f6e5d1605e52e3d414ad4c285a583d11bcfff2f7a3be93bee06117de5",
+    glyph_sha256: "cb992b6a906e74dce8a20f585dc7c3befd47b7f99356f6e0acfeff69b324a367",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, glyph_sha256: "6092e20a2f8a4925449780db726c4912ccee956a094589d3cb63ede3b5d7383b" }),
-      Object.freeze({ original_char_code: 14, glyph_sha256: "40e6d476435323a686a4ef5f02ac43f6b6b5e3612887c18105b82575e76e2e9b" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "afd53079aef8914177830dd32a4751df81d06ef083e4d1a0fc641896dc827fb4" }),
+      Object.freeze({ original_char_code: 14, glyph_sha256: "e8cb8e148c83465beb80f9a888fecb2b5b9a0e4625701b97cc149ffc893ed1ed" }),
     ]),
   }),
   Object.freeze({
@@ -778,10 +788,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 17,
     source_unicode: "\u0011",
     target_unicode: "η",
-    glyph_sha256: "8a211c038232f3e28545e3d2f4a42ebd349a8cc27e45bc0a6775b4cd105cfb9c",
+    glyph_sha256: "9d63d43c9de79f2045762af5a19d73f86c29c9dfbbb96ca3913f7a7d3fe83255",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, glyph_sha256: "6092e20a2f8a4925449780db726c4912ccee956a094589d3cb63ede3b5d7383b" }),
-      Object.freeze({ original_char_code: 14, glyph_sha256: "40e6d476435323a686a4ef5f02ac43f6b6b5e3612887c18105b82575e76e2e9b" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "afd53079aef8914177830dd32a4751df81d06ef083e4d1a0fc641896dc827fb4" }),
+      Object.freeze({ original_char_code: 14, glyph_sha256: "e8cb8e148c83465beb80f9a888fecb2b5b9a0e4625701b97cc149ffc893ed1ed" }),
     ]),
   }),
   Object.freeze({
@@ -791,10 +801,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 18,
     source_unicode: "\u0012",
     target_unicode: "θ",
-    glyph_sha256: "1687afb884c912cf4555cef231572f37ac3eabe87344bc993fc3880d5eabdd2a",
+    glyph_sha256: "2f363c697c4ee84b7785dc606f0b38c93d8f4d63ea076784943858eae5c58859",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, glyph_sha256: "6092e20a2f8a4925449780db726c4912ccee956a094589d3cb63ede3b5d7383b" }),
-      Object.freeze({ original_char_code: 14, glyph_sha256: "40e6d476435323a686a4ef5f02ac43f6b6b5e3612887c18105b82575e76e2e9b" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "afd53079aef8914177830dd32a4751df81d06ef083e4d1a0fc641896dc827fb4" }),
+      Object.freeze({ original_char_code: 14, glyph_sha256: "e8cb8e148c83465beb80f9a888fecb2b5b9a0e4625701b97cc149ffc893ed1ed" }),
     ]),
   }),
   Object.freeze({
@@ -804,10 +814,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 21,
     source_unicode: "\u0015",
     target_unicode: "λ",
-    glyph_sha256: "bdf1508d236990157b905ae312c6daf9452a27e2e15f0d239e174047d700327f",
+    glyph_sha256: "41831967f0efef3f08cc7cdc544673323d526955d54eb70a02c0759c7fd4a2ff",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 1, glyph_sha256: "30552b3ff5ae9fae4095b2a791d73b448221a488c7b6ede9ddfb6852f474a052" }),
-      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "d3461f539f11089075b8a98c57a23114902418575458cb92fad483e950129164" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "55bb60d8560069c0650380cf09cdd023866ca4b91bb92b2fe4b45a056da1bf47" }),
     ]),
   }),
   Object.freeze({
@@ -817,10 +827,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 21,
     source_unicode: "\u0015",
     target_unicode: "λ",
-    glyph_sha256: "50a0ec752f73c00a5126d9e2ac8c9d3b97058ebd24e08570f18a994cad8702bd",
+    glyph_sha256: "75980da7a10a36beb8fccf4970e9295c03fe44be69bf167dacfdead776e5163f",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, glyph_sha256: "6092e20a2f8a4925449780db726c4912ccee956a094589d3cb63ede3b5d7383b" }),
-      Object.freeze({ original_char_code: 14, glyph_sha256: "40e6d476435323a686a4ef5f02ac43f6b6b5e3612887c18105b82575e76e2e9b" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "afd53079aef8914177830dd32a4751df81d06ef083e4d1a0fc641896dc827fb4" }),
+      Object.freeze({ original_char_code: 14, glyph_sha256: "e8cb8e148c83465beb80f9a888fecb2b5b9a0e4625701b97cc149ffc893ed1ed" }),
     ]),
   }),
   Object.freeze({
@@ -830,10 +840,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 22,
     source_unicode: "\u0016",
     target_unicode: "μ",
-    glyph_sha256: "58753b33f3d1d72955b0f1ef1777c5455c5ba37588f5fd88a0271ddcc0f46a75",
+    glyph_sha256: "9bb6e58efa558b61d35a7d6c83ee5d6404c734858f689177a6527efe04065404",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 1, glyph_sha256: "30552b3ff5ae9fae4095b2a791d73b448221a488c7b6ede9ddfb6852f474a052" }),
-      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "d3461f539f11089075b8a98c57a23114902418575458cb92fad483e950129164" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "55bb60d8560069c0650380cf09cdd023866ca4b91bb92b2fe4b45a056da1bf47" }),
     ]),
   }),
   Object.freeze({
@@ -843,10 +853,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 23,
     source_unicode: "\u0017",
     target_unicode: "ν",
-    glyph_sha256: "d56aaf7b101a1a8f54fb062c3176637576fc6d46c262c250b1082d5c606853c7",
+    glyph_sha256: "6f42ddf03199aeb21b3487177b315979b4afafe5f3a499805c49bf5bd46d719e",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 1, glyph_sha256: "30552b3ff5ae9fae4095b2a791d73b448221a488c7b6ede9ddfb6852f474a052" }),
-      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "d3461f539f11089075b8a98c57a23114902418575458cb92fad483e950129164" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "55bb60d8560069c0650380cf09cdd023866ca4b91bb92b2fe4b45a056da1bf47" }),
     ]),
   }),
   Object.freeze({
@@ -856,10 +866,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 27,
     source_unicode: "\u001b",
     target_unicode: "σ",
-    glyph_sha256: "c9a619efc5cd6a08c8ca09b92aca0d61391929ca7846322b4baf0d3f38edc5d8",
+    glyph_sha256: "06ec7ab10994040dc4927dbc3da9884ebf14f0da502e9240cdaec07d1443998d",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, glyph_sha256: "6092e20a2f8a4925449780db726c4912ccee956a094589d3cb63ede3b5d7383b" }),
-      Object.freeze({ original_char_code: 14, glyph_sha256: "40e6d476435323a686a4ef5f02ac43f6b6b5e3612887c18105b82575e76e2e9b" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "afd53079aef8914177830dd32a4751df81d06ef083e4d1a0fc641896dc827fb4" }),
+      Object.freeze({ original_char_code: 14, glyph_sha256: "e8cb8e148c83465beb80f9a888fecb2b5b9a0e4625701b97cc149ffc893ed1ed" }),
     ]),
   }),
   Object.freeze({
@@ -869,10 +879,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 28,
     source_unicode: "\u001c",
     target_unicode: "τ",
-    glyph_sha256: "10338ccd15eb973844cbbc07005a82aa702020cd2910adb162e71870fc67f82a",
+    glyph_sha256: "c01bf46eb9a8d19c7fb57d94905839c2fc2ba40450c736e8996ccd72948fa4ab",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 1, glyph_sha256: "30552b3ff5ae9fae4095b2a791d73b448221a488c7b6ede9ddfb6852f474a052" }),
-      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "d3461f539f11089075b8a98c57a23114902418575458cb92fad483e950129164" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "55bb60d8560069c0650380cf09cdd023866ca4b91bb92b2fe4b45a056da1bf47" }),
     ]),
   }),
   Object.freeze({
@@ -882,10 +892,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 39,
     source_unicode: "'",
     target_unicode: "φ",
-    glyph_sha256: "4231ef8441ffbc9e7bc7693f3ec28d2de301d0edc6f9df6f69968a95af266e97",
+    glyph_sha256: "31ddaca9be2bbf03dd58481b7516a3447a4ce89938ce2d99067b37805e08debd",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 1, glyph_sha256: "30552b3ff5ae9fae4095b2a791d73b448221a488c7b6ede9ddfb6852f474a052" }),
-      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "d3461f539f11089075b8a98c57a23114902418575458cb92fad483e950129164" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "55bb60d8560069c0650380cf09cdd023866ca4b91bb92b2fe4b45a056da1bf47" }),
     ]),
   }),
   Object.freeze({
@@ -895,10 +905,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 82,
     source_unicode: "R",
     target_unicode: "∫",
-    glyph_sha256: "58d503ac1ab67ecadd8e1ec07991a8338ddd452f5c3069dcba0ebe52e42fb3ee",
+    glyph_sha256: "362d48887daf303c09269e0fbc69db2338f062ce758cd9e242d3306f9f0c1952",
     complete_font_enrollment: Object.freeze([82, 90]),
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 90, glyph_sha256: "063d12bd3f8fba24a0375a5da378e3a0acb6195c42f91625ea0798dba6545ed7" }),
+      Object.freeze({ original_char_code: 90, glyph_sha256: "e5844045853943e3424dc224e60ba1217a509b2cc8e20f67a3504b141ed3c9c9" }),
     ]),
   }),
   Object.freeze({
@@ -908,10 +918,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 90,
     source_unicode: "Z",
     target_unicode: "∫",
-    glyph_sha256: "063d12bd3f8fba24a0375a5da378e3a0acb6195c42f91625ea0798dba6545ed7",
+    glyph_sha256: "e5844045853943e3424dc224e60ba1217a509b2cc8e20f67a3504b141ed3c9c9",
     complete_font_enrollment: Object.freeze([82, 90]),
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 82, glyph_sha256: "58d503ac1ab67ecadd8e1ec07991a8338ddd452f5c3069dcba0ebe52e42fb3ee" }),
+      Object.freeze({ original_char_code: 82, glyph_sha256: "362d48887daf303c09269e0fbc69db2338f062ce758cd9e242d3306f9f0c1952" }),
     ]),
   }),
   Object.freeze({
@@ -921,7 +931,7 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 6,
     source_unicode: "\u0006",
     target_unicode: "±",
-    glyph_sha256: "4734e344eca1f8f73183a34504c1068146b425815a2a8ef6aa00a18dfd45d9a2",
+    glyph_sha256: "4dd026f859f9674351763f1eec5d88e6ef486555ea12f8eb6a433b1a95238a19",
     witnesses: Object.freeze([
       Object.freeze({ original_char_code: 0, glyph_sha256: "ed5df416bb312c2b49ed8936f226016a28e9a09fa52aba56281dd6a8a5430d19" }),
       Object.freeze({ original_char_code: 33, glyph_sha256: "a818ff8e95ae122382e0f0198e875400f4cc07ef1115dbe936ad5dd37933c4d4" }),
@@ -950,7 +960,7 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     glyph_sha256: "a818ff8e95ae122382e0f0198e875400f4cc07ef1115dbe936ad5dd37933c4d4",
     witnesses: Object.freeze([
       Object.freeze({ original_char_code: 0, glyph_sha256: "ed5df416bb312c2b49ed8936f226016a28e9a09fa52aba56281dd6a8a5430d19" }),
-      Object.freeze({ original_char_code: 6, glyph_sha256: "4734e344eca1f8f73183a34504c1068146b425815a2a8ef6aa00a18dfd45d9a2" }),
+      Object.freeze({ original_char_code: 6, glyph_sha256: "4dd026f859f9674351763f1eec5d88e6ef486555ea12f8eb6a433b1a95238a19" }),
     ]),
   }),
   Object.freeze({
@@ -960,10 +970,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 17,
     source_unicode: "\u0011",
     target_unicode: "η",
-    glyph_sha256: "712ac34ba1c3de89b2c233171e58eaa55e54ebcb0d4cec1609a788fa90eef047",
+    glyph_sha256: "b92c6fb549abb85d45c5ef490227e3accba0f512901b57fb72079a7232ed51fe",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
-      Object.freeze({ original_char_code: 25, glyph_sha256: "751c36c470d1f0292b9d39de8cfec243d0e1e4ca3b2a2648676a8048cdf75322" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "55bb60d8560069c0650380cf09cdd023866ca4b91bb92b2fe4b45a056da1bf47" }),
+      Object.freeze({ original_char_code: 25, glyph_sha256: "9554966ab58edc060791bd02f04513a8da4a749f80a943d2daa3460a393fee7f" }),
     ]),
   }),
   Object.freeze({
@@ -973,10 +983,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 18,
     source_unicode: "\u0012",
     target_unicode: "θ",
-    glyph_sha256: "38d2baa791ebd167d9d328153bd4cabcb722c833e759315f3a398537e0f57e03",
+    glyph_sha256: "23102a1771564bb5329a4dbceb26cb3c92ee878dc907664891121ffd96cd4924",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
-      Object.freeze({ original_char_code: 25, glyph_sha256: "751c36c470d1f0292b9d39de8cfec243d0e1e4ca3b2a2648676a8048cdf75322" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "55bb60d8560069c0650380cf09cdd023866ca4b91bb92b2fe4b45a056da1bf47" }),
+      Object.freeze({ original_char_code: 25, glyph_sha256: "9554966ab58edc060791bd02f04513a8da4a749f80a943d2daa3460a393fee7f" }),
     ]),
   }),
   Object.freeze({
@@ -986,10 +996,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 27,
     source_unicode: "\u001b",
     target_unicode: "σ",
-    glyph_sha256: "de609d12d1935bc3ff128046fa3c5f4330689ded53c9fc7a179a0b7c368f9f9a",
+    glyph_sha256: "dfba03d4b605f4ae62fd08d5829cc2e26549f0f40d2d2b9a11adf2db1046a10a",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
-      Object.freeze({ original_char_code: 25, glyph_sha256: "751c36c470d1f0292b9d39de8cfec243d0e1e4ca3b2a2648676a8048cdf75322" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "55bb60d8560069c0650380cf09cdd023866ca4b91bb92b2fe4b45a056da1bf47" }),
+      Object.freeze({ original_char_code: 25, glyph_sha256: "9554966ab58edc060791bd02f04513a8da4a749f80a943d2daa3460a393fee7f" }),
     ]),
   }),
   Object.freeze({
@@ -999,10 +1009,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 6,
     source_unicode: "\u0006",
     target_unicode: "±",
-    glyph_sha256: "009835b7eda7745c9e2e167ce0ed1b5e4ff9063af4c92280dffab3213f07e395",
+    glyph_sha256: "f7b39315fb585e4066816ab2d3d3d07e1b1d79bb9a30fdae7fbf5588d2873906",
     witnesses: Object.freeze([
       Object.freeze({ original_char_code: 0, glyph_sha256: "68b4a1e125aa58ed3e798029190dbf4e2f3937030f921cd995cf7c8ad2f2eedc" }),
-      Object.freeze({ original_char_code: 21, glyph_sha256: "d2622641d0fa27eba18c91fd6333cfad66cbc23918a88854242d2f0f4c6ca968" }),
+      Object.freeze({ original_char_code: 21, glyph_sha256: "520751dc437215219c1269212ade701dc57b1484416b9bad9ef3da2806bb53e9" }),
     ]),
   }),
 ]);
@@ -1157,13 +1167,26 @@ function type3GlyphImageMask(charProc, fontMatrix, ops) {
   if (!Number.isInteger(width) || !Number.isInteger(height) || width <= 0 || height <= 0) return null;
   if (width * height > MAX_TYPE3_GLYPH_MASK_PIXELS) return null;
   if (path.length > MAX_TYPE3_GLYPH_MASK_PATH_NODES) return null;
-  // Only an axis-aligned, non-degenerate placement has an unambiguous mirror
-  // decomposition; a rotated or skewed glyph program is left unrecognized.
+  // Exactly what this checks: the CharProc-local matrix, meaning the font's
+  // FontMatrix composed with the `cm` chain written inside this one glyph
+  // program. Exactly what it does NOT check, and cannot: the text matrix and
+  // the graphics CTM in force at the `Tj` that draws the glyph. Those are set
+  // by the page content stream outside the CharProc and are invisible here, so
+  // nothing below is a statement about the orientation the glyph is finally
+  // painted in.
+  //
+  // That gap is deliberate rather than tolerated. The key is the stored sample
+  // grid, which no matrix anywhere can alter, so painted orientation is not an
+  // input to it. This check survives only to hold the mask lane to the plain
+  // axis-aligned, non-degenerate scale-or-reflection bitmap idiom every
+  // enrolled entry was qualified on: a glyph program that rotates, shears, or
+  // collapses its own bitmap is a different construction and is keyed by the
+  // exact operator digest instead of by this lane.
   if (Math.abs(transform[1]) > 1e-9 || Math.abs(transform[2]) > 1e-9) return null;
   if (!(Math.abs(transform[0]) > 0) || !(Math.abs(transform[3]) > 0)) return null;
   const bits = fillAxisAlignedLatticePath(path, width, height);
   if (!bits) return null;
-  return { width, height, bits, mirror_x: transform[0] < 0, mirror_y: transform[3] < 0 };
+  return { width, height, bits };
 }
 
 function fillAxisAlignedLatticePath(path, width, height) {
@@ -1200,8 +1223,8 @@ function fillAxisAlignedLatticePath(path, width, height) {
     if (index + 1 >= path.length) return null;
     const x = lattice(path[index], width);
     // PDF.js emits the traced outline y-up in the unit square, so unit y 1 is
-    // image row 0. Reading it back as a row index keeps the grid in the
-    // stored sample order and leaves orientation to the canonical step.
+    // image row 0. Reading it back as a row index recovers the grid in the
+    // stored sample order, which is the order the key is taken in.
     const y = lattice(1 - path[index + 1], height);
     index += 2;
     if (x === null || y === null) return null;
@@ -1233,14 +1256,34 @@ function fillAxisAlignedLatticePath(path, width, height) {
 }
 
 /**
- * The producer-independent form of a decoded mask: mirrored back into the
- * orientation it is actually painted in, then cropped to its own ink. What is
- * deliberately dropped is everything a second producer would have chosen
- * differently for the same glyph — the placement matrix, the blank padding
- * around the ink, and the operator idiom that carried them.
+ * The producer-independent form of a decoded mask: the stored sample grid,
+ * cropped to its own ink.
+ *
+ * The grid as stored is the canonical form on purpose. It is the one thing in
+ * a Type-3 bitmap glyph that is a property of the glyph and of nothing else:
+ * every matrix that could reorient it — the CharProc's own `cm`, the font's
+ * FontMatrix, the text matrix, the page CTM — is chosen by the producer or by
+ * the page that draws the character, and only the first two are even reachable
+ * from inside a CharProc. Normalizing to painted orientation would therefore
+ * mean keying partly on data this function cannot see, and did: an earlier
+ * revision folded in `sign(FontMatrix x cm)` and gave two documents different
+ * keys for a pixel-identical comma.
+ *
+ * The accepted consequence is that a glyph painted rotated or reflected keys
+ * the same as the upright one. That is the correct answer for text set at an
+ * angle, which is still the same character. Where it could be wrong is a font
+ * that reuses one bitmap for two characters by reflecting it — the classic
+ * matched-parenthesis trick — and that case is already refused by the
+ * shape-code injectivity rule below: one shape standing at two enrolled codes
+ * of a font is ambiguous evidence and recovers nothing.
+ *
+ * Also deliberately dropped: the blank padding around the ink and the operator
+ * idiom that carried the samples. An inkless mask has no shape to key at all
+ * and is rejected here rather than collapsing every blank glyph of every font
+ * onto one digest.
  */
 function canonicalType3MaskBits(mask) {
-  const { width, height, bits, mirror_x: mirrorX, mirror_y: mirrorY } = mask;
+  const { width, height, bits } = mask;
   let top = height;
   let bottom = -1;
   let left = width;
@@ -1248,26 +1291,20 @@ function canonicalType3MaskBits(mask) {
   for (let row = 0; row < height; row += 1) {
     for (let column = 0; column < width; column += 1) {
       if (!bits[row * width + column]) continue;
-      const visualRow = mirrorY ? height - 1 - row : row;
-      const visualColumn = mirrorX ? width - 1 - column : column;
-      if (visualRow < top) top = visualRow;
-      if (visualRow > bottom) bottom = visualRow;
-      if (visualColumn < left) left = visualColumn;
-      if (visualColumn > right) right = visualColumn;
+      if (row < top) top = row;
+      if (row > bottom) bottom = row;
+      if (column < left) left = column;
+      if (column > right) right = column;
     }
   }
-  if (bottom < 0) return { width: 0, height: 0, packed: Buffer.alloc(0) };
+  if (bottom < 0) return null;
   const inkWidth = right - left + 1;
   const inkHeight = bottom - top + 1;
   const stride = (inkWidth + 7) >> 3;
   const packed = Buffer.alloc(stride * inkHeight);
   for (let row = 0; row < inkHeight; row += 1) {
     for (let column = 0; column < inkWidth; column += 1) {
-      const visualRow = top + row;
-      const visualColumn = left + column;
-      const sourceRow = mirrorY ? height - 1 - visualRow : visualRow;
-      const sourceColumn = mirrorX ? width - 1 - visualColumn : visualColumn;
-      if (bits[sourceRow * width + sourceColumn]) packed[row * stride + (column >> 3)] |= 128 >> (column & 7);
+      if (bits[(top + row) * width + left + column]) packed[row * stride + (column >> 3)] |= 128 >> (column & 7);
     }
   }
   return { width: inkWidth, height: inkHeight, packed };
@@ -1276,24 +1313,25 @@ function canonicalType3MaskBits(mask) {
 /**
  * The recovery key for one Type-3 glyph program.
  *
- * A glyph whose body is a single decoded image mask is keyed on the mask
- * itself, so the same Computer Modern raster keys identically no matter which
- * dvips-era toolchain packed it, which filter it was compressed with, or where
- * the producer placed it inside the glyph box. Anything else — an outline
- * CharProc, a multi-object program, a rotated placement — falls back to the
- * exact canonicalized operator digest, which is narrower but never wrong. The
- * two lanes are domain-separated, so a mask digest can never satisfy an
- * operator-keyed registry entry or the reverse.
+ * A glyph whose body is a single decoded image mask carrying ink is keyed on
+ * the stored mask grid, so the same Computer Modern raster keys identically no
+ * matter which dvips-era toolchain packed it, which filter it was compressed
+ * with, or where and which way round the producer placed it inside the glyph
+ * box. Anything else — an outline CharProc, a multi-object program, a glyph
+ * program that rotates or shears its own bitmap, an inkless mask with no shape
+ * to key — falls back to the exact canonicalized operator digest, which is
+ * narrower but never wrong. The two lanes are domain-separated, so a mask
+ * digest can never satisfy an operator-keyed registry entry or the reverse.
  */
 export function type3GlyphEvidenceSha256(charProc, fontMatrix, ops) {
   const mask = type3GlyphImageMask(charProc, fontMatrix, ops);
-  if (!mask) {
+  const canonical = mask ? canonicalType3MaskBits(mask) : null;
+  if (!canonical) {
     const operators = type3CharProcSha256(charProc);
     return operators === null
       ? null
       : createHash("sha256").update(`${TYPE3_CHARPROC_EVIDENCE_DOMAIN}:${operators}`).digest("hex");
   }
-  const canonical = canonicalType3MaskBits(mask);
   return createHash("sha256")
     .update(`${TYPE3_MASK_EVIDENCE_DOMAIN}:${canonical.width}x${canonical.height}:`)
     .update(canonical.packed)
@@ -1737,9 +1775,19 @@ function linkedRawType3Font(fontId, fontTokens, rawFonts) {
 
 /*
  * One glyph program is looked up once per registry entry that names it and
- * again for the enrolled-shape index, so the decode is memoized on the PDF.js
- * CharProc object itself. PDF.js caches Type-3 font objects per document, so
- * the same object comes back on every page the font is used on.
+ * again for the enrolled-shape index, so the decode is memoized. PDF.js caches
+ * Type-3 font objects per document, so the same font object comes back on
+ * every page the font is used on.
+ *
+ * The cache is keyed on the font and then the glyph id, not on the CharProc
+ * object alone, because the digest is a function of all three of the
+ * arguments below and only the CharProc is an object identity. A font owns
+ * exactly one FontMatrix and one CharProc for a given glyph id, so keying on
+ * the pair covers both; keying on a CharProc that two fonts happened to share
+ * would not, since the two fonts can declare different FontMatrix values and
+ * the matrix decides whether the mask lane is admissible at all. `ops` is the
+ * operator table of the single pinned PDF.js build loaded in this process and
+ * is therefore constant for the cache's lifetime.
  */
 const type3GlyphEvidenceCache = new WeakMap();
 
@@ -1748,10 +1796,15 @@ function type3GlyphEvidenceForCode(font, rawFont, code, ops) {
   if (typeof glyphId !== "string") return null;
   const charProc = font?.charProcOperatorList?.[glyphId];
   if (!charProc || typeof charProc !== "object") return null;
-  const cached = type3GlyphEvidenceCache.get(charProc);
+  let byGlyphId = type3GlyphEvidenceCache.get(font);
+  if (byGlyphId === undefined) {
+    byGlyphId = new Map();
+    type3GlyphEvidenceCache.set(font, byGlyphId);
+  }
+  const cached = byGlyphId.get(glyphId);
   if (cached !== undefined) return cached;
   const digest = type3GlyphEvidenceSha256(charProc, font?.fontMatrix, ops);
-  type3GlyphEvidenceCache.set(charProc, digest);
+  byGlyphId.set(glyphId, digest);
   return digest;
 }
 

--- a/server/layout-extraction.js
+++ b/server/layout-extraction.js
@@ -56,10 +56,27 @@ const RAW_PAGE_SPACE = Object.freeze({
   stage: "before_user_unit_and_page_rotation",
 });
 const MAX_PAINTED_RECTANGLES = 500;
-const TYPE3_GLYPH_CANONICALIZER_VERSION = "pdfjs-charproc-json-v1";
+/*
+ * Type-3 glyph evidence keys.
+ *
+ * v2 keys a legacy bitmap glyph on its decoded image mask instead of on the
+ * CharProc operator list. The operator list folds in the producer's idiom, the
+ * inline-image filter it chose, and the per-glyph placement matrix, none of
+ * which are properties of the glyph: two documents carrying a pixel-identical
+ * Computer Modern raster hashed differently under v1 and now hash the same.
+ * Non-mask glyph programs keep the exact operator digest under a separate
+ * domain tag, so the two lanes can never satisfy each other's registry entries.
+ */
+const TYPE3_GLYPH_EVIDENCE_VERSION = "pdfjs-type3-glyph-evidence-v2";
+const TYPE3_MASK_EVIDENCE_DOMAIN = "type3-glyph-image-mask-v1";
+const TYPE3_CHARPROC_EVIDENCE_DOMAIN = "pdfjs-charproc-json-v1";
 const MAX_TYPE3_GLYPH_CANONICAL_NODES = 100000;
 const MAX_TYPE3_GLYPH_CANONICAL_DEPTH = 32;
 const MAX_TYPE3_GLYPH_CANONICAL_BYTES = 250000;
+// PDF.js refuses to trace a mask wider or taller than 1000 samples, so a
+// larger grid can never arrive here; the area bound caps the working buffer.
+const MAX_TYPE3_GLYPH_MASK_PIXELS = 1_000_000;
+const MAX_TYPE3_GLYPH_MASK_PATH_NODES = 60_000;
 
 const TYPE3_RECOVERY_REGISTRY = Object.freeze([
   Object.freeze({
@@ -69,11 +86,11 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 11,
     source_unicode: "\u000b",
     target_unicode: "α",
-    charproc_sha256: "e688a83f98433c841694f990aabafe5245cfc9320f584d7f70da706f0eeba259",
+    glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093",
     allow_collapsed_whitespace: true,
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 25, charproc_sha256: "780b04fa47830ca782211b86dbedfe0adec0445bdf94d538bfe7adde08ed9445" }),
-      Object.freeze({ original_char_code: 26, charproc_sha256: "1500df39391626d02f9e98132f991f71899612069298e52340e12fb65590836f" }),
+      Object.freeze({ original_char_code: 25, glyph_sha256: "751c36c470d1f0292b9d39de8cfec243d0e1e4ca3b2a2648676a8048cdf75322" }),
+      Object.freeze({ original_char_code: 26, glyph_sha256: "ff3b8028f135ce4dbf41a3e3fa8415f54615e9c3e7253d13e9070a71679ccebc" }),
     ]),
   }),
   Object.freeze({
@@ -83,10 +100,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 58,
     source_unicode: ":",
     target_unicode: ".",
-    charproc_sha256: "2df559091df37cc5da5c1ce3e05eebc1075c4c041b83d96a1904d2c2f21edab0",
+    glyph_sha256: "2ed87b069c99482d0823c085da9c199582e6e4b51172a2b360d9b6652066e3ae",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 59, charproc_sha256: "42b5ebf435945b75e1dc1bc271bfbb4aa2dc02b8adc93cd26b4bb64dec9fde8a" }),
-      Object.freeze({ original_char_code: 61, charproc_sha256: "55447dde50a97970297d189788eb154c675c41e6d2eca2836949aefadd0b1780" }),
+      Object.freeze({ original_char_code: 59, glyph_sha256: "65e5727a8eb6528fe7013fcf6f2522e93c65ee868f0315850cefd2992e5b7e5b" }),
+      Object.freeze({ original_char_code: 61, glyph_sha256: "2406e228edd78d0d53cc29b48a3154626a47c6fda6b01450cf2c1155cd6b81f7" }),
     ]),
   }),
   Object.freeze({
@@ -96,10 +113,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 59,
     source_unicode: ";",
     target_unicode: ",",
-    charproc_sha256: "42b5ebf435945b75e1dc1bc271bfbb4aa2dc02b8adc93cd26b4bb64dec9fde8a",
+    glyph_sha256: "65e5727a8eb6528fe7013fcf6f2522e93c65ee868f0315850cefd2992e5b7e5b",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 58, charproc_sha256: "2df559091df37cc5da5c1ce3e05eebc1075c4c041b83d96a1904d2c2f21edab0" }),
-      Object.freeze({ original_char_code: 61, charproc_sha256: "55447dde50a97970297d189788eb154c675c41e6d2eca2836949aefadd0b1780" }),
+      Object.freeze({ original_char_code: 58, glyph_sha256: "2ed87b069c99482d0823c085da9c199582e6e4b51172a2b360d9b6652066e3ae" }),
+      Object.freeze({ original_char_code: 61, glyph_sha256: "2406e228edd78d0d53cc29b48a3154626a47c6fda6b01450cf2c1155cd6b81f7" }),
     ]),
   }),
   Object.freeze({
@@ -109,10 +126,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 25,
     source_unicode: "\u0019",
     target_unicode: "π",
-    charproc_sha256: "780b04fa47830ca782211b86dbedfe0adec0445bdf94d538bfe7adde08ed9445",
+    glyph_sha256: "751c36c470d1f0292b9d39de8cfec243d0e1e4ca3b2a2648676a8048cdf75322",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, charproc_sha256: "e688a83f98433c841694f990aabafe5245cfc9320f584d7f70da706f0eeba259" }),
-      Object.freeze({ original_char_code: 26, charproc_sha256: "1500df39391626d02f9e98132f991f71899612069298e52340e12fb65590836f" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
+      Object.freeze({ original_char_code: 26, glyph_sha256: "ff3b8028f135ce4dbf41a3e3fa8415f54615e9c3e7253d13e9070a71679ccebc" }),
     ]),
   }),
   Object.freeze({
@@ -122,10 +139,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 26,
     source_unicode: "\u001a",
     target_unicode: "ρ",
-    charproc_sha256: "1500df39391626d02f9e98132f991f71899612069298e52340e12fb65590836f",
+    glyph_sha256: "ff3b8028f135ce4dbf41a3e3fa8415f54615e9c3e7253d13e9070a71679ccebc",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, charproc_sha256: "e688a83f98433c841694f990aabafe5245cfc9320f584d7f70da706f0eeba259" }),
-      Object.freeze({ original_char_code: 25, charproc_sha256: "780b04fa47830ca782211b86dbedfe0adec0445bdf94d538bfe7adde08ed9445" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
+      Object.freeze({ original_char_code: 25, glyph_sha256: "751c36c470d1f0292b9d39de8cfec243d0e1e4ca3b2a2648676a8048cdf75322" }),
     ]),
   }),
   Object.freeze({
@@ -135,10 +152,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 33,
     source_unicode: "!",
     target_unicode: "ω",
-    charproc_sha256: "81b41121b5e19a2aebd37331ab3584fe08221ca1afcda83f4ce8b76997177074",
+    glyph_sha256: "4c740569ca05e182025cfeb2d99d35f6c2655f7674b919fe2f145a33ff4ffdd1",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, charproc_sha256: "e688a83f98433c841694f990aabafe5245cfc9320f584d7f70da706f0eeba259" }),
-      Object.freeze({ original_char_code: 25, charproc_sha256: "780b04fa47830ca782211b86dbedfe0adec0445bdf94d538bfe7adde08ed9445" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
+      Object.freeze({ original_char_code: 25, glyph_sha256: "751c36c470d1f0292b9d39de8cfec243d0e1e4ca3b2a2648676a8048cdf75322" }),
     ]),
   }),
   Object.freeze({
@@ -148,10 +165,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 61,
     source_unicode: "=",
     target_unicode: "/",
-    charproc_sha256: "55447dde50a97970297d189788eb154c675c41e6d2eca2836949aefadd0b1780",
+    glyph_sha256: "2406e228edd78d0d53cc29b48a3154626a47c6fda6b01450cf2c1155cd6b81f7",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 58, charproc_sha256: "2df559091df37cc5da5c1ce3e05eebc1075c4c041b83d96a1904d2c2f21edab0" }),
-      Object.freeze({ original_char_code: 59, charproc_sha256: "42b5ebf435945b75e1dc1bc271bfbb4aa2dc02b8adc93cd26b4bb64dec9fde8a" }),
+      Object.freeze({ original_char_code: 58, glyph_sha256: "2ed87b069c99482d0823c085da9c199582e6e4b51172a2b360d9b6652066e3ae" }),
+      Object.freeze({ original_char_code: 59, glyph_sha256: "65e5727a8eb6528fe7013fcf6f2522e93c65ee868f0315850cefd2992e5b7e5b" }),
     ]),
   }),
   Object.freeze({
@@ -161,10 +178,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 0,
     source_unicode: "\u0000",
     target_unicode: "−",
-    charproc_sha256: "fb1f6bf10138511bcefade47467b3e2f9ae691ab3dab097914be1f0f66305470",
+    glyph_sha256: "68b4a1e125aa58ed3e798029190dbf4e2f3937030f921cd995cf7c8ad2f2eedc",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 21, charproc_sha256: "05b4a9d88c1df64b3ac339ae6bb7ed82383b93bb08512842452db43453a28970" }),
-      Object.freeze({ original_char_code: 112, charproc_sha256: "772f491fc17e6bb3bc37c17ace6be704244ab121c7180d59319726e0af4b0efc" }),
+      Object.freeze({ original_char_code: 21, glyph_sha256: "d2622641d0fa27eba18c91fd6333cfad66cbc23918a88854242d2f0f4c6ca968" }),
+      Object.freeze({ original_char_code: 112, glyph_sha256: "f57899424fb6b62d3a54288b4fb0f41a9edc7b8e17bbd41f0a1e1fac6b743196" }),
     ]),
   }),
   Object.freeze({
@@ -174,10 +191,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 21,
     source_unicode: "\u0015",
     target_unicode: "≥",
-    charproc_sha256: "05b4a9d88c1df64b3ac339ae6bb7ed82383b93bb08512842452db43453a28970",
+    glyph_sha256: "d2622641d0fa27eba18c91fd6333cfad66cbc23918a88854242d2f0f4c6ca968",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 0, charproc_sha256: "fb1f6bf10138511bcefade47467b3e2f9ae691ab3dab097914be1f0f66305470" }),
-      Object.freeze({ original_char_code: 112, charproc_sha256: "772f491fc17e6bb3bc37c17ace6be704244ab121c7180d59319726e0af4b0efc" }),
+      Object.freeze({ original_char_code: 0, glyph_sha256: "68b4a1e125aa58ed3e798029190dbf4e2f3937030f921cd995cf7c8ad2f2eedc" }),
+      Object.freeze({ original_char_code: 112, glyph_sha256: "f57899424fb6b62d3a54288b4fb0f41a9edc7b8e17bbd41f0a1e1fac6b743196" }),
     ]),
   }),
   Object.freeze({
@@ -187,10 +204,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 112,
     source_unicode: "p",
     target_unicode: "√",
-    charproc_sha256: "772f491fc17e6bb3bc37c17ace6be704244ab121c7180d59319726e0af4b0efc",
+    glyph_sha256: "f57899424fb6b62d3a54288b4fb0f41a9edc7b8e17bbd41f0a1e1fac6b743196",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 0, charproc_sha256: "fb1f6bf10138511bcefade47467b3e2f9ae691ab3dab097914be1f0f66305470" }),
-      Object.freeze({ original_char_code: 21, charproc_sha256: "05b4a9d88c1df64b3ac339ae6bb7ed82383b93bb08512842452db43453a28970" }),
+      Object.freeze({ original_char_code: 0, glyph_sha256: "68b4a1e125aa58ed3e798029190dbf4e2f3937030f921cd995cf7c8ad2f2eedc" }),
+      Object.freeze({ original_char_code: 21, glyph_sha256: "d2622641d0fa27eba18c91fd6333cfad66cbc23918a88854242d2f0f4c6ca968" }),
     ]),
   }),
   Object.freeze({
@@ -200,10 +217,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 33,
     source_unicode: "!",
     target_unicode: "ω",
-    charproc_sha256: "0ebf4d75e5bdb232683c871c77579bc14887f9aaa397a3c8334c220ec09af0d9",
+    glyph_sha256: "ce4f89e61b842053344c92603d0588263e0118e0321411ae3f798b2f39445fe2",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, charproc_sha256: "c3d175e547d650cd0382115f3caed3b08d39f61827d10b26aad43eac6b6c4fa1" }),
-      Object.freeze({ original_char_code: 25, charproc_sha256: "994283a40dea8e4890f7216ef046a865f34ef7100cc1055de62d1eba7daf8fe2" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "e9705ccd52613dd5c8dcbff8618f9d825f88b29a9ddcedc01532fd7ba217385f" }),
+      Object.freeze({ original_char_code: 25, glyph_sha256: "fa64dc2c1de162435601ca8107e3a5027cc9dd3ca9d0aaa6998e5736c3f9564a" }),
     ]),
   }),
   Object.freeze({
@@ -213,10 +230,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 58,
     source_unicode: ":",
     target_unicode: ".",
-    charproc_sha256: "cdf3cbb1bd7626495858ebacb74816ba82ac139458edf75c6d737f6b121b65fe",
+    glyph_sha256: "8520f46225db90fbb8c41a8ffe4ced238a45f80f3dd74acf4d9b12ec29598513",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 59, charproc_sha256: "7c69e2ebf2eec772599fae11d278adcc3c88472af6279f9801865628040d981b" }),
-      Object.freeze({ original_char_code: 61, charproc_sha256: "dfa9c162caf4e99dafd16ca5d87e90f89d44c29312a2675e89aa789c5355d63e" }),
+      Object.freeze({ original_char_code: 59, glyph_sha256: "67bc7d266ae458bb1c5cf497d1de03ccbc4b85d03457ef2a54e7aa9e91b2ef6a" }),
+      Object.freeze({ original_char_code: 61, glyph_sha256: "7604ca52d40535d2c7205e425d56cb07e19c388dc6ff5806ffe87cc9d811c025" }),
     ]),
   }),
   Object.freeze({
@@ -226,10 +243,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 61,
     source_unicode: "=",
     target_unicode: "/",
-    charproc_sha256: "dfa9c162caf4e99dafd16ca5d87e90f89d44c29312a2675e89aa789c5355d63e",
+    glyph_sha256: "7604ca52d40535d2c7205e425d56cb07e19c388dc6ff5806ffe87cc9d811c025",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 58, charproc_sha256: "cdf3cbb1bd7626495858ebacb74816ba82ac139458edf75c6d737f6b121b65fe" }),
-      Object.freeze({ original_char_code: 59, charproc_sha256: "7c69e2ebf2eec772599fae11d278adcc3c88472af6279f9801865628040d981b" }),
+      Object.freeze({ original_char_code: 58, glyph_sha256: "8520f46225db90fbb8c41a8ffe4ced238a45f80f3dd74acf4d9b12ec29598513" }),
+      Object.freeze({ original_char_code: 59, glyph_sha256: "67bc7d266ae458bb1c5cf497d1de03ccbc4b85d03457ef2a54e7aa9e91b2ef6a" }),
     ]),
   }),
   Object.freeze({
@@ -239,10 +256,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 59,
     source_unicode: ";",
     target_unicode: ",",
-    charproc_sha256: "7c69e2ebf2eec772599fae11d278adcc3c88472af6279f9801865628040d981b",
+    glyph_sha256: "67bc7d266ae458bb1c5cf497d1de03ccbc4b85d03457ef2a54e7aa9e91b2ef6a",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 58, charproc_sha256: "cdf3cbb1bd7626495858ebacb74816ba82ac139458edf75c6d737f6b121b65fe" }),
-      Object.freeze({ original_char_code: 61, charproc_sha256: "dfa9c162caf4e99dafd16ca5d87e90f89d44c29312a2675e89aa789c5355d63e" }),
+      Object.freeze({ original_char_code: 58, glyph_sha256: "8520f46225db90fbb8c41a8ffe4ced238a45f80f3dd74acf4d9b12ec29598513" }),
+      Object.freeze({ original_char_code: 61, glyph_sha256: "7604ca52d40535d2c7205e425d56cb07e19c388dc6ff5806ffe87cc9d811c025" }),
     ]),
   }),
   Object.freeze({
@@ -252,10 +269,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 0,
     source_unicode: "\u0000",
     target_unicode: "−",
-    charproc_sha256: "0c8b34a3281f9e8e91b2d955f952a50d187cd06c432be27c015b78570e645e9d",
+    glyph_sha256: "ed5df416bb312c2b49ed8936f226016a28e9a09fa52aba56281dd6a8a5430d19",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 6, charproc_sha256: "b68b24c69a8802a7e57a1cabaa7c1153a0a305e5d29ba308b78d60c16a5464b7" }),
-      Object.freeze({ original_char_code: 33, charproc_sha256: "6ff1e08b5364a8ce02ac2390691fdfb1f2e532bd0a1dac95d01a155bbce482fc" }),
+      Object.freeze({ original_char_code: 6, glyph_sha256: "4734e344eca1f8f73183a34504c1068146b425815a2a8ef6aa00a18dfd45d9a2" }),
+      Object.freeze({ original_char_code: 33, glyph_sha256: "a818ff8e95ae122382e0f0198e875400f4cc07ef1115dbe936ad5dd37933c4d4" }),
     ]),
   }),
   Object.freeze({
@@ -265,10 +282,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 0,
     source_unicode: "\u0000",
     target_unicode: "−",
-    charproc_sha256: "b32276d22e1dd4133c20888ade044d27e59f2cbdfca0901c3b9d46006ed7dee9",
+    glyph_sha256: "3f6fdf2abc68f5693f9ea7cdec4d94214a57fb953fb66c747b86dd1f6293d807",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 21, charproc_sha256: "b57ae2e4cf2525371916a1a4bcf0c55165b9230b1038f2d5451cdbbad5a51dcc" }),
-      Object.freeze({ original_char_code: 112, charproc_sha256: "0c8ca6c662e9ca24f90a61f53206ea0719476473861471a1b04bf489b3cc37a3" }),
+      Object.freeze({ original_char_code: 21, glyph_sha256: "73a2cec4aa27d5042b9f4275179fbf2bb7b99413537597ede0537b7f19c8384c" }),
+      Object.freeze({ original_char_code: 112, glyph_sha256: "f15e035b5867fbee9918125e49566e00b94dcd8422649079c87207e94f7a9e63" }),
     ]),
   }),
   Object.freeze({
@@ -278,10 +295,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 0,
     source_unicode: "\u0000",
     target_unicode: "−",
-    charproc_sha256: "f56714c48094acb5e3fdb76a62fcce203b4ed0bc60ec49f57fba5bf6ee80d91a",
+    glyph_sha256: "183f30cb001ea6b5047c6f806e3a27fd095bcdde1470f7b1f351dba8ea94282e",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 21, charproc_sha256: "b6986c1595532ddd51fad9d8148c404111da8cb112c272d66f1d0c4acaa86395" }),
-      Object.freeze({ original_char_code: 112, charproc_sha256: "7d178f8e3e6ebbba7a97d5476fa81d88528b89b45fecae79124d7b497cb69973" }),
+      Object.freeze({ original_char_code: 21, glyph_sha256: "f9b735aa52a672962391a234ed5e79f5c30635d6ce2ea998f103ba616e39dbdf" }),
+      Object.freeze({ original_char_code: 112, glyph_sha256: "5dd2e8e832e3ed95c353d14854c6441e9f3ea10c1ff66466ba7b15cbf59546d7" }),
     ]),
   }),
   Object.freeze({
@@ -291,10 +308,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 58,
     source_unicode: ":",
     target_unicode: ".",
-    charproc_sha256: "bd8a8b68f402b7ae4df615c7fbd63e42decccc4f2dcf2cb6f56e871328466c67",
+    glyph_sha256: "8520f46225db90fbb8c41a8ffe4ced238a45f80f3dd74acf4d9b12ec29598513",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 59, charproc_sha256: "dec7c435ea1bb5cad4fb9020f992cfd9aa1c087e3b9dd144cbbe7f27f939e0f5" }),
-      Object.freeze({ original_char_code: 61, charproc_sha256: "f5b035495791c897c3fdc5a86f0d8290cdd67dee1a20a33ad40663b4636eb773" }),
+      Object.freeze({ original_char_code: 59, glyph_sha256: "5363832452620aa888b74219c2a632d1e58a27060bffb1cf6392bf5b2fad8316" }),
+      Object.freeze({ original_char_code: 61, glyph_sha256: "f1c63f92441a1dc720dac5d5d39e38da21d397d81e32c4a87a5bfa34c50b8f8d" }),
     ]),
   }),
   Object.freeze({
@@ -304,10 +321,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 59,
     source_unicode: ";",
     target_unicode: ",",
-    charproc_sha256: "dec7c435ea1bb5cad4fb9020f992cfd9aa1c087e3b9dd144cbbe7f27f939e0f5",
+    glyph_sha256: "5363832452620aa888b74219c2a632d1e58a27060bffb1cf6392bf5b2fad8316",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 58, charproc_sha256: "bd8a8b68f402b7ae4df615c7fbd63e42decccc4f2dcf2cb6f56e871328466c67" }),
-      Object.freeze({ original_char_code: 61, charproc_sha256: "f5b035495791c897c3fdc5a86f0d8290cdd67dee1a20a33ad40663b4636eb773" }),
+      Object.freeze({ original_char_code: 58, glyph_sha256: "8520f46225db90fbb8c41a8ffe4ced238a45f80f3dd74acf4d9b12ec29598513" }),
+      Object.freeze({ original_char_code: 61, glyph_sha256: "f1c63f92441a1dc720dac5d5d39e38da21d397d81e32c4a87a5bfa34c50b8f8d" }),
     ]),
   }),
   Object.freeze({
@@ -317,10 +334,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 61,
     source_unicode: "=",
     target_unicode: "/",
-    charproc_sha256: "f5b035495791c897c3fdc5a86f0d8290cdd67dee1a20a33ad40663b4636eb773",
+    glyph_sha256: "f1c63f92441a1dc720dac5d5d39e38da21d397d81e32c4a87a5bfa34c50b8f8d",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 58, charproc_sha256: "bd8a8b68f402b7ae4df615c7fbd63e42decccc4f2dcf2cb6f56e871328466c67" }),
-      Object.freeze({ original_char_code: 59, charproc_sha256: "dec7c435ea1bb5cad4fb9020f992cfd9aa1c087e3b9dd144cbbe7f27f939e0f5" }),
+      Object.freeze({ original_char_code: 58, glyph_sha256: "8520f46225db90fbb8c41a8ffe4ced238a45f80f3dd74acf4d9b12ec29598513" }),
+      Object.freeze({ original_char_code: 59, glyph_sha256: "5363832452620aa888b74219c2a632d1e58a27060bffb1cf6392bf5b2fad8316" }),
     ]),
   }),
   Object.freeze({
@@ -330,11 +347,11 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 11,
     source_unicode: "\u000b",
     target_unicode: "α",
-    charproc_sha256: "bab8aeb78893a19704c95538c54764abaae0cfe9d84812825f718e7687432f63",
+    glyph_sha256: "6092e20a2f8a4925449780db726c4912ccee956a094589d3cb63ede3b5d7383b",
     allow_collapsed_whitespace: true,
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 25, charproc_sha256: "3d439e1c736c51e1c18e75219c43d953b6f2c3ab588f50ceeb69f5567343492c" }),
-      Object.freeze({ original_char_code: 26, charproc_sha256: "fa4a3dbc3f77e082142e29cc43e4e21aaf61fcf6ddbaefae24f1767caaea34b8" }),
+      Object.freeze({ original_char_code: 25, glyph_sha256: "38b7cc2fac5858dfd6acc1c7936eb874900c61299c8758edc607cb91cbd68b39" }),
+      Object.freeze({ original_char_code: 26, glyph_sha256: "8271aed349c3127895bf7d96b57c83fd62b03cc6c9c9428e600a58b269899365" }),
     ]),
   }),
   Object.freeze({
@@ -344,10 +361,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 25,
     source_unicode: "\u0019",
     target_unicode: "π",
-    charproc_sha256: "3d439e1c736c51e1c18e75219c43d953b6f2c3ab588f50ceeb69f5567343492c",
+    glyph_sha256: "38b7cc2fac5858dfd6acc1c7936eb874900c61299c8758edc607cb91cbd68b39",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, charproc_sha256: "bab8aeb78893a19704c95538c54764abaae0cfe9d84812825f718e7687432f63" }),
-      Object.freeze({ original_char_code: 26, charproc_sha256: "fa4a3dbc3f77e082142e29cc43e4e21aaf61fcf6ddbaefae24f1767caaea34b8" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "6092e20a2f8a4925449780db726c4912ccee956a094589d3cb63ede3b5d7383b" }),
+      Object.freeze({ original_char_code: 26, glyph_sha256: "8271aed349c3127895bf7d96b57c83fd62b03cc6c9c9428e600a58b269899365" }),
     ]),
   }),
   Object.freeze({
@@ -357,10 +374,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 26,
     source_unicode: "\u001a",
     target_unicode: "ρ",
-    charproc_sha256: "fa4a3dbc3f77e082142e29cc43e4e21aaf61fcf6ddbaefae24f1767caaea34b8",
+    glyph_sha256: "8271aed349c3127895bf7d96b57c83fd62b03cc6c9c9428e600a58b269899365",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, charproc_sha256: "bab8aeb78893a19704c95538c54764abaae0cfe9d84812825f718e7687432f63" }),
-      Object.freeze({ original_char_code: 25, charproc_sha256: "3d439e1c736c51e1c18e75219c43d953b6f2c3ab588f50ceeb69f5567343492c" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "6092e20a2f8a4925449780db726c4912ccee956a094589d3cb63ede3b5d7383b" }),
+      Object.freeze({ original_char_code: 25, glyph_sha256: "38b7cc2fac5858dfd6acc1c7936eb874900c61299c8758edc607cb91cbd68b39" }),
     ]),
   }),
   Object.freeze({
@@ -370,11 +387,11 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 11,
     source_unicode: "\u000b",
     target_unicode: "α",
-    charproc_sha256: "c3d175e547d650cd0382115f3caed3b08d39f61827d10b26aad43eac6b6c4fa1",
+    glyph_sha256: "e9705ccd52613dd5c8dcbff8618f9d825f88b29a9ddcedc01532fd7ba217385f",
     allow_collapsed_whitespace: true,
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 25, charproc_sha256: "994283a40dea8e4890f7216ef046a865f34ef7100cc1055de62d1eba7daf8fe2" }),
-      Object.freeze({ original_char_code: 26, charproc_sha256: "ee4042a5a8e974c4bbcb77535105c9244e68a6d9c79181107ffab0fce453bfe0" }),
+      Object.freeze({ original_char_code: 25, glyph_sha256: "fa64dc2c1de162435601ca8107e3a5027cc9dd3ca9d0aaa6998e5736c3f9564a" }),
+      Object.freeze({ original_char_code: 26, glyph_sha256: "509f130688569e2b0b333a102fcaee164efdc687a94db9d7a40c928009129431" }),
     ]),
   }),
   Object.freeze({
@@ -384,10 +401,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 25,
     source_unicode: "\u0019",
     target_unicode: "π",
-    charproc_sha256: "994283a40dea8e4890f7216ef046a865f34ef7100cc1055de62d1eba7daf8fe2",
+    glyph_sha256: "fa64dc2c1de162435601ca8107e3a5027cc9dd3ca9d0aaa6998e5736c3f9564a",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, charproc_sha256: "c3d175e547d650cd0382115f3caed3b08d39f61827d10b26aad43eac6b6c4fa1" }),
-      Object.freeze({ original_char_code: 26, charproc_sha256: "ee4042a5a8e974c4bbcb77535105c9244e68a6d9c79181107ffab0fce453bfe0" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "e9705ccd52613dd5c8dcbff8618f9d825f88b29a9ddcedc01532fd7ba217385f" }),
+      Object.freeze({ original_char_code: 26, glyph_sha256: "509f130688569e2b0b333a102fcaee164efdc687a94db9d7a40c928009129431" }),
     ]),
   }),
   Object.freeze({
@@ -397,10 +414,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 26,
     source_unicode: "\u001a",
     target_unicode: "ρ",
-    charproc_sha256: "ee4042a5a8e974c4bbcb77535105c9244e68a6d9c79181107ffab0fce453bfe0",
+    glyph_sha256: "509f130688569e2b0b333a102fcaee164efdc687a94db9d7a40c928009129431",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, charproc_sha256: "c3d175e547d650cd0382115f3caed3b08d39f61827d10b26aad43eac6b6c4fa1" }),
-      Object.freeze({ original_char_code: 25, charproc_sha256: "994283a40dea8e4890f7216ef046a865f34ef7100cc1055de62d1eba7daf8fe2" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "e9705ccd52613dd5c8dcbff8618f9d825f88b29a9ddcedc01532fd7ba217385f" }),
+      Object.freeze({ original_char_code: 25, glyph_sha256: "fa64dc2c1de162435601ca8107e3a5027cc9dd3ca9d0aaa6998e5736c3f9564a" }),
     ]),
   }),
   Object.freeze({
@@ -410,10 +427,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 21,
     source_unicode: "\u0015",
     target_unicode: "≥",
-    charproc_sha256: "b57ae2e4cf2525371916a1a4bcf0c55165b9230b1038f2d5451cdbbad5a51dcc",
+    glyph_sha256: "73a2cec4aa27d5042b9f4275179fbf2bb7b99413537597ede0537b7f19c8384c",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 0, charproc_sha256: "b32276d22e1dd4133c20888ade044d27e59f2cbdfca0901c3b9d46006ed7dee9" }),
-      Object.freeze({ original_char_code: 112, charproc_sha256: "0c8ca6c662e9ca24f90a61f53206ea0719476473861471a1b04bf489b3cc37a3" }),
+      Object.freeze({ original_char_code: 0, glyph_sha256: "3f6fdf2abc68f5693f9ea7cdec4d94214a57fb953fb66c747b86dd1f6293d807" }),
+      Object.freeze({ original_char_code: 112, glyph_sha256: "f15e035b5867fbee9918125e49566e00b94dcd8422649079c87207e94f7a9e63" }),
     ]),
   }),
   Object.freeze({
@@ -423,10 +440,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 112,
     source_unicode: "p",
     target_unicode: "√",
-    charproc_sha256: "0c8ca6c662e9ca24f90a61f53206ea0719476473861471a1b04bf489b3cc37a3",
+    glyph_sha256: "f15e035b5867fbee9918125e49566e00b94dcd8422649079c87207e94f7a9e63",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 0, charproc_sha256: "b32276d22e1dd4133c20888ade044d27e59f2cbdfca0901c3b9d46006ed7dee9" }),
-      Object.freeze({ original_char_code: 21, charproc_sha256: "b57ae2e4cf2525371916a1a4bcf0c55165b9230b1038f2d5451cdbbad5a51dcc" }),
+      Object.freeze({ original_char_code: 0, glyph_sha256: "3f6fdf2abc68f5693f9ea7cdec4d94214a57fb953fb66c747b86dd1f6293d807" }),
+      Object.freeze({ original_char_code: 21, glyph_sha256: "73a2cec4aa27d5042b9f4275179fbf2bb7b99413537597ede0537b7f19c8384c" }),
     ]),
   }),
   Object.freeze({
@@ -436,10 +453,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 1,
     source_unicode: "\u0001",
     target_unicode: "⋅",
-    charproc_sha256: "33077f6f9b7f5c5631bd3cb7bbfc79b4da1fbd929b23f6e08e55c90566608c7a",
+    glyph_sha256: "2ed87b069c99482d0823c085da9c199582e6e4b51172a2b360d9b6652066e3ae",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 0, charproc_sha256: "fb1f6bf10138511bcefade47467b3e2f9ae691ab3dab097914be1f0f66305470" }),
-      Object.freeze({ original_char_code: 6, charproc_sha256: "4dedb5543e5ab5817e06920d50b7983b3febaf06c22feeb83bdbb3d8449e2c3c" }),
+      Object.freeze({ original_char_code: 0, glyph_sha256: "68b4a1e125aa58ed3e798029190dbf4e2f3937030f921cd995cf7c8ad2f2eedc" }),
+      Object.freeze({ original_char_code: 6, glyph_sha256: "009835b7eda7745c9e2e167ce0ed1b5e4ff9063af4c92280dffab3213f07e395" }),
     ]),
   }),
   Object.freeze({
@@ -449,10 +466,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 20,
     source_unicode: "\u0014",
     target_unicode: "≤",
-    charproc_sha256: "90da52fa2f67a6d3b82a7866614b7539c4e5454d2585dd223db8cb2428c6ce18",
+    glyph_sha256: "b7694606e91a2a5ad7ad6b16032289f5f4bcca7d7528ef93759e39908c68d8c4",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 0, charproc_sha256: "fb1f6bf10138511bcefade47467b3e2f9ae691ab3dab097914be1f0f66305470" }),
-      Object.freeze({ original_char_code: 1, charproc_sha256: "33077f6f9b7f5c5631bd3cb7bbfc79b4da1fbd929b23f6e08e55c90566608c7a" }),
+      Object.freeze({ original_char_code: 0, glyph_sha256: "68b4a1e125aa58ed3e798029190dbf4e2f3937030f921cd995cf7c8ad2f2eedc" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "2ed87b069c99482d0823c085da9c199582e6e4b51172a2b360d9b6652066e3ae" }),
     ]),
   }),
   Object.freeze({
@@ -462,10 +479,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 48,
     source_unicode: "0",
     target_unicode: "′",
-    charproc_sha256: "35220701523f8641fb0364aa66642008d3fcc04067a7a3c6b73cc2fd8b117c0c",
+    glyph_sha256: "a24e8c43c1c680cc6c2a676adb046c59ca00ebe5116ed583b37f3b1d6a39cc66",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 0, charproc_sha256: "0c8b34a3281f9e8e91b2d955f952a50d187cd06c432be27c015b78570e645e9d" }),
-      Object.freeze({ original_char_code: 6, charproc_sha256: "b68b24c69a8802a7e57a1cabaa7c1153a0a305e5d29ba308b78d60c16a5464b7" }),
+      Object.freeze({ original_char_code: 0, glyph_sha256: "ed5df416bb312c2b49ed8936f226016a28e9a09fa52aba56281dd6a8a5430d19" }),
+      Object.freeze({ original_char_code: 6, glyph_sha256: "4734e344eca1f8f73183a34504c1068146b425815a2a8ef6aa00a18dfd45d9a2" }),
     ]),
   }),
   Object.freeze({
@@ -475,10 +492,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 106,
     source_unicode: "j",
     target_unicode: "|",
-    charproc_sha256: "6ab8a73ddd4d36b2c52a405228bde08114d463329384ad6605d5c9d5095385d0",
+    glyph_sha256: "6b5b24f359788e9c53ad35f6de00ff0cdf7637eb8cb1b6efb124d96ba54c071f",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 0, charproc_sha256: "fb1f6bf10138511bcefade47467b3e2f9ae691ab3dab097914be1f0f66305470" }),
-      Object.freeze({ original_char_code: 1, charproc_sha256: "33077f6f9b7f5c5631bd3cb7bbfc79b4da1fbd929b23f6e08e55c90566608c7a" }),
+      Object.freeze({ original_char_code: 0, glyph_sha256: "68b4a1e125aa58ed3e798029190dbf4e2f3937030f921cd995cf7c8ad2f2eedc" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "2ed87b069c99482d0823c085da9c199582e6e4b51172a2b360d9b6652066e3ae" }),
     ]),
   }),
   Object.freeze({
@@ -488,10 +505,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 0,
     source_unicode: "\u0000",
     target_unicode: "(",
-    charproc_sha256: "eeae0f8c005ab72ff0fc77dda2d45be6bcca4359a98f882a1d33bf25619a6ae1",
+    glyph_sha256: "db8987d9df1b673b7c30dca2e284cf446998ad64b8a0a7a50c607cb3a08de761",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 1, charproc_sha256: "9a0788d07694db3951c5f1b847f8d50beb1e82e0dd877cf3d75ad2b9f0de0876" }),
-      Object.freeze({ original_char_code: 2, charproc_sha256: "add929da8d3840d8390cdbc6ad2746f411a6318e7c71cf97d789cac0dd24a693" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "a06c1a0819e09411d527d1313e0c91e68f2985038930a9bead785d1d62372154" }),
+      Object.freeze({ original_char_code: 2, glyph_sha256: "de6ca507791bcb2a932347364bab4103b89d0cc312119d313878eb3b904f66f6" }),
     ]),
   }),
   Object.freeze({
@@ -501,10 +518,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 1,
     source_unicode: "\u0001",
     target_unicode: ")",
-    charproc_sha256: "9a0788d07694db3951c5f1b847f8d50beb1e82e0dd877cf3d75ad2b9f0de0876",
+    glyph_sha256: "a06c1a0819e09411d527d1313e0c91e68f2985038930a9bead785d1d62372154",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 0, charproc_sha256: "eeae0f8c005ab72ff0fc77dda2d45be6bcca4359a98f882a1d33bf25619a6ae1" }),
-      Object.freeze({ original_char_code: 2, charproc_sha256: "add929da8d3840d8390cdbc6ad2746f411a6318e7c71cf97d789cac0dd24a693" }),
+      Object.freeze({ original_char_code: 0, glyph_sha256: "db8987d9df1b673b7c30dca2e284cf446998ad64b8a0a7a50c607cb3a08de761" }),
+      Object.freeze({ original_char_code: 2, glyph_sha256: "de6ca507791bcb2a932347364bab4103b89d0cc312119d313878eb3b904f66f6" }),
     ]),
   }),
   Object.freeze({
@@ -514,10 +531,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 2,
     source_unicode: "\u0002",
     target_unicode: "[",
-    charproc_sha256: "add929da8d3840d8390cdbc6ad2746f411a6318e7c71cf97d789cac0dd24a693",
+    glyph_sha256: "de6ca507791bcb2a932347364bab4103b89d0cc312119d313878eb3b904f66f6",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 0, charproc_sha256: "eeae0f8c005ab72ff0fc77dda2d45be6bcca4359a98f882a1d33bf25619a6ae1" }),
-      Object.freeze({ original_char_code: 1, charproc_sha256: "9a0788d07694db3951c5f1b847f8d50beb1e82e0dd877cf3d75ad2b9f0de0876" }),
+      Object.freeze({ original_char_code: 0, glyph_sha256: "db8987d9df1b673b7c30dca2e284cf446998ad64b8a0a7a50c607cb3a08de761" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "a06c1a0819e09411d527d1313e0c91e68f2985038930a9bead785d1d62372154" }),
     ]),
   }),
   Object.freeze({
@@ -527,10 +544,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 2,
     source_unicode: "\u0002",
     target_unicode: "[",
-    charproc_sha256: "24e2fb74862685748e4dda1996a1664497a46fb66fc842633cd13686f974cf80",
+    glyph_sha256: "6b0a15286d5c6eab2ff6a3ec1ae3f10b2bda4a2a502190a441875d1307a089ca",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 3, charproc_sha256: "2810f1eec224c30a86c790b2b990953f0b54f28f9a32a035649784962b075cb5" }),
-      Object.freeze({ original_char_code: 16, charproc_sha256: "e0188ef949df660ee321f0379d85dcde82054590708f27c0398434fbcbb9bbc3" }),
+      Object.freeze({ original_char_code: 3, glyph_sha256: "f760c316d37754edd56178f58f7935789b7cfec19a577e3de751f3437e258583" }),
+      Object.freeze({ original_char_code: 16, glyph_sha256: "dd4cc29a14d2086fc3affe1d8c0bed29b1dc1b29df911950c6b5320e347dfebc" }),
     ]),
   }),
   Object.freeze({
@@ -540,10 +557,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 3,
     source_unicode: "\u0003",
     target_unicode: "]",
-    charproc_sha256: "a23d3c42be14fa95a5745ed7c8bfecb7c1f575dccfc7dcb9a64f0a7523ef914f",
+    glyph_sha256: "1ea7f7dfe19ac962ae5a1408a4ebdb91046dd499d108474b0d830235a07921d9",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 0, charproc_sha256: "eeae0f8c005ab72ff0fc77dda2d45be6bcca4359a98f882a1d33bf25619a6ae1" }),
-      Object.freeze({ original_char_code: 1, charproc_sha256: "9a0788d07694db3951c5f1b847f8d50beb1e82e0dd877cf3d75ad2b9f0de0876" }),
+      Object.freeze({ original_char_code: 0, glyph_sha256: "db8987d9df1b673b7c30dca2e284cf446998ad64b8a0a7a50c607cb3a08de761" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "a06c1a0819e09411d527d1313e0c91e68f2985038930a9bead785d1d62372154" }),
     ]),
   }),
   Object.freeze({
@@ -553,10 +570,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 3,
     source_unicode: "\u0003",
     target_unicode: "]",
-    charproc_sha256: "2810f1eec224c30a86c790b2b990953f0b54f28f9a32a035649784962b075cb5",
+    glyph_sha256: "f760c316d37754edd56178f58f7935789b7cfec19a577e3de751f3437e258583",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 2, charproc_sha256: "24e2fb74862685748e4dda1996a1664497a46fb66fc842633cd13686f974cf80" }),
-      Object.freeze({ original_char_code: 16, charproc_sha256: "e0188ef949df660ee321f0379d85dcde82054590708f27c0398434fbcbb9bbc3" }),
+      Object.freeze({ original_char_code: 2, glyph_sha256: "6b0a15286d5c6eab2ff6a3ec1ae3f10b2bda4a2a502190a441875d1307a089ca" }),
+      Object.freeze({ original_char_code: 16, glyph_sha256: "dd4cc29a14d2086fc3affe1d8c0bed29b1dc1b29df911950c6b5320e347dfebc" }),
     ]),
   }),
   Object.freeze({
@@ -566,10 +583,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 16,
     source_unicode: "\u0010",
     target_unicode: "(",
-    charproc_sha256: "1784beab0bd30a40b0e4476f38975039ae3ab074f725b3a8b8ac7801e8c7b0c5",
+    glyph_sha256: "6e514ff075120591b98740dcd095c9f73ec09f5483c8705f75b7cc0e89178e31",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 0, charproc_sha256: "eeae0f8c005ab72ff0fc77dda2d45be6bcca4359a98f882a1d33bf25619a6ae1" }),
-      Object.freeze({ original_char_code: 1, charproc_sha256: "9a0788d07694db3951c5f1b847f8d50beb1e82e0dd877cf3d75ad2b9f0de0876" }),
+      Object.freeze({ original_char_code: 0, glyph_sha256: "db8987d9df1b673b7c30dca2e284cf446998ad64b8a0a7a50c607cb3a08de761" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "a06c1a0819e09411d527d1313e0c91e68f2985038930a9bead785d1d62372154" }),
     ]),
   }),
   Object.freeze({
@@ -579,10 +596,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 16,
     source_unicode: "\u0010",
     target_unicode: "(",
-    charproc_sha256: "e0188ef949df660ee321f0379d85dcde82054590708f27c0398434fbcbb9bbc3",
+    glyph_sha256: "dd4cc29a14d2086fc3affe1d8c0bed29b1dc1b29df911950c6b5320e347dfebc",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 2, charproc_sha256: "24e2fb74862685748e4dda1996a1664497a46fb66fc842633cd13686f974cf80" }),
-      Object.freeze({ original_char_code: 3, charproc_sha256: "2810f1eec224c30a86c790b2b990953f0b54f28f9a32a035649784962b075cb5" }),
+      Object.freeze({ original_char_code: 2, glyph_sha256: "6b0a15286d5c6eab2ff6a3ec1ae3f10b2bda4a2a502190a441875d1307a089ca" }),
+      Object.freeze({ original_char_code: 3, glyph_sha256: "f760c316d37754edd56178f58f7935789b7cfec19a577e3de751f3437e258583" }),
     ]),
   }),
   Object.freeze({
@@ -592,10 +609,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 17,
     source_unicode: "\u0011",
     target_unicode: ")",
-    charproc_sha256: "fd720e62a2ff88280ae62f59a9c3c75c64ff57767f5f6c2136e400abf6a06a4a",
+    glyph_sha256: "4a24a711ec6fb485ffd8a893be44c48f0a9b91450c50219fd94176ff32938b15",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 0, charproc_sha256: "eeae0f8c005ab72ff0fc77dda2d45be6bcca4359a98f882a1d33bf25619a6ae1" }),
-      Object.freeze({ original_char_code: 1, charproc_sha256: "9a0788d07694db3951c5f1b847f8d50beb1e82e0dd877cf3d75ad2b9f0de0876" }),
+      Object.freeze({ original_char_code: 0, glyph_sha256: "db8987d9df1b673b7c30dca2e284cf446998ad64b8a0a7a50c607cb3a08de761" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "a06c1a0819e09411d527d1313e0c91e68f2985038930a9bead785d1d62372154" }),
     ]),
   }),
   Object.freeze({
@@ -605,10 +622,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 17,
     source_unicode: "\u0011",
     target_unicode: ")",
-    charproc_sha256: "741b0e1ccef4470e9fc1446144de647f95d3f064c8ee0a30e932a6f0f21d5c36",
+    glyph_sha256: "c62e5e3a49164445ab07b6786922a5d8cd5d6806bc687aab4027a7b834f30381",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 2, charproc_sha256: "24e2fb74862685748e4dda1996a1664497a46fb66fc842633cd13686f974cf80" }),
-      Object.freeze({ original_char_code: 3, charproc_sha256: "2810f1eec224c30a86c790b2b990953f0b54f28f9a32a035649784962b075cb5" }),
+      Object.freeze({ original_char_code: 2, glyph_sha256: "6b0a15286d5c6eab2ff6a3ec1ae3f10b2bda4a2a502190a441875d1307a089ca" }),
+      Object.freeze({ original_char_code: 3, glyph_sha256: "f760c316d37754edd56178f58f7935789b7cfec19a577e3de751f3437e258583" }),
     ]),
   }),
   Object.freeze({
@@ -618,10 +635,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 18,
     source_unicode: "\u0012",
     target_unicode: "(",
-    charproc_sha256: "d0c76fc6c61d5272b91e030c99f55649bd7a738dd57be5e5987505e317d79489",
+    glyph_sha256: "2ea0b479a269492539f17c9eeb24b9836e2c337ac091081b66ec7267d67a6cbe",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 0, charproc_sha256: "eeae0f8c005ab72ff0fc77dda2d45be6bcca4359a98f882a1d33bf25619a6ae1" }),
-      Object.freeze({ original_char_code: 1, charproc_sha256: "9a0788d07694db3951c5f1b847f8d50beb1e82e0dd877cf3d75ad2b9f0de0876" }),
+      Object.freeze({ original_char_code: 0, glyph_sha256: "db8987d9df1b673b7c30dca2e284cf446998ad64b8a0a7a50c607cb3a08de761" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "a06c1a0819e09411d527d1313e0c91e68f2985038930a9bead785d1d62372154" }),
     ]),
   }),
   Object.freeze({
@@ -631,10 +648,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 19,
     source_unicode: "\u0013",
     target_unicode: ")",
-    charproc_sha256: "4787f4b191732cff06605637446e648294d85d36ddbe811db3be7d3790eddd21",
+    glyph_sha256: "30ce6ba7dc248d84d411a6050c735dc52420bbfc2e127330da96bb3876fdc176",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 0, charproc_sha256: "eeae0f8c005ab72ff0fc77dda2d45be6bcca4359a98f882a1d33bf25619a6ae1" }),
-      Object.freeze({ original_char_code: 1, charproc_sha256: "9a0788d07694db3951c5f1b847f8d50beb1e82e0dd877cf3d75ad2b9f0de0876" }),
+      Object.freeze({ original_char_code: 0, glyph_sha256: "db8987d9df1b673b7c30dca2e284cf446998ad64b8a0a7a50c607cb3a08de761" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "a06c1a0819e09411d527d1313e0c91e68f2985038930a9bead785d1d62372154" }),
     ]),
   }),
   Object.freeze({
@@ -644,10 +661,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 20,
     source_unicode: "\u0014",
     target_unicode: "[",
-    charproc_sha256: "2daf02b5e930be4e4d4cf68cb0d7fadd5f3e44238cc34e7308dd3bf39fbcf372",
+    glyph_sha256: "d7bb229a762f6389b264ecc8182d96463512edd9d15641adcddd80da1d62864a",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 0, charproc_sha256: "eeae0f8c005ab72ff0fc77dda2d45be6bcca4359a98f882a1d33bf25619a6ae1" }),
-      Object.freeze({ original_char_code: 1, charproc_sha256: "9a0788d07694db3951c5f1b847f8d50beb1e82e0dd877cf3d75ad2b9f0de0876" }),
+      Object.freeze({ original_char_code: 0, glyph_sha256: "db8987d9df1b673b7c30dca2e284cf446998ad64b8a0a7a50c607cb3a08de761" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "a06c1a0819e09411d527d1313e0c91e68f2985038930a9bead785d1d62372154" }),
     ]),
   }),
   Object.freeze({
@@ -657,10 +674,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 20,
     source_unicode: "\u0014",
     target_unicode: "[",
-    charproc_sha256: "42ccb43e7b055f57391032b7a14079d777e45451ccb5d28b5d7ed2cbff51ea3a",
+    glyph_sha256: "5d63c680f912fa771991bec647d6024bbffc00377ef7515cd5eb4a063ac6fb30",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 2, charproc_sha256: "24e2fb74862685748e4dda1996a1664497a46fb66fc842633cd13686f974cf80" }),
-      Object.freeze({ original_char_code: 3, charproc_sha256: "2810f1eec224c30a86c790b2b990953f0b54f28f9a32a035649784962b075cb5" }),
+      Object.freeze({ original_char_code: 2, glyph_sha256: "6b0a15286d5c6eab2ff6a3ec1ae3f10b2bda4a2a502190a441875d1307a089ca" }),
+      Object.freeze({ original_char_code: 3, glyph_sha256: "f760c316d37754edd56178f58f7935789b7cfec19a577e3de751f3437e258583" }),
     ]),
   }),
   Object.freeze({
@@ -670,10 +687,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 21,
     source_unicode: "\u0015",
     target_unicode: "]",
-    charproc_sha256: "50dd658a682af9da1e5f9e3ed106d7de7cd6f7b1df172736fe38b3a21469e225",
+    glyph_sha256: "c041f94f074b2255945dfb7dd0a115ae7ce4a97002147ca315fa7647362120a0",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 0, charproc_sha256: "eeae0f8c005ab72ff0fc77dda2d45be6bcca4359a98f882a1d33bf25619a6ae1" }),
-      Object.freeze({ original_char_code: 1, charproc_sha256: "9a0788d07694db3951c5f1b847f8d50beb1e82e0dd877cf3d75ad2b9f0de0876" }),
+      Object.freeze({ original_char_code: 0, glyph_sha256: "db8987d9df1b673b7c30dca2e284cf446998ad64b8a0a7a50c607cb3a08de761" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "a06c1a0819e09411d527d1313e0c91e68f2985038930a9bead785d1d62372154" }),
     ]),
   }),
   Object.freeze({
@@ -683,10 +700,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 21,
     source_unicode: "\u0015",
     target_unicode: "]",
-    charproc_sha256: "ebfd69f0be341fbb00596c55ae708eeccc641b0174b4972f377f14ad33d35649",
+    glyph_sha256: "5aac802aecbaec1d9ed686ae4ddc1bb6c8bce048462620ec5582b95c0299661d",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 2, charproc_sha256: "24e2fb74862685748e4dda1996a1664497a46fb66fc842633cd13686f974cf80" }),
-      Object.freeze({ original_char_code: 3, charproc_sha256: "2810f1eec224c30a86c790b2b990953f0b54f28f9a32a035649784962b075cb5" }),
+      Object.freeze({ original_char_code: 2, glyph_sha256: "6b0a15286d5c6eab2ff6a3ec1ae3f10b2bda4a2a502190a441875d1307a089ca" }),
+      Object.freeze({ original_char_code: 3, glyph_sha256: "f760c316d37754edd56178f58f7935789b7cfec19a577e3de751f3437e258583" }),
     ]),
   }),
   Object.freeze({
@@ -696,10 +713,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 1,
     source_unicode: "\u0001",
     target_unicode: "Δ",
-    charproc_sha256: "762215421d47ca10bd29483ca69c105402ef88b6c80b7c4b1072e10a81fc14cc",
+    glyph_sha256: "30552b3ff5ae9fae4095b2a791d73b448221a488c7b6ede9ddfb6852f474a052",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, charproc_sha256: "e688a83f98433c841694f990aabafe5245cfc9320f584d7f70da706f0eeba259" }),
-      Object.freeze({ original_char_code: 14, charproc_sha256: "a5a76e73ff8dec163f779ae9cbcb92f18349e41fb4ce34f2e6a443c5aff1ef56" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
+      Object.freeze({ original_char_code: 14, glyph_sha256: "8d55a727feda11508e29c3b5c500d64dc58ce7b6fdb3d9776ef1e0d2df7888a3" }),
     ]),
   }),
   Object.freeze({
@@ -709,10 +726,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 14,
     source_unicode: "\u000e",
     target_unicode: "δ",
-    charproc_sha256: "a5a76e73ff8dec163f779ae9cbcb92f18349e41fb4ce34f2e6a443c5aff1ef56",
+    glyph_sha256: "8d55a727feda11508e29c3b5c500d64dc58ce7b6fdb3d9776ef1e0d2df7888a3",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 1, charproc_sha256: "762215421d47ca10bd29483ca69c105402ef88b6c80b7c4b1072e10a81fc14cc" }),
-      Object.freeze({ original_char_code: 11, charproc_sha256: "e688a83f98433c841694f990aabafe5245cfc9320f584d7f70da706f0eeba259" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "30552b3ff5ae9fae4095b2a791d73b448221a488c7b6ede9ddfb6852f474a052" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
     ]),
   }),
   Object.freeze({
@@ -722,10 +739,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 14,
     source_unicode: "\u000e",
     target_unicode: "δ",
-    charproc_sha256: "b41124da800ba2c4ed342b553c9433dc8b0eaf4e6228dab9901d6f9cd4e4449d",
+    glyph_sha256: "40e6d476435323a686a4ef5f02ac43f6b6b5e3612887c18105b82575e76e2e9b",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, charproc_sha256: "bab8aeb78893a19704c95538c54764abaae0cfe9d84812825f718e7687432f63" }),
-      Object.freeze({ original_char_code: 15, charproc_sha256: "7c62980ea7b423af3bfd7f14a2b5efa95b4dd23f611c1a013ef7b7fd57cefb51" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "6092e20a2f8a4925449780db726c4912ccee956a094589d3cb63ede3b5d7383b" }),
+      Object.freeze({ original_char_code: 15, glyph_sha256: "8692c50f6e5d1605e52e3d414ad4c285a583d11bcfff2f7a3be93bee06117de5" }),
     ]),
   }),
   Object.freeze({
@@ -735,10 +752,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 15,
     source_unicode: "\u000f",
     target_unicode: "ϵ",
-    charproc_sha256: "376b93ca5b31fec7270e1c4ea1425de0c60c37146b03f2c5f9de6b979209462a",
+    glyph_sha256: "da7780d95a5aea753d5de0f042903c2e96618c719283db449cd0476c5e74a6a4",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 1, charproc_sha256: "762215421d47ca10bd29483ca69c105402ef88b6c80b7c4b1072e10a81fc14cc" }),
-      Object.freeze({ original_char_code: 11, charproc_sha256: "e688a83f98433c841694f990aabafe5245cfc9320f584d7f70da706f0eeba259" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "30552b3ff5ae9fae4095b2a791d73b448221a488c7b6ede9ddfb6852f474a052" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
     ]),
   }),
   Object.freeze({
@@ -748,10 +765,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 15,
     source_unicode: "\u000f",
     target_unicode: "ϵ",
-    charproc_sha256: "7c62980ea7b423af3bfd7f14a2b5efa95b4dd23f611c1a013ef7b7fd57cefb51",
+    glyph_sha256: "8692c50f6e5d1605e52e3d414ad4c285a583d11bcfff2f7a3be93bee06117de5",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, charproc_sha256: "bab8aeb78893a19704c95538c54764abaae0cfe9d84812825f718e7687432f63" }),
-      Object.freeze({ original_char_code: 14, charproc_sha256: "b41124da800ba2c4ed342b553c9433dc8b0eaf4e6228dab9901d6f9cd4e4449d" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "6092e20a2f8a4925449780db726c4912ccee956a094589d3cb63ede3b5d7383b" }),
+      Object.freeze({ original_char_code: 14, glyph_sha256: "40e6d476435323a686a4ef5f02ac43f6b6b5e3612887c18105b82575e76e2e9b" }),
     ]),
   }),
   Object.freeze({
@@ -761,10 +778,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 17,
     source_unicode: "\u0011",
     target_unicode: "η",
-    charproc_sha256: "a19a510f4227807eab4664f0736e8e6258fe26dcc46d7ac8d0c7a378691237cf",
+    glyph_sha256: "8a211c038232f3e28545e3d2f4a42ebd349a8cc27e45bc0a6775b4cd105cfb9c",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, charproc_sha256: "bab8aeb78893a19704c95538c54764abaae0cfe9d84812825f718e7687432f63" }),
-      Object.freeze({ original_char_code: 14, charproc_sha256: "b41124da800ba2c4ed342b553c9433dc8b0eaf4e6228dab9901d6f9cd4e4449d" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "6092e20a2f8a4925449780db726c4912ccee956a094589d3cb63ede3b5d7383b" }),
+      Object.freeze({ original_char_code: 14, glyph_sha256: "40e6d476435323a686a4ef5f02ac43f6b6b5e3612887c18105b82575e76e2e9b" }),
     ]),
   }),
   Object.freeze({
@@ -774,10 +791,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 18,
     source_unicode: "\u0012",
     target_unicode: "θ",
-    charproc_sha256: "700332af231f58b628cd690de8f32a0604206fdbfd85a5a9fe18846044fda42b",
+    glyph_sha256: "1687afb884c912cf4555cef231572f37ac3eabe87344bc993fc3880d5eabdd2a",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, charproc_sha256: "bab8aeb78893a19704c95538c54764abaae0cfe9d84812825f718e7687432f63" }),
-      Object.freeze({ original_char_code: 14, charproc_sha256: "b41124da800ba2c4ed342b553c9433dc8b0eaf4e6228dab9901d6f9cd4e4449d" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "6092e20a2f8a4925449780db726c4912ccee956a094589d3cb63ede3b5d7383b" }),
+      Object.freeze({ original_char_code: 14, glyph_sha256: "40e6d476435323a686a4ef5f02ac43f6b6b5e3612887c18105b82575e76e2e9b" }),
     ]),
   }),
   Object.freeze({
@@ -787,10 +804,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 21,
     source_unicode: "\u0015",
     target_unicode: "λ",
-    charproc_sha256: "25c0ac6215a1b5e1a1df1a3d643e7465f92f6708d5ba8030eefe30c4378cb3a2",
+    glyph_sha256: "bdf1508d236990157b905ae312c6daf9452a27e2e15f0d239e174047d700327f",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 1, charproc_sha256: "762215421d47ca10bd29483ca69c105402ef88b6c80b7c4b1072e10a81fc14cc" }),
-      Object.freeze({ original_char_code: 11, charproc_sha256: "e688a83f98433c841694f990aabafe5245cfc9320f584d7f70da706f0eeba259" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "30552b3ff5ae9fae4095b2a791d73b448221a488c7b6ede9ddfb6852f474a052" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
     ]),
   }),
   Object.freeze({
@@ -800,10 +817,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 21,
     source_unicode: "\u0015",
     target_unicode: "λ",
-    charproc_sha256: "2023b726a9e1f2d0e2d551201dec4d7c14bca4a7fd3367e17b2e8d1421a573f5",
+    glyph_sha256: "50a0ec752f73c00a5126d9e2ac8c9d3b97058ebd24e08570f18a994cad8702bd",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, charproc_sha256: "bab8aeb78893a19704c95538c54764abaae0cfe9d84812825f718e7687432f63" }),
-      Object.freeze({ original_char_code: 14, charproc_sha256: "b41124da800ba2c4ed342b553c9433dc8b0eaf4e6228dab9901d6f9cd4e4449d" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "6092e20a2f8a4925449780db726c4912ccee956a094589d3cb63ede3b5d7383b" }),
+      Object.freeze({ original_char_code: 14, glyph_sha256: "40e6d476435323a686a4ef5f02ac43f6b6b5e3612887c18105b82575e76e2e9b" }),
     ]),
   }),
   Object.freeze({
@@ -813,10 +830,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 22,
     source_unicode: "\u0016",
     target_unicode: "μ",
-    charproc_sha256: "2c7d9c60cea80cf491a5990df64a392b80506682bd8732664129d36f2f51cdb6",
+    glyph_sha256: "58753b33f3d1d72955b0f1ef1777c5455c5ba37588f5fd88a0271ddcc0f46a75",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 1, charproc_sha256: "762215421d47ca10bd29483ca69c105402ef88b6c80b7c4b1072e10a81fc14cc" }),
-      Object.freeze({ original_char_code: 11, charproc_sha256: "e688a83f98433c841694f990aabafe5245cfc9320f584d7f70da706f0eeba259" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "30552b3ff5ae9fae4095b2a791d73b448221a488c7b6ede9ddfb6852f474a052" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
     ]),
   }),
   Object.freeze({
@@ -826,10 +843,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 23,
     source_unicode: "\u0017",
     target_unicode: "ν",
-    charproc_sha256: "f463297f1a37674d79d82c72d69f9b7c2c0fcbe71a450af43b9876cba82e91b2",
+    glyph_sha256: "d56aaf7b101a1a8f54fb062c3176637576fc6d46c262c250b1082d5c606853c7",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 1, charproc_sha256: "762215421d47ca10bd29483ca69c105402ef88b6c80b7c4b1072e10a81fc14cc" }),
-      Object.freeze({ original_char_code: 11, charproc_sha256: "e688a83f98433c841694f990aabafe5245cfc9320f584d7f70da706f0eeba259" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "30552b3ff5ae9fae4095b2a791d73b448221a488c7b6ede9ddfb6852f474a052" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
     ]),
   }),
   Object.freeze({
@@ -839,10 +856,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 27,
     source_unicode: "\u001b",
     target_unicode: "σ",
-    charproc_sha256: "94bd43b8371d7d511c5adbbce53cb99f894fc15e2ba084ddd5bddb00a65ca02a",
+    glyph_sha256: "c9a619efc5cd6a08c8ca09b92aca0d61391929ca7846322b4baf0d3f38edc5d8",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, charproc_sha256: "bab8aeb78893a19704c95538c54764abaae0cfe9d84812825f718e7687432f63" }),
-      Object.freeze({ original_char_code: 14, charproc_sha256: "b41124da800ba2c4ed342b553c9433dc8b0eaf4e6228dab9901d6f9cd4e4449d" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "6092e20a2f8a4925449780db726c4912ccee956a094589d3cb63ede3b5d7383b" }),
+      Object.freeze({ original_char_code: 14, glyph_sha256: "40e6d476435323a686a4ef5f02ac43f6b6b5e3612887c18105b82575e76e2e9b" }),
     ]),
   }),
   Object.freeze({
@@ -852,10 +869,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 28,
     source_unicode: "\u001c",
     target_unicode: "τ",
-    charproc_sha256: "53992a8aa4b2134eee16941856f5e38adf6181e4c5f80354097626905cbf69a7",
+    glyph_sha256: "10338ccd15eb973844cbbc07005a82aa702020cd2910adb162e71870fc67f82a",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 1, charproc_sha256: "762215421d47ca10bd29483ca69c105402ef88b6c80b7c4b1072e10a81fc14cc" }),
-      Object.freeze({ original_char_code: 11, charproc_sha256: "e688a83f98433c841694f990aabafe5245cfc9320f584d7f70da706f0eeba259" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "30552b3ff5ae9fae4095b2a791d73b448221a488c7b6ede9ddfb6852f474a052" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
     ]),
   }),
   Object.freeze({
@@ -865,10 +882,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 39,
     source_unicode: "'",
     target_unicode: "φ",
-    charproc_sha256: "117a85afcd9bbddb35a7be9228c55001a0cc97e38df0402f2e8817ea96b33d2e",
+    glyph_sha256: "4231ef8441ffbc9e7bc7693f3ec28d2de301d0edc6f9df6f69968a95af266e97",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 1, charproc_sha256: "762215421d47ca10bd29483ca69c105402ef88b6c80b7c4b1072e10a81fc14cc" }),
-      Object.freeze({ original_char_code: 11, charproc_sha256: "e688a83f98433c841694f990aabafe5245cfc9320f584d7f70da706f0eeba259" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "30552b3ff5ae9fae4095b2a791d73b448221a488c7b6ede9ddfb6852f474a052" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
     ]),
   }),
   Object.freeze({
@@ -878,10 +895,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 82,
     source_unicode: "R",
     target_unicode: "∫",
-    charproc_sha256: "e5fa9eb07a6e6807fb2ef29b805950074c1095fec2dbdc857ba9f46e4fbaaf77",
+    glyph_sha256: "58d503ac1ab67ecadd8e1ec07991a8338ddd452f5c3069dcba0ebe52e42fb3ee",
     complete_font_enrollment: Object.freeze([82, 90]),
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 90, charproc_sha256: "4a183facdfcc364d036490de4893001dd292baad2d6a9e22cff0d81d92b6bf5b" }),
+      Object.freeze({ original_char_code: 90, glyph_sha256: "063d12bd3f8fba24a0375a5da378e3a0acb6195c42f91625ea0798dba6545ed7" }),
     ]),
   }),
   Object.freeze({
@@ -891,10 +908,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 90,
     source_unicode: "Z",
     target_unicode: "∫",
-    charproc_sha256: "4a183facdfcc364d036490de4893001dd292baad2d6a9e22cff0d81d92b6bf5b",
+    glyph_sha256: "063d12bd3f8fba24a0375a5da378e3a0acb6195c42f91625ea0798dba6545ed7",
     complete_font_enrollment: Object.freeze([82, 90]),
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 82, charproc_sha256: "e5fa9eb07a6e6807fb2ef29b805950074c1095fec2dbdc857ba9f46e4fbaaf77" }),
+      Object.freeze({ original_char_code: 82, glyph_sha256: "58d503ac1ab67ecadd8e1ec07991a8338ddd452f5c3069dcba0ebe52e42fb3ee" }),
     ]),
   }),
   Object.freeze({
@@ -904,10 +921,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 6,
     source_unicode: "\u0006",
     target_unicode: "±",
-    charproc_sha256: "b68b24c69a8802a7e57a1cabaa7c1153a0a305e5d29ba308b78d60c16a5464b7",
+    glyph_sha256: "4734e344eca1f8f73183a34504c1068146b425815a2a8ef6aa00a18dfd45d9a2",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 0, charproc_sha256: "0c8b34a3281f9e8e91b2d955f952a50d187cd06c432be27c015b78570e645e9d" }),
-      Object.freeze({ original_char_code: 33, charproc_sha256: "6ff1e08b5364a8ce02ac2390691fdfb1f2e532bd0a1dac95d01a155bbce482fc" }),
+      Object.freeze({ original_char_code: 0, glyph_sha256: "ed5df416bb312c2b49ed8936f226016a28e9a09fa52aba56281dd6a8a5430d19" }),
+      Object.freeze({ original_char_code: 33, glyph_sha256: "a818ff8e95ae122382e0f0198e875400f4cc07ef1115dbe936ad5dd37933c4d4" }),
     ]),
   }),
   Object.freeze({
@@ -917,10 +934,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 33,
     source_unicode: "!",
     target_unicode: "→",
-    charproc_sha256: "7d300b0750eccc0a4a46dc4308474d519a19002749ea7ed11bdba2daeaaf4776",
+    glyph_sha256: "3efef4ea645a3cd8776d728305dd613116e17b74b006570e8cc6fd8a4b1dbb4b",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 0, charproc_sha256: "fb1f6bf10138511bcefade47467b3e2f9ae691ab3dab097914be1f0f66305470" }),
-      Object.freeze({ original_char_code: 1, charproc_sha256: "33077f6f9b7f5c5631bd3cb7bbfc79b4da1fbd929b23f6e08e55c90566608c7a" }),
+      Object.freeze({ original_char_code: 0, glyph_sha256: "68b4a1e125aa58ed3e798029190dbf4e2f3937030f921cd995cf7c8ad2f2eedc" }),
+      Object.freeze({ original_char_code: 1, glyph_sha256: "2ed87b069c99482d0823c085da9c199582e6e4b51172a2b360d9b6652066e3ae" }),
     ]),
   }),
   Object.freeze({
@@ -930,10 +947,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 33,
     source_unicode: "!",
     target_unicode: "→",
-    charproc_sha256: "6ff1e08b5364a8ce02ac2390691fdfb1f2e532bd0a1dac95d01a155bbce482fc",
+    glyph_sha256: "a818ff8e95ae122382e0f0198e875400f4cc07ef1115dbe936ad5dd37933c4d4",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 0, charproc_sha256: "0c8b34a3281f9e8e91b2d955f952a50d187cd06c432be27c015b78570e645e9d" }),
-      Object.freeze({ original_char_code: 6, charproc_sha256: "b68b24c69a8802a7e57a1cabaa7c1153a0a305e5d29ba308b78d60c16a5464b7" }),
+      Object.freeze({ original_char_code: 0, glyph_sha256: "ed5df416bb312c2b49ed8936f226016a28e9a09fa52aba56281dd6a8a5430d19" }),
+      Object.freeze({ original_char_code: 6, glyph_sha256: "4734e344eca1f8f73183a34504c1068146b425815a2a8ef6aa00a18dfd45d9a2" }),
     ]),
   }),
   Object.freeze({
@@ -943,10 +960,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 17,
     source_unicode: "\u0011",
     target_unicode: "η",
-    charproc_sha256: "2fd7e5e9b50a6e5116b22bf8cc472eaaeccdc66b09680cbc8a67a9f10544f8da",
+    glyph_sha256: "712ac34ba1c3de89b2c233171e58eaa55e54ebcb0d4cec1609a788fa90eef047",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, charproc_sha256: "e688a83f98433c841694f990aabafe5245cfc9320f584d7f70da706f0eeba259" }),
-      Object.freeze({ original_char_code: 25, charproc_sha256: "780b04fa47830ca782211b86dbedfe0adec0445bdf94d538bfe7adde08ed9445" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
+      Object.freeze({ original_char_code: 25, glyph_sha256: "751c36c470d1f0292b9d39de8cfec243d0e1e4ca3b2a2648676a8048cdf75322" }),
     ]),
   }),
   Object.freeze({
@@ -956,10 +973,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 18,
     source_unicode: "\u0012",
     target_unicode: "θ",
-    charproc_sha256: "194bccf1b8ad8839f03bf6ebb90cf67cc7c97c8e386f21189d59900109299e58",
+    glyph_sha256: "38d2baa791ebd167d9d328153bd4cabcb722c833e759315f3a398537e0f57e03",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, charproc_sha256: "e688a83f98433c841694f990aabafe5245cfc9320f584d7f70da706f0eeba259" }),
-      Object.freeze({ original_char_code: 25, charproc_sha256: "780b04fa47830ca782211b86dbedfe0adec0445bdf94d538bfe7adde08ed9445" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
+      Object.freeze({ original_char_code: 25, glyph_sha256: "751c36c470d1f0292b9d39de8cfec243d0e1e4ca3b2a2648676a8048cdf75322" }),
     ]),
   }),
   Object.freeze({
@@ -969,10 +986,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 27,
     source_unicode: "\u001b",
     target_unicode: "σ",
-    charproc_sha256: "dae3aa06efc876bfa8242e02ad384046ce039fca3ff87523faab17bce15a75de",
+    glyph_sha256: "de609d12d1935bc3ff128046fa3c5f4330689ded53c9fc7a179a0b7c368f9f9a",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 11, charproc_sha256: "e688a83f98433c841694f990aabafe5245cfc9320f584d7f70da706f0eeba259" }),
-      Object.freeze({ original_char_code: 25, charproc_sha256: "780b04fa47830ca782211b86dbedfe0adec0445bdf94d538bfe7adde08ed9445" }),
+      Object.freeze({ original_char_code: 11, glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093" }),
+      Object.freeze({ original_char_code: 25, glyph_sha256: "751c36c470d1f0292b9d39de8cfec243d0e1e4ca3b2a2648676a8048cdf75322" }),
     ]),
   }),
   Object.freeze({
@@ -982,10 +999,10 @@ const TYPE3_RECOVERY_REGISTRY = Object.freeze([
     original_char_code: 6,
     source_unicode: "\u0006",
     target_unicode: "±",
-    charproc_sha256: "4dedb5543e5ab5817e06920d50b7983b3febaf06c22feeb83bdbb3d8449e2c3c",
+    glyph_sha256: "009835b7eda7745c9e2e167ce0ed1b5e4ff9063af4c92280dffab3213f07e395",
     witnesses: Object.freeze([
-      Object.freeze({ original_char_code: 0, charproc_sha256: "fb1f6bf10138511bcefade47467b3e2f9ae691ab3dab097914be1f0f66305470" }),
-      Object.freeze({ original_char_code: 21, charproc_sha256: "05b4a9d88c1df64b3ac339ae6bb7ed82383b93bb08512842452db43453a28970" }),
+      Object.freeze({ original_char_code: 0, glyph_sha256: "68b4a1e125aa58ed3e798029190dbf4e2f3937030f921cd995cf7c8ad2f2eedc" }),
+      Object.freeze({ original_char_code: 21, glyph_sha256: "d2622641d0fa27eba18c91fd6333cfad66cbc23918a88854242d2f0f4c6ca968" }),
     ]),
   }),
 ]);
@@ -1075,6 +1092,214 @@ export function type3CharProcSha256(charProc) {
   }
 }
 
+function multiplyType3Transform(outer, inner) {
+  return [
+    outer[0] * inner[0] + outer[2] * inner[1],
+    outer[1] * inner[0] + outer[3] * inner[1],
+    outer[0] * inner[2] + outer[2] * inner[3],
+    outer[1] * inner[2] + outer[3] * inner[3],
+    outer[0] * inner[4] + outer[2] * inner[5] + outer[4],
+    outer[1] * inner[4] + outer[3] * inner[5] + outer[5],
+  ];
+}
+
+/**
+ * Rebuilds the decoded 1-bit image-mask grid from the outline PDF.js compiles
+ * for a Type-3 bitmap glyph.
+ *
+ * PDF.js does not hand out the decoded mask samples: for a Type-3 glyph whose
+ * body is a single inline image mask it decodes the samples (applying /Decode,
+ * /BlackIs1 and any CCITT or Flate filter), traces the painted pixels, and
+ * emits one `rawFillPath` whose vertices sit exactly on the pixel lattice,
+ * expressed in the unit square as `x / width` and `1 - row / height`. Every
+ * edge is therefore axis-parallel and integral, and filling that outline with
+ * the non-zero rule recovers the painted samples exactly. Verified bit for bit
+ * against the 123 distinct inline masks of the Shannon reference document,
+ * decoded independently straight out of the CharProcs streams.
+ */
+function type3GlyphImageMask(charProc, fontMatrix, ops) {
+  if (!charProc || !Array.isArray(charProc.fnArray) || !Array.isArray(charProc.argsArray)) return null;
+  if (!Array.isArray(fontMatrix) || fontMatrix.length !== 6 || !fontMatrix.every(Number.isFinite)) return null;
+  if (![ops?.save, ops?.restore, ops?.transform, ops?.constructPath, ops?.rawFillPath,
+    ops?.setCharWidthAndBounds].every(Number.isFinite)) return null;
+  let current = [...fontMatrix];
+  const stack = [];
+  let painted = null;
+  for (let index = 0; index < charProc.fnArray.length; index += 1) {
+    const operation = charProc.fnArray[index];
+    const args = charProc.argsArray[index];
+    if (operation === ops.save) {
+      if (stack.length > MAX_TYPE3_GLYPH_CANONICAL_DEPTH) return null;
+      stack.push([...current]);
+    } else if (operation === ops.restore) {
+      if (stack.length === 0) return null;
+      current = stack.pop();
+    } else if (operation === ops.transform) {
+      if (!Array.isArray(args) || args.length !== 6 || !args.every(Number.isFinite)) return null;
+      current = multiplyType3Transform(current, args);
+    } else if (operation === ops.setCharWidthAndBounds) {
+      // Declares the glyph's advance and bounds. It paints nothing, and its
+      // numbers are exactly the producer-specific placement this key drops.
+    } else if (operation === ops.constructPath) {
+      // A second painted object means this is not a plain single-mask glyph.
+      if (painted || args?.[0] !== ops.rawFillPath) return null;
+      painted = { path: args?.[1]?.[0], box: args?.[2], transform: current };
+    } else {
+      return null;
+    }
+  }
+  if (!painted) return null;
+  const { path, box, transform } = painted;
+  if (!ArrayBuffer.isView(path) || !ArrayBuffer.isView(box) || box.length !== 4) return null;
+  if (box[0] !== 0 || box[1] !== 0) return null;
+  const width = box[2];
+  const height = box[3];
+  if (!Number.isInteger(width) || !Number.isInteger(height) || width <= 0 || height <= 0) return null;
+  if (width * height > MAX_TYPE3_GLYPH_MASK_PIXELS) return null;
+  if (path.length > MAX_TYPE3_GLYPH_MASK_PATH_NODES) return null;
+  // Only an axis-aligned, non-degenerate placement has an unambiguous mirror
+  // decomposition; a rotated or skewed glyph program is left unrecognized.
+  if (Math.abs(transform[1]) > 1e-9 || Math.abs(transform[2]) > 1e-9) return null;
+  if (!(Math.abs(transform[0]) > 0) || !(Math.abs(transform[3]) > 0)) return null;
+  const bits = fillAxisAlignedLatticePath(path, width, height);
+  if (!bits) return null;
+  return { width, height, bits, mirror_x: transform[0] < 0, mirror_y: transform[3] < 0 };
+}
+
+function fillAxisAlignedLatticePath(path, width, height) {
+  const crossings = Array.from({ length: height }, () => []);
+  const lattice = (value, extent) => {
+    const scaled = value * extent;
+    const rounded = Math.round(scaled);
+    if (!Number.isFinite(scaled) || Math.abs(scaled - rounded) > 1e-3) return null;
+    return rounded < 0 || rounded > extent ? null : rounded;
+  };
+  const addEdge = (fromX, fromY, toX, toY) => {
+    if (fromX !== toX) return fromY === toY;
+    const direction = toY > fromY ? 1 : -1;
+    for (let row = Math.min(fromY, toY); row < Math.max(fromY, toY); row += 1) {
+      crossings[row].push([fromX, direction]);
+    }
+    return true;
+  };
+  let startX = 0;
+  let startY = 0;
+  let cursorX = 0;
+  let cursorY = 0;
+  let open = false;
+  for (let index = 0; index < path.length;) {
+    const operation = path[index];
+    index += 1;
+    if (operation !== DRAW_OPS.moveTo && operation !== DRAW_OPS.lineTo && operation !== DRAW_OPS.closePath) return null;
+    if (operation === DRAW_OPS.closePath) {
+      if (open && !addEdge(cursorX, cursorY, startX, startY)) return null;
+      cursorX = startX;
+      cursorY = startY;
+      continue;
+    }
+    if (index + 1 >= path.length) return null;
+    const x = lattice(path[index], width);
+    // PDF.js emits the traced outline y-up in the unit square, so unit y 1 is
+    // image row 0. Reading it back as a row index keeps the grid in the
+    // stored sample order and leaves orientation to the canonical step.
+    const y = lattice(1 - path[index + 1], height);
+    index += 2;
+    if (x === null || y === null) return null;
+    if (operation === DRAW_OPS.moveTo) {
+      if (open && !addEdge(cursorX, cursorY, startX, startY)) return null;
+      startX = x;
+      startY = y;
+      open = true;
+    } else if (!open || !addEdge(cursorX, cursorY, x, y)) {
+      return null;
+    }
+    cursorX = x;
+    cursorY = y;
+  }
+  if (open && !addEdge(cursorX, cursorY, startX, startY)) return null;
+  const bits = new Uint8Array(width * height);
+  for (let row = 0; row < height; row += 1) {
+    const edges = crossings[row].sort((left, right) => left[0] - right[0]);
+    let winding = 0;
+    let previous = 0;
+    for (const [x, direction] of edges) {
+      if (winding !== 0) bits.fill(1, row * width + previous, row * width + x);
+      winding += direction;
+      previous = x;
+    }
+    if (winding !== 0) return null;
+  }
+  return bits;
+}
+
+/**
+ * The producer-independent form of a decoded mask: mirrored back into the
+ * orientation it is actually painted in, then cropped to its own ink. What is
+ * deliberately dropped is everything a second producer would have chosen
+ * differently for the same glyph — the placement matrix, the blank padding
+ * around the ink, and the operator idiom that carried them.
+ */
+function canonicalType3MaskBits(mask) {
+  const { width, height, bits, mirror_x: mirrorX, mirror_y: mirrorY } = mask;
+  let top = height;
+  let bottom = -1;
+  let left = width;
+  let right = -1;
+  for (let row = 0; row < height; row += 1) {
+    for (let column = 0; column < width; column += 1) {
+      if (!bits[row * width + column]) continue;
+      const visualRow = mirrorY ? height - 1 - row : row;
+      const visualColumn = mirrorX ? width - 1 - column : column;
+      if (visualRow < top) top = visualRow;
+      if (visualRow > bottom) bottom = visualRow;
+      if (visualColumn < left) left = visualColumn;
+      if (visualColumn > right) right = visualColumn;
+    }
+  }
+  if (bottom < 0) return { width: 0, height: 0, packed: Buffer.alloc(0) };
+  const inkWidth = right - left + 1;
+  const inkHeight = bottom - top + 1;
+  const stride = (inkWidth + 7) >> 3;
+  const packed = Buffer.alloc(stride * inkHeight);
+  for (let row = 0; row < inkHeight; row += 1) {
+    for (let column = 0; column < inkWidth; column += 1) {
+      const visualRow = top + row;
+      const visualColumn = left + column;
+      const sourceRow = mirrorY ? height - 1 - visualRow : visualRow;
+      const sourceColumn = mirrorX ? width - 1 - visualColumn : visualColumn;
+      if (bits[sourceRow * width + sourceColumn]) packed[row * stride + (column >> 3)] |= 128 >> (column & 7);
+    }
+  }
+  return { width: inkWidth, height: inkHeight, packed };
+}
+
+/**
+ * The recovery key for one Type-3 glyph program.
+ *
+ * A glyph whose body is a single decoded image mask is keyed on the mask
+ * itself, so the same Computer Modern raster keys identically no matter which
+ * dvips-era toolchain packed it, which filter it was compressed with, or where
+ * the producer placed it inside the glyph box. Anything else — an outline
+ * CharProc, a multi-object program, a rotated placement — falls back to the
+ * exact canonicalized operator digest, which is narrower but never wrong. The
+ * two lanes are domain-separated, so a mask digest can never satisfy an
+ * operator-keyed registry entry or the reverse.
+ */
+export function type3GlyphEvidenceSha256(charProc, fontMatrix, ops) {
+  const mask = type3GlyphImageMask(charProc, fontMatrix, ops);
+  if (!mask) {
+    const operators = type3CharProcSha256(charProc);
+    return operators === null
+      ? null
+      : createHash("sha256").update(`${TYPE3_CHARPROC_EVIDENCE_DOMAIN}:${operators}`).digest("hex");
+  }
+  const canonical = canonicalType3MaskBits(mask);
+  return createHash("sha256")
+    .update(`${TYPE3_MASK_EVIDENCE_DOMAIN}:${canonical.width}x${canonical.height}:`)
+    .update(canonical.packed)
+    .digest("hex");
+}
+
 function fontEncodingDifferences(font, context) {
   const encoding = context.lookup(font.get(PDFName.of("Encoding")), PDFDict);
   const differences = encoding?.lookup(PDFName.of("Differences"), PDFArray);
@@ -1105,14 +1330,41 @@ function rawType3Fonts(pdfLibPage) {
     for (const [, reference] of fonts.entries()) {
       const font = context.lookup(reference, PDFDict);
       if (font?.get(PDFName.of("Subtype"))?.toString() !== "/Type3") continue;
-      if (font.has(PDFName.of("ToUnicode"))) continue;
+      /*
+       * A font carrying its own /ToUnicode is deliberately left alone: PDF.js
+       * already maps those glyphs, and overriding a valid producer-supplied
+       * mapping would be a regression, not a recovery. It is still parsed and
+       * kept here as a *competitor*, so that a page whose glyphs match both it
+       * and a recoverable font is reported as ambiguous instead of silently
+       * linking to the recoverable one. Retaining zero-width slots made many
+       * more link attempts succeed, so the pool they have to be unique against
+       * has to be the whole page, not just the recoverable part of it.
+       */
+      const recoverable = !font.has(PDFName.of("ToUnicode"));
       const first = font.lookup(PDFName.of("FirstChar"), PDFNumber)?.asNumber();
       const last = font.lookup(PDFName.of("LastChar"), PDFNumber)?.asNumber();
       const widthsArray = font.lookup(PDFName.of("Widths"), PDFArray);
       const codeToGlyph = fontEncodingDifferences(font, context);
       if (!Number.isSafeInteger(first) || !Number.isSafeInteger(last) || !widthsArray || !codeToGlyph) continue;
-      if (first < 0 || last > 127 || last < first || widthsArray.size() !== last - first + 1) continue;
+      if (first < 0 || last < first || widthsArray.size() !== last - first + 1) continue;
+      /*
+       * Two separate width views, because the two consumers need opposite
+       * things from a declared zero.
+       *
+       * `widths` keeps every declared slot, zeros included. It is the linker's
+       * evidence: a drawn glyph whose declared width is 0 is a fact about the
+       * font, and dropping it turned the linker's `widths.get(code) === width`
+       * test into `undefined === 0`, so a single legitimately zero-width drawn
+       * glyph voided an otherwise perfect font match.
+       *
+       * `metricWidths` keeps only the positive slots, because that is what a
+       * TFM scale can actually be fitted to: `metricScaleInterval` divides by
+       * the reference width and an observed 0 pins the scale into
+       * (-0.5/ref, +0.5/ref), which no real scale satisfies. Feeding zeros to
+       * the family fingerprint would abolish family resolution outright.
+       */
       const widths = new Map();
+      const metricWidths = new Map();
       let valid = true;
       for (let code = first; code <= last; code += 1) {
         const width = widthsArray.lookup(code - first, PDFNumber)?.asNumber();
@@ -1120,9 +1372,20 @@ function rawType3Fonts(pdfLibPage) {
           valid = false;
           break;
         }
-        if (width > 0) widths.set(code, width);
+        widths.set(code, width);
+        if (width > 0) metricWidths.set(code, width);
       }
-      if (valid && widths.size > 0) records.push({ widths, codeToGlyph });
+      if (!valid) continue;
+      // The official Computer Modern encodings only reach code 127, so a font
+      // declaring higher codes cannot be one of them and can only ever be a
+      // competitor. Same for a font with no positive width at all: nothing can
+      // fingerprint its family.
+      records.push({
+        widths,
+        metricWidths,
+        codeToGlyph,
+        recoverable: recoverable && last <= 127 && metricWidths.size > 0,
+      });
     }
     return records;
   } catch {
@@ -1468,14 +1731,78 @@ function linkedRawType3Font(fontId, fontTokens, rawFonts) {
   }
   const candidates = rawFonts.filter(raw => [...observed].every(([code, width]) => raw.widths.get(code) === width)
     && [...glyphIds].every(([code, glyphId]) => raw.codeToGlyph.get(code) === glyphId));
-  if (candidates.length !== 1) return null;
+  if (candidates.length !== 1 || !candidates[0].recoverable) return null;
   return candidates[0];
 }
 
-function charProcDigestForCode(font, rawFont, code) {
+/*
+ * One glyph program is looked up once per registry entry that names it and
+ * again for the enrolled-shape index, so the decode is memoized on the PDF.js
+ * CharProc object itself. PDF.js caches Type-3 font objects per document, so
+ * the same object comes back on every page the font is used on.
+ */
+const type3GlyphEvidenceCache = new WeakMap();
+
+function type3GlyphEvidenceForCode(font, rawFont, code, ops) {
   const glyphId = rawFont.codeToGlyph.get(code);
   if (typeof glyphId !== "string") return null;
-  return type3CharProcSha256(font?.charProcOperatorList?.[glyphId]);
+  const charProc = font?.charProcOperatorList?.[glyphId];
+  if (!charProc || typeof charProc !== "object") return null;
+  const cached = type3GlyphEvidenceCache.get(charProc);
+  if (cached !== undefined) return cached;
+  const digest = type3GlyphEvidenceSha256(charProc, font?.fontMatrix, ops);
+  type3GlyphEvidenceCache.set(charProc, digest);
+  return digest;
+}
+
+/**
+ * Every officially enrolled code of `family` that this font actually draws,
+ * mapped to its glyph evidence digest.
+ */
+function enrolledGlyphEvidence(font, rawFont, family, ops) {
+  const byCode = new Map();
+  for (const key of Object.keys(CM_CODEPOINTS[family] ?? {})) {
+    const code = Number(key);
+    const digest = type3GlyphEvidenceForCode(font, rawFont, code, ops);
+    if (digest !== null) byCode.set(code, digest);
+  }
+  return byCode;
+}
+
+/**
+ * Corroboration the shape key has to earn back.
+ *
+ * Keying on the decoded mask deliberately discards the placement matrix, and
+ * placement is real evidence: a Computer Modern period and a Computer Modern
+ * centred dot at the same design size are the *same* nine-by-nine blob, told
+ * apart only by how high above the baseline the producer put it. Under the old
+ * CharProc key that difference was inside the digest. It is no longer, so the
+ * matcher requires instead that the shape identify the code on its own within
+ * the font it came from: a digest that appears at two enrolled codes of the
+ * same font is ambiguous evidence and recovers nothing.
+ */
+function evidenceIdentifiesCode(enrolled, code, digest) {
+  if (digest === null || enrolled.get(code) !== digest) return false;
+  let seen = 0;
+  for (const candidate of enrolled.values()) {
+    if (candidate === digest) seen += 1;
+    if (seen > 1) return false;
+  }
+  return seen === 1;
+}
+
+/**
+ * The second thing the matcher has to earn back, this time for Block A.
+ *
+ * Retaining zero-width slots is what lets a legacy font link at all, but it
+ * also means a drawn glyph can now reach the registry with no advance width
+ * behind it, and a zero advance is invisible to the TFM fingerprint that
+ * qualifies the family. A recovered code must therefore carry a positive
+ * declared width — which, being positive, is one of the widths
+ * `uniqueComputerModernFamily` had to fit to the family's own metrics.
+ */
+function metricPinnedCode(rawFont, code) {
+  return rawFont.metricWidths.has(code);
 }
 
 /**
@@ -1484,14 +1811,36 @@ function charProcDigestForCode(font, rawFont, code) {
  * single-witness entry relies on this so that its reduced corroboration is
  * still the whole of the evidence its font can offer.
  */
-function fontMatchesCompleteEnrollment(font, rawFont, family, declaredCodes) {
+function fontMatchesCompleteEnrollment(enrolled, family, declaredCodes) {
   const declared = new Set(declaredCodes);
   for (const key of Object.keys(CM_CODEPOINTS[family] ?? {})) {
     const code = Number(key);
-    const present = charProcDigestForCode(font, rawFont, code) !== null;
-    if (present !== declared.has(code)) return false;
+    if (enrolled.has(code) !== declared.has(code)) return false;
   }
   return true;
+}
+
+/**
+ * Registry entries whose whole evidence the font satisfies. A code matched by
+ * more than one entry is reported as such and recovers nothing: two entries
+ * disagreeing about one glyph is exactly the ambiguity this pipeline abstains
+ * on, and it is newly reachable now that the key no longer separates entries
+ * by their producer's placement.
+ */
+function matchingRegistryEntries(enrolled, rawFont, family) {
+  const byCode = new Map();
+  for (const registry of TYPE3_RECOVERY_REGISTRY) {
+    if (registry.family !== family) continue;
+    if (!metricPinnedCode(rawFont, registry.original_char_code)) continue;
+    if (!evidenceIdentifiesCode(enrolled, registry.original_char_code, registry.glyph_sha256)) continue;
+    if (registry.witnesses.some(witness => !metricPinnedCode(rawFont, witness.original_char_code)
+      || !evidenceIdentifiesCode(enrolled, witness.original_char_code, witness.glyph_sha256))) continue;
+    if (registry.complete_font_enrollment
+      && !fontMatchesCompleteEnrollment(enrolled, family, registry.complete_font_enrollment)) continue;
+    if (!byCode.has(registry.original_char_code)) byCode.set(registry.original_char_code, []);
+    byCode.get(registry.original_char_code).push(registry);
+  }
+  return [...byCode.values()].filter(entries => entries.length === 1).map(entries => entries[0]);
 }
 
 function collectType3GlyphRecoveries({ textContent, operators, pdfjsPage, pdfLibPage, pdfjsLib }) {
@@ -1521,15 +1870,11 @@ function collectType3GlyphRecoveries({ textContent, operators, pdfjsPage, pdfLib
     if (!font) continue;
     const rawFont = linkedRawType3Font(fontId, fontTokens, rawFonts);
     if (!rawFont) continue;
-    const family = uniqueComputerModernFamily(rawFont.widths);
+    const family = uniqueComputerModernFamily(rawFont.metricWidths);
     if (!family || family.startsWith("unsupported:")) continue;
-    for (const registry of TYPE3_RECOVERY_REGISTRY.filter(entry => entry.family === family)) {
-      const targetDigest = charProcDigestForCode(font, rawFont, registry.original_char_code);
-      if (targetDigest !== registry.charproc_sha256) continue;
-      const witnessDigests = registry.witnesses.map(witness => charProcDigestForCode(font, rawFont, witness.original_char_code));
-      if (witnessDigests.some((digest, index) => digest !== registry.witnesses[index].charproc_sha256)) continue;
-      if (registry.complete_font_enrollment
-        && !fontMatchesCompleteEnrollment(font, rawFont, family, registry.complete_font_enrollment)) continue;
+    const enrolled = enrolledGlyphEvidence(font, rawFont, family, pdfjsLib?.OPS ?? {});
+    for (const registry of matchingRegistryEntries(enrolled, rawFont, family)) {
+      const witnessDigests = registry.witnesses.map(witness => witness.glyph_sha256);
       for (const token of fontTokens) {
         const glyph = token.glyph;
         if (glyph.originalCharCode !== registry.original_char_code || glyph.unicode !== registry.source_unicode) continue;
@@ -1555,10 +1900,10 @@ function collectType3GlyphRecoveries({ textContent, operators, pdfjsPage, pdfLib
           source_font_id: fontId,
           registry_id: registry.id,
           qualification: registry.qualification,
-          charproc_sha256: registry.charproc_sha256,
-          witness_charproc_sha256: witnessDigests,
+          glyph_sha256: registry.glyph_sha256,
+          witness_glyph_sha256: witnessDigests,
           tfm_reference_version: CM_TFM_REFERENCE_VERSION,
-          canonicalizer_version: TYPE3_GLYPH_CANONICALIZER_VERSION,
+          glyph_evidence_version: TYPE3_GLYPH_EVIDENCE_VERSION,
         });
       }
     }
@@ -1644,34 +1989,37 @@ export function inspectType3GlyphEvidenceForPage({ textContent, operators, pdfjs
       omissions.push({ font_id: fontId, reason: "raw_type3_font_link_ambiguous_or_unavailable", scope: "type3_glyph", count: fontTokens.length });
       continue;
     }
-    const family = uniqueComputerModernFamily(rawFont.widths);
+    const family = uniqueComputerModernFamily(rawFont.metricWidths);
     const official = family ? CM_CODEPOINTS[family] : null;
     const witnessCodes = family ? CM_WITNESS_CODEPOINTS[family] : null;
-    const mappedCodeCharprocSha256 = official ? Object.fromEntries([...new Set([
+    const mappedCodeGlyphSha256 = official ? Object.fromEntries([...new Set([
       ...Object.keys(official),
       ...Object.keys(witnessCodes ?? {}),
     ])]
       .map(Number)
       .sort((left, right) => left - right)
-      .map(code => [code, charProcDigestForCode(font, rawFont, code)])) : {};
+      .map(code => [code, type3GlyphEvidenceForCode(font, rawFont, code, ops)])) : {};
+    const enrolled = family ? enrolledGlyphEvidence(font, rawFont, family, ops) : new Map();
+    const matchedByCode = new Map();
+    if (family) {
+      for (const entry of matchingRegistryEntries(enrolled, rawFont, family)) {
+        matchedByCode.set(entry.original_char_code, entry);
+      }
+    }
     for (const token of fontTokens) {
       const code = token.glyph.originalCharCode;
       if (!Number.isSafeInteger(code)) {
         omissions.push({ font_id: fontId, reason: "original_char_code_unavailable", scope: "type3_glyph", count: 1 });
         continue;
       }
-      const digest = charProcDigestForCode(font, rawFont, code);
-      if (!digest) omissions.push({ font_id: fontId, reason: "charproc_digest_unavailable", scope: "glyph_evidence", count: 1 });
-      const registryEvidenceMatchIds = TYPE3_RECOVERY_REGISTRY.filter(entry => entry.family === family
-        && entry.original_char_code === code
-        && entry.source_unicode === token.glyph.unicode
-        && entry.target_unicode === official?.[code]
-        && entry.charproc_sha256 === digest
-        && entry.witnesses.every(witness => mappedCodeCharprocSha256[witness.original_char_code] === witness.charproc_sha256)
-        && (!entry.complete_font_enrollment
-          || fontMatchesCompleteEnrollment(font, rawFont, family, entry.complete_font_enrollment)))
-        .map(entry => entry.id)
-        .sort();
+      const digest = type3GlyphEvidenceForCode(font, rawFont, code, ops);
+      if (!digest) omissions.push({ font_id: fontId, reason: "glyph_evidence_unavailable", scope: "glyph_evidence", count: 1 });
+      const matched = matchedByCode.get(code) ?? null;
+      const registryEvidenceMatchIds = matched
+        && matched.source_unicode === token.glyph.unicode
+        && matched.target_unicode === official?.[code]
+        ? [matched.id]
+        : [];
       occurrences.push({
         family,
         family_status: !family
@@ -1682,13 +2030,13 @@ export function inspectType3GlyphEvidenceForPage({ textContent, operators, pdfjs
         original_char_code: code,
         source_unicode: typeof token.glyph.unicode === "string" ? token.glyph.unicode : "",
         intended_unicode: official?.[code] ?? null,
-        charproc_sha256: digest,
-        mapped_code_charproc_sha256: mappedCodeCharprocSha256,
+        glyph_sha256: digest,
+        mapped_code_glyph_sha256: mappedCodeGlyphSha256,
         registry_evidence_match_ids: registryEvidenceMatchIds,
         operator_index: token.operator_index,
         glyph_index: token.glyph_index,
         tfm_reference_version: CM_TFM_REFERENCE_VERSION,
-        canonicalizer_version: TYPE3_GLYPH_CANONICALIZER_VERSION,
+        glyph_evidence_version: TYPE3_GLYPH_EVIDENCE_VERSION,
       });
     }
   }
@@ -3166,10 +3514,10 @@ export function validatePdfLayoutSemantics(payload, {
             && recovery.original_char_code === registry.original_char_code
             && recovery.operator_unicode === registry.source_unicode
             && recovery.target_unicode === registry.target_unicode
-            && recovery.charproc_sha256 === registry.charproc_sha256
-            && sameJson(recovery.witness_charproc_sha256, registry.witnesses.map(witness => witness.charproc_sha256))
+            && recovery.glyph_sha256 === registry.glyph_sha256
+            && sameJson(recovery.witness_glyph_sha256, registry.witnesses.map(witness => witness.glyph_sha256))
             && recovery.tfm_reference_version === CM_TFM_REFERENCE_VERSION
-            && recovery.canonicalizer_version === TYPE3_GLYPH_CANONICALIZER_VERSION,
+            && recovery.glyph_evidence_version === TYPE3_GLYPH_EVIDENCE_VERSION,
           `item ${item.id} glyph-recovery registry evidence is invalid`);
           const exactScalarBinding = recovery.binding_kind === "exact_text_scalar"
             && recovery.source_unicode === recovery.operator_unicode
@@ -3853,10 +4201,10 @@ export async function validatePdfLayoutSourceEvidence(payload, {
             font_name: expectedFontName,
             registry_id: recovery.registry_id,
             qualification: recovery.qualification,
-            charproc_sha256: recovery.charproc_sha256,
-            witness_charproc_sha256: recovery.witness_charproc_sha256,
+            glyph_sha256: recovery.glyph_sha256,
+            witness_glyph_sha256: recovery.witness_glyph_sha256,
             tfm_reference_version: recovery.tfm_reference_version,
-            canonicalizer_version: recovery.canonicalizer_version,
+            glyph_evidence_version: recovery.glyph_evidence_version,
           }));
           const comparisons = [
             ["text", outputItem.text, expectedText],
@@ -4224,10 +4572,10 @@ export async function extractPdfLayout({
           font_name: publicFontName,
           registry_id: recovery.registry_id,
           qualification: recovery.qualification,
-          charproc_sha256: recovery.charproc_sha256,
-          witness_charproc_sha256: recovery.witness_charproc_sha256,
+          glyph_sha256: recovery.glyph_sha256,
+          witness_glyph_sha256: recovery.witness_glyph_sha256,
           tfm_reference_version: recovery.tfm_reference_version,
-          canonicalizer_version: recovery.canonicalizer_version,
+          glyph_evidence_version: recovery.glyph_evidence_version,
         }));
         if (!geometryItem.valid) {
           invalidGeometry = true;

--- a/server/layout-extraction.js
+++ b/server/layout-extraction.js
@@ -1172,21 +1172,23 @@ function type3GlyphImageMask(charProc, fontMatrix, ops) {
   // program. Exactly what it does NOT check, and cannot: the text matrix and
   // the graphics CTM in force at the `Tj` that draws the glyph. Those are set
   // by the page content stream outside the CharProc and are invisible here, so
-  // nothing below is a statement about the orientation the glyph is finally
-  // painted in.
+  // the absolute orientation the glyph is finally painted in is not knowable
+  // from a CharProc, and nothing here claims to know it.
   //
-  // That gap is deliberate rather than tolerated. The key is the stored sample
-  // grid, which no matrix anywhere can alter, so painted orientation is not an
-  // input to it. This check survives only to hold the mask lane to the plain
-  // axis-aligned, non-degenerate scale-or-reflection bitmap idiom every
-  // enrolled entry was qualified on: a glyph program that rotates, shears, or
-  // collapses its own bitmap is a different construction and is keyed by the
-  // exact operator digest instead of by this lane.
+  // Two things come out of the matrix. First, admissibility: the mask lane is
+  // held to the plain axis-aligned, non-degenerate scale-or-reflection bitmap
+  // idiom every enrolled entry was qualified on, so a glyph program that
+  // rotates, shears, or collapses its own bitmap is a different construction
+  // and is keyed by the exact operator digest instead. Second, the sign of the
+  // CharProc-local determinant, which is not part of the key — it is
+  // producer-dependent in absolute terms — but is comparable between two
+  // glyphs of the same font. `type3FontPaintOrientation` uses it for exactly
+  // that and nothing else.
   if (Math.abs(transform[1]) > 1e-9 || Math.abs(transform[2]) > 1e-9) return null;
   if (!(Math.abs(transform[0]) > 0) || !(Math.abs(transform[3]) > 0)) return null;
   const bits = fillAxisAlignedLatticePath(path, width, height);
   if (!bits) return null;
-  return { width, height, bits };
+  return { width, height, bits, paint_orientation: Math.sign(transform[0] * transform[3]) };
 }
 
 function fillAxisAlignedLatticePath(path, width, height) {
@@ -1271,11 +1273,26 @@ function fillAxisAlignedLatticePath(path, width, height) {
  *
  * The accepted consequence is that a glyph painted rotated or reflected keys
  * the same as the upright one. That is the correct answer for text set at an
- * angle, which is still the same character. Where it could be wrong is a font
- * that reuses one bitmap for two characters by reflecting it — the classic
- * matched-parenthesis trick — and that case is already refused by the
- * shape-code injectivity rule below: one shape standing at two enrolled codes
- * of a font is ambiguous evidence and recovers nothing.
+ * angle, which is still the same character. Where it is wrong is a reflection
+ * that turns the shape into a *different* enrolled character, and Computer
+ * Modern has those: 16 of the shipped registry digests — eight mirror pairs,
+ * the parenthesis and bracket pairs of the two enrolled cmex fonts — are the
+ * exact horizontal mirror of another shipped digest. Measured, by mirroring
+ * every registry grid the reference document resolves and looking the result
+ * back up. A CharProc holding the stored raster of `]` but painting it
+ * reflected paints `[`, and the grid alone cannot tell the two apart.
+ *
+ * Shape-code injectivity does not refuse that case, and an earlier revision of
+ * this comment wrongly claimed it did. Injectivity asks whether one shape
+ * stands at two enrolled codes of the font. The reflected glyph stands at one
+ * code holding one raster; its mirror image lives at a different code holding
+ * a different, genuinely mirrored raster. Both codes are injective and both
+ * recover, one of them as the wrong character. Demonstrated on the Shannon
+ * reference document by negating the x scale of a single CMEX CharProc `cm`
+ * while leaving its mask bytes byte-identical.
+ *
+ * What refuses it is `type3FontPaintOrientation`: reflection relative to the
+ * font's own siblings is detectable without knowing any absolute orientation.
  *
  * Also deliberately dropped: the blank padding around the ink and the operator
  * idiom that carried the samples. An inkless mask has no shape to key at all
@@ -1322,10 +1339,20 @@ function canonicalType3MaskBits(mask) {
  * to key — falls back to the exact canonicalized operator digest, which is
  * narrower but never wrong. The two lanes are domain-separated, so a mask
  * digest can never satisfy an operator-keyed registry entry or the reverse.
+ *
+ * `fontPaintOrientation` is the one sign every mask-lane glyph of this font
+ * agrees on, from `type3FontPaintOrientation`, and is required for the mask
+ * lane rather than optional: a caller with no font-wide answer gets the
+ * operator lane, which is the safe direction. A glyph whose own CharProc-local
+ * determinant sign disagrees with its siblings is reflected relative to them
+ * and is refused the grid key.
  */
-export function type3GlyphEvidenceSha256(charProc, fontMatrix, ops) {
+export function type3GlyphEvidenceSha256(charProc, fontMatrix, ops, fontPaintOrientation) {
   const mask = type3GlyphImageMask(charProc, fontMatrix, ops);
-  const canonical = mask ? canonicalType3MaskBits(mask) : null;
+  const oriented = mask !== null
+    && (fontPaintOrientation === 1 || fontPaintOrientation === -1)
+    && mask.paint_orientation === fontPaintOrientation;
+  const canonical = oriented ? canonicalType3MaskBits(mask) : null;
   if (!canonical) {
     const operators = type3CharProcSha256(charProc);
     return operators === null
@@ -1791,6 +1818,69 @@ function linkedRawType3Font(fontId, fontTokens, rawFonts) {
  */
 const type3GlyphEvidenceCache = new WeakMap();
 
+const type3FontPaintOrientationCache = new WeakMap();
+
+/**
+ * The single paint convention every mask-lane glyph of one embedded font
+ * agrees on, as `1` or `-1`, or `null` when the font has none.
+ *
+ * The grid key deliberately discards orientation, which is right — the stored
+ * samples are the glyph and the matrices around them are the producer. But it
+ * leaves reflection unpoliced, and in Computer Modern reflection is not a
+ * harmless re-orientation of the same character: mirroring the `]` raster
+ * paints a `[`, and both are separately enrolled. So orientation has to be
+ * checked somewhere, and the only place it can be checked honestly is between
+ * glyphs of one font.
+ *
+ * The comparison is the sign of the CharProc-local determinant — FontMatrix
+ * composed with the glyph's own `cm`. That sign is meaningless in absolute
+ * terms, because producers split the flip differently: the Shannon reference
+ * document carries it in `FontMatrix [1 0 0 -1]` and gives every glyph of
+ * every one of its 24 Type-3 fonts sign -1, while other dvips-era producers
+ * leave FontMatrix upright and come out uniformly +1. Keying on it, or
+ * demanding a particular value of it, would make the same painted glyph key
+ * two ways — the exact producer dependence the grid key exists to remove.
+ * Comparing it *within* one font asks a different and answerable question: a
+ * font sets all of its bitmaps the same way round, so a glyph whose sign
+ * differs from its siblings is reflected relative to them, whatever absolute
+ * convention the producer chose.
+ *
+ * Unanimity, not a majority, because a majority is a vote an adversary can
+ * win by flipping more glyphs, and because most legacy fonts here carry one to
+ * four mask glyphs, where a majority is not defined. A font that disagrees
+ * with itself has no convention to normalize against and gets no grid keys at
+ * all; every glyph falls to the operator digest and abstains.
+ *
+ * Measured, not assumed: all 24 embedded Type-3 fonts of the Shannon
+ * reference document and all 92 of the five legacy TeX corpus documents are
+ * unanimous, and none of the 116 is mixed. Mirroring one CMEX CharProc `cm`
+ * makes exactly its own font mixed and nothing else.
+ *
+ * The scan covers every entry of `charProcOperatorList`, which PDF.js builds
+ * eagerly from the whole /CharProcs dictionary when the font is loaded rather
+ * than lazily per drawn glyph, so the answer is a property of the font and not
+ * of which page happened to be extracted first.
+ */
+export function type3FontPaintOrientation(font, ops) {
+  const cached = type3FontPaintOrientationCache.get(font);
+  if (cached !== undefined) return cached;
+  const charProcs = font?.charProcOperatorList;
+  let orientation = null;
+  if (charProcs && typeof charProcs === "object") {
+    for (const glyphId of Object.keys(charProcs)) {
+      const mask = type3GlyphImageMask(charProcs[glyphId], font?.fontMatrix, ops);
+      if (mask === null) continue;
+      if (orientation === null) orientation = mask.paint_orientation;
+      else if (orientation !== mask.paint_orientation) {
+        orientation = null;
+        break;
+      }
+    }
+  }
+  type3FontPaintOrientationCache.set(font, orientation);
+  return orientation;
+}
+
 function type3GlyphEvidenceForCode(font, rawFont, code, ops) {
   const glyphId = rawFont.codeToGlyph.get(code);
   if (typeof glyphId !== "string") return null;
@@ -1803,7 +1893,7 @@ function type3GlyphEvidenceForCode(font, rawFont, code, ops) {
   }
   const cached = byGlyphId.get(glyphId);
   if (cached !== undefined) return cached;
-  const digest = type3GlyphEvidenceSha256(charProc, font?.fontMatrix, ops);
+  const digest = type3GlyphEvidenceSha256(charProc, font?.fontMatrix, ops, type3FontPaintOrientation(font, ops));
   byGlyphId.set(glyphId, digest);
   return digest;
 }

--- a/server/markdown-conversion.js
+++ b/server/markdown-conversion.js
@@ -8,7 +8,7 @@ const RENDERER = Object.freeze({
   name: "pdf-tools.layout-markdown-renderer",
   version: "1.14.0",
 });
-const SUPPORTED_LAYOUT_IR_VERSION = "1.4.0";
+const SUPPORTED_LAYOUT_IR_VERSION = "1.5.0";
 
 // Bounded geometric table inference. A run of adjacent lines is treated as a
 // table only when every row fills every detected column, so ragged or

--- a/server/output-schemas.js
+++ b/server/output-schemas.js
@@ -653,10 +653,10 @@ const layoutGlyphRecovery = object({
   font_name: nullable(string),
   registry_id: string,
   qualification: string,
-  charproc_sha256: string,
-  witness_charproc_sha256: stringArray,
+  glyph_sha256: string,
+  witness_glyph_sha256: stringArray,
   tfm_reference_version: string,
-  canonicalizer_version: string,
+  glyph_evidence_version: string,
 });
 const layoutRawItemProperties = {
   id: string,

--- a/server/output-schemas.js
+++ b/server/output-schemas.js
@@ -886,7 +886,7 @@ export const TOOL_SUCCESS_OUTPUT_SCHEMAS = Object.freeze({
     truncated: boolean,
   }),
   read_pdf_layout: object({
-    ir: object({ name: { const: "pdf-tools.extraction-ir" }, version: { const: "1.4.0" } }),
+    ir: object({ name: { const: "pdf-tools.extraction-ir" }, version: { const: "1.5.0" } }),
     parser: object({ name: { const: "pdfjs-dist" }, version: { const: "5.4.624" } }),
     source: object({
       pdf_path: string,
@@ -898,7 +898,7 @@ export const TOOL_SUCCESS_OUTPUT_SCHEMAS = Object.freeze({
       kind: { const: "source_parser_ir_options" },
       source_sha256: { type: "string", pattern: "^[a-f0-9]{64}$" },
       parser_version: { const: "5.4.624" },
-      ir_version: { const: "1.4.0" },
+      ir_version: { const: "1.5.0" },
       requested_start_page: integer,
       requested_end_page: integer,
       max_items: integer,
@@ -952,7 +952,7 @@ export const TOOL_SUCCESS_OUTPUT_SCHEMAS = Object.freeze({
       }),
       layout: object({
         name: { const: "pdf-tools.extraction-ir" },
-        version: { const: "1.4.0" },
+        version: { const: "1.5.0" },
         parser_name: { const: "pdfjs-dist" },
         parser_version: { const: "5.4.624" },
         page_range: object({

--- a/test/convert-pdf-to-markdown.test.js
+++ b/test/convert-pdf-to-markdown.test.js
@@ -309,7 +309,7 @@ describe("convert_pdf_to_markdown MCP tool", () => {
       conversion_status: "complete",
       saved_output: null,
       provenance: {
-        layout: { name: "pdf-tools.extraction-ir", version: "1.4.0", parser_version: "5.4.624" },
+        layout: { name: "pdf-tools.extraction-ir", version: "1.5.0", parser_version: "5.4.624" },
       },
       pages_needing_vision: [],
     });

--- a/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
+++ b/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
@@ -30,7 +30,7 @@
     }
   },
   "layout_contract_bindings": {
-    "layout_output_schema_sha256": "32a19880d173639311152afdded7791981144b5e0c22d796e69fb9ee12b71182",
+    "layout_output_schema_sha256": "2f9f7f087d0221c358faf22f1dff7129ed67927c1e9715c4da6a718d014fc5c2",
     "layout_evidence_contract_sha256": "39cb7e89cd65558bb661ebc0edab517dabc9398908750de6c3b56d511b887bef"
   },
   "validator_sources": [
@@ -55,8 +55,8 @@
     {
       "role": "layout_extraction_module",
       "path": "server/layout-extraction.js",
-      "bytes": 241647,
-      "sha256": "7d85c75d77f3a7b860f214c3e65ca82321d5a121c675fd9403cea251a6eeddc4"
+      "bytes": 244653,
+      "sha256": "b3d9e8cc866ec9fd096a8d2f03f9e001f40382daca4d733c55f7b4db04c1979a"
     },
     {
       "role": "type3_cm_reference_module",
@@ -74,13 +74,13 @@
       "role": "markdown_conversion_module",
       "path": "server/markdown-conversion.js",
       "bytes": 110346,
-      "sha256": "413942fcde5d55c97a5f041d9a1d2966c8297b061366dff53b3a03c0e367b041"
+      "sha256": "aae5208e3c2fdeff5b0d425a023caccb616c02b484834b7a6abb2d2de323abde"
     },
     {
       "role": "output_schemas_module",
       "path": "server/output-schemas.js",
       "bytes": 51699,
-      "sha256": "e8f4b2fc99a58a28c9466a86c944efd03842bd946945c5b7cfc274a19fab0b57"
+      "sha256": "774bb9590e1730062298e4f465b3f4db13dea571973614759133b745012b492f"
     },
     {
       "role": "package_json",
@@ -119,7 +119,7 @@
       "sha256": "6e4429db62fcbe1dd73141d8c20a48b564d41f8bf8920d88775846995e1daf94"
     }
   ],
-  "validator_source_set_sha256": "0a5f70dacb1ab47b8be38ce92fe562a81472fdaa3cbfbbf2a846a99bab042c1b",
+  "validator_source_set_sha256": "ab21e48bdd7d4623eacbbd9e1db3377861013f436991f5d27ce5ea7cb938811a",
   "pdfjs_version": "5.4.624",
   "generation_contract": {
     "source_path": "source.pdf",
@@ -140,8 +140,8 @@
       "source_sha256": "706dcc669a763bc88852eff3bfdf3ee428d3ff1dac01b85e2b60942e907d5403",
       "source_bytes": 2325,
       "page_count": 1,
-      "layout_ir_sha256": "6ad3f6d5e918f94b7c4db54ce3b2e69b47088a1ab9031f00e72ecea00663b00d",
-      "layout_id_scope_sha256": "dc21d85fb188236f9abd8fca6ab41733f3f72b3dc2ed2343fde2cc99e8051053",
+      "layout_ir_sha256": "5843271edce6bb5b8ea0f6cf6dd9a6a6d29d85a5d008321adcbb96075df8c2c2",
+      "layout_id_scope_sha256": "300445df1b501b4a13e0de925bf765d64438df250a40f96e9f46d193215ea5a9",
       "layout_extraction_status": "complete",
       "facts": [
         {
@@ -154,11 +154,11 @@
           "geometry_status": "eligible",
           "geometry_reason": null,
           "observed_occurrence_sha256": [
-            "3e7ca5dbc9354d284e30d4aae6d21a11d72cce508770695ae7e744539c2a4077"
+            "69db2408e6593b0166a9ddf7b76f9fa62b916d854fc17449b73cc74a1293c7f1"
           ],
           "approved_occurrence": {
             "source_sha256": "706dcc669a763bc88852eff3bfdf3ee428d3ff1dac01b85e2b60942e907d5403",
-            "layout_ir_sha256": "6ad3f6d5e918f94b7c4db54ce3b2e69b47088a1ab9031f00e72ecea00663b00d",
+            "layout_ir_sha256": "5843271edce6bb5b8ea0f6cf6dd9a6a6d29d85a5d008321adcbb96075df8c2c2",
             "page": 1,
             "line_id": "p0001-l000003",
             "line_start_code_point": 12,
@@ -180,7 +180,7 @@
               "width": 129.164,
               "height": 14
             },
-            "occurrence_sha256": "3e7ca5dbc9354d284e30d4aae6d21a11d72cce508770695ae7e744539c2a4077"
+            "occurrence_sha256": "69db2408e6593b0166a9ddf7b76f9fa62b916d854fc17449b73cc74a1293c7f1"
           }
         },
         {
@@ -193,11 +193,11 @@
           "geometry_status": "eligible",
           "geometry_reason": null,
           "observed_occurrence_sha256": [
-            "0bd6e8fcf11351307e688214ea423ad70f977af277c1fa520722ce11f1870914"
+            "b51723f91242115044529171ec43562d3cc25591caf472e18f4cc6062ea3e6dc"
           ],
           "approved_occurrence": {
             "source_sha256": "706dcc669a763bc88852eff3bfdf3ee428d3ff1dac01b85e2b60942e907d5403",
-            "layout_ir_sha256": "6ad3f6d5e918f94b7c4db54ce3b2e69b47088a1ab9031f00e72ecea00663b00d",
+            "layout_ir_sha256": "5843271edce6bb5b8ea0f6cf6dd9a6a6d29d85a5d008321adcbb96075df8c2c2",
             "page": 1,
             "line_id": "p0001-l000009",
             "line_start_code_point": 7,
@@ -219,7 +219,7 @@
               "width": 107.38,
               "height": 14
             },
-            "occurrence_sha256": "0bd6e8fcf11351307e688214ea423ad70f977af277c1fa520722ce11f1870914"
+            "occurrence_sha256": "b51723f91242115044529171ec43562d3cc25591caf472e18f4cc6062ea3e6dc"
           }
         }
       ]
@@ -230,8 +230,8 @@
       "source_sha256": "c9baaed165000f0e7112e2bfc89e070e0bda26c7ce3f1f16b0dbeebb67e9f11f",
       "source_bytes": 2571,
       "page_count": 1,
-      "layout_ir_sha256": "48a83b5b566da2e4a40eae5f1ea8c0df21c8d89858d12ac7629151b159ff316c",
-      "layout_id_scope_sha256": "d0a1e7b03b9f4fa1487c449f1c3b026c7a2e20db191835b21618a867fb3a4e2b",
+      "layout_ir_sha256": "0accbec8655168b538bbbcc3ce1309f85cb97ff9d6bc3bfcc2c0915e63694a49",
+      "layout_id_scope_sha256": "bc7f08e592ed7fdfd3161de8906c9a1b8bc4f97eb65fd032628cb5d2aa8c217d",
       "layout_extraction_status": "complete",
       "facts": [
         {
@@ -244,11 +244,11 @@
           "geometry_status": "eligible",
           "geometry_reason": null,
           "observed_occurrence_sha256": [
-            "e6d0fc2ed3ecd6101d86b486764004ffac18a45040f3f776f9faaae5a57505b4"
+            "803d927b1ee4dfc64b24ae3b1aca1151baafc1e5d9942fba1a4ce0d922e8cf10"
           ],
           "approved_occurrence": {
             "source_sha256": "c9baaed165000f0e7112e2bfc89e070e0bda26c7ce3f1f16b0dbeebb67e9f11f",
-            "layout_ir_sha256": "48a83b5b566da2e4a40eae5f1ea8c0df21c8d89858d12ac7629151b159ff316c",
+            "layout_ir_sha256": "0accbec8655168b538bbbcc3ce1309f85cb97ff9d6bc3bfcc2c0915e63694a49",
             "page": 1,
             "line_id": "p0001-l000003",
             "line_start_code_point": 13,
@@ -270,7 +270,7 @@
               "width": 124.474,
               "height": 14
             },
-            "occurrence_sha256": "e6d0fc2ed3ecd6101d86b486764004ffac18a45040f3f776f9faaae5a57505b4"
+            "occurrence_sha256": "803d927b1ee4dfc64b24ae3b1aca1151baafc1e5d9942fba1a4ce0d922e8cf10"
           }
         },
         {
@@ -283,11 +283,11 @@
           "geometry_status": "eligible",
           "geometry_reason": null,
           "observed_occurrence_sha256": [
-            "ca179e00203263e74656b0db928d4bf38fe1fa34a460751c6e92f75c99bced88"
+            "7afe02692ffe081fb7c38d3e4ba086e63b9e959eb34e9bf0e6b5b635a6cd9a71"
           ],
           "approved_occurrence": {
             "source_sha256": "c9baaed165000f0e7112e2bfc89e070e0bda26c7ce3f1f16b0dbeebb67e9f11f",
-            "layout_ir_sha256": "48a83b5b566da2e4a40eae5f1ea8c0df21c8d89858d12ac7629151b159ff316c",
+            "layout_ir_sha256": "0accbec8655168b538bbbcc3ce1309f85cb97ff9d6bc3bfcc2c0915e63694a49",
             "page": 1,
             "line_id": "p0001-l000013",
             "line_start_code_point": 13,
@@ -309,7 +309,7 @@
               "width": 119.854,
               "height": 14
             },
-            "occurrence_sha256": "ca179e00203263e74656b0db928d4bf38fe1fa34a460751c6e92f75c99bced88"
+            "occurrence_sha256": "7afe02692ffe081fb7c38d3e4ba086e63b9e959eb34e9bf0e6b5b635a6cd9a71"
           }
         }
       ]
@@ -320,8 +320,8 @@
       "source_sha256": "aaaae6795676db9e33f79e75f4662808ee9646f8f2bb12a319f74e3edb11c101",
       "source_bytes": 2427,
       "page_count": 1,
-      "layout_ir_sha256": "6990ff692d6bf77d3d0927798e3f489fbf0b2610648703e460adbac48c340a67",
-      "layout_id_scope_sha256": "743193d482bdbc76d954465f4b1188a1d9f26472a75d7ebddb6aa5dd2a84d500",
+      "layout_ir_sha256": "90a0bb0ae0472b59ab196501c0c5a3fa15bc031169333535604ae65870b2504a",
+      "layout_id_scope_sha256": "f77b421a22a952da02d7548c2a67043b0ce26c3211ed01206c61c80d742e2fd0",
       "layout_extraction_status": "partial",
       "facts": [
         {
@@ -334,11 +334,11 @@
           "geometry_status": "eligible",
           "geometry_reason": null,
           "observed_occurrence_sha256": [
-            "ac6f90e26c3b688bfafa76d84ac8f428a5768010dd252654be30cafdb25c1965"
+            "2ecb50238ca1ca8fd4dcc1ac13720d02df7758e10cac795693849dca5aa5424d"
           ],
           "approved_occurrence": {
             "source_sha256": "aaaae6795676db9e33f79e75f4662808ee9646f8f2bb12a319f74e3edb11c101",
-            "layout_ir_sha256": "6990ff692d6bf77d3d0927798e3f489fbf0b2610648703e460adbac48c340a67",
+            "layout_ir_sha256": "90a0bb0ae0472b59ab196501c0c5a3fa15bc031169333535604ae65870b2504a",
             "page": 1,
             "line_id": "p0001-l000007",
             "line_start_code_point": 8,
@@ -360,7 +360,7 @@
               "width": 192.166,
               "height": 13
             },
-            "occurrence_sha256": "ac6f90e26c3b688bfafa76d84ac8f428a5768010dd252654be30cafdb25c1965"
+            "occurrence_sha256": "2ecb50238ca1ca8fd4dcc1ac13720d02df7758e10cac795693849dca5aa5424d"
           }
         }
       ]
@@ -371,8 +371,8 @@
       "source_sha256": "370dc0ac71939cba9db8584327c87899716dc770ac9ee8cad33fc27b5e73b73c",
       "source_bytes": 2622,
       "page_count": 1,
-      "layout_ir_sha256": "a44fdb37beeb5641039201ed281691316ffff8f1c73a6474c8f252c1d2d93a49",
-      "layout_id_scope_sha256": "b01c82424bed46b9dcece38076fe6afb2e789796eca24b913f221c1038632aa0",
+      "layout_ir_sha256": "c22410a455c199ea3c5ee1d998644901dc1847b92315e1e6880ae1efb7dc7d96",
+      "layout_id_scope_sha256": "466a0724a1e01ba0ad4dab1ff011326706653a14550232c32c9b853796f5e9d5",
       "layout_extraction_status": "partial",
       "facts": [
         {
@@ -385,11 +385,11 @@
           "geometry_status": "eligible",
           "geometry_reason": null,
           "observed_occurrence_sha256": [
-            "244587b8f4d4154d50c69e20bd2fdbe083fc1348475f113695d6c076d95b5054"
+            "7dc05de02c219302169a9bfe23f584d94f5f89af45778460dabd15e1163b8a45"
           ],
           "approved_occurrence": {
             "source_sha256": "370dc0ac71939cba9db8584327c87899716dc770ac9ee8cad33fc27b5e73b73c",
-            "layout_ir_sha256": "a44fdb37beeb5641039201ed281691316ffff8f1c73a6474c8f252c1d2d93a49",
+            "layout_ir_sha256": "c22410a455c199ea3c5ee1d998644901dc1847b92315e1e6880ae1efb7dc7d96",
             "page": 1,
             "line_id": "p0001-l000015",
             "line_start_code_point": 9,
@@ -411,7 +411,7 @@
               "width": 52.02,
               "height": 12
             },
-            "occurrence_sha256": "244587b8f4d4154d50c69e20bd2fdbe083fc1348475f113695d6c076d95b5054"
+            "occurrence_sha256": "7dc05de02c219302169a9bfe23f584d94f5f89af45778460dabd15e1163b8a45"
           }
         }
       ]
@@ -422,8 +422,8 @@
       "source_sha256": "8287bc8965aef64fe33ae81b0abc2f2c3a9df4dc86c2335982f0747e0ae851e9",
       "source_bytes": 25293,
       "page_count": 1,
-      "layout_ir_sha256": "a25c5f2587cef8bdedb9e2dd4925a25667aff9640183c5fb0fe73164ba35c7f0",
-      "layout_id_scope_sha256": "a28715eb3d3addd218f6cd5a85c932169a976f50285517bdae7b98eff4b45a11",
+      "layout_ir_sha256": "b7018d51d53a789f6857c8e67ebe7638b9e840f4de84c0ab7e2695188fc260d8",
+      "layout_id_scope_sha256": "79526576c9d96a1c8ed80057eeebfd30af25397c4e9d9d0c78dfd94629a13ece",
       "layout_extraction_status": "partial",
       "facts": [
         {
@@ -446,8 +446,8 @@
       "source_sha256": "570b9f004596d5f8c0fc1f52c2ea3d1d0e88f987f287aa7692be2a5b3a6fc042",
       "source_bytes": 8183,
       "page_count": 1,
-      "layout_ir_sha256": "9d8101d0b7a660277414d1b75fa5f38fae63cfcdd8410738dfb96c7d35351ff4",
-      "layout_id_scope_sha256": "9dbda80edc7a834a75ab867dc1d8286a6de8059df4e17690c3e7df71c748d1d0",
+      "layout_ir_sha256": "b5df48fb430cd72a88e3614907b575dfd6ab337ced32463d65ed3a48184ad653",
+      "layout_id_scope_sha256": "a60151ff605ad4b854ab54372850e4ba53a016bd3bc4978e51436aeb2871c88a",
       "layout_extraction_status": "partial",
       "facts": [
         {
@@ -470,8 +470,8 @@
       "source_sha256": "b5374f2e96b6205a6cf824ba90b55ffa23612658eca169270682c9445daa476f",
       "source_bytes": 25899,
       "page_count": 2,
-      "layout_ir_sha256": "cab31fdb2d19f11f487a85e78a3cf0beed0a74c5caecff589452ee923f716d78",
-      "layout_id_scope_sha256": "02048af4c69b538aa51da7dcc5864c29adae5aba9dc1d0fbfeb9b367f78aded9",
+      "layout_ir_sha256": "5490daf3dc793f8936e34230478562d66b1ef44ee0c014da8347a0e0ef7dde0b",
+      "layout_id_scope_sha256": "85d956e6b2879fe1ab9456e88a88b33c3713548ce865048f463410a2426a513a",
       "layout_extraction_status": "partial",
       "facts": [
         {
@@ -484,11 +484,11 @@
           "geometry_status": "eligible",
           "geometry_reason": null,
           "observed_occurrence_sha256": [
-            "4f00fbeea7d0373d2b50619a6ae32e21b4d0f62325de9737b030fee7c040f04d"
+            "7878cb35d95daf09f848817d99b035ec200b88a29294b99916149813e598bce9"
           ],
           "approved_occurrence": {
             "source_sha256": "b5374f2e96b6205a6cf824ba90b55ffa23612658eca169270682c9445daa476f",
-            "layout_ir_sha256": "cab31fdb2d19f11f487a85e78a3cf0beed0a74c5caecff589452ee923f716d78",
+            "layout_ir_sha256": "5490daf3dc793f8936e34230478562d66b1ef44ee0c014da8347a0e0ef7dde0b",
             "page": 1,
             "line_id": "p0001-l000003",
             "line_start_code_point": 11,
@@ -510,7 +510,7 @@
               "width": 113.596,
               "height": 14
             },
-            "occurrence_sha256": "4f00fbeea7d0373d2b50619a6ae32e21b4d0f62325de9737b030fee7c040f04d"
+            "occurrence_sha256": "7878cb35d95daf09f848817d99b035ec200b88a29294b99916149813e598bce9"
           }
         },
         {
@@ -533,8 +533,8 @@
       "source_sha256": "2938fbd44c847b950a87a691fa1d1a956e5c12e1ea17482e30d8e255e6876dde",
       "source_bytes": 2411,
       "page_count": 1,
-      "layout_ir_sha256": "7479b0118c8a011b915ca2c2d8613ff2a0146226801454b91823f653bb5217dd",
-      "layout_id_scope_sha256": "3d1ab489028b1f68a17f766d266a36fa3108d48fd01f73a7aa192f8b587654d7",
+      "layout_ir_sha256": "5e653d422616652e6ff387589f202bcfeab979478d13d42a4ffac470c66e9032",
+      "layout_id_scope_sha256": "e83f0965031d8e04e20048dc7922ca3199337dee85ee35db9c490eaf88546480",
       "layout_extraction_status": "complete",
       "facts": [
         {
@@ -547,11 +547,11 @@
           "geometry_status": "eligible",
           "geometry_reason": null,
           "observed_occurrence_sha256": [
-            "8b1025458ae39e9e61daf8215773b8a1fe3441a8691b6e91a7c92f5369969248"
+            "e093a5234f6f74406b01cfeade864c5be7ae283ddd0fcf5d8c019ea9dfab4541"
           ],
           "approved_occurrence": {
             "source_sha256": "2938fbd44c847b950a87a691fa1d1a956e5c12e1ea17482e30d8e255e6876dde",
-            "layout_ir_sha256": "7479b0118c8a011b915ca2c2d8613ff2a0146226801454b91823f653bb5217dd",
+            "layout_ir_sha256": "5e653d422616652e6ff387589f202bcfeab979478d13d42a4ffac470c66e9032",
             "page": 1,
             "line_id": "p0001-l000003",
             "line_start_code_point": 19,
@@ -573,7 +573,7 @@
               "width": 198.394,
               "height": 14
             },
-            "occurrence_sha256": "8b1025458ae39e9e61daf8215773b8a1fe3441a8691b6e91a7c92f5369969248"
+            "occurrence_sha256": "e093a5234f6f74406b01cfeade864c5be7ae283ddd0fcf5d8c019ea9dfab4541"
           }
         },
         {
@@ -586,11 +586,11 @@
           "geometry_status": "eligible",
           "geometry_reason": null,
           "observed_occurrence_sha256": [
-            "153ef78a0680c88cff43f086f07455ebde020441522f99ecfa48994841cc78b7"
+            "53e8636451c938c98a5e01365928a204363dfd9ac74048d60cfff0305803dae3"
           ],
           "approved_occurrence": {
             "source_sha256": "2938fbd44c847b950a87a691fa1d1a956e5c12e1ea17482e30d8e255e6876dde",
-            "layout_ir_sha256": "7479b0118c8a011b915ca2c2d8613ff2a0146226801454b91823f653bb5217dd",
+            "layout_ir_sha256": "5e653d422616652e6ff387589f202bcfeab979478d13d42a4ffac470c66e9032",
             "page": 1,
             "line_id": "p0001-l000005",
             "line_start_code_point": 19,
@@ -612,7 +612,7 @@
               "width": 194.488,
               "height": 14
             },
-            "occurrence_sha256": "153ef78a0680c88cff43f086f07455ebde020441522f99ecfa48994841cc78b7"
+            "occurrence_sha256": "53e8636451c938c98a5e01365928a204363dfd9ac74048d60cfff0305803dae3"
           }
         },
         {
@@ -625,11 +625,11 @@
           "geometry_status": "eligible",
           "geometry_reason": null,
           "observed_occurrence_sha256": [
-            "9d362985ea069b9f96ccbd66111c85e7df220e2cc50ae50eb3537ccd6f8b48c8"
+            "fbdf33852b0ea6cc179487e4e9d87f90210cc34fe6069c1b78dd97a89a506179"
           ],
           "approved_occurrence": {
             "source_sha256": "2938fbd44c847b950a87a691fa1d1a956e5c12e1ea17482e30d8e255e6876dde",
-            "layout_ir_sha256": "7479b0118c8a011b915ca2c2d8613ff2a0146226801454b91823f653bb5217dd",
+            "layout_ir_sha256": "5e653d422616652e6ff387589f202bcfeab979478d13d42a4ffac470c66e9032",
             "page": 1,
             "line_id": "p0001-l000009",
             "line_start_code_point": 25,
@@ -651,7 +651,7 @@
               "width": 234.22,
               "height": 14
             },
-            "occurrence_sha256": "9d362985ea069b9f96ccbd66111c85e7df220e2cc50ae50eb3537ccd6f8b48c8"
+            "occurrence_sha256": "fbdf33852b0ea6cc179487e4e9d87f90210cc34fe6069c1b78dd97a89a506179"
           }
         }
       ]

--- a/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
+++ b/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
@@ -55,8 +55,8 @@
     {
       "role": "layout_extraction_module",
       "path": "server/layout-extraction.js",
-      "bytes": 244653,
-      "sha256": "b3d9e8cc866ec9fd096a8d2f03f9e001f40382daca4d733c55f7b4db04c1979a"
+      "bytes": 249759,
+      "sha256": "f2cbbb7f0e0af9fee0429dbc709ecf51756e59a92d8d836d5d5f4464b6ece967"
     },
     {
       "role": "type3_cm_reference_module",
@@ -119,7 +119,7 @@
       "sha256": "6e4429db62fcbe1dd73141d8c20a48b564d41f8bf8920d88775846995e1daf94"
     }
   ],
-  "validator_source_set_sha256": "ab21e48bdd7d4623eacbbd9e1db3377861013f436991f5d27ce5ea7cb938811a",
+  "validator_source_set_sha256": "754bf2266dda1ab873c5841e0cfaf03f332112552740015d08265a900cc85fca",
   "pdfjs_version": "5.4.624",
   "generation_contract": {
     "source_path": "source.pdf",

--- a/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
+++ b/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
@@ -30,7 +30,7 @@
     }
   },
   "layout_contract_bindings": {
-    "layout_output_schema_sha256": "55cd7faeb1d5d84710416cedbf3ebd131d861c0451051328c427469e7e91fb3f",
+    "layout_output_schema_sha256": "32a19880d173639311152afdded7791981144b5e0c22d796e69fb9ee12b71182",
     "layout_evidence_contract_sha256": "39cb7e89cd65558bb661ebc0edab517dabc9398908750de6c3b56d511b887bef"
   },
   "validator_sources": [
@@ -55,8 +55,8 @@
     {
       "role": "layout_extraction_module",
       "path": "server/layout-extraction.js",
-      "bytes": 226574,
-      "sha256": "67985913e8ea78c85deee53efb1a8d273fe82ac9522e052f3d56b60b3fdab434"
+      "bytes": 241647,
+      "sha256": "7d85c75d77f3a7b860f214c3e65ca82321d5a121c675fd9403cea251a6eeddc4"
     },
     {
       "role": "type3_cm_reference_module",
@@ -79,8 +79,8 @@
     {
       "role": "output_schemas_module",
       "path": "server/output-schemas.js",
-      "bytes": 51704,
-      "sha256": "865e1d3e56f47f55bee663a150314e818ed71d24ce28636d2401896038001cac"
+      "bytes": 51699,
+      "sha256": "e8f4b2fc99a58a28c9466a86c944efd03842bd946945c5b7cfc274a19fab0b57"
     },
     {
       "role": "package_json",
@@ -119,7 +119,7 @@
       "sha256": "6e4429db62fcbe1dd73141d8c20a48b564d41f8bf8920d88775846995e1daf94"
     }
   ],
-  "validator_source_set_sha256": "f79c19f4d9b377e363e3336a365f9d4a4f5df0704a72f03895e930c3833ce468",
+  "validator_source_set_sha256": "0a5f70dacb1ab47b8be38ce92fe562a81472fdaa3cbfbbf2a846a99bab042c1b",
   "pdfjs_version": "5.4.624",
   "generation_contract": {
     "source_path": "source.pdf",

--- a/test/legacy-tex-corpus-live.test.js
+++ b/test/legacy-tex-corpus-live.test.js
@@ -13,14 +13,32 @@ import { uniqueComputerModernFamily } from "../server/layout-extraction.js";
  * baseline.
  *
  * Nothing in this file describes desired behaviour. Every recorded
- * `strict_recovery_count` here is zero, and that zero IS the defect this
+ * `strict_recovery_count` here is still zero, and that zero IS the defect this
  * corpus exists to track: PDF Tools recovers Computer Modern Type-3 bitmap
  * mathematics on the Shannon document and recovers none of it on any of these
  * five, even though they are the same fonts drawn by the same era of
- * toolchain. Three of the four cr.yp.to papers do not even resolve a font
- * family, and none of the four links a single glyph occurrence to a raw
- * Type-3 font. The numbers below are what the shipped code does today,
- * measured, not what it should do.
+ * toolchain. The numbers below are what the shipped code does today, measured,
+ * not what it should do.
+ *
+ * Two of the three stacked causes have since been removed, and the baseline
+ * was raised to record that:
+ *
+ *   1. The linker used to drop zero-width slots from a font's width map while
+ *      still demanding an exact width match for every drawn glyph, so a single
+ *      legitimately zero-width glyph voided the whole font. All four
+ *      Ghostscript 6.52 papers linked exactly nothing; they now link 52,493
+ *      occurrences between them.
+ *   2. The recovery key used to be the CharProc operator list, which folds in
+ *      the producer's idiom and the per-glyph placement matrix. It is now the
+ *      decoded image mask.
+ *
+ * What is left is the third cause, and it is why every recovery count here is
+ * still zero: none of these documents resolves a Computer Modern family for
+ * the fonts that carry its mathematics — three of the four cr.yp.to papers
+ * resolve no family at all — and the one document that does resolve families
+ * for ten fonts (astro-ph) rasterised them at its own PK resolution, which
+ * matches no enrolled shape. Producer-independent family identification from
+ * matched shape sets is the next step, not this one.
  *
  * Interface: one directory variable, `PDF_TOOLS_LEGACY_CORPUS_DIR`, holding
  * all five documents under the fixed basenames listed in DOCUMENTS. A single
@@ -91,8 +109,8 @@ const BASELINE = Object.freeze({
     layout_admissible_font_count: 19,
     computer_modern_family_font_count: 0,
     observed_type3_occurrence_count: 78175,
-    linked_type3_occurrence_count: 0,
-    omitted_type3_occurrence_count: 78175,
+    linked_type3_occurrence_count: 5440,
+    omitted_type3_occurrence_count: 72735,
     classified_occurrence_count: 0,
     officially_named_occurrence_count: 0,
     registry_evidence_occurrence_count: 0,
@@ -108,8 +126,8 @@ const BASELINE = Object.freeze({
     layout_admissible_font_count: 10,
     computer_modern_family_font_count: 0,
     observed_type3_occurrence_count: 40704,
-    linked_type3_occurrence_count: 0,
-    omitted_type3_occurrence_count: 40704,
+    linked_type3_occurrence_count: 7484,
+    omitted_type3_occurrence_count: 33220,
     classified_occurrence_count: 0,
     officially_named_occurrence_count: 0,
     registry_evidence_occurrence_count: 0,
@@ -125,8 +143,8 @@ const BASELINE = Object.freeze({
     layout_admissible_font_count: 18,
     computer_modern_family_font_count: 0,
     observed_type3_occurrence_count: 92502,
-    linked_type3_occurrence_count: 0,
-    omitted_type3_occurrence_count: 92502,
+    linked_type3_occurrence_count: 17335,
+    omitted_type3_occurrence_count: 75167,
     classified_occurrence_count: 0,
     officially_named_occurrence_count: 0,
     registry_evidence_occurrence_count: 0,
@@ -134,34 +152,35 @@ const BASELINE = Object.freeze({
     abstention_reasons: Object.freeze(["raw_type3_font_link_ambiguous_or_unavailable"]),
   }),
   "sf": Object.freeze({
+    // Exactly one sf font resolves a Computer Modern family, and the ten
+    // occurrences it now classifies still recover nothing: their rasters are
+    // this document's own PK resolution and match no enrolled shape.
     producer: "GNU Ghostscript 6.52",
     creator: null,
     page_count: 15,
     size_bytes: 268946,
     type3_font_count: 16,
     layout_admissible_font_count: 15,
-    // Exactly one sf font does resolve a Computer Modern family, and it still
-    // recovers nothing, because no occurrence in this document ever links to a
-    // raw font in the first place. Family resolution is not the only block.
     computer_modern_family_font_count: 1,
     observed_type3_occurrence_count: 74271,
-    linked_type3_occurrence_count: 0,
-    omitted_type3_occurrence_count: 74271,
-    classified_occurrence_count: 0,
-    officially_named_occurrence_count: 0,
+    linked_type3_occurrence_count: 22234,
+    omitted_type3_occurrence_count: 52037,
+    classified_occurrence_count: 10,
+    officially_named_occurrence_count: 2,
     registry_evidence_occurrence_count: 0,
     strict_recovery_count: 0,
     abstention_reasons: Object.freeze(["raw_type3_font_link_ambiguous_or_unavailable"]),
   }),
   "astro-ph-9402001": Object.freeze({
+    // 18 of the 22 fonts carry a /ToUnicode and are deliberately left to
+    // PDF.js, so 10 fonts whose widths do fingerprint a Computer Modern
+    // family never become link candidates. This document is unaffected by
+    // the zero-width linker fix: its drawn glyphs all had positive widths.
     producer: "GPL Ghostscript GIT PRERELEASE 9.22",
     creator: "dvips 5.518",
     page_count: 37,
     size_bytes: 929486,
     type3_font_count: 22,
-    // 18 of the 22 fonts carry a /ToUnicode and are refused by the linker's
-    // admission rules outright, so 10 fonts whose widths do fingerprint a
-    // Computer Modern family never become link candidates.
     layout_admissible_font_count: 4,
     computer_modern_family_font_count: 10,
     observed_type3_occurrence_count: 100114,
@@ -169,9 +188,6 @@ const BASELINE = Object.freeze({
     omitted_type3_occurrence_count: 100070,
     classified_occurrence_count: 12,
     officially_named_occurrence_count: 11,
-    // The study's second cause, isolated: codes are preserved and 11
-    // occurrences carry an official Unicode mapping, yet not one matches any
-    // registry CharProc digest, so nothing is recovered.
     registry_evidence_occurrence_count: 0,
     strict_recovery_count: 0,
     abstention_reasons: Object.freeze(["raw_type3_font_link_ambiguous_or_unavailable"]),
@@ -196,11 +212,13 @@ function type3FontDictionaries(pdfLibDocument) {
 }
 
 /**
- * Positive-width slots of a Type-3 font, built the way the shipped
- * `rawType3Fonts` builds them — zero widths dropped, because
- * `metricScaleInterval` cannot fit a scale to an observed zero. Measured here
- * independently of that private helper so the baseline records a document
- * fact rather than a re-export of the code under study.
+ * Positive-width slots of a Type-3 font: the view the shipped `rawType3Fonts`
+ * hands to the family fingerprint, with zero widths dropped because
+ * `metricScaleInterval` cannot fit a scale to an observed zero. The linker
+ * keeps those zeros — that is the fix this baseline records — but the
+ * fingerprint must not see them. Measured here independently of that private
+ * helper so the baseline records a document fact rather than a re-export of
+ * the code under study.
  */
 function positiveWidthSlots(font) {
   const first = font.lookup(PDFName.of("FirstChar"), PDFNumber)?.asNumber();
@@ -217,11 +235,14 @@ function positiveWidthSlots(font) {
   return widths.size > 0 ? { first, last, widths } : null;
 }
 
-/** Mirrors the admission rules `rawType3Fonts` applies before a font is even
- * a link candidate: no `/ToUnicode`, codes confined to 0..127, a well-formed
- * `/Widths`, and a present `/Encoding /Differences` array. This is a close
- * mirror rather than that private helper itself, so the figure it produces is
- * a readable document fact and not a re-export of the code under study. */
+/** Mirrors the rules that decide whether a font can be the *answer* the
+ * linker returns: no `/ToUnicode`, codes confined to 0..127, a well-formed
+ * `/Widths`, and a present `/Encoding /Differences` array. Every other Type-3
+ * font on the page is still parsed and still competes for the link, so a
+ * glyph set matching two fonts abstains rather than picking the recoverable
+ * one; only the winner has to clear this bar. This is a close mirror rather
+ * than that private helper itself, so the figure it produces is a readable
+ * document fact and not a re-export of the code under study. */
 function layoutAdmissible(context, font, slots) {
   if (font.has(PDFName.of("ToUnicode"))) return false;
   if (!slots || slots.last > 127) return false;
@@ -366,9 +387,12 @@ describe.runIf(Boolean(CORPUS_DIR))("legacy dvips-era Computer Modern Type-3 cor
     ).toBe(0);
 
     // The four cr.yp.to papers are the hardest case: GNU Ghostscript 6.52
-    // repacks glyph names to /a0 /a1 /a2..., and not one of their 285,652
-    // observed occurrences even links to a raw Type-3 font, so the pipeline
-    // never reaches the family fingerprint or any CharProc digest at all.
+    // repacks glyph names to /a0 /a1 /a2.... Their 285,652 observed
+    // occurrences used to link to a raw Type-3 font exactly zero times,
+    // because every one of these fonts declares at least one zero-width slot
+    // and the linker treated a declared zero as a missing width. They now
+    // link, which is the whole of what the linker fix bought; what they still
+    // cannot do is put a Computer Modern family behind the link.
     const ghostscript652 = measured.filter(entry => entry.producer === "GNU Ghostscript 6.52");
     expect(ghostscript652).toHaveLength(4);
     expect(ghostscript652.reduce((sum, entry) => sum + entry.observed_type3_occurrence_count, 0))
@@ -376,9 +400,14 @@ describe.runIf(Boolean(CORPUS_DIR))("legacy dvips-era Computer Modern Type-3 cor
     for (const entry of ghostscript652) {
       expect(
         entry.linked_type3_occurrence_count,
-        "a Ghostscript 6.52 paper now links Type-3 occurrences: update the recorded baseline deliberately",
-      ).toBe(0);
-      expect(entry.classified_occurrence_count).toBe(0);
+        "a Ghostscript 6.52 paper stopped linking Type-3 occurrences: the zero-width linker fix regressed",
+      ).toBeGreaterThan(0);
     }
+    // Family resolution, not linking, is what now blocks the four papers, and
+    // it blocks all but ten of their linked occurrences.
+    expect(
+      ghostscript652.reduce((sum, entry) => sum + entry.classified_occurrence_count, 0),
+      "a Ghostscript 6.52 paper now classifies more occurrences into a Computer Modern family: update the recorded baseline deliberately",
+    ).toBe(10);
   }, 600_000);
 });

--- a/test/legacy-tex-corpus-live.test.js
+++ b/test/legacy-tex-corpus-live.test.js
@@ -39,6 +39,11 @@ import { uniqueComputerModernFamily } from "../server/layout-extraction.js";
  * for ten fonts (astro-ph) rasterised them at its own PK resolution, which
  * matches no enrolled shape.
  *
+ * Both routes past that third cause have since been investigated to a
+ * conclusion and both are closed. Findings (a)-(d) below close the shape
+ * route; findings (e)-(g) close every metric-derived route. Read them before
+ * attempting anything here.
+ *
  * Identifying the family from the set of matched glyph SHAPES, rather than
  * from `widths[code]`, was investigated as the way through and was measured to
  * be a dead end. It is recorded here so it is not attempted again blind. Four
@@ -97,6 +102,70 @@ import { uniqueComputerModernFamily } from "../server/layout-extraction.js";
  * font pins `cmsy5` off just two such advances, and the two occurrences it
  * officially names mean nothing. Only the missing digest match keeps that
  * coincidence out of the output.
+ *
+ * The obvious way around THAT — reconstruct each inked glyph's advance from
+ * the spacer that follows it, then fingerprint as usual — was also measured,
+ * and it closes the last metric-derived route to these four documents. Three
+ * findings, all measured on these exact documents and recorded in full in
+ * `docs/evidence/legacy-tex-metric-routes-closed-2026-08.md`:
+ *
+ *   e. The spacer does not carry a per-character advance. It carries an
+ *      inter-glyph DISPLACEMENT — advance plus interword space plus kern plus
+ *      grid rounding — which is not a function of the inked glyph. Only
+ *      53.0/77.4/59.1/51.3% of inked occurrences are followed by a spacer at
+ *      all; in pippenger 7,725 of 15,010 show operations (51.5%) hold one
+ *      inked glyph and no spacer, the run-final displacement having been
+ *      folded into the following `Td`. Where a spacer does follow, the map is
+ *      many-to-many: 222 of pippenger's 333 inked codes with a spacer partner
+ *      take more than one spacer code, and the modal displacement for a code
+ *      accounts for only 43.7-46.8% of its observations. Ground truth from a
+ *      decoded page-1 line settles it: in ONE fourteen-glyph show operation
+ *      the letter `t` takes displacements 33, 54, 29 and 30, while `.`, `I`
+ *      and `w` each report exactly 51 because they only ever occur before a
+ *      word space. That is the word space, not the letter.
+ *   f. Granting a perfect solution to both blockers at once still fits
+ *      nothing. Taking the 15 ground-truth roman characters read off page 1 of
+ *      pippenger and placing them at their TRUE OT1 slots with their best-case
+ *      reconstructed advances, ZERO Computer Modern metrics fit at ±0.5, ±1,
+ *      ±2, ±3, ±5, ±8 or ±12 — out to 24x the shipped ±0.5 tolerance, under
+ *      both the min and the mode statistic. The per-character implied scale
+ *      against cmr10 ranges 66.6 px/em (`n`) to 183.6 px/em (`.`), and one
+ *      font cannot be drawn at two scales, so there is no signal to loosen a
+ *      tolerance toward.
+ *   g. The category error, which would have defeated both of the above
+ *      anyway. Ghostscript 6.52 does not emit one Type-3 font per TeX font; it
+ *      emits GLYPH CACHE PAGES. Each of the four documents contains one Type-3
+ *      font — `9 0 R` in all four — carrying 171/168/168/164 inked glyphs,
+ *      more than the 128 slots any Computer Modern font has. In pippenger's
+ *      `9 0 R`, code 10 is the small roman `I` (mask 21x41) and code 49 is the
+ *      large bold `I` (mask 39x69), same object. "This font's family" has no
+ *      answer, so no font-level identification of any kind — metric or shape —
+ *      can work for this producer.
+ *
+ * And the abstention is demonstrably right rather than merely cautious. The
+ * one stable metric candidate in the whole corpus, m3's `408 0 R`, fits cmmi7
+ * under min, mode AND max, at a scale that puts a 7 pt metric at 10.4 pt. Its
+ * seven unique width-pins predict `L`, `M`, `i`, `w`, `l`, `psi` and `varphi`.
+ * Rendered, the mask pinned to capital `L` is an x-height box with no
+ * ascender; the one pinned to `M` is 47 px wide against a 113-unit advance
+ * (0.42, where pippenger's real bold `M` is 0.94) and descends below the
+ * baseline; the one pinned to `l` is a superscript raster drawn entirely above
+ * the baseline. The line that font helps draw is
+ * `4x² + 1x³ + 5x⁴ + 9x⁵ ∈ R[x] → R[x][y]/(x²−y)`, set by five different
+ * Type-3 fonts — one per raster size the cache needed, which is finding (g)
+ * again. Shipping the metric route would have emitted those seven letters in
+ * place of digits and exponents.
+ *
+ * So every recovery figure below is zero because every metric-derived route
+ * and the shape route are both closed, and the closure is a property of what
+ * GNU Ghostscript 6.52 wrote into these files rather than a limit on effort.
+ * The only remaining theoretical route is an external labelled bitmap
+ * reference — a METAFONT run at each document's own mode and resolution —
+ * which no document here records and nothing in this repository can pin. None
+ * of this makes the zeros acceptable; it records why they are here. And none
+ * of it applies to astro-ph-9402001.pdf, which preserves its TeX codes,
+ * fingerprints ten fonts correctly, and fails for the unrelated reason in (a)
+ * and obstacle 3: its rasters are 300 dpi and match no enrolled shape.
  *
  * Interface: one directory variable, `PDF_TOOLS_LEGACY_CORPUS_DIR`, holding
  * all five documents under the fixed basenames listed in DOCUMENTS. A single
@@ -462,7 +531,12 @@ describe.runIf(Boolean(CORPUS_DIR))("legacy dvips-era Computer Modern Type-3 cor
       ).toBeGreaterThan(0);
     }
     // Family resolution, not linking, is what now blocks the four papers, and
-    // it blocks all but ten of their linked occurrences.
+    // it blocks all but ten of their linked occurrences. It blocks them
+    // permanently: their Type-3 objects are glyph cache pages holding more
+    // inked glyphs than any Computer Modern font has slots, so no font-level
+    // family answer exists to be found. See findings (e)-(g) in this file's
+    // header and docs/evidence/legacy-tex-metric-routes-closed-2026-08.md.
+    // Raising this number would mean a coincidence got through, not a fix.
     expect(
       ghostscript652.reduce((sum, entry) => sum + entry.classified_occurrence_count, 0),
       "a Ghostscript 6.52 paper now classifies more occurrences into a Computer Modern family: update the recorded baseline deliberately",

--- a/test/legacy-tex-corpus-live.test.js
+++ b/test/legacy-tex-corpus-live.test.js
@@ -1,0 +1,384 @@
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
+import { PDFArray, PDFDict, PDFDocument, PDFName, PDFNumber } from "pdf-lib";
+import { describe, expect, it } from "vitest";
+import { uniqueComputerModernFamily } from "../server/layout-extraction.js";
+
+/**
+ * Legacy dvips-era Computer Modern Type-3 corpus, bound as a pinned failing
+ * baseline.
+ *
+ * Nothing in this file describes desired behaviour. Every recorded
+ * `strict_recovery_count` here is zero, and that zero IS the defect this
+ * corpus exists to track: PDF Tools recovers Computer Modern Type-3 bitmap
+ * mathematics on the Shannon document and recovers none of it on any of these
+ * five, even though they are the same fonts drawn by the same era of
+ * toolchain. Three of the four cr.yp.to papers do not even resolve a font
+ * family, and none of the four links a single glyph occurrence to a raw
+ * Type-3 font. The numbers below are what the shipped code does today,
+ * measured, not what it should do.
+ *
+ * Interface: one directory variable, `PDF_TOOLS_LEGACY_CORPUS_DIR`, holding
+ * all five documents under the fixed basenames listed in DOCUMENTS. A single
+ * variable was chosen over five because five separate variables permit a
+ * partially configured run — three set, two unset — which would silently
+ * characterize part of the corpus and look like a pass. With one variable the
+ * suite is either fully skipped or fully measured: once the directory is
+ * given, a missing or wrong-digest document is a hard failure, never a skip.
+ *
+ * The documents are third-party and are deliberately NOT committed. Sources:
+ *   https://cr.yp.to/papers/pippenger.pdf
+ *   https://cr.yp.to/papers/nfscircuit.pdf
+ *   https://cr.yp.to/papers/m3.pdf
+ *   https://cr.yp.to/papers/sf.pdf
+ *   https://arxiv.org/pdf/astro-ph/9402001
+ */
+
+const execFileAsync = promisify(execFile);
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const INVENTORY_SCRIPT = path.join(REPO_ROOT, "scripts", "inventory-type3-glyphs.mjs");
+const CORPUS_DIR = process.env.PDF_TOOLS_LEGACY_CORPUS_DIR;
+
+const DOCUMENTS = Object.freeze([
+  Object.freeze({
+    name: "pippenger",
+    file: "pippenger.pdf",
+    url: "https://cr.yp.to/papers/pippenger.pdf",
+    sha256: "ec45c2193abf5acfb5adaaf71c4b4f7b487d90b21f80b7b6d48fd51fd655ccae",
+  }),
+  Object.freeze({
+    name: "nfscircuit",
+    file: "nfscircuit.pdf",
+    url: "https://cr.yp.to/papers/nfscircuit.pdf",
+    sha256: "eee46391621b5d5d2de5de93e7c34217c5c8a6b2db517a682e52d6fb336f6f46",
+  }),
+  Object.freeze({
+    name: "m3",
+    file: "m3.pdf",
+    url: "https://cr.yp.to/papers/m3.pdf",
+    sha256: "988189c6600a24b242c39cd617ea13307e2c3f9880bbafd4914c33ae20be5fc5",
+  }),
+  Object.freeze({
+    name: "sf",
+    file: "sf.pdf",
+    url: "https://cr.yp.to/papers/sf.pdf",
+    sha256: "5a094ee9709d51817b1184e9c01e2e3acf9e3fdc0153a5d876c9cbb138cf34d9",
+  }),
+  Object.freeze({
+    name: "astro-ph-9402001",
+    file: "astro-ph-9402001.pdf",
+    url: "https://arxiv.org/pdf/astro-ph/9402001",
+    sha256: "eb0f80aea9c3c359e3826866a9c8128d41862937f5002dbd016a6f6adbbc0041",
+  }),
+]);
+
+/**
+ * Recorded baseline. Captured programmatically: each object below is exactly
+ * the `measured` object a real run of `measureDocument` printed, spliced back
+ * in unedited. No figure here was typed by hand on both sides of an assertion.
+ */
+const BASELINE = Object.freeze({
+  "pippenger": Object.freeze({
+    producer: "GNU Ghostscript 6.52",
+    creator: null,
+    page_count: 21,
+    size_bytes: 292684,
+    type3_font_count: 22,
+    layout_admissible_font_count: 19,
+    computer_modern_family_font_count: 0,
+    observed_type3_occurrence_count: 78175,
+    linked_type3_occurrence_count: 0,
+    omitted_type3_occurrence_count: 78175,
+    classified_occurrence_count: 0,
+    officially_named_occurrence_count: 0,
+    registry_evidence_occurrence_count: 0,
+    strict_recovery_count: 0,
+    abstention_reasons: Object.freeze(["raw_type3_font_link_ambiguous_or_unavailable"]),
+  }),
+  "nfscircuit": Object.freeze({
+    producer: "GNU Ghostscript 6.52",
+    creator: null,
+    page_count: 11,
+    size_bytes: 186703,
+    type3_font_count: 12,
+    layout_admissible_font_count: 10,
+    computer_modern_family_font_count: 0,
+    observed_type3_occurrence_count: 40704,
+    linked_type3_occurrence_count: 0,
+    omitted_type3_occurrence_count: 40704,
+    classified_occurrence_count: 0,
+    officially_named_occurrence_count: 0,
+    registry_evidence_occurrence_count: 0,
+    strict_recovery_count: 0,
+    abstention_reasons: Object.freeze(["raw_type3_font_link_ambiguous_or_unavailable"]),
+  }),
+  "m3": Object.freeze({
+    producer: "GNU Ghostscript 6.52",
+    creator: null,
+    page_count: 19,
+    size_bytes: 276417,
+    type3_font_count: 20,
+    layout_admissible_font_count: 18,
+    computer_modern_family_font_count: 0,
+    observed_type3_occurrence_count: 92502,
+    linked_type3_occurrence_count: 0,
+    omitted_type3_occurrence_count: 92502,
+    classified_occurrence_count: 0,
+    officially_named_occurrence_count: 0,
+    registry_evidence_occurrence_count: 0,
+    strict_recovery_count: 0,
+    abstention_reasons: Object.freeze(["raw_type3_font_link_ambiguous_or_unavailable"]),
+  }),
+  "sf": Object.freeze({
+    producer: "GNU Ghostscript 6.52",
+    creator: null,
+    page_count: 15,
+    size_bytes: 268946,
+    type3_font_count: 16,
+    layout_admissible_font_count: 15,
+    // Exactly one sf font does resolve a Computer Modern family, and it still
+    // recovers nothing, because no occurrence in this document ever links to a
+    // raw font in the first place. Family resolution is not the only block.
+    computer_modern_family_font_count: 1,
+    observed_type3_occurrence_count: 74271,
+    linked_type3_occurrence_count: 0,
+    omitted_type3_occurrence_count: 74271,
+    classified_occurrence_count: 0,
+    officially_named_occurrence_count: 0,
+    registry_evidence_occurrence_count: 0,
+    strict_recovery_count: 0,
+    abstention_reasons: Object.freeze(["raw_type3_font_link_ambiguous_or_unavailable"]),
+  }),
+  "astro-ph-9402001": Object.freeze({
+    producer: "GPL Ghostscript GIT PRERELEASE 9.22",
+    creator: "dvips 5.518",
+    page_count: 37,
+    size_bytes: 929486,
+    type3_font_count: 22,
+    // 18 of the 22 fonts carry a /ToUnicode and are refused by the linker's
+    // admission rules outright, so 10 fonts whose widths do fingerprint a
+    // Computer Modern family never become link candidates.
+    layout_admissible_font_count: 4,
+    computer_modern_family_font_count: 10,
+    observed_type3_occurrence_count: 100114,
+    linked_type3_occurrence_count: 44,
+    omitted_type3_occurrence_count: 100070,
+    classified_occurrence_count: 12,
+    officially_named_occurrence_count: 11,
+    // The study's second cause, isolated: codes are preserved and 11
+    // occurrences carry an official Unicode mapping, yet not one matches any
+    // registry CharProc digest, so nothing is recovered.
+    registry_evidence_occurrence_count: 0,
+    strict_recovery_count: 0,
+    abstention_reasons: Object.freeze(["raw_type3_font_link_ambiguous_or_unavailable"]),
+  }),
+});
+
+function type3FontDictionaries(pdfLibDocument) {
+  const seen = new Map();
+  for (let index = 0; index < pdfLibDocument.getPageCount(); index += 1) {
+    const page = pdfLibDocument.getPage(index);
+    const context = page.doc.context;
+    const fonts = page.node.Resources()?.lookup(PDFName.of("Font"), PDFDict);
+    if (!fonts) continue;
+    for (const [, reference] of fonts.entries()) {
+      const font = context.lookup(reference, PDFDict);
+      if (font?.get(PDFName.of("Subtype"))?.toString() !== "/Type3") continue;
+      const key = String(reference);
+      if (!seen.has(key)) seen.set(key, font);
+    }
+  }
+  return { context: pdfLibDocument.context, fonts: [...seen.values()] };
+}
+
+/**
+ * Positive-width slots of a Type-3 font, built the way the shipped
+ * `rawType3Fonts` builds them — zero widths dropped, because
+ * `metricScaleInterval` cannot fit a scale to an observed zero. Measured here
+ * independently of that private helper so the baseline records a document
+ * fact rather than a re-export of the code under study.
+ */
+function positiveWidthSlots(font) {
+  const first = font.lookup(PDFName.of("FirstChar"), PDFNumber)?.asNumber();
+  const last = font.lookup(PDFName.of("LastChar"), PDFNumber)?.asNumber();
+  const widthsArray = font.lookup(PDFName.of("Widths"), PDFArray);
+  if (!Number.isSafeInteger(first) || !Number.isSafeInteger(last) || !widthsArray) return null;
+  if (first < 0 || last < first || widthsArray.size() !== last - first + 1) return null;
+  const widths = new Map();
+  for (let code = first; code <= last; code += 1) {
+    const width = widthsArray.lookup(code - first, PDFNumber)?.asNumber();
+    if (!Number.isSafeInteger(width) || width < 0) return null;
+    if (width > 0) widths.set(code, width);
+  }
+  return widths.size > 0 ? { first, last, widths } : null;
+}
+
+/** Mirrors the admission rules `rawType3Fonts` applies before a font is even
+ * a link candidate: no `/ToUnicode`, codes confined to 0..127, a well-formed
+ * `/Widths`, and a present `/Encoding /Differences` array. This is a close
+ * mirror rather than that private helper itself, so the figure it produces is
+ * a readable document fact and not a re-export of the code under study. */
+function layoutAdmissible(context, font, slots) {
+  if (font.has(PDFName.of("ToUnicode"))) return false;
+  if (!slots || slots.last > 127) return false;
+  const encoding = context.lookup(font.get(PDFName.of("Encoding")), PDFDict);
+  return Boolean(encoding?.lookup(PDFName.of("Differences"), PDFArray));
+}
+
+const measurements = new Map();
+
+async function measureDocument(document) {
+  if (measurements.has(document.name)) return measurements.get(document.name);
+  const corpusDirectory = await fs.realpath(CORPUS_DIR);
+  const sourcePath = path.join(corpusDirectory, document.file);
+  const bytes = await fs.readFile(sourcePath);
+  const sha256 = createHash("sha256").update(bytes).digest("hex");
+
+  const pdfLibDocument = await PDFDocument.load(bytes, {
+    ignoreEncryption: true,
+    updateMetadata: false,
+  });
+  const { context, fonts } = type3FontDictionaries(pdfLibDocument);
+  let admissible = 0;
+  let familyResolving = 0;
+  for (const font of fonts) {
+    const slots = positiveWidthSlots(font);
+    if (layoutAdmissible(context, font, slots)) admissible += 1;
+    if (slots && uniqueComputerModernFamily(slots.widths)) familyResolving += 1;
+  }
+
+  const { stdout } = await execFileAsync(
+    process.execPath,
+    [INVENTORY_SCRIPT, "--source", sourcePath],
+    { cwd: REPO_ROOT, maxBuffer: 16_000_000 },
+  );
+  const report = JSON.parse(stdout);
+
+  const measured = {
+    producer: pdfLibDocument.getProducer() ?? null,
+    creator: pdfLibDocument.getCreator() ?? null,
+    page_count: report.source.page_count,
+    size_bytes: report.source.size_bytes,
+    type3_font_count: fonts.length,
+    layout_admissible_font_count: admissible,
+    computer_modern_family_font_count: familyResolving,
+    observed_type3_occurrence_count: report.coverage.observed_type3_occurrence_count,
+    linked_type3_occurrence_count: report.coverage.linked_type3_occurrence_count,
+    omitted_type3_occurrence_count: report.coverage.omitted_type3_occurrence_count,
+    classified_occurrence_count: report.coverage.classified_occurrence_count,
+    officially_named_occurrence_count: report.coverage.officially_named_occurrence_count,
+    registry_evidence_occurrence_count: report.coverage.registry_evidence_occurrence_count,
+    strict_recovery_count: report.coverage.strict_recovery_count,
+    abstention_reasons: report.abstentions.map(entry => entry.reason).sort(),
+  };
+  const result = { sha256, measured, report };
+  measurements.set(document.name, result);
+  return result;
+}
+
+describe.runIf(Boolean(CORPUS_DIR))("legacy dvips-era Computer Modern Type-3 corpus", () => {
+  for (const document of DOCUMENTS) {
+    it(`characterizes today's behaviour on ${document.file}`, async () => {
+      const { sha256, measured } = await measureDocument(document);
+      expect(sha256, `${document.file} is not the pinned document from ${document.url}`)
+        .toBe(document.sha256);
+
+      // Harness guard. A broken measurement — an unreadable PDF, an inventory
+      // run that produced an empty report, a document with no Type-3 content
+      // at all — would otherwise satisfy every zero below and read as a pass.
+      expect(measured.page_count).toBeGreaterThan(0);
+      expect(measured.type3_font_count).toBeGreaterThan(0);
+      expect(
+        measured.observed_type3_occurrence_count,
+        "no Type-3 glyph occurrences were observed at all; the measurement, not the document, is wrong",
+      ).toBeGreaterThan(10_000);
+
+      const expected = BASELINE[document.name];
+      // Exact document facts. These are properties of the pinned bytes and of
+      // a pinned pdfjs-dist; a change here is a real change in what the
+      // pipeline sees, not an improvement in what it recovers.
+      expect({
+        producer: measured.producer,
+        creator: measured.creator,
+        page_count: measured.page_count,
+        size_bytes: measured.size_bytes,
+        type3_font_count: measured.type3_font_count,
+        observed_type3_occurrence_count: measured.observed_type3_occurrence_count,
+        abstention_reasons: measured.abstention_reasons,
+      }).toEqual({
+        producer: expected.producer,
+        creator: expected.creator,
+        page_count: expected.page_count,
+        size_bytes: expected.size_bytes,
+        type3_font_count: expected.type3_font_count,
+        observed_type3_occurrence_count: expected.observed_type3_occurrence_count,
+        abstention_reasons: [...expected.abstention_reasons],
+      });
+
+      // Directional. Each recovery-shaped count is fenced from both sides with
+      // its own message, so a regression and an improvement fail differently
+      // and neither can pass silently. Raising any recorded number here is a
+      // deliberate, reviewable edit — and for strict_recovery_count it is the
+      // point of the work this baseline exists to measure.
+      const directional = [
+        ["layout_admissible_font_count", "Type-3 fonts admitted by the layout font linker"],
+        ["computer_modern_family_font_count", "Type-3 fonts resolving to a Computer Modern family"],
+        ["linked_type3_occurrence_count", "Type-3 occurrences linked to a raw font"],
+        ["classified_occurrence_count", "occurrences classified into a Computer Modern family"],
+        ["officially_named_occurrence_count", "occurrences with an official Unicode mapping"],
+        ["registry_evidence_occurrence_count", "occurrences matching a registry digest"],
+        ["strict_recovery_count", "strictly recovered occurrences"],
+      ];
+      for (const [key, label] of directional) {
+        expect(
+          measured[key],
+          `${label} regressed below the recorded baseline for ${document.file}`,
+        ).toBeGreaterThanOrEqual(expected[key]);
+        expect(
+          measured[key],
+          `${label} improved for ${document.file}: update the recorded baseline in this file deliberately`,
+        ).toBeLessThanOrEqual(expected[key]);
+      }
+    }, 180_000);
+  }
+
+  /**
+   * Corpus-level statement of the gap, so the headline claim is asserted once
+   * rather than only implied by five per-document blocks.
+   */
+  it("recovers nothing at all across the whole corpus", async () => {
+    const measured = [];
+    for (const document of DOCUMENTS) measured.push((await measureDocument(document)).measured);
+    expect(measured).toHaveLength(DOCUMENTS.length);
+    const total = key => measured.reduce((sum, entry) => sum + entry[key], 0);
+
+    // Guard: the corpus really is a large body of legacy Type-3 mathematics.
+    expect(total("observed_type3_occurrence_count")).toBeGreaterThan(300_000);
+    expect(total("type3_font_count")).toBeGreaterThan(50);
+
+    expect(
+      total("strict_recovery_count"),
+      "the legacy corpus now recovers something: this is the tracked defect being fixed, so update the recorded baseline deliberately",
+    ).toBe(0);
+
+    // The four cr.yp.to papers are the hardest case: GNU Ghostscript 6.52
+    // repacks glyph names to /a0 /a1 /a2..., and not one of their 285,652
+    // observed occurrences even links to a raw Type-3 font, so the pipeline
+    // never reaches the family fingerprint or any CharProc digest at all.
+    const ghostscript652 = measured.filter(entry => entry.producer === "GNU Ghostscript 6.52");
+    expect(ghostscript652).toHaveLength(4);
+    expect(ghostscript652.reduce((sum, entry) => sum + entry.observed_type3_occurrence_count, 0))
+      .toBeGreaterThan(200_000);
+    for (const entry of ghostscript652) {
+      expect(
+        entry.linked_type3_occurrence_count,
+        "a Ghostscript 6.52 paper now links Type-3 occurrences: update the recorded baseline deliberately",
+      ).toBe(0);
+      expect(entry.classified_occurrence_count).toBe(0);
+    }
+  }, 600_000);
+});

--- a/test/legacy-tex-corpus-live.test.js
+++ b/test/legacy-tex-corpus-live.test.js
@@ -37,8 +37,66 @@ import { uniqueComputerModernFamily } from "../server/layout-extraction.js";
  * the fonts that carry its mathematics — three of the four cr.yp.to papers
  * resolve no family at all — and the one document that does resolve families
  * for ten fonts (astro-ph) rasterised them at its own PK resolution, which
- * matches no enrolled shape. Producer-independent family identification from
- * matched shape sets is the next step, not this one.
+ * matches no enrolled shape.
+ *
+ * Identifying the family from the set of matched glyph SHAPES, rather than
+ * from `widths[code]`, was investigated as the way through and was measured to
+ * be a dead end. It is recorded here so it is not attempted again blind. Four
+ * findings, each measured on these exact documents:
+ *
+ *   a. There is no bitmap reference to match against. The pinned official CTAN
+ *      `cm/ps-type3` fonts are cubic-Bézier OUTLINE programs: all 41 glyph
+ *      programs of the labeled reference fixture take the exact-operator
+ *      evidence lane and none takes the image-mask lane. `cm/mf.zip` is
+ *      METAFONT source, and turning it into the PK rasters these documents
+ *      actually carry needs a METAFONT run at a mode and resolution that no
+ *      document here records.
+ *   b. Bridging outline to bitmap is never exact, and no threshold separates
+ *      right from wrong. Rasterising the official CTAN outline for cmmi alpha
+ *      across 225,225 combinations of resolution (60-110 px/em in 0.05 steps),
+ *      alpha threshold, and sub-pixel offset reproduced the Shannon document's
+ *      reviewed alpha raster's ink box 241 times and its bits ZERO times; the
+ *      closest was 72 of 1748 pixels wrong, 4.1%. Repeating that against three
+ *      Shannon rasters of known identity, scoring every one of the 41 reference
+ *      slots that could reproduce the target's ink box at any resolution, the
+ *      correct slot's best agreement was 4.3% wrong for alpha, 2.1% for omega
+ *      and 14.5% for sigma, while the best WRONG slot reached 20.1% for alpha
+ *      and 24.5% for sigma. So a threshold has to admit 14.5% to identify
+ *      sigma and reject 20.1% to not misread alpha — a 1.4x window, already
+ *      that narrow against a reference holding 41 of the roughly 9,600 (font,
+ *      slot) pairs Computer Modern actually has. Widening the reference can
+ *      only close the window further. That is a similarity threshold that
+ *      could misfire, which is the guess this pipeline abstains rather than
+ *      make.
+ *   c. Even an exact matcher would not determine a family. One digest in the
+ *      shipped registry already stands at two different (family, slot) pairs:
+ *      the same bitmap is `cmmi-pk-raster-period-2df559-v1` (math-italic slot
+ *      58, ".") and `cmsy-pk-raster-centered-dot-33077f-v1` (math-symbol slot
+ *      1, "⋅"). Shape identifies a code only once the family is already known,
+ *      which is the direction the shipped matcher runs in and the opposite of
+ *      the direction proposed.
+ *   d. There is no cross-document anchor either. The mask key is genuinely
+ *      producer-independent — the four cr.yp.to papers share 387 to 440 of
+ *      their 451 to 581 distinct inked shapes with each other, being one PK
+ *      library at 720 dpi — but they share exactly ONE shape with Shannon
+ *      (600 dpi) and none at all with astro-ph (300 dpi), and that one shared
+ *      shape is a 41x3 solid rectangle, a fraction rule rather than a
+ *      character.
+ *
+ * Independently of all of that, the four Ghostscript 6.52 papers could not
+ * recover through the shipped safeguards even given a perfect shape matcher.
+ * That producer splits every character into TWO Type-3 glyphs: an inked glyph
+ * declaring `0 0 llx lly urx ury d1`, advance zero, and a separate ink-free
+ * advance glyph declaring `w 0 0 0 0 0 d1`. Read straight out of the bytes the
+ * split is total — 584/457/537/530 inked CharProcs, every one of them zero
+ * advance, against 98/99/102/106 advance-only CharProcs, no exceptions — so
+ * the inked codes and the positive-width codes are disjoint sets. Positive
+ * width pinning therefore rejects every inked code in these four documents by
+ * construction, and the family fingerprint can only ever see spacer advances
+ * at renumbered codes. That is what `sf` demonstrates: its one family-resolving
+ * font pins `cmsy5` off just two such advances, and the two occurrences it
+ * officially names mean nothing. Only the missing digest match keeps that
+ * coincidence out of the output.
  *
  * Interface: one directory variable, `PDF_TOOLS_LEGACY_CORPUS_DIR`, holding
  * all five documents under the fixed basenames listed in DOCUMENTS. A single

--- a/test/markdown-conversion.test.js
+++ b/test/markdown-conversion.test.js
@@ -124,13 +124,13 @@ function markCollapsedAlpha(item) {
     font_name: item.font_name,
     registry_id: "cmmi-pk-raster-alpha-e688a8-v1",
     qualification: "ctan-cm-encoding-plus-reviewed-pk-raster-v1",
-    charproc_sha256: "e688a83f98433c841694f990aabafe5245cfc9320f584d7f70da706f0eeba259",
-    witness_charproc_sha256: [
-      "780b04fa47830ca782211b86dbedfe0adec0445bdf94d538bfe7adde08ed9445",
-      "1500df39391626d02f9e98132f991f71899612069298e52340e12fb65590836f",
+    glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093",
+    witness_glyph_sha256: [
+      "751c36c470d1f0292b9d39de8cfec243d0e1e4ca3b2a2648676a8048cdf75322",
+      "ff3b8028f135ce4dbf41a3e3fa8415f54615e9c3e7253d13e9070a71679ccebc",
     ],
     tfm_reference_version: "ctan-cm-tfm-9c0f99fa34c7",
-    canonicalizer_version: "pdfjs-charproc-json-v1",
+    glyph_evidence_version: "pdfjs-type3-glyph-evidence-v2",
   }];
   item.geometry_provenance.formula = "pdfjs_collapsed_type3_operator_advance_box_approximation";
   item.geometry_provenance.advance_source = "operator_advance_width";

--- a/test/markdown-conversion.test.js
+++ b/test/markdown-conversion.test.js
@@ -124,10 +124,10 @@ function markCollapsedAlpha(item) {
     font_name: item.font_name,
     registry_id: "cmmi-pk-raster-alpha-e688a8-v1",
     qualification: "ctan-cm-encoding-plus-reviewed-pk-raster-v1",
-    glyph_sha256: "31c3617c687647586397cd1efa5cfcdd0ae1ea108242960caabb736e76bda093",
+    glyph_sha256: "55bb60d8560069c0650380cf09cdd023866ca4b91bb92b2fe4b45a056da1bf47",
     witness_glyph_sha256: [
-      "751c36c470d1f0292b9d39de8cfec243d0e1e4ca3b2a2648676a8048cdf75322",
-      "ff3b8028f135ce4dbf41a3e3fa8415f54615e9c3e7253d13e9070a71679ccebc",
+      "9554966ab58edc060791bd02f04513a8da4a749f80a943d2daa3460a393fee7f",
+      "eaa7d3cbe50f3ec7903d72addc77f88a471c1dfdc2fd9eb02ce0fbf800068507",
     ],
     tfm_reference_version: "ctan-cm-tfm-9c0f99fa34c7",
     glyph_evidence_version: "pdfjs-type3-glyph-evidence-v2",
@@ -363,8 +363,10 @@ describe("layout Markdown renderer", () => {
     // Pin the complete normalized envelope, not a value derived from a second
     // invocation, so any unreviewed serialized delta fails this regression.
     const serialized = JSON.stringify(pinnable);
+    // Previously cb581702fc7339b3eea5f15f31e49c907639622ef7c571b22870538598853572,
+    // before the extraction IR version in the provenance envelope became 1.5.0.
     expect(createHash("sha256").update(serialized).digest("hex"))
-      .toBe("cb581702fc7339b3eea5f15f31e49c907639622ef7c571b22870538598853572");
+      .toBe("e5a35996c69239297339bc97433b52d6595caf5c360becb12d793828a78bd8b2");
     const body = result.markdown.split("\n\n## Conversion gaps\n\n", 1)[0];
     expect(JSON.stringify({
       body,

--- a/test/mcp-contract.test.js
+++ b/test/mcp-contract.test.js
@@ -83,6 +83,9 @@ const EXAMPLE_PDF = path.join(REPO_ROOT, "example-fw9.pdf");
 // 2026-08-07: list_pdfs gains an offset parameter so a flat folder holding
 // more than 200 PDFs is fully reachable, and its description states the cap
 // and the paging. Previously c65cd62a1d46c6b5837aa7bf12a1851717e4b09dc274182dcb07dac982e8fc64.
+// 2026-08-06: read_pdf_layout glyph-recovery evidence is re-keyed onto the
+// decoded Type-3 image mask, renaming charproc_sha256/witness_charproc_sha256/
+// canonicalizer_version to glyph_sha256/witness_glyph_sha256/glyph_evidence_version.
 const TOOL_CONTRACT_SHA256 = "a594a3a23f6722fb121b9d2a57bad03fc60fda5e352583f07139d191914c8d52";
 
 const CLOSED_READ = Object.freeze({

--- a/test/mcp-contract.test.js
+++ b/test/mcp-contract.test.js
@@ -50,7 +50,7 @@ const EXAMPLE_PDF = path.join(REPO_ROOT, "example-fw9.pdf");
 // source text as escaped body text.
 // 2026-08-03: convert_pdf_to_markdown renderer 1.4.0 adds conservative
 // source-backed title, introduction, part, and appendix structure.
-// 2026-08-03: convert_pdf_to_markdown renderer 1.5.0 adds bounded drop-cap
+// 2026-08-03: convert_pdf_to_markdown renderer 1.4.0 adds bounded drop-cap
 // continuation while preserving ordinary printed line-end hyphens.
 // 2026-08-03: convert_pdf_to_markdown renderer 1.6.0 adds bounded, local
 // math-operator spacing with explicit limitations.
@@ -86,6 +86,10 @@ const EXAMPLE_PDF = path.join(REPO_ROOT, "example-fw9.pdf");
 // 2026-08-06: read_pdf_layout glyph-recovery evidence is re-keyed onto the
 // decoded Type-3 image mask, renaming charproc_sha256/witness_charproc_sha256/
 // canonicalizer_version to glyph_sha256/witness_glyph_sha256/glyph_evidence_version.
+// 2026-08-06: the Type-3 glyph evidence key became the stored image-mask sample
+// grid, with no matrix of any kind taking part, so every published digest
+// changed and the extraction IR went to 1.5.0. Previously
+// dafeaf19570eece1bb3901f883ea456216b7f46ea6872b80a9eb205c24b9e45f.
 const TOOL_CONTRACT_SHA256 = "a594a3a23f6722fb121b9d2a57bad03fc60fda5e352583f07139d191914c8d52";
 
 const CLOSED_READ = Object.freeze({
@@ -423,7 +427,7 @@ describe.each(RUNTIMES)("$name runtime discovery", runtime => {
     });
     expect(result.isError).not.toBe(true);
     expect(result.structuredContent).toMatchObject({
-      ir: { name: "pdf-tools.extraction-ir", version: "1.4.0" },
+      ir: { name: "pdf-tools.extraction-ir", version: "1.5.0" },
       parser: { name: "pdfjs-dist", version: "5.4.624" },
       page_range: { start_page: 1, end_page: 1 },
     });

--- a/test/mcp-contract.test.js
+++ b/test/mcp-contract.test.js
@@ -50,7 +50,7 @@ const EXAMPLE_PDF = path.join(REPO_ROOT, "example-fw9.pdf");
 // source text as escaped body text.
 // 2026-08-03: convert_pdf_to_markdown renderer 1.4.0 adds conservative
 // source-backed title, introduction, part, and appendix structure.
-// 2026-08-03: convert_pdf_to_markdown renderer 1.4.0 adds bounded drop-cap
+// 2026-08-03: convert_pdf_to_markdown renderer 1.5.0 adds bounded drop-cap
 // continuation while preserving ordinary printed line-end hyphens.
 // 2026-08-03: convert_pdf_to_markdown renderer 1.6.0 adds bounded, local
 // math-operator spacing with explicit limitations.
@@ -90,7 +90,7 @@ const EXAMPLE_PDF = path.join(REPO_ROOT, "example-fw9.pdf");
 // grid, with no matrix of any kind taking part, so every published digest
 // changed and the extraction IR went to 1.5.0. Previously
 // dafeaf19570eece1bb3901f883ea456216b7f46ea6872b80a9eb205c24b9e45f.
-const TOOL_CONTRACT_SHA256 = "a594a3a23f6722fb121b9d2a57bad03fc60fda5e352583f07139d191914c8d52";
+const TOOL_CONTRACT_SHA256 = "b980fc09c3b9c886f01e08b82fe67df569e5cafa5471dd4c3e549ac6d8e26fc0";
 
 const CLOSED_READ = Object.freeze({
   readOnlyHint: true,

--- a/test/pdfjs-worker-contract.test.js
+++ b/test/pdfjs-worker-contract.test.js
@@ -184,7 +184,7 @@ describe.sequential("one-shot PDF.js worker contracts", () => {
     };
     const layout = await run("extract_layout", common);
     expect(layout.layout).toMatchObject({
-      ir: { name: "pdf-tools.extraction-ir", version: "1.4.0" },
+      ir: { name: "pdf-tools.extraction-ir", version: "1.5.0" },
       parser: { name: "pdfjs-dist", version: "5.4.624" },
       pages: expect.any(Array),
     });

--- a/test/read-pdf-layout.test.js
+++ b/test/read-pdf-layout.test.js
@@ -13,6 +13,7 @@ import {
   extractPdfLayout,
   pdfjsFactoryDirectory,
   type3CharProcSha256,
+  type3GlyphEvidenceSha256,
   uniqueComputerModernFamily,
   validatePdfLayoutSemantics,
   validatePdfLayoutSourceEvidence,
@@ -68,6 +69,100 @@ describe("qualified legacy Type-3 glyph evidence", () => {
       "b32276d22e1dd4133c20888ade044d27e59f2cbdfca0901c3b9d46006ed7dee9",
     );
     expect(type3CharProcSha256({ fnArray: [49], argsArray: [new Float32Array(100001)] })).toBeNull();
+  });
+
+  /**
+   * The shipped recovery key. `minusCharProc` is a real dvipdfmx-shaped Type-3
+   * glyph: one 41x3 inline image mask, placed by a `cm` inside a `q`/`Q`, under
+   * a y-flipping FontMatrix. Everything asserted below is a property of the
+   * decoded mask, and everything varied below is a property of the producer.
+   */
+  describe("producer-independent Type-3 glyph shape key", () => {
+    // PDF.js operator numbers, taken from the pinned build rather than typed,
+    // so an upstream renumbering fails here instead of silently keying on the
+    // wrong operators.
+    let OPS = null;
+    beforeAll(async () => {
+      ({ OPS } = await import("pdfjs-dist/legacy/build/pdf.mjs"));
+    });
+    const FLIPPED = [1, 0, 0, -1, 0, 0];
+
+    it("keys the same raster identically across producer idiom and placement", () => {
+      const key = type3GlyphEvidenceSha256(minusCharProc(), FLIPPED, OPS);
+      expect(key).toMatch(/^[0-9a-f]{64}$/);
+
+      // Same mask, moved: a different producer would not put the bitmap at the
+      // same offset, and the old CharProc digest folded that offset in.
+      const moved = minusCharProc();
+      moved.argsArray[2] = [41, 0, 0, 3, 12, 30.25];
+      expect(type3GlyphEvidenceSha256(moved, FLIPPED, OPS)).toBe(key);
+
+      // Same mask, no q/Q wrapper and different declared glyph metrics: the
+      // dvips idiom rather than the dvipdfmx one.
+      const bare = {
+        fnArray: [OPS.setCharWidthAndBounds, OPS.transform, OPS.constructPath],
+        argsArray: [[52, 0, 0, 0, 41, 3], [41, 0, 0, 3, 0, 0], minusCharProc().argsArray[3]],
+      };
+      expect(type3GlyphEvidenceSha256(bare, [1, 0, 0, 1, 0, 0], OPS)).toBe(key);
+
+      // The v1 CharProc digests of the same three programs all differ, which
+      // is exactly the portability defect this key exists to remove.
+      expect(new Set([minusCharProc(), moved, bare].map(type3CharProcSha256)).size).toBe(3);
+    });
+
+    it("refuses to conflate a different raster, mirror, or grid", () => {
+      const key = type3GlyphEvidenceSha256(minusCharProc(), FLIPPED, OPS);
+      const oneBit = minusCharProc();
+      oneBit.argsArray[3][1][0][14] = 0;
+      expect(type3GlyphEvidenceSha256(oneBit, FLIPPED, OPS)).not.toBe(key);
+      // An unflipped FontMatrix paints the stored rows the other way up, so the
+      // same samples are a different glyph and must key differently. The 41x3
+      // bar above is its own mirror image, so this needs an asymmetric raster:
+      // an L filling row 0 column 0 and all of row 1 of a 2x2 grid.
+      const asymmetric = () => ({
+        fnArray: [OPS.setCharWidthAndBounds, OPS.transform, OPS.constructPath],
+        argsArray: [
+          [4, 0, 0, 0, 2, 2],
+          [2, 0, 0, 2, 0, 0],
+          [94, [new Float32Array([
+            0, 0, 1, 1, 0.5, 1, 1, 0.5, 0.5, 1, 1, 0.5, 1, 1, 0, 1, 0, 0,
+          ])], new Float32Array([0, 0, 2, 2])],
+        ],
+      });
+      const upright = type3GlyphEvidenceSha256(asymmetric(), [1, 0, 0, 1, 0, 0], OPS);
+      const mirrored = type3GlyphEvidenceSha256(asymmetric(), FLIPPED, OPS);
+      expect(upright).toMatch(/^[0-9a-f]{64}$/);
+      expect(mirrored).not.toBe(upright);
+      // Mirrored twice is the identity, so the normalisation is a genuine
+      // orientation fix and not an arbitrary relabelling.
+      expect(type3GlyphEvidenceSha256(asymmetric(), [-1, 0, 0, -1, 0, 0], OPS))
+        .not.toBe(mirrored);
+      const wider = minusCharProc();
+      wider.argsArray[3][2] = new Float32Array([0, 0, 82, 3]);
+      expect(type3GlyphEvidenceSha256(wider, FLIPPED, OPS)).not.toBe(key);
+      // A mask key and an operator-lane key are domain-separated and cannot
+      // collide even when they cover the same glyph program.
+      expect(key).not.toBe(type3CharProcSha256(minusCharProc()));
+    });
+
+    it("falls back to the exact operator digest for a program it cannot decode", () => {
+      const outline = { fnArray: [OPS.setCharWidthAndBounds, OPS.fill], argsArray: [[52, 0, 0, 0, 4, 4], null] };
+      const outlineKey = type3GlyphEvidenceSha256(outline, FLIPPED, OPS);
+      expect(outlineKey).toMatch(/^[0-9a-f]{64}$/);
+      expect(outlineKey).not.toBe(type3CharProcSha256(outline));
+      // Two painted objects are not a single decodable mask, and a rotated
+      // placement has no unambiguous mirror decomposition. Both leave the mask
+      // lane rather than being keyed on a guess.
+      const twice = minusCharProc();
+      twice.fnArray = [...twice.fnArray, 91];
+      twice.argsArray = [...twice.argsArray, minusCharProc().argsArray[3]];
+      expect(type3GlyphEvidenceSha256(twice, FLIPPED, OPS)).toBe(
+        type3GlyphEvidenceSha256({ fnArray: twice.fnArray, argsArray: twice.argsArray }, [0, 1, -1, 0, 0, 0], OPS),
+      );
+      const rotated = type3GlyphEvidenceSha256(minusCharProc(), [0, 1, -1, 0, 0, 0], OPS);
+      expect(rotated).not.toBe(type3GlyphEvidenceSha256(minusCharProc(), FLIPPED, OPS));
+      expect(type3GlyphEvidenceSha256(null, FLIPPED, OPS)).toBeNull();
+    });
   });
 
   it("requires one unique official Computer Modern encoding family", () => {
@@ -1343,13 +1438,13 @@ describe("Extraction IR hostile reconstruction", () => {
       font_name: item.font_name,
       registry_id: "cmsy-pk-raster-minus-v1",
       qualification: "ctan-cm-encoding-plus-reviewed-pk-raster-v1",
-      charproc_sha256: "b32276d22e1dd4133c20888ade044d27e59f2cbdfca0901c3b9d46006ed7dee9",
-      witness_charproc_sha256: [
-        "b57ae2e4cf2525371916a1a4bcf0c55165b9230b1038f2d5451cdbbad5a51dcc",
-        "0c8ca6c662e9ca24f90a61f53206ea0719476473861471a1b04bf489b3cc37a3",
+      glyph_sha256: "3f6fdf2abc68f5693f9ea7cdec4d94214a57fb953fb66c747b86dd1f6293d807",
+      witness_glyph_sha256: [
+        "73a2cec4aa27d5042b9f4275179fbf2bb7b99413537597ede0537b7f19c8384c",
+        "f15e035b5867fbee9918125e49566e00b94dcd8422649079c87207e94f7a9e63",
       ],
       tfm_reference_version: "ctan-cm-tfm-9c0f99fa34c7",
-      canonicalizer_version: "pdfjs-charproc-json-v1",
+      glyph_evidence_version: "pdfjs-type3-glyph-evidence-v2",
     }];
     expect(() => validatePdfLayoutSemantics(forged)).toThrow(/registry evidence is invalid/);
   });
@@ -1377,13 +1472,13 @@ describe("Extraction IR hostile reconstruction", () => {
       font_name: item.font_name,
       registry_id: "cmsy-pk-raster-minus-v1",
       qualification: "ctan-cm-encoding-plus-reviewed-pk-raster-v1",
-      charproc_sha256: "b32276d22e1dd4133c20888ade044d27e59f2cbdfca0901c3b9d46006ed7dee9",
-      witness_charproc_sha256: [
-        "b57ae2e4cf2525371916a1a4bcf0c55165b9230b1038f2d5451cdbbad5a51dcc",
-        "0c8ca6c662e9ca24f90a61f53206ea0719476473861471a1b04bf489b3cc37a3",
+      glyph_sha256: "3f6fdf2abc68f5693f9ea7cdec4d94214a57fb953fb66c747b86dd1f6293d807",
+      witness_glyph_sha256: [
+        "73a2cec4aa27d5042b9f4275179fbf2bb7b99413537597ede0537b7f19c8384c",
+        "f15e035b5867fbee9918125e49566e00b94dcd8422649079c87207e94f7a9e63",
       ],
       tfm_reference_version: "ctan-cm-tfm-9c0f99fa34c7",
-      canonicalizer_version: "pdfjs-charproc-json-v1",
+      glyph_evidence_version: "pdfjs-type3-glyph-evidence-v2",
     }];
     forged.pages[0].lines[0].text = "−";
     forged.pages[0].flow_text = "−";

--- a/test/read-pdf-layout.test.js
+++ b/test/read-pdf-layout.test.js
@@ -12,8 +12,10 @@ import { PDFDocument, PDFName, PDFNumber, StandardFonts, degrees } from "pdf-lib
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   extractPdfLayout,
+  inspectType3GlyphEvidenceForPage,
   pdfjsFactoryDirectory,
   type3CharProcSha256,
+  type3FontPaintOrientation,
   type3GlyphEvidenceSha256,
   uniqueComputerModernFamily,
   validatePdfLayoutSemantics,
@@ -46,6 +48,32 @@ const HORIZONTAL_GEOMETRY_PROVENANCE = {
 };
 
 describe("qualified legacy Type-3 glyph evidence", () => {
+  const streamObject = (data) => Buffer.concat([
+    Buffer.from(`<< /Length ${data.length} >>\nstream\n`, "latin1"),
+    data,
+    Buffer.from("\nendstream", "latin1"),
+  ]);
+
+  function assemblePdf(bodies) {
+    const header = Buffer.from("%PDF-1.4\n%\xE2\xE3\xCF\xD3\n", "latin1");
+    const chunks = [header];
+    const offsets = [];
+    let offset = header.length;
+    bodies.forEach((body, index) => {
+      const prefix = Buffer.from(`${index + 1} 0 obj\n`, "latin1");
+      const suffix = Buffer.from("\nendobj\n", "latin1");
+      offsets.push(offset);
+      chunks.push(prefix, body, suffix);
+      offset += prefix.length + body.length + suffix.length;
+    });
+    let xref = `xref\n0 ${bodies.length + 1}\n0000000000 65535 f \n`;
+    for (const value of offsets) xref += `${String(value).padStart(10, "0")} 00000 n \n`;
+    xref += `trailer\n<< /Size ${bodies.length + 1} /Root 1 0 R >>\n`
+      + `startxref\n${offset}\n%%EOF\n`;
+    chunks.push(Buffer.from(xref, "latin1"));
+    return new Uint8Array(Buffer.concat(chunks));
+  }
+
   const minusCharProc = () => ({
     fnArray: [49, 10, 12, 91, 11],
     argsArray: [
@@ -92,16 +120,29 @@ describe("qualified legacy Type-3 glyph evidence", () => {
       ({ OPS } = pdfjsLib);
     });
     const FLIPPED = [1, 0, 0, -1, 0, 0];
+    const packageDirectory = path.dirname(require.resolve("pdfjs-dist/package.json"));
+    /*
+     * The fourth argument is the font's unanimous CharProc-local determinant
+     * sign, which `type3FontPaintOrientation` computes over the whole
+     * /CharProcs dictionary and which the mask lane requires. Every fixture
+     * below is a one-glyph font, so the font's sign is just that glyph's own:
+     * `FLIPPED` over a positive-scale `cm` composes to -1, an upright
+     * FontMatrix over the same `cm` to +1. The two are equal-and-opposite on
+     * purpose — passing each font its own sign is exactly what production
+     * does, and the keys still have to agree across them.
+     */
+    const FLIPPED_FONT = -1;
+    const UPRIGHT_FONT = 1;
 
     it("keys the same raster identically across producer idiom and placement", () => {
-      const key = type3GlyphEvidenceSha256(minusCharProc(), FLIPPED, OPS);
+      const key = type3GlyphEvidenceSha256(minusCharProc(), FLIPPED, OPS, FLIPPED_FONT);
       expect(key).toMatch(/^[0-9a-f]{64}$/);
 
       // Same mask, moved: a different producer would not put the bitmap at the
       // same offset, and the old CharProc digest folded that offset in.
       const moved = minusCharProc();
       moved.argsArray[2] = [41, 0, 0, 3, 12, 30.25];
-      expect(type3GlyphEvidenceSha256(moved, FLIPPED, OPS)).toBe(key);
+      expect(type3GlyphEvidenceSha256(moved, FLIPPED, OPS, FLIPPED_FONT)).toBe(key);
 
       // Same mask, no q/Q wrapper and different declared glyph metrics: the
       // dvips idiom rather than the dvipdfmx one.
@@ -109,7 +150,7 @@ describe("qualified legacy Type-3 glyph evidence", () => {
         fnArray: [OPS.setCharWidthAndBounds, OPS.transform, OPS.constructPath],
         argsArray: [[52, 0, 0, 0, 41, 3], [41, 0, 0, 3, 0, 0], minusCharProc().argsArray[3]],
       };
-      expect(type3GlyphEvidenceSha256(bare, [1, 0, 0, 1, 0, 0], OPS)).toBe(key);
+      expect(type3GlyphEvidenceSha256(bare, [1, 0, 0, 1, 0, 0], OPS, UPRIGHT_FONT)).toBe(key);
 
       // The v1 CharProc digests of the same three programs all differ, which
       // is exactly the portability defect this key exists to remove.
@@ -135,32 +176,6 @@ describe("qualified legacy Type-3 glyph evidence", () => {
       // An asymmetric 8x8 "F": not its own mirror in either axis, so a key that
       // reorients the grid cannot pass these by accident.
       const INK_ROWS = Object.freeze([0xfe, 0x80, 0x80, 0xf8, 0x80, 0x80, 0x80, 0x80]);
-
-      const streamObject = (data) => Buffer.concat([
-        Buffer.from(`<< /Length ${data.length} >>\nstream\n`, "latin1"),
-        data,
-        Buffer.from("\nendstream", "latin1"),
-      ]);
-
-      function assemblePdf(bodies) {
-        const header = Buffer.from("%PDF-1.4\n%\xE2\xE3\xCF\xD3\n", "latin1");
-        const chunks = [header];
-        const offsets = [];
-        let offset = header.length;
-        bodies.forEach((body, index) => {
-          const prefix = Buffer.from(`${index + 1} 0 obj\n`, "latin1");
-          const suffix = Buffer.from("\nendobj\n", "latin1");
-          offsets.push(offset);
-          chunks.push(prefix, body, suffix);
-          offset += prefix.length + body.length + suffix.length;
-        });
-        let xref = `xref\n0 ${bodies.length + 1}\n0000000000 65535 f \n`;
-        for (const value of offsets) xref += `${String(value).padStart(10, "0")} 00000 n \n`;
-        xref += `trailer\n<< /Size ${bodies.length + 1} /Root 1 0 R >>\n`
-          + `startxref\n${offset}\n%%EOF\n`;
-        chunks.push(Buffer.from(xref, "latin1"));
-        return new Uint8Array(Buffer.concat(chunks));
-      }
 
       function buildType3MaskPdf({ fontMatrix, glyphName, charCode, charProc, textMatrix }) {
         return assemblePdf([
@@ -234,7 +249,6 @@ describe("qualified legacy Type-3 glyph evidence", () => {
        * the FontMatrix, and the text matrix all come back out of the parser.
        */
       async function measureBuiltDocument(bytes) {
-        const packageDirectory = path.dirname(require.resolve("pdfjs-dist/package.json"));
         const document = await pdfjsLib.getDocument({
           data: bytes,
           useWorkerFetch: false,
@@ -275,7 +289,11 @@ describe("qualified legacy Type-3 glyph evidence", () => {
             font_matrix: [...font.fontMatrix],
             local_matrix: local,
             placement: compose(textMatrix, local),
-            evidence_sha256: type3GlyphEvidenceSha256(charProc, font.fontMatrix, OPS),
+            // A one-glyph font, so its unanimous paint orientation is this
+            // glyph's own CharProc-local determinant sign.
+            evidence_sha256: type3GlyphEvidenceSha256(
+              charProc, font.fontMatrix, OPS, Math.sign(local[0] * local[3]),
+            ),
             charproc_sha256: type3CharProcSha256(charProc),
           };
         } finally {
@@ -341,16 +359,138 @@ describe("qualified legacy Type-3 glyph evidence", () => {
         // it or with each other.
         expect(new Set([baseline, ...distinct]).size).toBe(4);
       });
+
+      /**
+       * The attack the grid key on its own cannot see, and the safeguard that
+       * does: reflection relative to a font's own siblings.
+       *
+       * Nothing above distinguishes a glyph from its mirror image, and it must
+       * not: an upright document and a y-flipped one are two producers writing
+       * the same character. But mirroring is not always a re-orientation of the
+       * same character. In Computer Modern it is usually a DIFFERENT enrolled
+       * character — every cmex parenthesis and bracket pair is one raster and
+       * its mirror — so a CharProc that stores the `]` raster and negates the x
+       * scale of its own `cm` paints a `[` while keying as `]`. Reproduced on
+       * the Shannon reference document by editing exactly that one number and
+       * leaving the mask bytes byte-identical: it kept emitting `]` eleven
+       * times, with no gap reported.
+       *
+       * The two documents below are the same font twice, holding the same two
+       * copies of the same 8x8 mask, differing only in whether the second
+       * glyph's `cm` is reflected. Absolute orientation is not consulted and
+       * cannot be — the page's text matrix is not visible from a CharProc — so
+       * the whole of the evidence is that one glyph disagrees with its
+       * siblings.
+       */
+      describe("one font, one glyph reflected relative to its siblings", () => {
+        function buildTwoGlyphType3MaskPdf({ mirrorSecondGlyph }) {
+          const proc = placement => Buffer.concat([
+            Buffer.from(`1000 0 0 0 800 800 d1\nq ${placement} cm\n`
+              + "BI /IM true /W 8 /H 8 /BPC 1 ID ", "latin1"),
+            Buffer.from(INK_ROWS.map(row => ~row & 0xff)),
+            Buffer.from("\nEI\nQ\n", "latin1"),
+          ]);
+          return assemblePdf([
+            Buffer.from("<< /Type /Catalog /Pages 2 0 R >>", "latin1"),
+            Buffer.from("<< /Type /Pages /Kids [3 0 R] /Count 1 >>", "latin1"),
+            Buffer.from("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] "
+              + "/Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>", "latin1"),
+            streamObject(Buffer.from("BT /F1 1 Tf 1 0 0 1 20 60 Tm <4142> Tj ET\n", "latin1")),
+            Buffer.from("<< /Type /Font /Subtype /Type3 /FontBBox [0 0 8 8] "
+              + "/FontMatrix [0.01 0 0 0.01 0 0] /CharProcs 6 0 R "
+              + "/Encoding << /Type /Encoding /Differences [65 /upright /sibling] >> "
+              + "/FirstChar 65 /LastChar 66 /Widths [10 10] /Resources << >> >>", "latin1"),
+            Buffer.from("<< /upright 7 0 R /sibling 8 0 R >>", "latin1"),
+            streamObject(proc("800 0 0 800 0 0")),
+            // Same eight mask bytes either way. The only difference between the
+            // two documents is the sign of this one number, and the matching
+            // translation that puts the reflected ink back in the same box.
+            streamObject(proc(mirrorSecondGlyph ? "-800 0 0 800 800 0" : "800 0 0 800 0 0")),
+          ]);
+        }
+
+        async function measureFont(mirrorSecondGlyph) {
+          const document = await pdfjsLib.getDocument({
+            data: buildTwoGlyphType3MaskPdf({ mirrorSecondGlyph }),
+            useWorkerFetch: false,
+            isEvalSupported: false,
+            cMapUrl: pdfjsFactoryDirectory(path.join(packageDirectory, "cmaps")),
+            cMapPacked: true,
+            standardFontDataUrl: pdfjsFactoryDirectory(path.join(packageDirectory, "standard_fonts")),
+          }).promise;
+          try {
+            const page = await document.getPage(1);
+            const operators = await page.getOperatorList();
+            let fontId = null;
+            for (let index = 0; index < operators.fnArray.length; index += 1) {
+              if (operators.fnArray[index] === OPS.setFont) [fontId] = operators.argsArray[index];
+            }
+            const font = page.commonObjs.get(fontId);
+            expect(Object.keys(font.charProcOperatorList ?? {})).toEqual(["upright", "sibling"]);
+            const orientation = type3FontPaintOrientation(font, OPS);
+            const keyFor = (glyphId, assumedOrientation) => type3GlyphEvidenceSha256(
+              font.charProcOperatorList[glyphId], font.fontMatrix, OPS, assumedOrientation,
+            );
+            return {
+              orientation,
+              upright: keyFor("upright", orientation),
+              sibling: keyFor("sibling", orientation),
+              // What the sibling keys as when its OWN sign is taken for its
+              // font's convention, which is all a per-glyph check could ever
+              // ask. The reflected `cm` makes that sign -1 and the unreflected
+              // one +1, so this is the mask-lane key in both documents.
+              sibling_self_signed: keyFor("sibling", mirrorSecondGlyph ? -1 : 1),
+              operator_upright: type3CharProcSha256(font.charProcOperatorList.upright),
+              operator_sibling: type3CharProcSha256(font.charProcOperatorList.sibling),
+            };
+          } finally {
+            await document.destroy();
+          }
+        }
+
+        it("keys both glyphs on the grid when the font agrees with itself", async () => {
+          const uniform = await measureFont(false);
+          // A real, unanimous convention, and both glyphs reach the mask lane.
+          expect(uniform.orientation).toBe(1);
+          expect(uniform.upright).toMatch(/^[0-9a-f]{64}$/);
+          // Same stored grid, so the same key. This is the behaviour the whole
+          // producer-independent scheme exists for and it is not weakened.
+          expect(uniform.sibling).toBe(uniform.upright);
+          expect(uniform.upright).not.toBe(uniform.operator_upright);
+        });
+
+        it("refuses the grid key to a whole font that disagrees with itself", async () => {
+          const uniform = await measureFont(false);
+          const mirrored = await measureFont(true);
+
+          // The mask bytes are untouched, so the reflected glyph's stored grid
+          // is still bit-for-bit the upright one's. Keyed on its own sign it
+          // would collide with the upright glyph exactly as before — which is
+          // the defect, since the ink now paints mirrored.
+          expect(mirrored.sibling_self_signed).toBe(uniform.upright);
+
+          // The font has no convention, so no glyph of it is grid-keyed.
+          expect(mirrored.orientation).toBeNull();
+          expect(mirrored.sibling).not.toBe(uniform.upright);
+          expect(mirrored.upright).not.toBe(uniform.upright);
+          // Not silence: both fall to the placement-bearing operator lane,
+          // which is domain-separated from every mask-keyed registry entry and
+          // therefore recovers nothing.
+          expect(mirrored.sibling).toMatch(/^[0-9a-f]{64}$/);
+          expect(mirrored.sibling).not.toBe(mirrored.operator_sibling);
+          expect(mirrored.sibling).not.toBe(mirrored.upright);
+        });
+      });
     });
 
     it("refuses to conflate a different raster or a different grid", () => {
-      const key = type3GlyphEvidenceSha256(minusCharProc(), FLIPPED, OPS);
+      const key = type3GlyphEvidenceSha256(minusCharProc(), FLIPPED, OPS, FLIPPED_FONT);
       const oneBit = minusCharProc();
       oneBit.argsArray[3][1][0][14] = 0;
-      expect(type3GlyphEvidenceSha256(oneBit, FLIPPED, OPS)).not.toBe(key);
+      expect(type3GlyphEvidenceSha256(oneBit, FLIPPED, OPS, FLIPPED_FONT)).not.toBe(key);
       const wider = minusCharProc();
       wider.argsArray[3][2] = new Float32Array([0, 0, 82, 3]);
-      expect(type3GlyphEvidenceSha256(wider, FLIPPED, OPS)).not.toBe(key);
+      expect(type3GlyphEvidenceSha256(wider, FLIPPED, OPS, FLIPPED_FONT)).not.toBe(key);
       // A mask key and an operator-lane key are domain-separated and cannot
       // collide even when they cover the same glyph program.
       expect(key).not.toBe(type3CharProcSha256(minusCharProc()));
@@ -372,9 +512,9 @@ describe("qualified legacy Type-3 glyph evidence", () => {
           [94, [new Float32Array([0, 0, 1, 1, 0, 0, 1, 0, 1, 4])], new Float32Array([0, 0, 41, 3])],
         ],
       });
-      const inked = type3GlyphEvidenceSha256(minusCharProc(), FLIPPED, OPS);
-      const first = type3GlyphEvidenceSha256(blank([52, 0, 0, 0, 41, 3]), FLIPPED, OPS);
-      const second = type3GlyphEvidenceSha256(blank([31, 0, 0, 0, 41, 3]), FLIPPED, OPS);
+      const inked = type3GlyphEvidenceSha256(minusCharProc(), FLIPPED, OPS, FLIPPED_FONT);
+      const first = type3GlyphEvidenceSha256(blank([52, 0, 0, 0, 41, 3]), FLIPPED, OPS, FLIPPED_FONT);
+      const second = type3GlyphEvidenceSha256(blank([31, 0, 0, 0, 41, 3]), FLIPPED, OPS, FLIPPED_FONT);
       expect(first).toMatch(/^[0-9a-f]{64}$/);
       expect(first).not.toBe(inked);
       // The mask lane ignores declared metrics, so two blank programs that
@@ -385,7 +525,7 @@ describe("qualified legacy Type-3 glyph evidence", () => {
 
     it("falls back to the exact operator digest for a program it cannot decode", () => {
       const outline = { fnArray: [OPS.setCharWidthAndBounds, OPS.fill], argsArray: [[52, 0, 0, 0, 4, 4], null] };
-      const outlineKey = type3GlyphEvidenceSha256(outline, FLIPPED, OPS);
+      const outlineKey = type3GlyphEvidenceSha256(outline, FLIPPED, OPS, FLIPPED_FONT);
       expect(outlineKey).toMatch(/^[0-9a-f]{64}$/);
       expect(outlineKey).not.toBe(type3CharProcSha256(outline));
       // Two painted objects are not a single decodable mask, and a CharProc
@@ -395,12 +535,14 @@ describe("qualified legacy Type-3 glyph evidence", () => {
       const twice = minusCharProc();
       twice.fnArray = [...twice.fnArray, 91];
       twice.argsArray = [...twice.argsArray, minusCharProc().argsArray[3]];
-      expect(type3GlyphEvidenceSha256(twice, FLIPPED, OPS)).toBe(
-        type3GlyphEvidenceSha256({ fnArray: twice.fnArray, argsArray: twice.argsArray }, [0, 1, -1, 0, 0, 0], OPS),
+      expect(type3GlyphEvidenceSha256(twice, FLIPPED, OPS, FLIPPED_FONT)).toBe(
+        type3GlyphEvidenceSha256(
+          { fnArray: twice.fnArray, argsArray: twice.argsArray }, [0, 1, -1, 0, 0, 0], OPS, FLIPPED_FONT,
+        ),
       );
-      const rotated = type3GlyphEvidenceSha256(minusCharProc(), [0, 1, -1, 0, 0, 0], OPS);
-      expect(rotated).not.toBe(type3GlyphEvidenceSha256(minusCharProc(), FLIPPED, OPS));
-      expect(type3GlyphEvidenceSha256(null, FLIPPED, OPS)).toBeNull();
+      const rotated = type3GlyphEvidenceSha256(minusCharProc(), [0, 1, -1, 0, 0, 0], OPS, FLIPPED_FONT);
+      expect(rotated).not.toBe(type3GlyphEvidenceSha256(minusCharProc(), FLIPPED, OPS, FLIPPED_FONT));
+      expect(type3GlyphEvidenceSha256(null, FLIPPED, OPS, FLIPPED_FONT)).toBeNull();
     });
   });
 
@@ -413,6 +555,138 @@ describe("qualified legacy Type-3 glyph evidence", () => {
       .toBe("computer-modern-math-italic");
     expect(uniqueComputerModernFamily([[0, 52]])).toBeNull();
     expect(uniqueComputerModernFamily([[40, 32], [41, 32]])).toBeNull();
+  });
+
+  /**
+   * The linker's uniqueness pool is the WHOLE page's Type-3 fonts, not the
+   * recoverable subset of them.
+   *
+   * PDF.js hands back a glyph's code, advance and CharProc name but not the
+   * font dictionary it came from, so the raw font has to be re-identified from
+   * the page by matching those three. Two fonts on one page can answer to the
+   * same evidence, and when they do the honest answer is that the linker does
+   * not know which one it is holding.
+   *
+   * The two kinds of font that are themselves ineligible are exactly the ones
+   * it is tempting to drop from that pool: a font carrying its own /ToUnicode,
+   * whose producer-supplied mapping is deliberately left alone, and a font
+   * declaring codes past 127, which no official Computer Modern encoding
+   * reaches. Dropping either would silently resolve the ambiguity in favour of
+   * the recoverable font. They stay in the pool as competitors and stay
+   * ineligible themselves, and both halves are asserted below.
+   */
+  describe("whole-page Type-3 link competition", () => {
+    const MASK_ROWS = Object.freeze([0xfe, 0x80, 0x80, 0xf8, 0x80, 0x80, 0x80, 0x80]);
+    const charProcBody = Buffer.concat([
+      Buffer.from("1000 0 0 0 800 800 d1\nq 800 0 0 800 0 0 cm\n"
+        + "BI /IM true /W 8 /H 8 /BPC 1 ID ", "latin1"),
+      Buffer.from(MASK_ROWS.map(row => ~row & 0xff)),
+      Buffer.from("\nEI\nQ\n", "latin1"),
+    ]);
+    // A Type-3 font body with the shared identity the linker matches on: the
+    // same two codes, the same two advances and the same two CharProc names.
+    const type3Font = extra => Buffer.from("<< /Type /Font /Subtype /Type3 /FontBBox [0 0 8 8] "
+      + "/FontMatrix [0.01 0 0 0.01 0 0] /CharProcs 6 0 R "
+      + "/Encoding << /Type /Encoding /Differences [65 /upright /sibling] >> "
+      + `${extra} /Resources << >> >>`, "latin1");
+    const RECOVERABLE = "/FirstChar 65 /LastChar 66 /Widths [10 10]";
+    // Ineligible because PDF.js already maps it. `/Widths` is identical, so it
+    // is indistinguishable from the recoverable font on the linker's evidence.
+    const HAS_TO_UNICODE = `${RECOVERABLE} /ToUnicode 9 0 R`;
+    // Ineligible because no official Computer Modern encoding reaches past
+    // 127. Same two advances at the same two codes; the extra slots are the
+    // out-of-range declaration itself.
+    const OUT_OF_RANGE = `/FirstChar 65 /LastChar 200 /Widths [${["10", "10", ...Array(134).fill("7")].join(" ")}]`;
+
+    const TO_UNICODE_CMAP = Buffer.from(
+      "/CIDInit /ProcSet findresource begin 12 dict begin begincmap\n"
+      + "/CMapName /Custom def /CMapType 2 def\n"
+      + "1 begincodespacerange <00> <ff> endcodespacerange\n"
+      + "1 beginbfrange <41> <42> <0041> endbfrange\n"
+      + "endcmap CMapName currentdict /CMap defineresource pop end end\n", "latin1");
+
+    // `fonts` names exactly which of the two font dictionaries the page's
+    // /Resources offers, so a page can hold the recoverable font alone, the
+    // ineligible font alone, or both in competition.
+    function buildCompetitionPdf({ competitor, fonts, drawWith }) {
+      const resources = fonts.map(name => `/${name} ${name === "F1" ? "5" : "8"} 0 R`).join(" ");
+      return assemblePdf([
+        Buffer.from("<< /Type /Catalog /Pages 2 0 R >>", "latin1"),
+        Buffer.from("<< /Type /Pages /Kids [3 0 R] /Count 1 >>", "latin1"),
+        Buffer.from("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] "
+          + `/Resources << /Font << ${resources} >> >> /Contents 4 0 R >>`, "latin1"),
+        streamObject(Buffer.from(`BT /${drawWith} 1 Tf 1 0 0 1 20 60 Tm <4142> Tj ET\n`, "latin1")),
+        type3Font(RECOVERABLE),
+        Buffer.from("<< /upright 7 0 R /sibling 7 0 R >>", "latin1"),
+        streamObject(charProcBody),
+        type3Font(competitor ?? RECOVERABLE),
+        streamObject(TO_UNICODE_CMAP),
+      ]);
+    }
+
+    async function inspectCompetition(options) {
+      const bytes = buildCompetitionPdf(options);
+      const pdfLibDocument = await PDFDocument.load(bytes, { ignoreEncryption: true, updateMetadata: false });
+      const packageDirectory = path.dirname(require.resolve("pdfjs-dist/package.json"));
+      const pdfjsLib = await import("pdfjs-dist/legacy/build/pdf.mjs");
+      const document = await pdfjsLib.getDocument({
+        data: bytes,
+        useWorkerFetch: false,
+        isEvalSupported: false,
+        cMapUrl: pdfjsFactoryDirectory(path.join(packageDirectory, "cmaps")),
+        cMapPacked: true,
+        standardFontDataUrl: pdfjsFactoryDirectory(path.join(packageDirectory, "standard_fonts")),
+      }).promise;
+      try {
+        const page = await document.getPage(1);
+        const [textContent, operators] = await Promise.all([
+          page.getTextContent({ includeMarkedContent: false, disableNormalization: false }),
+          page.getOperatorList(),
+        ]);
+        const inventory = inspectType3GlyphEvidenceForPage({
+          textContent,
+          operators,
+          pdfjsPage: page,
+          pdfLibPage: pdfLibDocument.getPage(0),
+          pdfjsLib,
+        });
+        return {
+          occurrence_count: inventory.occurrences.length,
+          unlinked: inventory.omissions
+            .filter(omission => omission.reason === "raw_type3_font_link_ambiguous_or_unavailable")
+            .reduce((total, omission) => total + omission.count, 0),
+        };
+      } finally {
+        await document.destroy();
+      }
+    }
+
+    it("links the recoverable font when it is the only Type-3 font on the page", async () => {
+      // The positive control. Without this the ambiguity assertions below
+      // could pass because the fixture never links at all.
+      const alone = await inspectCompetition({ competitor: null, fonts: ["F1"], drawWith: "F1" });
+      expect(alone.unlinked).toBe(0);
+      expect(alone.occurrence_count).toBe(2);
+    });
+
+    for (const [label, competitor] of [["a /ToUnicode font", HAS_TO_UNICODE], ["an out-of-range font", OUT_OF_RANGE]]) {
+      it(`refuses to link when ${label} answers to the same evidence`, async () => {
+        const contested = await inspectCompetition({ competitor, fonts: ["F1", "F2"], drawWith: "F1" });
+        // The competitor is never drawn and can never be recovered from. It
+        // still makes the drawn font's identity ambiguous, and ambiguous is
+        // reported rather than resolved.
+        expect(contested.occurrence_count).toBe(0);
+        expect(contested.unlinked).toBe(2);
+      });
+
+      it(`keeps ${label} ineligible when it is the only font on the page`, async () => {
+        // Alone, so nothing competes with it and the link is unambiguous. What
+        // refuses it here is its own ineligibility and nothing else.
+        const drawn = await inspectCompetition({ competitor, fonts: ["F2"], drawWith: "F2" });
+        expect(drawn.occurrence_count).toBe(0);
+        expect(drawn.unlinked).toBe(2);
+      });
+    }
   });
 
   it("keeps ordinary punctuation and already-correct Unicode byte-for-byte unchanged", async () => {

--- a/test/read-pdf-layout.test.js
+++ b/test/read-pdf-layout.test.js
@@ -3,6 +3,7 @@ import { once } from "node:events";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
@@ -27,6 +28,7 @@ import {
 import { AjvJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/ajv";
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const require = createRequire(import.meta.url);
 const TWO_COLUMN = path.join(REPO_ROOT, "test/fixtures/eval/extraction/synthetic/two-column-order.pdf");
 const MIXED = path.join(REPO_ROOT, "test/fixtures/eval/extraction/synthetic/mixed-text-raster.pdf");
 const ROTATED_CROP = path.join(REPO_ROOT, "test/fixtures/golden-forms/rotated-signature.pdf");
@@ -72,18 +74,22 @@ describe("qualified legacy Type-3 glyph evidence", () => {
   });
 
   /**
-   * The shipped recovery key. `minusCharProc` is a real dvipdfmx-shaped Type-3
-   * glyph: one 41x3 inline image mask, placed by a `cm` inside a `q`/`Q`, under
-   * a y-flipping FontMatrix. Everything asserted below is a property of the
-   * decoded mask, and everything varied below is a property of the producer.
+   * The shipped recovery key: the stored sample grid of a Type-3 glyph's inline
+   * image mask, cropped to its ink. `minusCharProc` is a real dvipdfmx-shaped
+   * Type-3 glyph: one 41x3 inline image mask, placed by a `cm` inside a `q`/`Q`,
+   * under a y-flipping FontMatrix. Everything asserted below is a property of
+   * the decoded mask, and everything varied below is a property of the producer.
    */
   describe("producer-independent Type-3 glyph shape key", () => {
     // PDF.js operator numbers, taken from the pinned build rather than typed,
     // so an upstream renumbering fails here instead of silently keying on the
-    // wrong operators.
+    // wrong operators. The module itself is kept so the built fixtures below
+    // are parsed by the same pinned build the server uses.
+    let pdfjsLib = null;
     let OPS = null;
     beforeAll(async () => {
-      ({ OPS } = await import("pdfjs-dist/legacy/build/pdf.mjs"));
+      pdfjsLib = await import("pdfjs-dist/legacy/build/pdf.mjs");
+      ({ OPS } = pdfjsLib);
     });
     const FLIPPED = [1, 0, 0, -1, 0, 0];
 
@@ -110,33 +116,238 @@ describe("qualified legacy Type-3 glyph evidence", () => {
       expect(new Set([minusCharProc(), moved, bare].map(type3CharProcSha256)).size).toBe(3);
     });
 
-    it("refuses to conflate a different raster, mirror, or grid", () => {
+    /**
+     * The defect this replaces a pair of tests for.
+     *
+     * The withdrawn revision keyed on `sign(FontMatrix x CharProc cm)` and
+     * called the result the glyph's painted orientation. It is not: the text
+     * matrix and the page CTM are the other half of that product and neither is
+     * reachable from inside a CharProc. Two producers that render a
+     * pixel-identical glyph by splitting the y-flip differently between the
+     * FontMatrix and the text matrix — which is exactly how a dvipdfmx-shaped
+     * document and a Ghostscript-shaped one differ — got different keys.
+     *
+     * So this builds both documents rather than asserting on a hand-picked
+     * raster: the same eight mask bytes, reached through genuinely different
+     * producer idioms, landing on the page in exactly the same place.
+     */
+    describe("two producers, one bitmap", () => {
+      // An asymmetric 8x8 "F": not its own mirror in either axis, so a key that
+      // reorients the grid cannot pass these by accident.
+      const INK_ROWS = Object.freeze([0xfe, 0x80, 0x80, 0xf8, 0x80, 0x80, 0x80, 0x80]);
+
+      const streamObject = (data) => Buffer.concat([
+        Buffer.from(`<< /Length ${data.length} >>\nstream\n`, "latin1"),
+        data,
+        Buffer.from("\nendstream", "latin1"),
+      ]);
+
+      function assemblePdf(bodies) {
+        const header = Buffer.from("%PDF-1.4\n%\xE2\xE3\xCF\xD3\n", "latin1");
+        const chunks = [header];
+        const offsets = [];
+        let offset = header.length;
+        bodies.forEach((body, index) => {
+          const prefix = Buffer.from(`${index + 1} 0 obj\n`, "latin1");
+          const suffix = Buffer.from("\nendobj\n", "latin1");
+          offsets.push(offset);
+          chunks.push(prefix, body, suffix);
+          offset += prefix.length + body.length + suffix.length;
+        });
+        let xref = `xref\n0 ${bodies.length + 1}\n0000000000 65535 f \n`;
+        for (const value of offsets) xref += `${String(value).padStart(10, "0")} 00000 n \n`;
+        xref += `trailer\n<< /Size ${bodies.length + 1} /Root 1 0 R >>\n`
+          + `startxref\n${offset}\n%%EOF\n`;
+        chunks.push(Buffer.from(xref, "latin1"));
+        return new Uint8Array(Buffer.concat(chunks));
+      }
+
+      function buildType3MaskPdf({ fontMatrix, glyphName, charCode, charProc, textMatrix }) {
+        return assemblePdf([
+          Buffer.from("<< /Type /Catalog /Pages 2 0 R >>", "latin1"),
+          Buffer.from("<< /Type /Pages /Kids [3 0 R] /Count 1 >>", "latin1"),
+          Buffer.from("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] "
+            + "/Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>", "latin1"),
+          // No page-level `cm`, and a font size of 1, so the only placement the
+          // page contributes is the text matrix asserted on below.
+          streamObject(Buffer.from(
+            `BT /F1 1 Tf ${textMatrix.join(" ")} Tm `
+            + `<${charCode.toString(16).padStart(2, "0")}> Tj ET\n`,
+            "latin1",
+          )),
+          Buffer.from("<< /Type /Font /Subtype /Type3 /FontBBox [0 0 8 8] "
+            + `/FontMatrix [${fontMatrix.join(" ")}] /CharProcs 6 0 R `
+            + `/Encoding << /Type /Encoding /Differences [${charCode} /${glyphName}] >> `
+            + `/FirstChar ${charCode} /LastChar ${charCode} /Widths [10] `
+            + "/Resources << >> >>", "latin1"),
+          Buffer.from(`<< /${glyphName} 7 0 R >>`, "latin1"),
+          streamObject(charProc),
+        ]);
+      }
+
+      // dvipdfmx-shaped: a `q`/`Q` wrapper, an upright hundredths FontMatrix,
+      // the default /Decode, and raw binary samples (0 paints, so the bytes are
+      // the complement of the ink).
+      const dvipdfmxCharProc = (rows = INK_ROWS) => Buffer.concat([
+        Buffer.from("1000 0 0 0 800 800 d1\nq 800 0 0 800 0 0 cm\n"
+          + "BI /IM true /W 8 /H 8 /BPC 1 ID ", "latin1"),
+        Buffer.from(rows.map(row => ~row & 0xff)),
+        Buffer.from("\nEI\nQ\n", "latin1"),
+      ]);
+      // Ghostscript-shaped: no wrapper, a y-flipping unit FontMatrix, an
+      // inverted /Decode, and ASCIIHex-filtered samples (1 paints, so the bytes
+      // are the ink itself). Every byte of this program differs from the one
+      // above; the mask they decode to does not.
+      const ghostscriptCharProc = (rows = INK_ROWS) => Buffer.concat([
+        Buffer.from("10 0 0 -8 8 0 d1\n8 0 0 8 0 -8 cm\n"
+          + "BI /IM true /W 8 /H 8 /BPC 1 /D [1 0] /F /AHx ID ", "latin1"),
+        Buffer.from(`${Buffer.from(rows).toString("hex")}>`, "latin1"),
+        Buffer.from("\nEI\n", "latin1"),
+      ]);
+
+      const DVIPDFMX = Object.freeze({
+        fontMatrix: [0.01, 0, 0, 0.01, 0, 0],
+        glyphName: "shape",
+        charCode: 65,
+        textMatrix: [1, 0, 0, 1, 20, 60],
+      });
+      const GHOSTSCRIPT = Object.freeze({
+        fontMatrix: [1, 0, 0, -1, 0, 0],
+        glyphName: "Fbitmap",
+        charCode: 97,
+        textMatrix: [1, 0, 0, -1, 20, 68],
+      });
+
+      const compose = (outer, inner) => [
+        outer[0] * inner[0] + outer[2] * inner[1],
+        outer[1] * inner[0] + outer[3] * inner[1],
+        outer[0] * inner[2] + outer[2] * inner[3],
+        outer[1] * inner[2] + outer[3] * inner[3],
+        outer[0] * inner[4] + outer[2] * inner[5] + outer[4],
+        outer[1] * inner[4] + outer[3] * inner[5] + outer[5],
+      ];
+
+      /**
+       * Loads one built document through the pinned PDF.js and reports what the
+       * key is computed from, plus the two matrices that decide where the glyph
+       * actually lands. Nothing here is hand-typed: the CharProc operator list,
+       * the FontMatrix, and the text matrix all come back out of the parser.
+       */
+      async function measureBuiltDocument(bytes) {
+        const packageDirectory = path.dirname(require.resolve("pdfjs-dist/package.json"));
+        const document = await pdfjsLib.getDocument({
+          data: bytes,
+          useWorkerFetch: false,
+          isEvalSupported: false,
+          cMapUrl: pdfjsFactoryDirectory(path.join(packageDirectory, "cmaps")),
+          cMapPacked: true,
+          standardFontDataUrl: pdfjsFactoryDirectory(path.join(packageDirectory, "standard_fonts")),
+        }).promise;
+        try {
+          const page = await document.getPage(1);
+          const operators = await page.getOperatorList();
+          let fontId = null;
+          let fontSize = null;
+          let textMatrix = null;
+          let pageTransforms = 0;
+          for (let index = 0; index < operators.fnArray.length; index += 1) {
+            const operation = operators.fnArray[index];
+            const args = operators.argsArray[index];
+            if (operation === OPS.setFont) [fontId, fontSize] = args;
+            if (operation === OPS.setTextMatrix) textMatrix = [...args[0]];
+            if (operation === OPS.transform) pageTransforms += 1;
+          }
+          const font = page.commonObjs.get(fontId);
+          const entries = Object.entries(font.charProcOperatorList ?? {});
+          expect(entries).toHaveLength(1);
+          const [, charProc] = entries[0];
+          // The CharProc-local matrix the mask lane's guard inspects: the
+          // FontMatrix composed with this glyph program's own `cm`.
+          let local = [...font.fontMatrix];
+          for (let index = 0; index < charProc.fnArray.length; index += 1) {
+            if (charProc.fnArray[index] === OPS.transform) {
+              local = compose(local, charProc.argsArray[index]);
+            }
+          }
+          return {
+            font_size: fontSize,
+            page_transform_count: pageTransforms,
+            font_matrix: [...font.fontMatrix],
+            local_matrix: local,
+            placement: compose(textMatrix, local),
+            evidence_sha256: type3GlyphEvidenceSha256(charProc, font.fontMatrix, OPS),
+            charproc_sha256: type3CharProcSha256(charProc),
+          };
+        } finally {
+          await document.destroy();
+        }
+      }
+
+      const measureIdiom = (idiom, charProc) =>
+        measureBuiltDocument(buildType3MaskPdf({ ...idiom, charProc }));
+
+      it("gives one bitmap one key across two producer idioms that paint it identically", async () => {
+        const dvipdfmx = await measureIdiom(DVIPDFMX, dvipdfmxCharProc());
+        const ghostscript = await measureIdiom(GHOSTSCRIPT, ghostscriptCharProc());
+
+        // Both documents put the same 8x8 mask on the same eight points of the
+        // page, at the same scale and the same way up, so any renderer produces
+        // identical pixels. Nothing outside the text matrix moves the glyph:
+        // there is no page-level `cm` and the font size is 1 in both.
+        for (const measured of [dvipdfmx, ghostscript]) {
+          expect(measured.page_transform_count).toBe(0);
+          expect(measured.font_size).toBe(1);
+        }
+        expect(dvipdfmx.placement).toEqual([8, 0, 0, 8, 20, 60]);
+        expect(ghostscript.placement).toEqual(dvipdfmx.placement);
+
+        // They are nonetheless different programs from different producers, and
+        // they split that identical placement across the FontMatrix, the `cm`
+        // and the text matrix in opposite ways. The withdrawn key read the sign
+        // of `local_matrix` and so separated them; this asserts the two signs
+        // really are opposite, so the test cannot pass vacuously.
+        expect(dvipdfmx.font_matrix).not.toEqual(ghostscript.font_matrix);
+        expect(Math.sign(dvipdfmx.local_matrix[3]))
+          .toBe(-Math.sign(ghostscript.local_matrix[3]));
+        expect(dvipdfmx.charproc_sha256).not.toBe(ghostscript.charproc_sha256);
+
+        expect(dvipdfmx.evidence_sha256).toMatch(/^[0-9a-f]{64}$/);
+        expect(ghostscript.evidence_sha256).toBe(dvipdfmx.evidence_sha256);
+      });
+
+      it("still separates two bitmaps that differ, in either axis or in ink", async () => {
+        const baseline = (await measureIdiom(DVIPDFMX, dvipdfmxCharProc())).evidence_sha256;
+        const keyOf = async rows => {
+          // Measured through both producers every time, so a variant that only
+          // one idiom separates would fail here rather than look distinct.
+          const first = await measureIdiom(DVIPDFMX, dvipdfmxCharProc(rows));
+          const second = await measureIdiom(GHOSTSCRIPT, ghostscriptCharProc(rows));
+          expect(second.evidence_sha256).toBe(first.evidence_sha256);
+          return first.evidence_sha256;
+        };
+
+        const oneBitFewer = [...INK_ROWS];
+        oneBitFewer[0] &= ~0x02;
+        const upsideDown = [...INK_ROWS].reverse();
+        const backToFront = INK_ROWS.map(row => {
+          let flipped = 0;
+          for (let bit = 0; bit < 8; bit += 1) if (row & (1 << bit)) flipped |= 128 >> bit;
+          return flipped;
+        });
+
+        const distinct = await Promise.all([oneBitFewer, upsideDown, backToFront].map(keyOf));
+        // Reversing the stored rows or the stored columns is a different
+        // bitmap, not a different view of this one, and must not collide with
+        // it or with each other.
+        expect(new Set([baseline, ...distinct]).size).toBe(4);
+      });
+    });
+
+    it("refuses to conflate a different raster or a different grid", () => {
       const key = type3GlyphEvidenceSha256(minusCharProc(), FLIPPED, OPS);
       const oneBit = minusCharProc();
       oneBit.argsArray[3][1][0][14] = 0;
       expect(type3GlyphEvidenceSha256(oneBit, FLIPPED, OPS)).not.toBe(key);
-      // An unflipped FontMatrix paints the stored rows the other way up, so the
-      // same samples are a different glyph and must key differently. The 41x3
-      // bar above is its own mirror image, so this needs an asymmetric raster:
-      // an L filling row 0 column 0 and all of row 1 of a 2x2 grid.
-      const asymmetric = () => ({
-        fnArray: [OPS.setCharWidthAndBounds, OPS.transform, OPS.constructPath],
-        argsArray: [
-          [4, 0, 0, 0, 2, 2],
-          [2, 0, 0, 2, 0, 0],
-          [94, [new Float32Array([
-            0, 0, 1, 1, 0.5, 1, 1, 0.5, 0.5, 1, 1, 0.5, 1, 1, 0, 1, 0, 0,
-          ])], new Float32Array([0, 0, 2, 2])],
-        ],
-      });
-      const upright = type3GlyphEvidenceSha256(asymmetric(), [1, 0, 0, 1, 0, 0], OPS);
-      const mirrored = type3GlyphEvidenceSha256(asymmetric(), FLIPPED, OPS);
-      expect(upright).toMatch(/^[0-9a-f]{64}$/);
-      expect(mirrored).not.toBe(upright);
-      // Mirrored twice is the identity, so the normalisation is a genuine
-      // orientation fix and not an arbitrary relabelling.
-      expect(type3GlyphEvidenceSha256(asymmetric(), [-1, 0, 0, -1, 0, 0], OPS))
-        .not.toBe(mirrored);
       const wider = minusCharProc();
       wider.argsArray[3][2] = new Float32Array([0, 0, 82, 3]);
       expect(type3GlyphEvidenceSha256(wider, FLIPPED, OPS)).not.toBe(key);
@@ -145,14 +356,42 @@ describe("qualified legacy Type-3 glyph evidence", () => {
       expect(key).not.toBe(type3CharProcSha256(minusCharProc()));
     });
 
+    /**
+     * A mask with no ink has no shape, so it cannot be keyed as one. Left
+     * unguarded it cropped to 0x0 and every blank glyph of every font hashed to
+     * the single digest of an empty buffer.
+     */
+    it("sends an inkless mask to the placement-bearing operator lane", () => {
+      // A degenerate loop: two coincident vertical edges of opposite winding,
+      // which is a well-formed traced outline that fills nothing.
+      const blank = metrics => ({
+        fnArray: [OPS.setCharWidthAndBounds, OPS.transform, OPS.constructPath],
+        argsArray: [
+          metrics,
+          [41, 0, 0, 3, 0, 0],
+          [94, [new Float32Array([0, 0, 1, 1, 0, 0, 1, 0, 1, 4])], new Float32Array([0, 0, 41, 3])],
+        ],
+      });
+      const inked = type3GlyphEvidenceSha256(minusCharProc(), FLIPPED, OPS);
+      const first = type3GlyphEvidenceSha256(blank([52, 0, 0, 0, 41, 3]), FLIPPED, OPS);
+      const second = type3GlyphEvidenceSha256(blank([31, 0, 0, 0, 41, 3]), FLIPPED, OPS);
+      expect(first).toMatch(/^[0-9a-f]{64}$/);
+      expect(first).not.toBe(inked);
+      // The mask lane ignores declared metrics, so two blank programs that
+      // differ only there proves the fallback actually happened.
+      expect(second).not.toBe(first);
+      expect(first).not.toBe(type3CharProcSha256(blank([52, 0, 0, 0, 41, 3])));
+    });
+
     it("falls back to the exact operator digest for a program it cannot decode", () => {
       const outline = { fnArray: [OPS.setCharWidthAndBounds, OPS.fill], argsArray: [[52, 0, 0, 0, 4, 4], null] };
       const outlineKey = type3GlyphEvidenceSha256(outline, FLIPPED, OPS);
       expect(outlineKey).toMatch(/^[0-9a-f]{64}$/);
       expect(outlineKey).not.toBe(type3CharProcSha256(outline));
-      // Two painted objects are not a single decodable mask, and a rotated
-      // placement has no unambiguous mirror decomposition. Both leave the mask
-      // lane rather than being keyed on a guess.
+      // Two painted objects are not a single decodable mask, and a CharProc
+      // that rotates its own bitmap is outside the plain axis-aligned bitmap
+      // idiom the mask lane is held to. Both take the operator digest instead
+      // of being keyed on a guess.
       const twice = minusCharProc();
       twice.fnArray = [...twice.fnArray, 91];
       twice.argsArray = [...twice.argsArray, minusCharProc().argsArray[3]];
@@ -702,14 +941,14 @@ describe("read_pdf_layout MCP tool", () => {
     expect(first.isError).not.toBe(true);
     expect(JSON.stringify(first.structuredContent)).toBe(JSON.stringify(second.structuredContent));
     expect(first.structuredContent).toMatchObject({
-      ir: { name: "pdf-tools.extraction-ir", version: "1.4.0" },
+      ir: { name: "pdf-tools.extraction-ir", version: "1.5.0" },
       parser: { name: "pdfjs-dist", version: "5.4.624" },
       source: { sha256: expect.stringMatching(/^[a-f0-9]{64}$/) },
       id_scope: {
         kind: "source_parser_ir_options",
         source_sha256: expect.stringMatching(/^[a-f0-9]{64}$/),
         parser_version: "5.4.624",
-        ir_version: "1.4.0",
+        ir_version: "1.5.0",
         max_output_characters: 200000,
       },
       page_range: { requested_start_page: 1, requested_end_page: 1, start_page: 1, end_page: 1, total_pages: 1 },
@@ -1440,8 +1679,8 @@ describe("Extraction IR hostile reconstruction", () => {
       qualification: "ctan-cm-encoding-plus-reviewed-pk-raster-v1",
       glyph_sha256: "3f6fdf2abc68f5693f9ea7cdec4d94214a57fb953fb66c747b86dd1f6293d807",
       witness_glyph_sha256: [
-        "73a2cec4aa27d5042b9f4275179fbf2bb7b99413537597ede0537b7f19c8384c",
-        "f15e035b5867fbee9918125e49566e00b94dcd8422649079c87207e94f7a9e63",
+        "cf5071eb6c006bc80cf9399c28dc00f7e12d8e7f090942de46cb06d404481dd6",
+        "da5345f465509486a66762b6cf8918a3ba5c937f4ca8c7bc4657f4f905d0b4be",
       ],
       tfm_reference_version: "ctan-cm-tfm-9c0f99fa34c7",
       glyph_evidence_version: "pdfjs-type3-glyph-evidence-v2",
@@ -1474,8 +1713,8 @@ describe("Extraction IR hostile reconstruction", () => {
       qualification: "ctan-cm-encoding-plus-reviewed-pk-raster-v1",
       glyph_sha256: "3f6fdf2abc68f5693f9ea7cdec4d94214a57fb953fb66c747b86dd1f6293d807",
       witness_glyph_sha256: [
-        "73a2cec4aa27d5042b9f4275179fbf2bb7b99413537597ede0537b7f19c8384c",
-        "f15e035b5867fbee9918125e49566e00b94dcd8422649079c87207e94f7a9e63",
+        "cf5071eb6c006bc80cf9399c28dc00f7e12d8e7f090942de46cb06d404481dd6",
+        "da5345f465509486a66762b6cf8918a3ba5c937f4ca8c7bc4657f4f905d0b4be",
       ],
       tfm_reference_version: "ctan-cm-tfm-9c0f99fa34c7",
       glyph_evidence_version: "pdfjs-type3-glyph-evidence-v2",

--- a/test/shannon-type3-live.test.js
+++ b/test/shannon-type3-live.test.js
@@ -106,9 +106,9 @@ describe("external Shannon Type-3 recovery", () => {
       "cmsy-pk-raster-centered-dot-33077f-v1": 66,
       "cmsy-pk-raster-greater-equal-05b4a9-v1": 22,
       "cmsy-pk-raster-greater-equal-b57ae2-v1": 1,
-      "cmsy-pk-raster-less-or-equal-90da52-v1": 35,
+      "cmsy-pk-raster-less-or-equal-90da52-v1": 36,
       "cmsy-pk-raster-minus-0c8b34-v1": 64,
-      "cmsy-pk-raster-minus-fb1f6b-v1": 216,
+      "cmsy-pk-raster-minus-fb1f6b-v1": 222,
       "cmsy-pk-raster-minus-v1": 14,
       "cmsy-pk-raster-plus-or-minus-4dedb5-v1": 4,
       "cmsy-pk-raster-plus-or-minus-b68b24-v1": 1,
@@ -116,7 +116,7 @@ describe("external Shannon Type-3 recovery", () => {
       "cmsy-pk-raster-right-arrow-6ff1e0-v1": 16,
       "cmsy-pk-raster-right-arrow-7d300b-v1": 19,
       "cmsy-pk-raster-square-root-0c8ca6-v1": 1,
-      "cmsy-pk-raster-square-root-772f49-v1": 27,
+      "cmsy-pk-raster-square-root-772f49-v1": 28,
       "cmsy-pk-raster-vertical-6ab8a7-v1": 32,
     });
   }, 60_000);

--- a/test/type3-recovery-gate.test.js
+++ b/test/type3-recovery-gate.test.js
@@ -51,7 +51,10 @@ function parseRegistryEntries(source) {
       complete_font_enrollment: footprint
         ? footprint[1].split(",").map(value => Number(value.trim()))
         : null,
+      glyph_sha256: /glyph_sha256: "([0-9a-f]{64})"/.exec(head)?.[1] ?? null,
       witness_codes: [...tail.matchAll(/original_char_code: (\d+)/g)].map(match => Number(match[1])),
+      witnesses: [...tail.matchAll(/original_char_code: (\d+), glyph_sha256: "([0-9a-f]{64})"/g)]
+        .map(match => ({ original_char_code: Number(match[1]), glyph_sha256: match[2] })),
       source: text,
     };
   });
@@ -274,5 +277,106 @@ describe("Type-3 registry startup invariants", () => {
         "    complete_font_enrollment: Object.freeze([6, 0, 33]),\n    witnesses: Object.freeze([\n",
       ),
     ))).rejects.toThrow(`Type-3 registry ${TWO_WITNESS_ID} declares a font footprint it does not need`);
+  });
+});
+
+/**
+ * The two corroboration rules the matcher applies to every registry entry
+ * before it recovers anything.
+ *
+ * Both are module-private, and both sit behind `collectType3GlyphRecoveries`,
+ * which needs a real page carrying real enrolled Computer Modern rasters to
+ * reach — rasters this repository deliberately does not vendor. So these drive
+ * `matchingRegistryEntries` directly, through the same source-copy import the
+ * startup-invariant tests above use, with one test-only export appended. The
+ * module under test is still the shipped source text: delete either rule from
+ * server/layout-extraction.js and the copy loses it too.
+ *
+ * `enrolled` is what `enrolledGlyphEvidence` builds — every officially
+ * enrolled code the font actually draws, mapped to its glyph digest — and
+ * `rawFont` is consulted only for `metricWidths`, so a Map is the whole of it.
+ */
+describe("Type-3 registry match corroboration", () => {
+  // Two witnesses, so no complete_font_enrollment footprint to satisfy and the
+  // fixture below is the entry's whole evidence.
+  const ENTRY_ID = "cmmi-pk-raster-alpha-e688a8-v1";
+  const FAMILY = "computer-modern-math-italic";
+  let matchingRegistryEntries = null;
+  let entry = null;
+
+  const fixture = () => {
+    const enrolled = new Map([[entry.original_char_code, entry.glyph_sha256]]);
+    const metricWidths = new Map([[entry.original_char_code, 45]]);
+    for (const witness of entry.witnesses) {
+      enrolled.set(witness.original_char_code, witness.glyph_sha256);
+      metricWidths.set(witness.original_char_code, 41);
+    }
+    return { enrolled, rawFont: { metricWidths } };
+  };
+
+  const matchedIds = ({ enrolled, rawFont }) =>
+    matchingRegistryEntries(enrolled, rawFont, FAMILY).map(match => match.id);
+
+  beforeAll(async () => {
+    ({ matchingRegistryEntries } = await importMutatedLayoutModule(
+      "matcher-exposed",
+      source => `${source}\nexport { matchingRegistryEntries };\n`,
+    ));
+    entry = registryEntryById(ENTRY_ID);
+    expect(entry.glyph_sha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(entry.witnesses).toHaveLength(2);
+    expect(entry.complete_font_enrollment).toBeNull();
+    // The positive control every case below is measured against. Without it a
+    // safeguard could look enforced while the fixture simply never matched.
+    expect(matchedIds(fixture())).toContain(ENTRY_ID);
+  });
+
+  /**
+   * Shape-code injectivity. The grid key drops the placement matrix, and
+   * placement is what tells a Computer Modern period from a centred dot — the
+   * same nine-by-nine blob at two heights. So the shape has to identify the
+   * code on its own within its own font.
+   */
+  it("recovers nothing when one shape stands at two enrolled codes of the font", () => {
+    const contested = fixture();
+    // Code 12 is an officially enrolled math-italic slot that this entry does
+    // not name, now carrying the entry's own shape. Pinned with a positive
+    // width so nothing but injectivity can be doing the refusing.
+    expect(contested.enrolled.has(12)).toBe(false);
+    contested.enrolled.set(12, entry.glyph_sha256);
+    contested.rawFont.metricWidths.set(12, 45);
+    expect(matchedIds(contested)).not.toContain(ENTRY_ID);
+  });
+
+  it("recovers nothing when a witness shape stands at two enrolled codes", () => {
+    const contested = fixture();
+    contested.enrolled.set(12, entry.witnesses[0].glyph_sha256);
+    contested.rawFont.metricWidths.set(12, 41);
+    expect(matchedIds(contested)).not.toContain(ENTRY_ID);
+  });
+
+  /**
+   * Positive-width pinning. Keeping zero-width slots in the linker's width map
+   * is what lets a legacy font link at all, but it also lets a drawn glyph
+   * reach the registry with no advance behind it, and a zero advance is
+   * invisible to the TFM fingerprint that qualified the family. Every code the
+   * match rests on must be one the fingerprint could actually see.
+   */
+  it("recovers nothing when the recovered code carries no positive declared width", () => {
+    const unpinned = fixture();
+    // Still drawn, still the right shape — only its declared advance is zero,
+    // so `metricWidths` never held it.
+    unpinned.rawFont.metricWidths.delete(entry.original_char_code);
+    expect(unpinned.enrolled.get(entry.original_char_code)).toBe(entry.glyph_sha256);
+    expect(matchedIds(unpinned)).not.toContain(ENTRY_ID);
+  });
+
+  it("recovers nothing when a witness carries no positive declared width", () => {
+    for (const witness of entry.witnesses) {
+      const unpinned = fixture();
+      unpinned.rawFont.metricWidths.delete(witness.original_char_code);
+      expect(unpinned.enrolled.get(witness.original_char_code)).toBe(witness.glyph_sha256);
+      expect(matchedIds(unpinned)).not.toContain(ENTRY_ID);
+    }
   });
 });


### PR DESCRIPTION
## Why

A measured study found the Type-3 recovery registry does not transfer between
documents: across 11 dvips-era PDFs and 560,754 glyph occurrences, **0 of 29**
eligible occurrences matched any Shannon-derived digest. This branch fixes the
two mechanical causes, and establishes that the third is structural.

## What changed

**A real linker defect.** `rawType3Fonts` dropped zero-width slots from its
width map while `linkedRawType3Font` demanded an exact match for every drawn
code, so one drawn zero-width glyph voided an entire font. Four GNU Ghostscript
papers go from **0 to 52,493 linked occurrences**; Shannon gains 8 recoveries
from fonts that had been silently discarded.

**The key is now the glyph, not the producer's encoding of it.** It was a hash
of the canonicalized CharProc operator list, which folds in PK resolution, the
producer's operator idiom, and the per-glyph placement matrix. It is now the
decoded image-mask grid cropped to its ink box, with no matrix of any kind.
Verified by construction: three PDFs in different idioms — raw binary, Flate
with `/Decode [1 0]`, ASCIIHex with flipped FontMatrix and flipped `Tm` — all
key identically while their old digests all differed.

**Reflected paint abstains.** Keying the stored grid means a glyph *painted*
reflected would otherwise key as the upright one. Every mask-lane glyph of one
embedded font shares a paint convention, so a glyph whose composed determinant
sign disagrees with its siblings takes the placement-bearing operator lane.
Measured across 116 fonts, zero mixed; the sign differs *across* documents,
which is why the absolute sign cannot be keyed and the intra-font comparison
can. Unanimity, not majority — a majority is a vote an adversary wins by
flipping more glyphs.

## Shape-keyed family identification does not work, and that is a finding

Recorded in `docs/evidence/`. Four independent blocks, each measured:

- Ghostscript 6.52 splits every character into an **inked glyph with zero
  advance** plus a separate ink-free spacer carrying the width. Inked and
  positive-width codes are disjoint, so positive-width pinning would reject
  every recovery regardless of matcher quality.
- The pinned CTAN `ps-type3` fonts are outline programs; there is no bitmap
  reference, and METAFONT is neither installed nor pinned.
- Rasterising CTAN `α` across 225,225 resolution/threshold/offset combinations
  reproduced Shannon's reviewed ink box 241 times and its bits **zero** times.
  A usable threshold must admit 14.5% wrong and reject 20.1%.
- Inferring family from shape is ill-posed: one registry digest already stands
  at both cmmi 58 `.` and cmsy 1 `⋅`.

## Evidence

- Five third-party documents pinned by SHA-256 as a **failing baseline**,
  env-gated so `npm test` stays green without them. Assertions fire in both
  directions, so recovery getting better forces a deliberate update.
- The three safeguards paying for the loosening now have tests proven to go
  **red when the safeguard is deleted** — seven mutations, seven reds, each
  verified by deleting, running, and restoring.

## Verification

- `npm test` — **2110 passed, 89 skipped, 0 failed**
- `npm run test:node-native` — **62 passed, 0 failed, 9 skipped**
- Shannon live oracle — **1872**, per-registry map identical key-for-key
- Corpus live oracle — recovery **0**, baseline deliberately unraised
- `npm run build:mcpb` — 2997 files, 73,721,422 bytes,
  `e1428a69b5eac3681cafbc2fde34cd6f1f23dd53507dcf401bbbf034ddb9fead`;
  two clean isolated builds byte-identical
- `npm run smoke:mcpb` — passed darwin/arm64, 42 tools, 14 prompts
- Rebased onto `241a8dd`; both tool-contract pins recomputed. IR 1.4.0 → 1.5.0.

## Known gaps, stated rather than closed

- **Corpus recovery is still zero.** Every corpus gain is a link, not a
  recovery. Nothing was forced, and the one available candidate was refused:
  its family fit rested on four spacer widths, it had no witnesses, and an 18×2
  solid rectangle is the least identifying shape in the corpus.
- **Reflected paint is narrowed, not eliminated.** A producer reflecting every
  glyph in a font uniformly leaves no in-font signal. No corpus producer does
  this. See `docs/evidence/type3-reflected-paint-2026-08.md`.
- **`scripts/macos-claude-installed-shannon.mjs`** pins a markdown digest and
  character counts for an installed extension build. The +8 recoveries shift
  them and no installed build was available here, so they are left for a real
  installed-host evidence run rather than guessed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)