### PR TITLE
Build a self-contained Agent Plugins bundle, no npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ pdf-toolkit-mcp.zip
 .dolt/
 *.db
 windows-render-probe.json
+dist-plugin/

--- a/docs/agent-plugins-packaging.md
+++ b/docs/agent-plugins-packaging.md
@@ -89,14 +89,13 @@ The cost of that is real and must be stated rather than hidden: `PLUGIN_DATA` is
 
 ### 2. Native dependencies with no install lifecycle
 
-`@napi-rs/canvas` resolves to one of eleven platform packages, and the specification has no install or build hook. Two options:
+`@napi-rs/canvas` resolves to one of eleven platform packages, and the specification has no install or build hook.
 
-| Option | Cost | Risk |
-|---|---|---|
-| Publish a scoped npm package, `command: "npx"` | One publish per release | Requires network at first run; npm resolves the correct native binary |
-| Vendor every platform package under `PLUGIN_ROOT` | Very large package | No network needed; we own platform coverage, as MCPB already does |
+**Resolved: vendor into the plugin directory, no npm.** An earlier draft weighed publishing a scoped npm package and launching via `command: "npx"`. That was the wrong call — npm is not an Agent Plugins distribution channel at all (distribution is a git repo, a local directory, or a client marketplace; there is no registry), and `npx` would require a publish and a network round-trip at first run. `command: "node"` with the server carried under `${PLUGIN_ROOT}` needs neither.
 
-`pdf-tools` and `pdf-toolkit-mcp` are both taken on npm by unrelated projects, so a scoped name is required either way.
+The bundle is built by `scripts/build-agent-plugin.mjs` (`npm run build:plugin`), which reuses the MCPB build's `prepareCleanStage` verbatim — the same locked production dependencies, integrity-verified native canvas packages, secret scan, and symlink ban that gate the shipped `.mcpb`. It then drops the MCPB `manifest.json`, writes `plugin.json` and `mcp.json`, and copies the workflow skill. Reusing the stage rather than reimplementing it is deliberate: a second bundler would drift from the first.
+
+Coverage matches the MCPB — the same five native platforms — so rasterization works everywhere the MCPB does, at roughly 175 MB unpacked. A smaller no-render variant (server plus a `PDF_RENDERER_UNAVAILABLE` message on the two render tools, ~33 MB) is a planned `--platforms` flag on the same builder, not yet implemented. `pdf-tools` and `pdf-toolkit-mcp` are both taken on npm by unrelated projects, which is now moot.
 
 ### 3. Package containment
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "test:all": "node scripts/run-all-test-suites.mjs",
     "test:pdf-lib-worker": "vitest run test/pdf-lib-subprocess-boundary.test.js test/pdf-lib-worker-contract.test.js test/output-schema.test.js test/input-validation.test.js test/save-lifecycle.test.js",
     "test:node-native": "node scripts/run-node-test-suites.mjs",
