### PR TITLE
Bind three path handlers to the file the policy check accepted

### DIFF
--- a/docs/MCP_CONTRACT.md
+++ b/docs/MCP_CONTRACT.md
@@ -278,7 +278,11 @@ the `text/html;profile=mcp-app` media type.
 PDF file resources are dynamic and therefore are not included in
 `resources/list`. `get_pdf_resource_uri` applies the filesystem allowlist, then
 encodes the absolute platform path as one percent-encoded segment under the
-canonical `pdf://local/` authority. The symmetric decoder handles POSIX,
+canonical `pdf://local/` authority. The encoded path is the canonical one, and
+`pdf_path` reports the same value, so a URI that outlives the call still names
+the file the allowlist accepted rather than a name that can be repointed before
+`resources/read` runs. Where the requested path traverses a symlink the two
+differ: on macOS a temp root under `/var` reports `/private/var`. The symmetric decoder handles POSIX,
 Windows-drive, UNC, Unicode, and RFC 3986 reserved characters without allowing
 URI query/fragment ambiguity. `resources/read` re-applies the allowlist before
 returning the PDF as an `application/pdf` blob. Schema-valid string URIs that

--- a/pdf-toolkit-mcp-share/server/helpers.js
+++ b/pdf-toolkit-mcp-share/server/helpers.js
@@ -1668,6 +1668,10 @@ async function bindAtomicOutputDirectory(
     };
   } catch (error) {
     if (error?.code === "ATOMIC_OUTPUT_DIRECTORY_CHANGED") throw error;
+    // A refusal is not a race. Rewrapping it as a directory change would tell
+    // the caller to retry an operation the policy will never allow, and would
+    // hide the real reason it stopped.
+    if (error?.code === "path_policy_denied") throw error;
     throw atomicOutputDirectoryChangedError(error);
   }
 }
@@ -1703,6 +1707,10 @@ async function assertAtomicOutputDirectory(binding, assertPathAllowed, fileSyste
     await assertPathAllowed(canonicalAfter);
   } catch (error) {
     if (error?.code === "ATOMIC_OUTPUT_DIRECTORY_CHANGED") throw error;
+    // A refusal is not a race. Rewrapping it as a directory change would tell
+    // the caller to retry an operation the policy will never allow, and would
+    // hide the real reason it stopped.
+    if (error?.code === "path_policy_denied") throw error;
     throw atomicOutputDirectoryChangedError(error);
   }
 }

--- a/pdf-toolkit-mcp-share/server/index.js
+++ b/pdf-toolkit-mcp-share/server/index.js
@@ -267,6 +267,46 @@ function resolvePath(inputPath) {
   return assertPathAllowed(normalizeUserPath(inputPath));
 }
 
