### PR TITLE
Bring the path-handler open guard under an injected-fs harness

### DIFF
--- a/pdf-toolkit-mcp-share/server/helpers.js
+++ b/pdf-toolkit-mcp-share/server/helpers.js
@@ -1607,6 +1607,38 @@ const PDF_OUTPUT_LOCK_CANDIDATE_PATTERN = /^\.pdf-tools-output-transaction\.lock
 const PDF_OUTPUT_STALE_LOCK_PATTERN = /^\.pdf-tools-output-transaction\.lock\.stale-[a-f0-9-]+$/;
 const PDF_OUTPUT_LOCK_OWNER_NAME = "owner.json";
 const NOFOLLOW_READ_FLAGS = fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW ?? 0);
+
+// Open a canonical path for reading and prove the descriptor is the same
+// regular file that was inspected a moment earlier. O_NOFOLLOW refuses a final
+// component that became a symlink after canonicalization; the device/inode
+// compare refuses a replacement that reused the name in the window between the
+// lstat and the open (CWE-367). The caller owns closing the returned handle.
+//
+// fsOps is injected so this window can be forced in a test: a filesystem whose
+// open() reaches a different inode than the preceding lstat() must be rejected
+// here rather than read.
+export async function openVerifiedRegularFile(fsOps, canonicalPath) {
+  const beforeStat = await fsOps.lstat(canonicalPath);
+  if (beforeStat.isSymbolicLink() || !beforeStat.isFile()) {
+    throw new Error(`Not a regular file: ${path.basename(canonicalPath)}`);
+  }
+  const handle = await fsOps.open(canonicalPath, NOFOLLOW_READ_FLAGS);
+  try {
+    const descriptorStat = await handle.stat();
+    if (
+      !descriptorStat.isFile()
+      || descriptorStat.dev !== beforeStat.dev
+      || descriptorStat.ino !== beforeStat.ino
+    ) {
+      throw new Error("The file changed while it was being opened. Retry the request.");
+    }
+    return { handle, stat: descriptorStat };
+  } catch (error) {
+    await handle.close().catch(() => {});
+    throw error;
+  }
+}
+
 const RECOVERY_DIRECTORY_GUARD_FAILURE = Symbol("recoveryDirectoryGuardFailure");
 const JOURNAL_EXPECTATION_FAILURE = Symbol("journalExpectationFailure");
 const JOURNAL_PUBLISHED_EXPECTATION = Symbol("journalPublishedExpectation");

--- a/pdf-toolkit-mcp-share/server/index.js
+++ b/pdf-toolkit-mcp-share/server/index.js
@@ -279,33 +279,9 @@ function resolveCanonicalPath(inputPath) {
   return canonicalPath;
 }
 