-    "test:concurrent": "node scripts/test-concurrent-suites.mjs"
+    "test:concurrent": "node scripts/test-concurrent-suites.mjs",
+    "build:plugin": "node scripts/build-agent-plugin.mjs"
   },
   "repository": {
     "type": "git",

--- a/scripts/build-agent-plugin.mjs
+++ b/scripts/build-agent-plugin.mjs
@@ -1,0 +1,160 @@
+// Build a self-contained Agent Plugins 1.0.0 plugin directory.
+//
+// The plugin is a directory that carries the server and its locked
+// dependencies, launched with `command: "node"` and no npm, no npx, and no
+// install step on the host. It reuses the MCPB build's staging verbatim —
+// locked production deps, integrity-verified native canvas packages, a secret
+// scan, and a symlink ban — so the two artifacts cannot drift. On top of that
+// stage it drops a root `plugin.json`, an `mcp.json`, and the workflow skill,
+// and removes the MCPB-only `manifest.json`.
+//
+// Usage: node scripts/build-agent-plugin.mjs [output-dir]
+//   default output: dist-plugin/pdf-tools
+//
+// Coverage: this ships the same five native canvas platforms the MCPB ships,
+// so rasterization works everywhere the MCPB does. A smaller no-render variant
+// is a planned build flag, not yet implemented.
+
+import { cpSync, mkdirSync, rmSync, writeFileSync, readdirSync, statSync, existsSync } from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import { spawn } from "child_process";
+import { prepareCleanStage } from "./build-mcpb.mjs";
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(SCRIPT_DIR, "..");
+const SKILLS_SOURCE = path.join(REPO_ROOT, "plugins", "pdf-tools-workflow", "skills");
+const PACKAGE_JSON = JSON.parse(
+  (await import("fs")).readFileSync(path.join(REPO_ROOT, "package.json"), "utf8"),
+);
+
+const PLUGIN_MANIFEST = {
+  $schema: "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  name: "pdf-tools",
+  version: PACKAGE_JSON.version,
+  description:
+    "Local PDF workflow: inspect, fill, sign, merge, split, extract, render, and validate PDFs on your machine. Bundles the server and its evidence-first workflow.",
+  author: {
+    name: "Open Document Alliance",
+    url: "https://github.com/Open-Document-Alliance",
+  },
+  homepage: "https://github.com/Open-Document-Alliance/PDF-Tools",
+  repository: "https://github.com/Open-Document-Alliance/PDF-Tools",
+  license: "MIT",
+  keywords: ["pdf", "forms", "signature", "extraction", "accessibility", "mcp"],
+};
+
+const MCP_CONFIG = {
+  $schema: "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  mcpServers: {
+    "pdf-tools": {
+      type: "stdio",
+      command: "node",
+      // Spec expands only ${PLUGIN_ROOT} and ${PLUGIN_DATA}. Nothing here
+      // depends on ${HOME} or a host user-config mechanism, which is why the
+      // server was made to fail closed rather than grant home folders when it
+      // is handed no configuration.
+      args: ["${PLUGIN_ROOT}/server/index.js"],
+      cwd: "${PLUGIN_ROOT}",
+    },
+  },
+};
+
+function directoryStats(root) {
+  let files = 0;
+  let bytes = 0;
+  const walk = (dir) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.isFile()) { files += 1; bytes += statSync(full).size; }
+    }
+  };
+  walk(root);
+  return { files, bytes };
+}
+
+// Launch the built server over stdio and confirm it lists tools. This proves
+// the bundle actually starts from its own directory — worker paths resolved by
+// adjacency, packages resolved from the bundled node_modules — without a host.
+function smokeLaunch(pluginDir) {
+  return new Promise((resolve, reject) => {
+    const serverPath = path.join(pluginDir, "server", "index.js");
+    const child = spawn(process.execPath, [serverPath], {
+      cwd: pluginDir,
+      // No allowed directories configured: the server starts and lists tools,
+      // and refuses file operations until configured. That is the intended
+      // fail-closed posture, and it is what a fresh install looks like.
+      env: { PATH: process.env.PATH ?? "" },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    const timer = setTimeout(() => { child.kill("SIGKILL"); reject(new Error("smoke launch timed out")); }, 20000);
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+      if (stdout.includes('"tools"')) {
+        clearTimeout(timer);
+        child.kill("SIGKILL");
+        resolve({ ok: true });
+      }
+    });
+    child.stderr.on("data", (chunk) => { stderr += chunk.toString(); });
+    child.on("error", (error) => { clearTimeout(timer); reject(error); });
+    child.on("exit", (code) => {
+      clearTimeout(timer);
+      if (!stdout.includes('"tools"')) {
+        reject(new Error(`server exited (code ${code}) without listing tools.\nstderr:\n${stderr.slice(0, 2000)}`));
+      }
+    });
+    // JSON-RPC: initialize, then tools/list.
+    const initialize = {
+      jsonrpc: "2.0", id: 1, method: "initialize",
+      params: { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "plugin-smoke", version: "1.0.0" } },
+    };
+    child.stdin.write(JSON.stringify(initialize) + "\n");
+    child.stdin.write(JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }) + "\n");
+    child.stdin.write(JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} }) + "\n");
+  });
+}
+
+async function main() {
+  const outputDir = path.resolve(process.argv[2] || path.join(REPO_ROOT, "dist-plugin", "pdf-tools"));
+  console.error(`[plugin] building Agent Plugins bundle → ${outputDir}`);
+
+  if (!existsSync(SKILLS_SOURCE)) {
+    throw new Error(`workflow skills not found at ${SKILLS_SOURCE}`);
+  }
+
+  const { stagingDir } = prepareCleanStage();
+  try {
+    // The stage is the verified MCPB payload. Convert it to a plugin:
+    // drop the MCPB manifest, add the Agent Plugins manifests and the skill.
+    rmSync(path.join(stagingDir, "manifest.json"), { force: true });
+    writeFileSync(path.join(stagingDir, "plugin.json"), JSON.stringify(PLUGIN_MANIFEST, null, 2) + "\n");
+    writeFileSync(path.join(stagingDir, "mcp.json"), JSON.stringify(MCP_CONFIG, null, 2) + "\n");
+    cpSync(SKILLS_SOURCE, path.join(stagingDir, "skills"), { recursive: true });
+
+    console.error("[plugin] smoke-launching the staged server over stdio…");
+    await smokeLaunch(stagingDir);
+    console.error("[plugin] server listed tools from its own directory.");
+
+    rmSync(outputDir, { recursive: true, force: true });
+    mkdirSync(path.dirname(outputDir), { recursive: true });
+    cpSync(stagingDir, outputDir, { recursive: true });
+
+    const { files, bytes } = directoryStats(outputDir);
+    console.error(`[plugin] done: ${files} files, ${(bytes / 1024 / 1024).toFixed(1)} MB uncompressed`);
+    console.error(`[plugin] layout: plugin.json, mcp.json, server/, skills/, node_modules/, dist-ui/`);
+    console.error(`[plugin] note: a fresh install has no allowed directories and refuses file`);
+    console.error(`[plugin]       operations until configured. In-band configuration under`);
+    console.error(`[plugin]       Agent Plugins (via \${PLUGIN_DATA}) is the next step, not this build.`);
+  } finally {
+    rmSync(stagingDir, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(`[plugin] build failed: ${error.message}`);
+  process.exit(1);
+});

--- a/scripts/build-mcpb.mjs
+++ b/scripts/build-mcpb.mjs
@@ -75,7 +75,7 @@ const FIRST_PARTY_TEXT_FILES = [
   "README.md",
   "manifest.mcpb.json",
 ];
-const NATIVE_TARGETS = [
+export const NATIVE_TARGETS = [
   {
     packageName: "@napi-rs/canvas-darwin-arm64",
     binary: "skia.darwin-arm64.node",
@@ -903,7 +903,10 @@ function verifyStagedProductionGraph(stagingDir, packages) {
   return { expected, packagedNativeAssetPaths };
 }
 
-function prepareCleanStage() {
+// Exported so the Agent Plugins bundle can reuse the identical staging —
+// locked deps, verified native packages, secret scan, symlink ban — instead of
+// a second, drifting implementation. Behaviour is unchanged for the MCPB build.
+export function prepareCleanStage() {
   const stagingDir = mkdtempSync(path.join(tmpdir(), "pdf-tools-mcpb-"));
   const downloadDir = path.join(stagingDir, ".native-packages");
   const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";


### PR DESCRIPTION
## Summary

Ships PDF Tools as a self-contained Agent Plugins 1.0.0 plugin directory — the payoff of the earlier packaging work — with **no npm publish and no npx**. Agent Plugins are distributed as a git repo or a directory, not through a registry, so the plugin carries the server itself and launches with `command: "node"` against `${PLUGIN_ROOT}/server/index.js`.

## How

`scripts/build-agent-plugin.mjs` (`npm run build:plugin`) reuses the MCPB build's `prepareCleanStage` verbatim — the same locked production dependencies, integrity-verified native canvas packages, secret scan, and symlink ban that gate the shipped `.mcpb`. It then removes the MCPB-only `manifest.json`, writes `plugin.json` and `mcp.json`, and copies the workflow skill so the guardrails install *with* the server rather than beside it.

Reusing the stage rather than writing a second bundler is deliberate: two bundlers drift, and the canvas integrity checks, symlink ban, and secret scan are already written and already gate the product.

## Blast radius on the shared build

`scripts/build-mcpb.mjs` changes by **exactly two added `export` keywords** (`prepareCleanStage`, `NATIVE_TARGETS`) — no logic touched. Proof it's neutral: a full `npm run build:mcpb` still produces **two byte-identical isolated builds** (its own reproducibility gate), SHA `9540daef…`, unchanged.

## Verification

- The builder smoke-launches the staged server over stdio and confirms it lists tools from its own directory — workers resolved by adjacency, packages from the bundled `node_modules`, no host.
- A separate MCP client against the built directory: **42 tools listed**, `list_pdfs` runs from the bundled deps when `ALLOWED_DIRECTORIES` is set, and refuses with `path_policy_denied` when it is not — the fail-closed posture from #94.
- `plugin.json` and `mcp.json` both **validate against the official 1.0.0 schemas** (`plugin.schema.json`, `mcp.schema.json`).
- `test-runner-contract` and `documentation-claims` pass (81 tests) — the new script and the added exports do not trip the import-closure classification.

Verified on Linux; this is build tooling (file copy + `node` launch) reusing `prepareCleanStage`, which is already release-proven on macOS. CI/release runs the plugin build on macOS.

## Coverage and what's deferred

Five native platforms, ~175 MB unpacked — rasterization works everywhere the MCPB works. Two follow-ups, both named in the code and docs:

1. A `--platforms` flag for a ~33 MB **no-render** variant (server + an accurate `PDF_RENDERER_UNAVAILABLE` on the two render tools). The degradation path already exists; this is a build-flag, not new runtime code.
2. **In-band allowed-directory configuration** via `${PLUGIN_DATA}`. Until it lands, a fresh plugin install starts and lists tools but refuses file operations until configured — correct and safe, but not yet convenient. This is the real gap between "the mechanism works" and "a user can use it out of the box."

The built directory (`dist-plugin/`) is a build artifact and is gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