+// resolvePath returns the caller's path, not the file the policy check accepted,
+// so a handler that opens that string can be sent somewhere else by a symlink
+// swapped in afterwards. This returns the canonical path instead, which names
+// one file and cannot be repointed by replacing a link. Use it wherever the
+// resolved path is then handed to the filesystem or to another process.
+function resolveCanonicalPath(inputPath) {
+  if (!inputPath) return inputPath;
+  const canonicalPath = canonicalizePathForPolicy(normalizeUserPath(inputPath));
+  assertPathAllowed(canonicalPath);
+  return canonicalPath;
+}
+
+const NOFOLLOW_READ_FLAGS = fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW ?? 0);
+
+// Open a canonical path for reading and prove the descriptor is the same
+// regular file that was inspected a moment earlier. O_NOFOLLOW refuses a final
+// component that became a symlink after canonicalization; the identity compare
+// catches a replacement that reused the name. Callers own closing the handle.
+async function openCanonicalRegularFile(canonicalPath) {
+  const beforeStat = await fs.lstat(canonicalPath);
+  if (beforeStat.isSymbolicLink() || !beforeStat.isFile()) {
+    throw new Error(`Not a regular file: ${path.basename(canonicalPath)}`);
+  }
+  const handle = await fs.open(canonicalPath, NOFOLLOW_READ_FLAGS);
+  try {
+    const descriptorStat = await handle.stat();
+    if (
+      !descriptorStat.isFile()
+      || descriptorStat.dev !== beforeStat.dev
+      || descriptorStat.ino !== beforeStat.ino
+    ) {
+      throw new Error("The file changed while it was being opened. Retry the request.");
+    }
+    return { handle, stat: descriptorStat };
+  } catch (error) {
+    await handle.close().catch(() => {});
+    throw error;
+  }
+}
+
 async function bindOutputPathForTransaction(outputPath) {
   const parentPath = await fs.realpath(path.dirname(outputPath));
   assertPathAllowed(parentPath);
@@ -5231,14 +5271,15 @@ async function handleToolCall(request) {
 
       case "get_pdf_resource_uri": {
         const { pdf_path } = args;
-        const resolvedPath = resolvePath(pdf_path);
-        
+        // A resource URI outlives this call, so it must name the file that was
+        // checked rather than a link that can be repointed before it is read.
+        const resolvedPath = resolveCanonicalPath(pdf_path);
+
         try {
-          // Verify the file exists
-          await fs.access(resolvedPath);
-          
-          // Get file info
-          const stats = await fs.stat(resolvedPath);
+          const stats = await fs.lstat(resolvedPath);
+          if (stats.isSymbolicLink() || !stats.isFile()) {
+            throw new Error(`Not a regular file: ${path.basename(resolvedPath)}`);
+          }
           const fileName = path.basename(resolvedPath);
           const fileSizeKB = (stats.size / 1024).toFixed(2);
           
@@ -5461,18 +5502,19 @@ async function handleToolCall(request) {
 
       case "read_pdf_bytes": {
         const { pdf_path, offset, byteCount } = args;
-        const resolvedPath = resolvePath(pdf_path);
+        const resolvedPath = resolveCanonicalPath(pdf_path);
         const MAX_CHUNK = 524288; // 512KB max per chunk
         const clampedByteCount = Math.min(byteCount || MAX_CHUNK, MAX_CHUNK);
 
-        const stats = await fs.stat(resolvedPath);
-        const totalBytes = stats.size;
-        const clampedOffset = Math.min(offset || 0, totalBytes);
-        const end = Math.min(clampedOffset + clampedByteCount, totalBytes);
-
         let fileHandle;
         try {
-          fileHandle = await fs.open(resolvedPath, "r");
+          // Size comes from the open descriptor rather than a separate stat of
+          // the name, so the bytes read are the file that was checked.
+          const opened = await openCanonicalRegularFile(resolvedPath);
+          fileHandle = opened.handle;
+          const totalBytes = opened.stat.size;
+          const clampedOffset = Math.min(offset || 0, totalBytes);
+          const end = Math.min(clampedOffset + clampedByteCount, totalBytes);
           const buffer = Buffer.alloc(end - clampedOffset);
           await fileHandle.read(buffer, 0, buffer.length, clampedOffset);
 
@@ -6671,10 +6713,16 @@ async function handleToolCall(request) {
         if (!rawPath || typeof rawPath !== "string") {
           throw new Error("'path' is required and must be a string.");
         }
-        const resolved = resolvePath(rawPath);
+        // The canonical path is what gets handed to a platform process, so a
+        // link cannot make that process act on a file outside the allowed set.
+        const resolved = resolveCanonicalPath(rawPath);
         // Existence check first — better error than spawn failure.
-        try { await fs.access(resolved); } catch {
+        let revealStat;
+        try { revealStat = await fs.lstat(resolved); } catch {
           throw new Error(`File not found: ${resolved}`);
+        }
+        if (revealStat.isSymbolicLink()) {
+          throw new Error(`Not a regular file or folder: ${path.basename(resolved)}`);
         }
 
         const plat = osPlatform();

--- a/scripts/test-suite-classification.mjs
+++ b/scripts/test-suite-classification.mjs
@@ -80,6 +80,7 @@ export const CHECKOUT_LOCAL_MUTATING_TEST_SUITES = Object.freeze([
   "test/list-pdfs-default-directory.test.js",
   "test/metadata-provenance.test.js",
   "test/mutation-input-limits.test.js",
+  "test/path-handler-toctou.test.js",
   "test/pdfjs-worker-contract.test.js",
   "test/render-pdf-page.test.js",
   "test/sandbox-boundary-findings.test.js",

--- a/server/helpers.js
+++ b/server/helpers.js
@@ -1668,6 +1668,10 @@ async function bindAtomicOutputDirectory(
     };
   } catch (error) {
     if (error?.code === "ATOMIC_OUTPUT_DIRECTORY_CHANGED") throw error;
+    // A refusal is not a race. Rewrapping it as a directory change would tell
+    // the caller to retry an operation the policy will never allow, and would
+    // hide the real reason it stopped.
+    if (error?.code === "path_policy_denied") throw error;
     throw atomicOutputDirectoryChangedError(error);
   }
 }
@@ -1703,6 +1707,10 @@ async function assertAtomicOutputDirectory(binding, assertPathAllowed, fileSyste
     await assertPathAllowed(canonicalAfter);
   } catch (error) {
     if (error?.code === "ATOMIC_OUTPUT_DIRECTORY_CHANGED") throw error;
+    // A refusal is not a race. Rewrapping it as a directory change would tell
+    // the caller to retry an operation the policy will never allow, and would
+    // hide the real reason it stopped.
+    if (error?.code === "path_policy_denied") throw error;
     throw atomicOutputDirectoryChangedError(error);
   }
 }

--- a/server/index.js
+++ b/server/index.js
@@ -267,6 +267,46 @@ function resolvePath(inputPath) {
   return assertPathAllowed(normalizeUserPath(inputPath));
 }
 
+// resolvePath returns the caller's path, not the file the policy check accepted,
+// so a handler that opens that string can be sent somewhere else by a symlink
+// swapped in afterwards. This returns the canonical path instead, which names
+// one file and cannot be repointed by replacing a link. Use it wherever the
+// resolved path is then handed to the filesystem or to another process.
+function resolveCanonicalPath(inputPath) {
+  if (!inputPath) return inputPath;
+  const canonicalPath = canonicalizePathForPolicy(normalizeUserPath(inputPath));
+  assertPathAllowed(canonicalPath);
+  return canonicalPath;
+}
+
+const NOFOLLOW_READ_FLAGS = fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW ?? 0);
+
+// Open a canonical path for reading and prove the descriptor is the same
+// regular file that was inspected a moment earlier. O_NOFOLLOW refuses a final
+// component that became a symlink after canonicalization; the identity compare
+// catches a replacement that reused the name. Callers own closing the handle.
+async function openCanonicalRegularFile(canonicalPath) {
+  const beforeStat = await fs.lstat(canonicalPath);
+  if (beforeStat.isSymbolicLink() || !beforeStat.isFile()) {
+    throw new Error(`Not a regular file: ${path.basename(canonicalPath)}`);
+  }
+  const handle = await fs.open(canonicalPath, NOFOLLOW_READ_FLAGS);
+  try {
+    const descriptorStat = await handle.stat();
+    if (
+      !descriptorStat.isFile()
+      || descriptorStat.dev !== beforeStat.dev
+      || descriptorStat.ino !== beforeStat.ino
+    ) {
+      throw new Error("The file changed while it was being opened. Retry the request.");
+    }
+    return { handle, stat: descriptorStat };
+  } catch (error) {
+    await handle.close().catch(() => {});
+    throw error;
+  }
+}
+
 async function bindOutputPathForTransaction(outputPath) {
   const parentPath = await fs.realpath(path.dirname(outputPath));
   assertPathAllowed(parentPath);
@@ -5231,14 +5271,15 @@ async function handleToolCall(request) {
 
       case "get_pdf_resource_uri": {
         const { pdf_path } = args;
-        const resolvedPath = resolvePath(pdf_path);
-        
+        // A resource URI outlives this call, so it must name the file that was
+        // checked rather than a link that can be repointed before it is read.
+        const resolvedPath = resolveCanonicalPath(pdf_path);
+
         try {
-          // Verify the file exists
-          await fs.access(resolvedPath);
-          
-          // Get file info
-          const stats = await fs.stat(resolvedPath);
+          const stats = await fs.lstat(resolvedPath);
+          if (stats.isSymbolicLink() || !stats.isFile()) {
+            throw new Error(`Not a regular file: ${path.basename(resolvedPath)}`);
+          }
           const fileName = path.basename(resolvedPath);
           const fileSizeKB = (stats.size / 1024).toFixed(2);
           
@@ -5461,18 +5502,19 @@ async function handleToolCall(request) {
 
       case "read_pdf_bytes": {
         const { pdf_path, offset, byteCount } = args;
-        const resolvedPath = resolvePath(pdf_path);
+        const resolvedPath = resolveCanonicalPath(pdf_path);
         const MAX_CHUNK = 524288; // 512KB max per chunk
         const clampedByteCount = Math.min(byteCount || MAX_CHUNK, MAX_CHUNK);
 
-        const stats = await fs.stat(resolvedPath);
-        const totalBytes = stats.size;
-        const clampedOffset = Math.min(offset || 0, totalBytes);
-        const end = Math.min(clampedOffset + clampedByteCount, totalBytes);
-
         let fileHandle;
         try {
-          fileHandle = await fs.open(resolvedPath, "r");
+          // Size comes from the open descriptor rather than a separate stat of
+          // the name, so the bytes read are the file that was checked.
+          const opened = await openCanonicalRegularFile(resolvedPath);
+          fileHandle = opened.handle;
+          const totalBytes = opened.stat.size;
+          const clampedOffset = Math.min(offset || 0, totalBytes);
+          const end = Math.min(clampedOffset + clampedByteCount, totalBytes);
           const buffer = Buffer.alloc(end - clampedOffset);
           await fileHandle.read(buffer, 0, buffer.length, clampedOffset);
 
@@ -6671,10 +6713,16 @@ async function handleToolCall(request) {
         if (!rawPath || typeof rawPath !== "string") {
           throw new Error("'path' is required and must be a string.");
         }
-        const resolved = resolvePath(rawPath);
+        // The canonical path is what gets handed to a platform process, so a
+        // link cannot make that process act on a file outside the allowed set.
+        const resolved = resolveCanonicalPath(rawPath);
         // Existence check first — better error than spawn failure.
-        try { await fs.access(resolved); } catch {
+        let revealStat;
+        try { revealStat = await fs.lstat(resolved); } catch {
           throw new Error(`File not found: ${resolved}`);
+        }
+        if (revealStat.isSymbolicLink()) {
+          throw new Error(`Not a regular file or folder: ${path.basename(resolved)}`);
         }
 
         const plat = osPlatform();

--- a/test/mcp-contract.test.js
+++ b/test/mcp-contract.test.js
@@ -575,10 +575,15 @@ describe.each(RUNTIMES)("$name runtime discovery", runtime => {
       arguments: { pdf_path: specialPdf },
     });
     expect(uriResult.isError).not.toBe(true);
-    const expectedUri = pathToPdfResourceUri(specialPdf);
+    // The URI names the canonical file, not the name the caller happened to
+    // use, so it cannot be repointed by replacing a link between this call and
+    // the resources/read that follows it. On macOS the canonical form differs
+    // from the requested one whenever a temp root sits under a symlink.
+    const canonicalPdf = await fs.realpath(specialPdf);
+    const expectedUri = pathToPdfResourceUri(canonicalPdf);
     expect(uriResult.structuredContent).toMatchObject({
       uri: expectedUri,
-      pdf_path: specialPdf,
+      pdf_path: canonicalPdf,
     });
     expect(expectedUri).not.toContain(" ");
     expect(expectedUri).not.toContain("#");

--- a/test/path-handler-toctou.test.js
+++ b/test/path-handler-toctou.test.js
@@ -1,0 +1,225 @@
+import fs from "fs/promises";
+import path from "path";
+import { fileURLToPath } from "url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { recoverPdfOutputTransactions } from "../server/helpers.js";
+import { createTestTempDirectory, removeTestTempDirectory } from "./helpers/temp-directory.js";
+
+// Three handlers resolved a path and then stat/open/spawned that same string,
+// without the O_NOFOLLOW open and identity rebind that server/bounded-pdf-file.js
+// applies everywhere else. The policy check therefore validated one file while
+// the operation could reach another (CWE-367). These assert the boundary holds
+// on the paths those handlers take, and that legitimate symlinks keep working.
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.join(__dirname, "..");
+const SERVER_ENTRY = path.join(REPO_ROOT, "server", "index.js");
+const EXAMPLE_PDF = path.join(REPO_ROOT, "example-fw9.pdf");
+
+function textFromToolResult(result) {
+  return result.content?.map(item => item.type === "text" ? item.text : "").join(" ") || "";
+}
+
+function structuredErrorCode(result) {
+  return result.structuredContent?.error?.code;
+}
+
+describe("path handler symlink containment", () => {
+  let client;
+  let transport;
+  let tempDirectory;
+  let allowedDirectory;
+  let outsideDirectory;
+  let secretPath;
+  let escapingLink;
+  let internalLink;
+  let realPdfPath;
+
+  beforeAll(async () => {
+    tempDirectory = await createTestTempDirectory(REPO_ROOT, "path-handler-toctou");
+    allowedDirectory = path.join(tempDirectory, "allowed");
+    outsideDirectory = path.join(tempDirectory, "outside");
+    await fs.mkdir(allowedDirectory, { recursive: true });
+    await fs.mkdir(outsideDirectory, { recursive: true });
+
+    // A document the user never allowed this server to reach.
+    secretPath = path.join(outsideDirectory, "secret.pdf");
+    await fs.copyFile(EXAMPLE_PDF, secretPath);
+
+    // A real document inside the allowed set, and a symlink to it. The symlink
+    // is legitimate: it resolves to a permitted file, so it must keep working.
+    realPdfPath = path.join(allowedDirectory, "real.pdf");
+    await fs.copyFile(EXAMPLE_PDF, realPdfPath);
+    internalLink = path.join(allowedDirectory, "link-to-real.pdf");
+    await fs.symlink(realPdfPath, internalLink);
+
+    // A symlink that lives inside the allowed set but points out of it. The
+    // name passes a prefix test; the file it reaches does not.
+    escapingLink = path.join(allowedDirectory, "innocent.pdf");
+    await fs.symlink(secretPath, escapingLink);
+
+    client = new Client({ name: "pdf-tools-toctou-client", version: "1.0.0" });
+    transport = new StdioClientTransport({
+      command: process.execPath,
+      args: [SERVER_ENTRY],
+      cwd: REPO_ROOT,
+      env: {
+        PATH: process.env.PATH ?? "",
+        HOME: path.join(tempDirectory, "home"),
+        ALLOWED_DIRECTORIES: allowedDirectory,
+        DEFAULT_PROFILES_DIR: path.join(tempDirectory, "profiles"),
+      },
+      stderr: "pipe",
+    });
+    await client.connect(transport);
+  }, 30_000);
+
+  afterAll(async () => {
+    try {
+      await transport?.close();
+    } finally {
+      await removeTestTempDirectory(tempDirectory);
+    }
+  });
+
+  it("refuses read_pdf_bytes through a symlink that leaves the allowed set", async () => {
+    const result = await client.callTool({
+      name: "read_pdf_bytes",
+      arguments: { pdf_path: escapingLink, offset: 0, byteCount: 64 },
+    });
+
+    expect(structuredErrorCode(result)).toBe("path_policy_denied");
+    expect(result.structuredContent?.bytes).toBeUndefined();
+  }, 30_000);
+
+  it("still reads a symlink that resolves inside the allowed set", async () => {
+    const result = await client.callTool({
+      name: "read_pdf_bytes",
+      arguments: { pdf_path: internalLink, offset: 0, byteCount: 64 },
+    });
+
+    // Containment must not be bought by refusing every symlink; a link to a
+    // permitted file is an ordinary way to organise documents.
+    expect(structuredErrorCode(result)).toBeUndefined();
+    expect(result.structuredContent?.bytes).toBeTruthy();
+  }, 30_000);
+
+  it("reports the canonical path it actually read, not the name it was given", async () => {
+    const result = await client.callTool({
+      name: "read_pdf_bytes",
+      arguments: { pdf_path: internalLink, offset: 0, byteCount: 64 },
+    });
+
+    // The caller uses this path for follow-up calls. Echoing the symlink name
+    // back leaves a second window in which that name can be repointed.
+    expect(result.structuredContent?.pdfPath).toBe(await fs.realpath(realPdfPath));
+  }, 30_000);
+
+  it("refuses get_pdf_resource_uri through an escaping symlink", async () => {
+    const result = await client.callTool({
+      name: "get_pdf_resource_uri",
+      arguments: { pdf_path: escapingLink },
+    });
+
+    expect(structuredErrorCode(result)).toBe("path_policy_denied");
+    expect(result.structuredContent?.uri).toBeUndefined();
+  }, 30_000);
+
+  it("binds a resource URI to the canonical file", async () => {
+    const result = await client.callTool({
+      name: "get_pdf_resource_uri",
+      arguments: { pdf_path: internalLink },
+    });
+
+    // A resource URI outlives the call that produced it, so it must name the
+    // file that was checked rather than a link that can be retargeted later.
+    expect(result.structuredContent?.pdf_path).toBe(await fs.realpath(realPdfPath));
+  }, 30_000);
+
+  it("refuses reveal_in_finder through an escaping symlink", async () => {
+    const result = await client.callTool({
+      name: "reveal_in_finder",
+      arguments: { path: escapingLink },
+    });
+
+    // This one hands a path to a platform process, so a denial must happen
+    // before the spawn rather than being reported after it.
+    expect(structuredErrorCode(result)).toBe("path_policy_denied");
+    expect(textFromToolResult(result)).not.toContain("Revealed");
+  }, 30_000);
+
+  it.skipIf(process.platform === "win32")(
+    "refuses read_pdf_bytes on a named pipe inside the allowed set",
+    async () => {
+      // A FIFO passes an existence check and lives at a permitted path, but
+      // reading it is not reading a document: the open can block on a writer
+      // that never arrives. The guard is "regular file", not "exists".
+      const fifoPath = path.join(allowedDirectory, "pipe.pdf");
+      const { spawnSync } = await import("child_process");
+      const made = spawnSync("mkfifo", [fifoPath]);
+      if (made.status !== 0) return; // mkfifo unavailable; nothing to assert
+
+      const result = await client.callTool({
+        name: "read_pdf_bytes",
+        arguments: { pdf_path: fifoPath, offset: 0, byteCount: 16 },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.structuredContent?.bytes).toBeUndefined();
+      await fs.rm(fifoPath, { force: true });
+    },
+    30_000,
+  );
+
+  it("refuses read_pdf_bytes on a directory rather than failing obscurely", async () => {
+    const result = await client.callTool({
+      name: "read_pdf_bytes",
+      arguments: { pdf_path: allowedDirectory, offset: 0, byteCount: 64 },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent?.bytes).toBeUndefined();
+  }, 30_000);
+});
+
+describe("atomic output recovery error classification", () => {
+  let tempDirectory;
+  let outputDirectory;
+
+  beforeAll(async () => {
+    tempDirectory = await createTestTempDirectory(REPO_ROOT, "toctou-error-classification");
+    outputDirectory = path.join(tempDirectory, "output");
+    await fs.mkdir(outputDirectory, { recursive: true });
+  }, 30_000);
+
+  afterAll(async () => {
+    await removeTestTempDirectory(tempDirectory);
+  });
+
+  it("surfaces a policy denial as a denial, not as a retryable directory change", async () => {
+    const denial = new Error("The requested path is outside the configured allowed directories.");
+    denial.code = "path_policy_denied";
+
+    const failure = await recoverPdfOutputTransactions(outputDirectory, {
+      assertPathAllowed: async () => { throw denial; },
+    }).then(() => null, error => error);
+
+    // Rewrapping a refusal as ATOMIC_OUTPUT_DIRECTORY_CHANGED tells the caller
+    // to retry an operation that cannot succeed, and hides the real reason.
+    expect(failure).not.toBeNull();
+    expect(failure.code).toBe("path_policy_denied");
+  }, 30_000);
+
+  it("still reports a genuine directory change as a directory change", async () => {
+    const missingDirectory = path.join(tempDirectory, "not-there");
+
+    const failure = await recoverPdfOutputTransactions(missingDirectory, {
+      assertPathAllowed: async () => {},
+    }).then(() => null, error => error);
+
+    expect(failure).not.toBeNull();
+    expect(failure.code).toBe("ATOMIC_OUTPUT_DIRECTORY_CHANGED");
+  }, 30_000);
+});


### PR DESCRIPTION
## Summary

Three handlers resolved a caller's path and then stat'd, opened, or spawned that same string. `resolvePath` returns the path as given rather than the file the policy check accepted, so each of those operations re-resolved the name a second time — and a symlink swapped in between the two resolutions is followed. `server/bounded-pdf-file.js` already avoids this everywhere else; `read_pdf_bytes`, `get_pdf_resource_uri`, and `reveal_in_finder` did not. This is the shape of CVE-2025-53109 in the reference MCP filesystem server.

**What was already safe, stated plainly:** a static symlink pointing outside the allowed set was contained, because the policy check canonicalizes before comparing. Six of the ten new tests passed before this change and are regression guards, not fixes. What was *not* contained is the second resolution, and the canonical path was also handed back to the caller as the path to use next — which widened the same window rather than closing it.

## Changes

- **`resolveCanonicalPath`** returns the canonical path and asserts policy on it, for handlers that then touch the filesystem or hand a path to another process.
- **`openCanonicalRegularFile`** opens with `O_NOFOLLOW` and compares the descriptor's device and inode against the file that was inspected, so a final component replaced after canonicalization is refused rather than read.
- **`read_pdf_bytes`** takes its size from the open descriptor instead of a separate `stat` of the name, so the bytes returned come from the file that was checked.
- **`reveal_in_finder`** hands the canonical path to the platform process.
- **Policy denials are no longer masked.** `bindAtomicOutputDirectory` and `assertAtomicOutputDirectory` rewrapped every error from their re-check as `ATOMIC_OUTPUT_DIRECTORY_CHANGED`. A refusal discovered during a race is not a race; reporting it as one tells the caller to retry something the policy will never allow.

Legitimate symlinks still work. They are resolved, checked, and read through their target — containment is not bought by refusing every link.

No new error codes: the structured schema admits three, and a non-regular file or a changed file reports `tool_execution_failed` through the existing path.

## Observable contract change

`get_pdf_resource_uri` now reports the canonical path in both `uri` and `pdf_path`. Where a requested path traverses a symlink the two differ — on macOS a temp root under `/var` reports `/private/var`. `docs/MCP_CONTRACT.md` is updated to state this, and the reason: a resource URI outlives the call that produced it, so it must name the file the allowlist accepted rather than a name that can be repointed before `resources/read` runs.

This is what the existing contract test was pinning, and it is why that assertion changed rather than the behaviour.

## Test evidence

`test/path-handler-toctou.test.js`, ten cases. Three failed before this change and pass after. The named-pipe case fails if the regular-file guard is removed.

**What is not covered, precisely.** The device and inode comparison and `O_NOFOLLOW` defend a race this suite does not force: both survive mutation. Reproducing the swap needs an injected filesystem, and these handlers are exercised through a real server over stdio. They are kept because the race is real, not because a test proves them. `server/bounded-pdf-file.js` is tested for exactly these races through injected `fsOps`, and bringing these handlers under that harness is the obvious follow-up.

Affected suites on macOS ARM64, at `a31838b`:

```
Test Files  9 passed (9)
Tests       256 passed (256)
```

Covering `path-handler-toctou`, `atomic-output`, `atomic-output-recovery`, `mcp-contract`, `output-schema`, `test-runner-contract`, `documentation-claims`, `allowed-directories`, and `sandbox-boundary-findings`.

Not the full aggregate: another lane was building a TeX toolchain on the same host and a full run was killed under memory pressure. These are the suites that reach the changed code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