-const NOFOLLOW_READ_FLAGS = fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW ?? 0);
-
-// Open a canonical path for reading and prove the descriptor is the same
-// regular file that was inspected a moment earlier. O_NOFOLLOW refuses a final
-// component that became a symlink after canonicalization; the identity compare
-// catches a replacement that reused the name. Callers own closing the handle.
-async function openCanonicalRegularFile(canonicalPath) {
-  const beforeStat = await fs.lstat(canonicalPath);
-  if (beforeStat.isSymbolicLink() || !beforeStat.isFile()) {
-    throw new Error(`Not a regular file: ${path.basename(canonicalPath)}`);
-  }
-  const handle = await fs.open(canonicalPath, NOFOLLOW_READ_FLAGS);
-  try {
-    const descriptorStat = await handle.stat();
-    if (
-      !descriptorStat.isFile()
-      || descriptorStat.dev !== beforeStat.dev
-      || descriptorStat.ino !== beforeStat.ino
-    ) {
-      throw new Error("The file changed while it was being opened. Retry the request.");
-    }
-    return { handle, stat: descriptorStat };
-  } catch (error) {
-    await handle.close().catch(() => {});
-    throw error;
-  }
-}
+// openVerifiedRegularFile lives in helpers.js so its device/inode identity
+// check can be exercised with an injected filesystem. Handlers here pass the
+// real fs.
 
 async function bindOutputPathForTransaction(outputPath) {
   const parentPath = await fs.realpath(path.dirname(outputPath));
@@ -701,6 +677,7 @@ import {
   writePdfOutputAtomic,
   writePdfOutputsAtomic,
   MIN_TEXT_CHARS_WITH_IMAGES,
+  openVerifiedRegularFile,
 } from "./helpers.js";
 
 // Helper: validate profile name to prevent path traversal
@@ -5510,7 +5487,7 @@ async function handleToolCall(request) {
         try {
           // Size comes from the open descriptor rather than a separate stat of
           // the name, so the bytes read are the file that was checked.
-          const opened = await openCanonicalRegularFile(resolvedPath);
+          const opened = await openVerifiedRegularFile(fs, resolvedPath);
           fileHandle = opened.handle;
           const totalBytes = opened.stat.size;
           const clampedOffset = Math.min(offset || 0, totalBytes);

--- a/server/helpers.js
+++ b/server/helpers.js
@@ -1607,6 +1607,38 @@ const PDF_OUTPUT_LOCK_CANDIDATE_PATTERN = /^\.pdf-tools-output-transaction\.lock
 const PDF_OUTPUT_STALE_LOCK_PATTERN = /^\.pdf-tools-output-transaction\.lock\.stale-[a-f0-9-]+$/;
 const PDF_OUTPUT_LOCK_OWNER_NAME = "owner.json";
 const NOFOLLOW_READ_FLAGS = fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW ?? 0);
+
+// Open a canonical path for reading and prove the descriptor is the same
+// regular file that was inspected a moment earlier. O_NOFOLLOW refuses a final
+// component that became a symlink after canonicalization; the device/inode
+// compare refuses a replacement that reused the name in the window between the
+// lstat and the open (CWE-367). The caller owns closing the returned handle.
+//
+// fsOps is injected so this window can be forced in a test: a filesystem whose
+// open() reaches a different inode than the preceding lstat() must be rejected
+// here rather than read.
+export async function openVerifiedRegularFile(fsOps, canonicalPath) {
+  const beforeStat = await fsOps.lstat(canonicalPath);
+  if (beforeStat.isSymbolicLink() || !beforeStat.isFile()) {
+    throw new Error(`Not a regular file: ${path.basename(canonicalPath)}`);
+  }
+  const handle = await fsOps.open(canonicalPath, NOFOLLOW_READ_FLAGS);
+  try {
+    const descriptorStat = await handle.stat();
+    if (
+      !descriptorStat.isFile()
+      || descriptorStat.dev !== beforeStat.dev
+      || descriptorStat.ino !== beforeStat.ino
+    ) {
+      throw new Error("The file changed while it was being opened. Retry the request.");
+    }
+    return { handle, stat: descriptorStat };
+  } catch (error) {
+    await handle.close().catch(() => {});
+    throw error;
+  }
+}
+
 const RECOVERY_DIRECTORY_GUARD_FAILURE = Symbol("recoveryDirectoryGuardFailure");
 const JOURNAL_EXPECTATION_FAILURE = Symbol("journalExpectationFailure");
 const JOURNAL_PUBLISHED_EXPECTATION = Symbol("journalPublishedExpectation");

--- a/server/index.js
+++ b/server/index.js
@@ -279,33 +279,9 @@ function resolveCanonicalPath(inputPath) {
   return canonicalPath;
 }
 
-const NOFOLLOW_READ_FLAGS = fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW ?? 0);
-
-// Open a canonical path for reading and prove the descriptor is the same
-// regular file that was inspected a moment earlier. O_NOFOLLOW refuses a final
-// component that became a symlink after canonicalization; the identity compare
-// catches a replacement that reused the name. Callers own closing the handle.
-async function openCanonicalRegularFile(canonicalPath) {
-  const beforeStat = await fs.lstat(canonicalPath);
-  if (beforeStat.isSymbolicLink() || !beforeStat.isFile()) {
-    throw new Error(`Not a regular file: ${path.basename(canonicalPath)}`);
-  }
-  const handle = await fs.open(canonicalPath, NOFOLLOW_READ_FLAGS);
-  try {
-    const descriptorStat = await handle.stat();
-    if (
-      !descriptorStat.isFile()
-      || descriptorStat.dev !== beforeStat.dev
-      || descriptorStat.ino !== beforeStat.ino
-    ) {
-      throw new Error("The file changed while it was being opened. Retry the request.");
-    }
-    return { handle, stat: descriptorStat };
-  } catch (error) {
-    await handle.close().catch(() => {});
-    throw error;
-  }
-}
+// openVerifiedRegularFile lives in helpers.js so its device/inode identity
+// check can be exercised with an injected filesystem. Handlers here pass the
+// real fs.
 
 async function bindOutputPathForTransaction(outputPath) {
   const parentPath = await fs.realpath(path.dirname(outputPath));
@@ -701,6 +677,7 @@ import {
   writePdfOutputAtomic,
   writePdfOutputsAtomic,
   MIN_TEXT_CHARS_WITH_IMAGES,
+  openVerifiedRegularFile,
 } from "./helpers.js";
 
 // Helper: validate profile name to prevent path traversal
@@ -5510,7 +5487,7 @@ async function handleToolCall(request) {
         try {
           // Size comes from the open descriptor rather than a separate stat of
           // the name, so the bytes read are the file that was checked.
-          const opened = await openCanonicalRegularFile(resolvedPath);
+          const opened = await openVerifiedRegularFile(fs, resolvedPath);
           fileHandle = opened.handle;
           const totalBytes = opened.stat.size;
           const clampedOffset = Math.min(offset || 0, totalBytes);

--- a/test/open-verified-regular-file.test.js
+++ b/test/open-verified-regular-file.test.js
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import { openVerifiedRegularFile } from "../server/helpers.js";
+
+// openVerifiedRegularFile defends a TOCTOU race that a real-filesystem test
+// cannot force reliably: the swap has to happen in the window between the lstat
+// and the open. Injecting fsOps makes that window explicit, so the device/inode
+// identity check and the O_NOFOLLOW-descriptor check are exercised rather than
+// merely present. The path-handler suite covers the integrated behaviour; this
+// covers the guard itself.
+
+function regularFileStat({ dev, ino, size = 1024 }) {
+  return {
+    dev,
+    ino,
+    size,
+    isFile: () => true,
+    isSymbolicLink: () => false,
+  };
+}
+
+function fakeHandle(descriptorStat) {
+  return {
+    stat: async () => descriptorStat,
+    close: async () => {},
+  };
+}
+
+describe("openVerifiedRegularFile identity guard", () => {
+  it("rejects a file whose inode changed between lstat and open", async () => {
+    // The name was inspected as inode 100 and opened as inode 200 — a
+    // replacement that reused the path in the race window.
+    const fsOps = {
+      lstat: async () => regularFileStat({ dev: 1, ino: 100 }),
+      open: async () => fakeHandle(regularFileStat({ dev: 1, ino: 200 })),
+    };
+
+    await expect(openVerifiedRegularFile(fsOps, "/allowed/doc.pdf"))
+      .rejects.toThrow(/changed while it was being opened/);
+  });
+
+  it("rejects a file whose device changed between lstat and open", async () => {
+    const fsOps = {
+      lstat: async () => regularFileStat({ dev: 1, ino: 100 }),
+      open: async () => fakeHandle(regularFileStat({ dev: 9, ino: 100 })),
+    };
+
+    await expect(openVerifiedRegularFile(fsOps, "/allowed/doc.pdf"))
+      .rejects.toThrow(/changed while it was being opened/);
+  });
+
+  it("closes the descriptor when the identity check fails", async () => {
+    let closed = false;
+    const fsOps = {
+      lstat: async () => regularFileStat({ dev: 1, ino: 100 }),
+      open: async () => ({
+        stat: async () => regularFileStat({ dev: 1, ino: 200 }),
+        close: async () => { closed = true; },
+      }),
+    };
+
+    await expect(openVerifiedRegularFile(fsOps, "/allowed/doc.pdf")).rejects.toThrow();
+    // A leaked descriptor on the rejection path is its own bug.
+    expect(closed).toBe(true);
+  });
+
+  it("rejects a symlink at the final component before opening", async () => {
+    let opened = false;
+    const fsOps = {
+      lstat: async () => ({
+        isFile: () => false,
+        isSymbolicLink: () => true,
+      }),
+      open: async () => { opened = true; return fakeHandle(regularFileStat({ dev: 1, ino: 1 })); },
+    };
+
+    await expect(openVerifiedRegularFile(fsOps, "/allowed/link.pdf"))
+      .rejects.toThrow(/Not a regular file/);
+    // The guard must refuse before it opens, not after.
+    expect(opened).toBe(false);
+  });
+
+  it("rejects a descriptor that is no longer a regular file", async () => {
+    // lstat saw a regular file; the descriptor reports otherwise.
+    const fsOps = {
+      lstat: async () => regularFileStat({ dev: 1, ino: 100 }),
+      open: async () => fakeHandle({
+        dev: 1,
+        ino: 100,
+        isFile: () => false,
+      }),
+    };
+
+    await expect(openVerifiedRegularFile(fsOps, "/allowed/doc.pdf"))
+      .rejects.toThrow(/changed while it was being opened/);
+  });
+
+  it("returns the handle and descriptor stat when identity holds", async () => {
+    const descriptorStat = regularFileStat({ dev: 1, ino: 100, size: 4096 });
+    const handle = fakeHandle(descriptorStat);
+    const fsOps = {
+      lstat: async () => regularFileStat({ dev: 1, ino: 100 }),
+      open: async () => handle,
+    };
+
+    const result = await openVerifiedRegularFile(fsOps, "/allowed/doc.pdf");
+    expect(result.handle).toBe(handle);
+    expect(result.stat.size).toBe(4096);
+  });
+});


### PR DESCRIPTION
## Summary

PR #95 added a device/inode identity check and an `O_NOFOLLOW` open to the three path handlers, and its own commit message said both survived mutation: the suite exercised them through a real server over stdio, where the TOCTOU swap they defend cannot be forced, so deleting either guard left every test green. A guard kept "because the race is real, not because a test proves it" is a guard one refactor away from silent removal. This closes that gap.

## Change

The open guard moves from `server/index.js` into `server/helpers.js` as an exported `openVerifiedRegularFile(fsOps, canonicalPath)`, matching the injected-filesystem pattern the `bounded-pdf-file.js` readers already use. Behaviour is unchanged; `read_pdf_bytes` calls it with the real `fs`. What changes is that the window between the `lstat` and the `open` is now reachable in a test.

## Test evidence

`test/open-verified-regular-file.test.js` injects a filesystem whose `open()` reaches a different inode, device, or file type than the preceding `lstat`, and asserts the guard refuses rather than returns the handle. It also asserts the descriptor is closed on the rejection path, and that a final-component symlink is refused before any `open`.

**Verified load-bearing by mutation** — the specific thing #95 could not claim:

- Removing the `dev`/`ino`/`isFile` identity check fails 4 of 6 cases.
- Removing the pre-open symlink guard fails the 5th.

The integrated path-handler suite from #95 passes unchanged. macOS ARM64, at `842f874`:

```
Test Files  2 passed (2)   (open-verified-regular-file, path-handler-toctou)
Tests       16 passed (16)
```

The unit test is filesystem-mocked and platform-independent; the integration suite is unchanged from #95, which already passed on macOS. Not the full aggregate — another lane was holding the host under load, and these are the suites that reach the changed code.

Mirrored into the share runtime. No new dependencies, no behaviour change, no new error codes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
