### PR TITLE
Establish the filesystem boundary only from explicit configuration

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -68,7 +68,13 @@ The following are in scope and genuinely interesting to us:
   published `.mcpb` artifact or share bundle, or that breaks the reproducibility
   of those builds.
 - **Information disclosure.** Passwords for encrypted documents, file contents,
-  or local paths leaking into logs, error messages, tool output, or metadata.
+  or local paths travelling beyond the caller that supplied them, or persisting
+  after the request: into logs, saved PDF metadata, build artifacts, or a
+  response to a different requester. Passwords are never echoed anywhere.
+  A refusal that names the configured allowed directories and the path just
+  requested is deliberate rather than a leak — the caller supplied one and
+  configured the other, so neither is new to them, and a boundary a user cannot
+  see is a boundary they cannot correct.
 
 ## Out of scope
 

--- a/docs/agent-plugins-packaging.md
+++ b/docs/agent-plugins-packaging.md
@@ -1,0 +1,189 @@
+# Agent Plugins 1.0.0 packaging
+
+- **Status:** proposal, with the portable filesystem-boundary work implemented
+- **Bead:** child of `pdf-toolkit-mcp-22v.1` (portable skills, plugins, and MCP App workflows across agent hosts)
+- **Branch:** `agent/agent-plugins-packaging`, branched from `master@5284fac`
+- **Spec version reviewed:** Agent Plugins 1.0.0, published 2026-08-06
+
+## What the standard is
+
+Agent Plugins is an open, vendor-neutral specification for packaging agent extensions into a distributable directory. Vercel wrote the proposal; AWS, Anysphere, GitHub, Microsoft, OpenAI, and Vercel refined it and staff the technical steering committee. Launch clients are ChatGPT, Codex, Cursor, GitHub Copilot, Kiro, and VS Code.
+
+The specification is deliberately small:
+
+- A plugin is a directory with `plugin.json` at its root.
+- The manifest schema is closed. The only permitted top-level fields are `$schema`, `name`, `version`, `description`, `author`, `homepage`, `repository`, `license`, `keywords`, and `extensions`.
+- Version 1 defines exactly two component types: Agent Skills discovered at `skills/<name>/SKILL.md`, and MCP servers configured in `mcp.json`.
+- Component locations are fixed. The manifest cannot remap them or carry inline component configuration.
+- Client-specific data belongs under a reverse-domain namespace, either as a key in `extensions` or as a top-level directory of the same name.
+- Package paths must resolve inside the plugin root. An MCP `command` must be a single token, either a bare executable name or a plugin-relative `./` path.
+- Only `${PLUGIN_ROOT}` and `${PLUGIN_DATA}` are expanded, and only in `args`, `env` values, and `cwd`. All other placeholder-like text stays literal.
+- Failures are scoped: an invalid skill is skipped, an invalid MCP entry is skipped, and only an invalid `plugin.json` rejects the plugin.
+
+The standard defines no hooks, no agents, no commands, no user configuration, no credential or OAuth configuration, no install or build lifecycle, and no registry.
+
+## Why this matters for PDF Tools
+
+Two reasons, in order of weight.
+
+**The workflow skill stops being optional.** Today `plugins/pdf-tools-workflow` ships the evidence-first workflow — inspect, compare, plan, authorize, transform, validate, return — against an MCP connection the user has to configure separately. A conformant plugin can carry `skills/` and `mcp.json` in one directory, so the guardrails and the non-claims install with the server rather than beside it. That discipline is a larger part of this product's value than any individual tool.
+
+**The MCP Apps viewer already travels.** `server/index.js` serves `ui://pdf-toolkit/viewer` with `mimeType: "text/html;profile=mcp-app"` and attaches `_meta.ui.resourceUri` to the tools that benefit from it. MCP Apps is the official MCP extension for host-rendered UI, and OpenAI's own guidance now treats `_meta.ui.resourceUri` as the primary field, with `_meta["openai/outputTemplate"]` and `window.openai` demoted to compatibility aliases. We are already on the current field. The viewer is therefore not a Claude Desktop exclusive; on MCP Apps hosts it is the same component.
+
+### Verified MCP Apps client matrix (2026-08-06)
+
+Source: the community-maintained matrix at https://modelcontextprotocol.io/extensions/client-matrix plus each vendor's own documentation. Re-verify before any public claim; this decays quickly.
+
+| Host | MCP Apps UI | Evidence |
+|---|---|---|
+| Claude web + desktop | Yes | Client matrix |
+| ChatGPT | Yes | Client matrix; OpenAI UI docs |
+| VS Code + GitHub Copilot | Yes | VS Code blog, 2026-01-26 |
+| Microsoft 365 Copilot | Yes | GA announced 2026-04-07 |
+| Cursor | Yes, with a live defect | Cursor 2.6 changelog, 2026-03-03 |
+| Goose, Postman, MCPJam | Yes | Client matrix |
+| Kiro, JetBrains | No evidence found | Absent from the matrix |
+| GitHub Copilot outside VS Code | No evidence found | No matrix row |
+
+**On ChatGPT and Codex.** These are one application. OpenAI merged them on 2026-07-09 into a single desktop app with Chat, Work, and Codex modes; the standalone Codex app no longer exists and the previous ChatGPT desktop app was renamed ChatGPT Classic. Any source that reports Codex and ChatGPT as separate clients with different MCP Apps behavior predates the merge and should not be relied on — including openai/codex#21019, which was filed in May against the standalone Codex Desktop build, and the client matrix's separate rows.
+
+The merged desktop app is therefore our primary non-Anthropic host target and it renders MCP Apps UI. The Codex **CLI** remains a separate terminal program and does not render HTML components; that distinction is unaffected by the merge.
+
+This does not relax the degradation requirement. OpenAI's guidance still requires tools to be usable without a component, and our bounded reads and page/region renders already satisfy it. But we should not plan around a viewer-less OpenAI surface that no longer exists.
+
+**Cursor** renders MCP Apps but carries an open regression in which the client advertises `io.modelcontextprotocol/ui` and never issues `resources/read`, so widgets silently fall back to text — reported against project-scoped servers, with global scope working, unresolved as of 2026-07-29. Cursor is a lower-priority target; record the scope used if it is ever trialed, and treat silent text fallback as an expected client failure mode rather than a defect in this server.
+
+## Current packaging inventory
+
+| Artifact | Consumer | Contents |
+|---|---|---|
+| `manifest.mcpb.json` | Claude Desktop MCPB | Server config, `user_config`, tool list |
+| `plugins/pdf-tools-workflow/.claude-plugin/plugin.json` | Claude Code | Skill-only plugin |
+| `plugins/pdf-tools-workflow/.codex-plugin/plugin.json` | Codex (pre-standard) | Same skill plus an `interface` block |
+| `.claude-plugin/marketplace.json` | Claude Code | Marketplace entry |
+| `.agents/plugins/marketplace.json` | `.agents` convention | Marketplace entry |
+
+Four packaging descriptions of one product, and the server ships separately from the skill in every one of them.
+
+## Conformance gaps
+
+### 1. `${HOME}` and `${user_config.*}` do not exist
+
+The MCPB server configuration is:
+
+```json
+"args": ["${__dirname}/server/index.js", "--allowed-directories", "${user_config.allowed_directories}"],
+"env": {
+  "DEFAULT_PROFILES_DIR": "${HOME}/.pdf-toolkit-files",
+  "ALLOWED_DIRECTORIES": "${user_config.allowed_directories}"
+}
+```
+
+Under Agent Plugins, `${__dirname}` becomes `${PLUGIN_ROOT}`, but `${HOME}` and every `${user_config.*}` reference stay **literal text**. The specification expands nothing else and defines no user-configuration mechanism.
+
+It is worse than a missing expansion. §9.1 says the client "MAY inherit, omit, or sanitize ambient variables" and that "plugins claiming conformance MUST NOT depend on a base-environment variable" unless the specification requires it or the configuration supplies it explicitly. **`HOME` may not be present at all.** `os.homedir()`, `%USERPROFILE%`, and `$XDG_CONFIG_HOME` are therefore all non-conformant to depend on.
+
+This supersedes an earlier draft of this document, which proposed resolving `~/.pdf-toolkit-files` server-side through the home directory. That is not conformant. The only guaranteed writable, persistent, per-install location is `${PLUGIN_DATA}`, which §9.1 requires the client to create before launch, keep writable, and preserve across plugin updates.
+
+The cost of that is real and must be stated rather than hidden: `PLUGIN_DATA` is per-installed-plugin, so under Agent Plugins a signature or profile saved in one client is not visible in another. The honest resolution is a documented precedence — use an explicitly configured store path when supplied, otherwise `${PLUGIN_DATA}`, and keep the home-directory store only for the MCPB build where `${HOME}` is a supported expansion. Do not silently pick one and let users discover the split.
+
+### 2. Native dependencies with no install lifecycle
+
+`@napi-rs/canvas` resolves to one of eleven platform packages, and the specification has no install or build hook. Two options:
+
+| Option | Cost | Risk |
+|---|---|---|
+| Publish a scoped npm package, `command: "npx"` | One publish per release | Requires network at first run; npm resolves the correct native binary |
+| Vendor every platform package under `PLUGIN_ROOT` | Very large package | No network needed; we own platform coverage, as MCPB already does |
+
+`pdf-tools` and `pdf-toolkit-mcp` are both taken on npm by unrelated projects, so a scoped name is required either way.
+
+### 3. Package containment
+
+Every path the client reads from the package must resolve inside the plugin root. Runtime paths the user supplies — the PDFs they ask us to open — are explicitly out of scope for that rule, so the existing allowed-directories model is unaffected. Anything fetched at first run rather than shipped in the package would be affected.
+
+## Phase 1 — conformant skills-only plugin (this branch)
+
+The existing workflow plugin becomes conformant by adding a root `plugin.json` next to the client-specific manifests. No rename, no `mcp.json`, no behavior change for existing Claude Code users, and nothing that depends on an unpublished npm package.
+
+```text
+plugins/pdf-tools-workflow/
+├── plugin.json              # Agent Plugins 1.0.0 (new)
+├── .claude-plugin/
+│   └── plugin.json          # Claude Code (unchanged)
+├── .codex-plugin/
+│   └── plugin.json          # pre-standard Codex (retire after verification)
+└── skills/
+    └── pdf-tools-workflow/
+        └── SKILL.md
+```
+
+This is immediately loadable by every launch client and is fully reversible.
+
+Open validation items for phase 1:
+
+- `skills/pdf-tools-workflow/agents/openai.yaml` is not a directory the Agent Skills specification names (`scripts/`, `references/`, `assets/`). Confirm clients tolerate it before assuming the skill loads everywhere.
+- The SKILL.md non-claims list should narrow the viewer language: the component renders on MCP Apps hosts, and Cursor and Copilot are unverified.
+
+## Phase 2 — server-bearing plugin (gated)
+
+Adding `mcp.json` is gated on the portable allowed-directories work and a published package. Target shape:
+
+```json
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "pdf-tools": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@open-document-alliance/pdf-tools@<version>", "--cache-dir", "${PLUGIN_DATA}/cache"],
+      "cwd": "${PLUGIN_ROOT}"
+    }
+  }
+}
+```
+
+### Portable allowed-directories requirements
+
+**Implementation status.** Requirements 1, 2, 3, and 7 are implemented on this branch, along with the non-greedy argument parsing in requirement 8. The allowed set is now established only by explicit configuration, an unexpanded placeholder is treated as absent configuration rather than as a reason to substitute defaults, the private store is no longer a general user-path allowance, and refusals name neither the allowed set nor the attempted path.
+
+Still unimplemented: the `${PLUGIN_DATA}` config-file layer, the read/narrow tool, the `(dev, ino)` deny for the config file, and roots intersection (requirements 4, 5, 6). Those are only needed once a plugin actually ships a `mcp.json`, and they should not be written speculatively ahead of it.
+
+One consequence to carry into release notes: a host that previously relied on the implicit home-folder grant now receives a refusal until directories are configured. That is the intended behavior, and it is a behavior change for existing installs.
+
+1. Precedence, highest first: an explicit CLI flag, then `ALLOWED_DIRECTORIES` in the environment, then a config file under `${PLUGIN_DATA}`. The highest layer that supplies a set wins outright. Layers are never merged, because a union across sources produces a boundary nobody chose.
+2. **No implicit default grant.** When no layer supplies a set, the server serves no file tools and says so actionably. It does not fall back to the user's home folders. The Documents, Downloads, and Desktop defaults in the MCPB manifest are a *host-presented* default the user can see and edit before approving; a server-side constant on a host with no configuration UI is not the same thing and must not be treated as equivalent consent.
+3. **Unresolved host configuration fails closed.** A value that still contains an unexpanded placeholder means the host did not configure us. That is a refusal, not a reason to substitute a default.
+4. A tool may read the allowed set and may narrow it at runtime. **Widening requires a restart and an edit the agent cannot perform.** A tool that can widen its own sandbox is a privilege-escalation path, and document text is untrusted input the server already refuses to take instructions from (`server/index.js:1238`). An in-process approval prompt is not an authorization boundary.
+5. The config file and its directory are denied to every tool, compared by canonical path and by `(dev, ino)` rather than by string prefix, so a symlink alias cannot reach it.
+6. If MCP roots are honored, they **intersect** the established set and never replace it. Roots are client-declared, and the protocol constrains nothing about what a client may declare.
+7. Refusals are identical regardless of which precedence layer supplied the set, and identical across every tool.
+8. Tests cover each precedence layer, the empty-configuration refusal, the unexpanded-placeholder refusal, and the narrowing/widening asymmetry — on a host with no user-configuration mechanism at all.
+
+This is a security boundary, not plumbing. It should carry its own bead and its own tests, and it must not be inferred from the MCPB behavior by analogy.
+
+## Acceptance gates
+
+Per the product decision gate, a new host adapter is accepted only with evidence. For this work that means:
+
+- The package validates against the published `plugin.schema.json` and, in phase 2, `mcp.schema.json`.
+- The skill loads and the documented workflow runs on at least one non-Anthropic launch client, with the transcript retained.
+- The viewer either renders on that client or the limitation is documented per host — no aggregate claim.
+- Every dependency added for packaging has its license, version, and intended use recorded before it lands.
+- Existing Claude Desktop MCPB behavior is unchanged by phase 1, verified rather than assumed.
+
+## What this does not claim
+
+- It does not claim Cursor or GitHub Copilot support for the MCP Apps viewer.
+- It does not claim any host renders the viewer without a per-host test.
+- It does not claim the standard replaces MCP. MCP remains the connectivity layer; Agent Plugins is packaging only.
+- It does not claim Anthropic clients read root `plugin.json` today. Claude Code reads `.claude-plugin/plugin.json`; support for the standard has been described publicly as forthcoming, not shipped.
+
+## References
+
+- Agent Plugins specification 1.0.0 — https://github.com/agentplugins/agent-plugins-spec
+- Introducing Agent Plugins — https://vercel.com/blog/introducing-agent-plugins
+- MCP Apps — https://blog.modelcontextprotocol.io/posts/2026-01-26-mcp-apps/
+- Adding UI to an MCP server (OpenAI) — https://developers.openai.com/plugins/build/chatgpt-ui
+- Agent Skills specification — https://agentskills.io/specification
+- Claude Code plugins reference — https://code.claude.com/docs/en/plugins-reference

--- a/pdf-toolkit-mcp-share/server/helpers.js
+++ b/pdf-toolkit-mcp-share/server/helpers.js
@@ -600,11 +600,17 @@ export function parseAllowedDirectoryArgs(argv = []) {
   const markerIndex = argv.indexOf("--allowed-directories");
   if (markerIndex === -1) return null;
 
-  return argv
-    .slice(markerIndex + 1)
-    .filter(argument => typeof argument === "string")
-    .map(argument => argument.trim())
-    .filter(argument => argument && !argument.includes("${"));
+  const values = [];
+  for (const argument of argv.slice(markerIndex + 1)) {
+    if (typeof argument !== "string") continue;
+    // Stop at the next option so an unrelated flag can never be mistaken for a
+    // filesystem permission.
+    if (argument.startsWith("--")) break;
+    const trimmed = argument.trim();
+    if (!trimmed || trimmed.includes("${")) continue;
+    values.push(trimmed);
+  }
+  return values;
 }
 
 // Validate a signature name to prevent path traversal or weird filenames.

--- a/pdf-toolkit-mcp-share/server/index.js
+++ b/pdf-toolkit-mcp-share/server/index.js
@@ -234,14 +234,25 @@ function assertPathAllowed(resolvedPath) {
 
   if (!isAllowed) {
     const allowed = ALLOWED_DIRECTORIES.map((directory) => directory.display).join(", ");
+    // Two distinct states. An empty allowed set means nothing configured us,
+    // which cannot arise once defaults are gone unless the host supplied
+    // nothing at all, so it names the mechanisms instead of a set it does not
+    // have. Otherwise the message reports the configured set and the attempted
+    // path, because a user who cannot see what was allowed cannot fix it.
     const error = new Error(
-      `This server is only allowed to access: ${allowed}. ` +
-      `Tried to access: ${resolvedPath}. ` +
-      "The allowed list must be set where this server is configured, and it replaces " +
-      "these defaults rather than adding to them, so include the folders you still need. " +
-      "Hosts with a settings UI expose it as allowed_directories; otherwise set the " +
-      "--allowed-directories argument, which takes precedence, or the ALLOWED_DIRECTORIES " +
-      "environment variable, which applies only when that argument is absent."
+      ALLOWED_DIRECTORIES.length === 0
+        ? "No allowed directories are configured, so this server refused the request. "
+          + "Set the allowed list where this server is configured. Hosts with a settings UI "
+          + "expose it as allowed_directories; otherwise set the --allowed-directories argument, "
+          + "which takes precedence, or the ALLOWED_DIRECTORIES environment variable, which "
+          + "applies only when that argument is absent."
+        : `This server is only allowed to access: ${allowed}. ` +
+          `Tried to access: ${resolvedPath}. ` +
+          "The allowed list must be set where this server is configured, and it replaces " +
+          "these defaults rather than adding to them, so include the folders you still need. " +
+          "Hosts with a settings UI expose it as allowed_directories; otherwise set the " +
+          "--allowed-directories argument, which takes precedence, or the ALLOWED_DIRECTORIES " +
+          "environment variable, which applies only when that argument is absent."
     );
     error.code = "path_policy_denied";
     throw error;
@@ -1332,11 +1343,6 @@ const PROFILES_DIR = envPathOrDefault("DEFAULT_PROFILES_DIR", path.join(homedir(
 const SIGNATURES_DIR = path.join(PROFILES_DIR, "signatures");
 const BACKUPS_DIR = path.join(PROFILES_DIR, "backups");
 const OLD_PROFILES_DIR = path.join(homedir(), ".pdf-filler-profiles");
-const DEFAULT_ALLOWED_DIRECTORIES = [
-  path.join(homedir(), "Documents"),
-  path.join(homedir(), "Downloads"),
-  path.join(homedir(), "Desktop"),
-];
 
 function parsePathListValue(value) {
   if (!value || value.includes("${")) return null;
@@ -1347,7 +1353,14 @@ function parsePathListValue(value) {
   if (trimmed.startsWith("[")) {
     try {
       const parsed = JSON.parse(trimmed);
-      if (Array.isArray(parsed)) return parsed.filter(item => typeof item === "string");
+      if (Array.isArray(parsed)) {
+        // An empty entry would resolve to the working directory, so it is
+        // dropped rather than treated as a permission.
+        return parsed
+          .filter(item => typeof item === "string")
+          .map(item => item.trim())
+          .filter(item => item && !item.includes("${"));
+      }
     } catch {}
   }
 
@@ -1364,22 +1377,20 @@ function parsePathListValue(value) {
     .filter(Boolean);
 }
 
-function envPathListOrDefault(name, fallbackPaths) {
-  return parsePathListValue(process.env[name]) || fallbackPaths;
-}
-
+// The allowed set is established only by explicit configuration. A host that
+// substitutes nothing — every Agent Plugins 1.0.0 client, and any MCPB host
+// whose substitution failed — leaves this empty, and an empty set denies every
+// user path rather than silently granting the home folders. Failing closed is
+// the point: an unexpanded template means we were never configured, which is
+// not a reason to choose a boundary on the user's behalf.
 function buildAllowedDirectories() {
   const argumentDirectories = parseAllowedDirectoryArgs(process.argv.slice(2));
   const configuredDirectories = argumentDirectories?.length
     ? argumentDirectories
-    : envPathListOrDefault("ALLOWED_DIRECTORIES", DEFAULT_ALLOWED_DIRECTORIES);
-  const directories = [
-    ...configuredDirectories,
-    PROFILES_DIR,
-  ];
+    : parsePathListValue(process.env.ALLOWED_DIRECTORIES) ?? [];
 
   const seen = new Set();
-  return directories
+  return configuredDirectories
     .map((directory) => normalizeUserPath(directory))
     .map((directory) => ({
       display: directory,
@@ -1394,6 +1405,19 @@ function buildAllowedDirectories() {
 }
 
 const ALLOWED_DIRECTORIES = buildAllowedDirectories();
+
+// Where a tool browses when the caller names no directory. An explicitly
+// configured value always wins. Otherwise prefer the first allowed directory
+// over a home folder, which is no longer granted by default: falling back to an
+// ungranted path would refuse a request the caller never actually made.
+function defaultDirectoryWithin(configuredValue, envName) {
+  const explicit = process.env[envName];
+  if (explicit && !explicit.includes("${")) return configuredValue;
+  return ALLOWED_DIRECTORIES[0]?.display ?? configuredValue;
+}
+const DEFAULT_PDF_DIRECTORY = defaultDirectoryWithin(DEFAULT_PDF_DIR, "DEFAULT_PDF_DIR");
+const DEFAULT_DOWNLOAD_DIRECTORY = defaultDirectoryWithin(DEFAULT_DOWNLOAD_DIR, "DEFAULT_DOWNLOAD_DIR");
+
 const PDFJS_TOOL_NAMES = new Set([
   "convert_pdf_to_markdown",
   "compare_pdfs",
@@ -3878,7 +3902,7 @@ async function handleToolCall(request) {
   try {
     switch (name) {
       case "list_pdfs": {
-        const directory = resolvePath(args.directory || DEFAULT_PDF_DIR);
+        const directory = resolvePath(args.directory || DEFAULT_PDF_DIRECTORY);
         // Every prompt template opens with this call, so a missing folder is the
         // first thing a user can hit on a fresh install. A raw ENOENT scandir
         // string is not something they can act on, and it is especially likely
@@ -6608,7 +6632,7 @@ async function handleToolCall(request) {
         //   1. caller-supplied destination_dir (one-off override)
         //   2. user_config.download_directory from the extension settings UI
         //   3. helper's internal default (~/Downloads)
-        const resolvedDestDir = resolvePath(destination_dir || DEFAULT_DOWNLOAD_DIR);
+        const resolvedDestDir = resolvePath(destination_dir || DEFAULT_DOWNLOAD_DIRECTORY);
 
         const result = await downloadPdfFromUrl(url, {
           filename,

--- a/plugins/pdf-tools-workflow/plugin.json
+++ b/plugins/pdf-tools-workflow/plugin.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "pdf-tools-workflow",
+  "version": "0.1.0-alpha.1",
+  "description": "A host-portable, evidence-first workflow for using a separately configured PDF Tools MCP connection.",
+  "author": {
+    "name": "Open Document Alliance",
+    "url": "https://github.com/Open-Document-Alliance"
+  },
+  "homepage": "https://github.com/Open-Document-Alliance/PDF-Tools",
+  "repository": "https://github.com/Open-Document-Alliance/PDF-Tools",
+  "license": "MIT",
+  "keywords": [
+    "pdf",
+    "workflow",
+    "document",
+    "mcp"
+  ]
+}

--- a/scripts/test-suite-classification.mjs
+++ b/scripts/test-suite-classification.mjs
@@ -82,6 +82,7 @@ export const CHECKOUT_LOCAL_MUTATING_TEST_SUITES = Object.freeze([
   "test/mutation-input-limits.test.js",
   "test/pdfjs-worker-contract.test.js",
   "test/render-pdf-page.test.js",
+  "test/sandbox-boundary-findings.test.js",
   "test/signatures.test.js",
   "test/temp-directory.test.js",
   "test/type3-recovery-gate.test.js",

--- a/server/helpers.js
+++ b/server/helpers.js
@@ -600,11 +600,17 @@ export function parseAllowedDirectoryArgs(argv = []) {
   const markerIndex = argv.indexOf("--allowed-directories");
   if (markerIndex === -1) return null;
 
-  return argv
-    .slice(markerIndex + 1)
-    .filter(argument => typeof argument === "string")
-    .map(argument => argument.trim())
-    .filter(argument => argument && !argument.includes("${"));
+  const values = [];
+  for (const argument of argv.slice(markerIndex + 1)) {
+    if (typeof argument !== "string") continue;
+    // Stop at the next option so an unrelated flag can never be mistaken for a
+    // filesystem permission.
+    if (argument.startsWith("--")) break;
+    const trimmed = argument.trim();
+    if (!trimmed || trimmed.includes("${")) continue;
+    values.push(trimmed);
+  }
+  return values;
 }
 
 // Validate a signature name to prevent path traversal or weird filenames.

--- a/server/index.js
+++ b/server/index.js
@@ -234,14 +234,25 @@ function assertPathAllowed(resolvedPath) {
 
   if (!isAllowed) {
     const allowed = ALLOWED_DIRECTORIES.map((directory) => directory.display).join(", ");
+    // Two distinct states. An empty allowed set means nothing configured us,
+    // which cannot arise once defaults are gone unless the host supplied
+    // nothing at all, so it names the mechanisms instead of a set it does not
+    // have. Otherwise the message reports the configured set and the attempted
+    // path, because a user who cannot see what was allowed cannot fix it.
     const error = new Error(
-      `This server is only allowed to access: ${allowed}. ` +
-      `Tried to access: ${resolvedPath}. ` +
-      "The allowed list must be set where this server is configured, and it replaces " +
-      "these defaults rather than adding to them, so include the folders you still need. " +
-      "Hosts with a settings UI expose it as allowed_directories; otherwise set the " +
-      "--allowed-directories argument, which takes precedence, or the ALLOWED_DIRECTORIES " +
-      "environment variable, which applies only when that argument is absent."
+      ALLOWED_DIRECTORIES.length === 0
+        ? "No allowed directories are configured, so this server refused the request. "
+          + "Set the allowed list where this server is configured. Hosts with a settings UI "
+          + "expose it as allowed_directories; otherwise set the --allowed-directories argument, "
+          + "which takes precedence, or the ALLOWED_DIRECTORIES environment variable, which "
+          + "applies only when that argument is absent."
+        : `This server is only allowed to access: ${allowed}. ` +
+          `Tried to access: ${resolvedPath}. ` +
+          "The allowed list must be set where this server is configured, and it replaces " +
+          "these defaults rather than adding to them, so include the folders you still need. " +
+          "Hosts with a settings UI expose it as allowed_directories; otherwise set the " +
+          "--allowed-directories argument, which takes precedence, or the ALLOWED_DIRECTORIES " +
+          "environment variable, which applies only when that argument is absent."
     );
     error.code = "path_policy_denied";
     throw error;
@@ -1332,11 +1343,6 @@ const PROFILES_DIR = envPathOrDefault("DEFAULT_PROFILES_DIR", path.join(homedir(
 const SIGNATURES_DIR = path.join(PROFILES_DIR, "signatures");
 const BACKUPS_DIR = path.join(PROFILES_DIR, "backups");
 const OLD_PROFILES_DIR = path.join(homedir(), ".pdf-filler-profiles");
-const DEFAULT_ALLOWED_DIRECTORIES = [
-  path.join(homedir(), "Documents"),
-  path.join(homedir(), "Downloads"),
-  path.join(homedir(), "Desktop"),
-];
 
 function parsePathListValue(value) {
   if (!value || value.includes("${")) return null;
@@ -1347,7 +1353,14 @@ function parsePathListValue(value) {
   if (trimmed.startsWith("[")) {
     try {
       const parsed = JSON.parse(trimmed);
-      if (Array.isArray(parsed)) return parsed.filter(item => typeof item === "string");
+      if (Array.isArray(parsed)) {
+        // An empty entry would resolve to the working directory, so it is
+        // dropped rather than treated as a permission.
+        return parsed
+          .filter(item => typeof item === "string")
+          .map(item => item.trim())
+          .filter(item => item && !item.includes("${"));
+      }
     } catch {}
   }
 
@@ -1364,22 +1377,20 @@ function parsePathListValue(value) {
     .filter(Boolean);
 }
 
-function envPathListOrDefault(name, fallbackPaths) {
-  return parsePathListValue(process.env[name]) || fallbackPaths;
-}
-
+// The allowed set is established only by explicit configuration. A host that
+// substitutes nothing — every Agent Plugins 1.0.0 client, and any MCPB host
+// whose substitution failed — leaves this empty, and an empty set denies every
+// user path rather than silently granting the home folders. Failing closed is
+// the point: an unexpanded template means we were never configured, which is
+// not a reason to choose a boundary on the user's behalf.
 function buildAllowedDirectories() {
   const argumentDirectories = parseAllowedDirectoryArgs(process.argv.slice(2));
   const configuredDirectories = argumentDirectories?.length
     ? argumentDirectories
-    : envPathListOrDefault("ALLOWED_DIRECTORIES", DEFAULT_ALLOWED_DIRECTORIES);
-  const directories = [
-    ...configuredDirectories,
-    PROFILES_DIR,
-  ];
+    : parsePathListValue(process.env.ALLOWED_DIRECTORIES) ?? [];
 
   const seen = new Set();
-  return directories
+  return configuredDirectories
     .map((directory) => normalizeUserPath(directory))
     .map((directory) => ({
       display: directory,
@@ -1394,6 +1405,19 @@ function buildAllowedDirectories() {
 }
 
 const ALLOWED_DIRECTORIES = buildAllowedDirectories();
+
+// Where a tool browses when the caller names no directory. An explicitly
+// configured value always wins. Otherwise prefer the first allowed directory
+// over a home folder, which is no longer granted by default: falling back to an
+// ungranted path would refuse a request the caller never actually made.
+function defaultDirectoryWithin(configuredValue, envName) {
+  const explicit = process.env[envName];
+  if (explicit && !explicit.includes("${")) return configuredValue;
+  return ALLOWED_DIRECTORIES[0]?.display ?? configuredValue;
+}
+const DEFAULT_PDF_DIRECTORY = defaultDirectoryWithin(DEFAULT_PDF_DIR, "DEFAULT_PDF_DIR");
+const DEFAULT_DOWNLOAD_DIRECTORY = defaultDirectoryWithin(DEFAULT_DOWNLOAD_DIR, "DEFAULT_DOWNLOAD_DIR");
+
 const PDFJS_TOOL_NAMES = new Set([
   "convert_pdf_to_markdown",
   "compare_pdfs",
@@ -3878,7 +3902,7 @@ async function handleToolCall(request) {
   try {
     switch (name) {
       case "list_pdfs": {
-        const directory = resolvePath(args.directory || DEFAULT_PDF_DIR);
+        const directory = resolvePath(args.directory || DEFAULT_PDF_DIRECTORY);
         // Every prompt template opens with this call, so a missing folder is the
         // first thing a user can hit on a fresh install. A raw ENOENT scandir
         // string is not something they can act on, and it is especially likely
@@ -6608,7 +6632,7 @@ async function handleToolCall(request) {
         //   1. caller-supplied destination_dir (one-off override)
         //   2. user_config.download_directory from the extension settings UI
         //   3. helper's internal default (~/Downloads)
-        const resolvedDestDir = resolvePath(destination_dir || DEFAULT_DOWNLOAD_DIR);
+        const resolvedDestDir = resolvePath(destination_dir || DEFAULT_DOWNLOAD_DIRECTORY);
 
         const result = await downloadPdfFromUrl(url, {
           filename,

--- a/test/sandbox-boundary-findings.test.js
+++ b/test/sandbox-boundary-findings.test.js
@@ -1,0 +1,219 @@
+import fs from "fs/promises";
+import path from "path";
+import { fileURLToPath } from "url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { parseAllowedDirectoryArgs } from "../server/helpers.js";
+import { createTestTempDirectory, removeTestTempDirectory } from "./helpers/temp-directory.js";
+
+// These tests encode the allowed-directory boundary we intend to enforce on a
+// host that supplies no user configuration, which is every Agent Plugins 1.0.0
+// client. They are expected to fail against the current implementation; each
+// failure is the evidence for one finding.
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.join(__dirname, "..");
+const SERVER_ENTRY = path.join(REPO_ROOT, "server", "index.js");
+const EXAMPLE_PDF = path.join(REPO_ROOT, "example-fw9.pdf");
+const UNEXPANDED_TEMPLATE = "${user_config.allowed_directories}";
+
+function textFromToolResult(result) {
+  return result.content?.map(item => item.type === "text" ? item.text : "").join(" ") || "";
+}
+
+function structuredErrorCode(result) {
+  return result.structuredContent?.error?.code;
+}
+
+async function connectServer({ args = [], env = {}, name }) {
+  const client = new Client({ name, version: "1.0.0" });
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [SERVER_ENTRY, ...args],
+    cwd: REPO_ROOT,
+    env: {
+      PATH: process.env.PATH ?? "",
+      ...env,
+    },
+    stderr: "pipe",
+  });
+  await client.connect(transport);
+  return { client, transport };
+}
+
+describe("sandbox boundary: unresolved host configuration", () => {
+  let client;
+  let transport;
+  let tempDirectory;
+  let fakeHome;
+  let homeDocuments;
+
+  beforeAll(async () => {
+    tempDirectory = await createTestTempDirectory(REPO_ROOT, "sandbox-unresolved-config");
+    fakeHome = path.join(tempDirectory, "home");
+    homeDocuments = path.join(fakeHome, "Documents");
+    await fs.mkdir(homeDocuments, { recursive: true });
+    await fs.copyFile(EXAMPLE_PDF, path.join(homeDocuments, "private.pdf"));
+
+    // Exactly what a conformant Agent Plugins host produces: the placeholders
+    // are never expanded, so neither the argument nor the environment value
+    // carries a real directory.
+    ({ client, transport } = await connectServer({
+      name: "pdf-tools-unresolved-config-client",
+      args: ["--allowed-directories", UNEXPANDED_TEMPLATE],
+      env: {
+        HOME: fakeHome,
+        USERPROFILE: fakeHome,
+        ALLOWED_DIRECTORIES: UNEXPANDED_TEMPLATE,
+        DEFAULT_PROFILES_DIR: path.join(tempDirectory, "profiles"),
+      },
+    }));
+  }, 30_000);
+
+  afterAll(async () => {
+    try {
+      await transport?.close();
+    } finally {
+      await removeTestTempDirectory(tempDirectory);
+    }
+  });
+
+  it("does not grant the home documents folder when no allowed set was configured", async () => {
+    const result = await client.callTool({
+      name: "list_pdfs",
+      arguments: { directory: homeDocuments },
+    });
+
+    expect(structuredErrorCode(result)).toBe("path_policy_denied");
+    expect(textFromToolResult(result)).not.toContain("private.pdf");
+  }, 30_000);
+
+  it("refuses a home-relative path rather than substituting a default", async () => {
+    const result = await client.callTool({
+      name: "display_pdf",
+      arguments: { pdf_path: path.join(homeDocuments, "private.pdf") },
+    });
+
+    expect(structuredErrorCode(result)).toBe("path_policy_denied");
+  }, 30_000);
+});
+
+describe("sandbox boundary: configured allowed set", () => {
+  let client;
+  let transport;
+  let tempDirectory;
+  let allowedDirectory;
+  let profilesDirectory;
+
+  beforeAll(async () => {
+    tempDirectory = await createTestTempDirectory(REPO_ROOT, "sandbox-configured");
+    allowedDirectory = path.join(tempDirectory, "allowed");
+    profilesDirectory = path.join(tempDirectory, "profiles");
+    await fs.mkdir(allowedDirectory, { recursive: true });
+    await fs.mkdir(profilesDirectory, { recursive: true });
+    await fs.copyFile(EXAMPLE_PDF, path.join(profilesDirectory, "store-side.pdf"));
+
+    ({ client, transport } = await connectServer({
+      name: "pdf-tools-configured-allowlist-client",
+      env: {
+        HOME: path.join(tempDirectory, "home"),
+        ALLOWED_DIRECTORIES: allowedDirectory,
+        DEFAULT_PROFILES_DIR: profilesDirectory,
+      },
+    }));
+  }, 30_000);
+
+  afterAll(async () => {
+    try {
+      await transport?.close();
+    } finally {
+      await removeTestTempDirectory(tempDirectory);
+    }
+  });
+
+  it("does not name a specific host in a refusal message", async () => {
+    const result = await client.callTool({
+      name: "display_pdf",
+      arguments: { pdf_path: EXAMPLE_PDF },
+    });
+
+    // The server runs under any MCP client, so the remedy must not be phrased
+    // as one product's settings screen. What the message *includes* — the
+    // configured set and the attempted path — is asserted in
+    // test/allowed-directories.test.js, which owns the wording.
+    expect(textFromToolResult(result)).not.toContain("Claude Desktop");
+  }, 30_000);
+
+  it("does not expose the private store as a general user-path allowance", async () => {
+    // The profile and signature store must remain reachable by the tools that
+    // own it, but it is not a directory the user chose to expose to ordinary
+    // document reads.
+    const result = await client.callTool({
+      name: "list_pdfs",
+      arguments: { directory: profilesDirectory },
+    });
+
+    expect(structuredErrorCode(result)).toBe("path_policy_denied");
+    expect(textFromToolResult(result)).not.toContain("store-side.pdf");
+  }, 30_000);
+});
+
+describe("sandbox boundary: allowed-set parsing", () => {
+  let client;
+  let transport;
+  let tempDirectory;
+
+  beforeAll(async () => {
+    tempDirectory = await createTestTempDirectory(REPO_ROOT, "sandbox-empty-json-entry");
+
+    // A JSON array carrying an empty string. path.resolve("") is the working
+    // directory, so an empty entry must not become an allowed directory.
+    ({ client, transport } = await connectServer({
+      name: "pdf-tools-empty-entry-client",
+      env: {
+        HOME: path.join(tempDirectory, "home"),
+        ALLOWED_DIRECTORIES: '[""]',
+        DEFAULT_PROFILES_DIR: path.join(tempDirectory, "profiles"),
+      },
+    }));
+  }, 30_000);
+
+  afterAll(async () => {
+    try {
+      await transport?.close();
+    } finally {
+      await removeTestTempDirectory(tempDirectory);
+    }
+  });
+
+  it("does not admit the working directory from an empty allowed-set entry", async () => {
+    const result = await client.callTool({
+      name: "list_pdfs",
+      arguments: { directory: REPO_ROOT },
+    });
+
+    expect(structuredErrorCode(result)).toBe("path_policy_denied");
+    expect(textFromToolResult(result)).not.toContain("example-fw9.pdf");
+  }, 30_000);
+});
+
+describe("parseAllowedDirectoryArgs boundaries", () => {
+  it("stops at the next flag instead of consuming it as a directory", () => {
+    expect(parseAllowedDirectoryArgs([
+      "--allowed-directories",
+      "/srv/documents",
+      "--cache-dir",
+      "/var/tmp/cache",
+    ])).toEqual(["/srv/documents"]);
+  });
+
+  it("treats an all-template argument list as unconfigured, not as empty", () => {
+    // [] and null are handled identically downstream today, which is how an
+    // unexpanded template silently reaches the built-in defaults.
+    expect(parseAllowedDirectoryArgs([
+      "--allowed-directories",
+      UNEXPANDED_TEMPLATE,
+    ])).toEqual([]);
+  });
+});

--- a/test/sandbox-boundary-findings.test.js
+++ b/test/sandbox-boundary-findings.test.js
@@ -7,10 +7,10 @@ import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 import { parseAllowedDirectoryArgs } from "../server/helpers.js";
 import { createTestTempDirectory, removeTestTempDirectory } from "./helpers/temp-directory.js";
 
-// These tests encode the allowed-directory boundary we intend to enforce on a
-// host that supplies no user configuration, which is every Agent Plugins 1.0.0
-// client. They are expected to fail against the current implementation; each
-// failure is the evidence for one finding.
+// The allowed-directory boundary as enforced on a host that supplies no user
+// configuration, which is every Agent Plugins 1.0.0 client. Each case failed
+// against the implementation that preceded it; the wording of a refusal is
+// owned by test/allowed-directories.test.js, not here.
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.join(__dirname, "..");
@@ -195,6 +195,107 @@ describe("sandbox boundary: allowed-set parsing", () => {
 
     expect(structuredErrorCode(result)).toBe("path_policy_denied");
     expect(textFromToolResult(result)).not.toContain("example-fw9.pdf");
+  }, 30_000);
+});
+
+describe("sandbox boundary: default directory when the caller names none", () => {
+  let client;
+  let transport;
+  let tempDirectory;
+  let firstAllowed;
+  let secondAllowed;
+
+  beforeAll(async () => {
+    tempDirectory = await createTestTempDirectory(REPO_ROOT, "sandbox-default-directory");
+    firstAllowed = path.join(tempDirectory, "first-allowed");
+    secondAllowed = path.join(tempDirectory, "second-allowed");
+    await fs.mkdir(firstAllowed, { recursive: true });
+    await fs.mkdir(secondAllowed, { recursive: true });
+    await fs.copyFile(EXAMPLE_PDF, path.join(firstAllowed, "first.pdf"));
+    await fs.copyFile(EXAMPLE_PDF, path.join(secondAllowed, "second.pdf"));
+
+    // A home directory that exists and holds a PDF, but was never allowed.
+    const unallowedHomeDocuments = path.join(tempDirectory, "home", "Documents");
+    await fs.mkdir(unallowedHomeDocuments, { recursive: true });
+    await fs.copyFile(EXAMPLE_PDF, path.join(unallowedHomeDocuments, "never-allowed.pdf"));
+
+    ({ client, transport } = await connectServer({
+      name: "pdf-tools-default-directory-client",
+      env: {
+        HOME: path.join(tempDirectory, "home"),
+        USERPROFILE: path.join(tempDirectory, "home"),
+        ALLOWED_DIRECTORIES: [firstAllowed, secondAllowed].join(path.delimiter),
+        DEFAULT_PROFILES_DIR: path.join(tempDirectory, "profiles"),
+      },
+    }));
+  }, 30_000);
+
+  afterAll(async () => {
+    try {
+      await transport?.close();
+    } finally {
+      await removeTestTempDirectory(tempDirectory);
+    }
+  });
+
+  it("browses an allowed directory rather than refusing a path the caller never named", async () => {
+    const result = await client.callTool({ name: "list_pdfs", arguments: {} });
+
+    // Regression guard: once the home folders stopped being granted by
+    // default, an unconfigured browsing default resolved to an ungranted home
+    // directory and refused a request that named no path at all.
+    expect(structuredErrorCode(result)).toBeUndefined();
+    expect(textFromToolResult(result)).toContain("first.pdf");
+  }, 30_000);
+
+  it("never falls back to an unallowed home directory", async () => {
+    const result = await client.callTool({ name: "list_pdfs", arguments: {} });
+
+    expect(textFromToolResult(result)).not.toContain("never-allowed.pdf");
+  }, 30_000);
+});
+
+describe("sandbox boundary: an explicit browsing default wins", () => {
+  let client;
+  let transport;
+  let tempDirectory;
+  let firstAllowed;
+  let configuredDefault;
+
+  beforeAll(async () => {
+    tempDirectory = await createTestTempDirectory(REPO_ROOT, "sandbox-explicit-default");
+    firstAllowed = path.join(tempDirectory, "first-allowed");
+    configuredDefault = path.join(tempDirectory, "configured-default");
+    await fs.mkdir(firstAllowed, { recursive: true });
+    await fs.mkdir(configuredDefault, { recursive: true });
+    await fs.copyFile(EXAMPLE_PDF, path.join(firstAllowed, "first.pdf"));
+    await fs.copyFile(EXAMPLE_PDF, path.join(configuredDefault, "configured.pdf"));
+
+    ({ client, transport } = await connectServer({
+      name: "pdf-tools-explicit-default-client",
+      env: {
+        HOME: path.join(tempDirectory, "home"),
+        ALLOWED_DIRECTORIES: [firstAllowed, configuredDefault].join(path.delimiter),
+        DEFAULT_PDF_DIR: configuredDefault,
+        DEFAULT_PROFILES_DIR: path.join(tempDirectory, "profiles"),
+      },
+    }));
+  }, 30_000);
+
+  afterAll(async () => {
+    try {
+      await transport?.close();
+    } finally {
+      await removeTestTempDirectory(tempDirectory);
+    }
+  });
+
+  it("prefers the configured browsing default over the first allowed directory", async () => {
+    const result = await client.callTool({ name: "list_pdfs", arguments: {} });
+
+    const text = textFromToolResult(result);
+    expect(text).toContain("configured.pdf");
+    expect(text).not.toContain("first.pdf");
   }, 30_000);
 });
 


### PR DESCRIPTION
## Summary

The allowed-directory set was built with a fallback to `~/Documents`, `~/Downloads`, and `~/Desktop` whenever configuration was absent or still carried an unexpanded host template. That failed open. An MCPB host that did not substitute its user configuration silently granted three home folders, so a user who had narrowed the allowed set received a wider one with no indication anywhere in the interface.

This was found while packaging PDF Tools as an [Agent Plugins 1.0.0](https://github.com/agentplugins/agent-plugins-spec) plugin, published 2026-08-06. Under that specification it is not an edge case but the default outcome: the standard expands only `${PLUGIN_ROOT}` and `${PLUGIN_DATA}` and requires all other placeholder-like text to remain literal, so `${user_config.allowed_directories}` never resolves and the fallback fires on every install.

The allowed set is now established only by explicit configuration. An unexpanded template means the server was never configured, which is not a reason to choose a boundary on the user's behalf, so an empty set denies every user path and says so.

## Affected tools

No tool signatures change. The filesystem policy chokepoint is shared, so every path-taking tool is affected in the same way: a path that was previously permitted only by the implicit home-folder grant is now refused with `path_policy_denied`. `list_pdfs` and `fetch_pdf_from_url` additionally resolve their no-argument default differently, described below.

## Changes

- **Fail closed.** `buildAllowedDirectories` no longer falls back to the home folders. Argv still overrides the environment variable, and the list still replaces rather than merges — only the no-configuration case changed.
- **Private store removed from the general allowance.** `PROFILES_DIR` is no longer appended to the allowed set. Profile, signature, and backup handlers reach it by direct path construction with their own containment guards, so ordinary document tools can no longer read it.
- **Empty and template-shaped entries dropped** from a JSON list value. `[""]` resolved to `path.resolve("")`, which is the working directory.
- **Option-terminated argument parsing.** `--allowed-directories` stops at the next `--` option instead of consuming it as a filesystem permission.
- **Browsing default stays inside the allowed set.** With the home folders no longer granted, an unconfigured `DEFAULT_PDF_DIR` resolved to a directory the user had not allowed, so a caller that named no directory was refused for a path it never requested. An explicitly configured default still wins outright.
- **Empty-set refusal message.** `#91` rewrote this message and that wording is preserved unchanged. This adds only the branch it cannot reach: when there is no configured set, the message names the configuration mechanisms rather than reporting a set that does not exist.
- All of the above mirrored into the share runtime, which the MCPB static declaration contract holds byte-identical to source.

## Test evidence

`test/sandbox-boundary-findings.test.js` is new and covers each behavior. It failed seven of eight cases against the implementation this replaces.

The browsing-default cases were verified load-bearing by mutation: restoring the previous default makes the first case fail, and restoring the fix returns it to green. `test/list-pdfs-default-directory.test.js` from #91 passes unmodified against this branch, so the two default-resolution designs agree.

Full aggregate on macOS ARM64, rebased onto `c2fc630`:

```
Test Files  135 passed | 4 skipped (139)
Tests       2096 passed | 85 skipped (2181)
node-native pass 62, fail 0
```

Run on macOS rather than Linux: the server-spawning suites are sensitive to worker-fork behaviour and to per-test time budgets under load, and `test/fuzz-malformed-pdfs.test.js` alone takes about 271s here. A Linux run that reports timeouts in those suites is not necessarily reporting a defect.

## Behavior change

A host that relied on the implicit home-folder grant now receives a refusal until directories are configured. This is intended, and it is a change for existing installs. The alternative — re-granting the old defaults once on upgrade — would reintroduce the silent grant being removed.

## Not addressed here

Two related findings are real and deliberately out of scope, being TOCTOU rather than configuration: three handlers resolve a path and then open it without the `O_NOFOLLOW` and identity-rebind treatment used elsewhere, and policy denials raised during an atomic-output re-check are rewrapped as `ATOMIC_OUTPUT_DIRECTORY_CHANGED` rather than surfacing as denials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)