### PR TITLE
Configure the allowed set from PLUGIN_DATA on plugin installs

### DIFF
--- a/docs/agent-plugins-packaging.md
+++ b/docs/agent-plugins-packaging.md
@@ -146,7 +146,11 @@ Adding `mcp.json` is gated on the portable allowed-directories work and a publis
 
 **Implementation status.** Requirements 1, 2, 3, and 7 are implemented on this branch, along with the non-greedy argument parsing in requirement 8. The allowed set is now established only by explicit configuration, an unexpanded placeholder is treated as absent configuration rather than as a reason to substitute defaults, the private store is no longer a general user-path allowance, and refusals name neither the allowed set nor the attempted path.
 
-Still unimplemented: the `${PLUGIN_DATA}` config-file layer, the read/narrow tool, the `(dev, ino)` deny for the config file, and roots intersection (requirements 4, 5, 6). Those are only needed once a plugin actually ships a `mcp.json`, and they should not be written speculatively ahead of it.
+The `${PLUGIN_DATA}` config-file layer is now implemented too, along with the self-escalation guard from requirement 5. `${PLUGIN_DATA}/config.json` is the lowest precedence layer, below the CLI flag and the environment variable, and layers are never merged. On first run the server writes a template with an empty list, and every refusal names that exact path, so a fresh install is actionable rather than merely safe. A set that would reach the config file is refused whole rather than trimmed, because an allowed set containing its own config lets a write tool rewrite the boundary on the next launch.
+
+Widening deliberately remains a human action: the config file is edited by the operator, not by a tool. A tool that can widen its own sandbox is a privilege-escalation path, and document text is untrusted input this server already refuses to take instructions from.
+
+Still unimplemented: a read-only tool reporting the active set and its source, runtime narrowing, and roots intersection (requirements 4 and 6). The read-only tool is the next useful increment; it was kept out of the config work because adding a tool moves the tool-contract digest and the pinned tool count, which deserves its own change.
 
 One consequence to carry into release notes: a host that previously relied on the implicit home-folder grant now receives a refusal until directories are configured. That is the intended behavior, and it is a behavior change for existing installs.
 

--- a/pdf-toolkit-mcp-share/server/index.js
+++ b/pdf-toolkit-mcp-share/server/index.js
@@ -24,7 +24,7 @@ import {
   degrees as pdfDegrees,
 } from "pdf-lib";
 import { fileURLToPath } from "url";
-import { constants as fsConstants, existsSync, realpathSync } from "fs";
+import { constants as fsConstants, existsSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from "fs";
 import fs from "fs/promises";
 import path from "path";
 import { homedir, platform as osPlatform } from "os";
@@ -242,10 +242,14 @@ function assertPathAllowed(resolvedPath) {
     const error = new Error(
       ALLOWED_DIRECTORIES.length === 0
         ? "No allowed directories are configured, so this server refused the request. "
-          + "Set the allowed list where this server is configured. Hosts with a settings UI "
-          + "expose it as allowed_directories; otherwise set the --allowed-directories argument, "
-          + "which takes precedence, or the ALLOWED_DIRECTORIES environment variable, which "
-          + "applies only when that argument is absent."
+          + (PLUGIN_DATA_CONFIG_PATH
+            ? `List the folders you want reachable in ${PLUGIN_DATA_CONFIG_PATH}, under `
+              + "\"allowedDirectories\", then restart this server. That file is edited by you, "
+              + "not by the assistant."
+            : "Set the allowed list where this server is configured. Hosts with a settings UI "
+              + "expose it as allowed_directories; otherwise set the --allowed-directories argument, "
+              + "which takes precedence, or the ALLOWED_DIRECTORIES environment variable, which "
+              + "applies only when that argument is absent.")
         : `This server is only allowed to access: ${allowed}. ` +
           `Tried to access: ${resolvedPath}. ` +
           "The allowed list must be set where this server is configured, and it replaces " +
@@ -1400,14 +1404,95 @@ function parsePathListValue(value) {
 // user path rather than silently granting the home folders. Failing closed is
 // the point: an unexpanded template means we were never configured, which is
 // not a reason to choose a boundary on the user's behalf.
+// Agent Plugins 1.0.0 has no user-configuration mechanism and expands only
+// ${PLUGIN_ROOT} and ${PLUGIN_DATA}, so a plugin install can reach neither the
+// CLI flag nor the environment variable a host would otherwise set. PLUGIN_DATA
+// is the one location that specification guarantees exists, stays writable, and
+// survives plugin updates, which makes it the only place a stored allowed set
+// can live. It is the lowest layer: a host that does supply configuration is
+// stating an intent a stored file must not override.
+const PLUGIN_DATA_CONFIG_NAME = "config.json";
+
+function pluginDataConfigPath() {
+  const pluginData = process.env.PLUGIN_DATA;
+  if (!pluginData || pluginData.includes("${")) return null;
+  return path.join(path.resolve(pluginData), PLUGIN_DATA_CONFIG_NAME);
+}
+
+// A fresh install has nothing configured and must refuse every path. Writing
+// the template turns "configure the allowed directories somehow" into a named
+// file the user can open. Editing it is a human action the agent cannot
+// perform, which is what keeps widening off the agent's own authority.
+function ensurePluginDataConfigTemplate(configPath) {
+  if (!configPath || existsSync(configPath)) return;
+  try {
+    mkdirSync(path.dirname(configPath), { recursive: true });
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        _comment: "Folders this server may read and write. Absolute paths only. "
+          + "It replaces any built-in default rather than adding to it, so list every "
+          + "folder you need. Restart the server after editing.",
+        allowedDirectories: [],
+      }, null, 2) + "\n",
+      { mode: 0o600 },
+    );
+  } catch {
+    // A read-only or unwritable PLUGIN_DATA is the host's business. Failing to
+    // write a hint must never be louder than the refusal it was meant to explain.
+  }
+}
+
+// Returns the configured list, or null when this layer supplies nothing. A
+// malformed file returns an empty list rather than null, to say "configured,
+// badly" rather than "not configured". Today both end at an empty set because
+// this is the lowest layer, so the distinction is defensive rather than
+// observable; it matters the moment anything is added below it.
+function readPluginDataConfig(configPath) {
+  if (!configPath || !existsSync(configPath)) return null;
+  let parsed;
+  try {
+    parsed = JSON.parse(readFileSync(configPath, "utf8"));
+  } catch {
+    console.error(`[pdf-tools] ${configPath} is not valid JSON. No directories are allowed until it is fixed.`);
+    return [];
+  }
+  if (!parsed || typeof parsed !== "object" || !Array.isArray(parsed.allowedDirectories)) {
+    console.error(`[pdf-tools] ${configPath} needs an "allowedDirectories" array. No directories are allowed until it is fixed.`);
+    return [];
+  }
+  return parsed.allowedDirectories
+    .filter(entry => typeof entry === "string")
+    .map(entry => entry.trim())
+    .filter(entry => entry && !entry.includes("${"));
+}
+
+// A set that reaches the config file lets any write tool rewrite the sandbox on
+// the next launch. Refuse the whole set rather than dropping the entry, so the
+// operator learns the boundary is wrong instead of quietly losing one folder.
+function grantsAccessToOwnConfig(directories, configPath) {
+  if (!configPath) return false;
+  const canonicalConfig = canonicalizePathForPolicy(configPath);
+  return directories.some(directory => isPathInsideDirectory(canonicalConfig, directory.canonical));
+}
+
 function buildAllowedDirectories() {
+  const configPath = pluginDataConfigPath();
   const argumentDirectories = parseAllowedDirectoryArgs(process.argv.slice(2));
-  const configuredDirectories = argumentDirectories?.length
-    ? argumentDirectories
-    : parsePathListValue(process.env.ALLOWED_DIRECTORIES) ?? [];
+  const environmentDirectories = parsePathListValue(process.env.ALLOWED_DIRECTORIES);
+
+  let configuredDirectories;
+  if (argumentDirectories?.length) {
+    configuredDirectories = argumentDirectories;
+  } else if (environmentDirectories?.length) {
+    configuredDirectories = environmentDirectories;
+  } else {
+    ensurePluginDataConfigTemplate(configPath);
+    configuredDirectories = readPluginDataConfig(configPath) ?? [];
+  }
 
   const seen = new Set();
-  return configuredDirectories
+  const resolved = configuredDirectories
     .map((directory) => normalizeUserPath(directory))
     .map((directory) => ({
       display: directory,
@@ -1419,8 +1504,18 @@ function buildAllowedDirectories() {
       seen.add(key);
       return true;
     });
+
+  if (grantsAccessToOwnConfig(resolved, configPath)) {
+    console.error(
+      `[pdf-tools] The allowed directories reach ${configPath}, which would let this `
+      + "server rewrite its own boundary. No directories are allowed until that entry is removed.",
+    );
+    return [];
+  }
+  return resolved;
 }
 
+const PLUGIN_DATA_CONFIG_PATH = pluginDataConfigPath();
 const ALLOWED_DIRECTORIES = buildAllowedDirectories();
 
 // Where a tool browses when the caller names no directory. An explicitly

--- a/scripts/build-agent-plugin.mjs
+++ b/scripts/build-agent-plugin.mjs
@@ -146,9 +146,9 @@ async function main() {
     const { files, bytes } = directoryStats(outputDir);
     console.error(`[plugin] done: ${files} files, ${(bytes / 1024 / 1024).toFixed(1)} MB uncompressed`);
     console.error(`[plugin] layout: plugin.json, mcp.json, server/, skills/, node_modules/, dist-ui/`);
-    console.error(`[plugin] note: a fresh install has no allowed directories and refuses file`);
-    console.error(`[plugin]       operations until configured. In-band configuration under`);
-    console.error(`[plugin]       Agent Plugins (via \${PLUGIN_DATA}) is the next step, not this build.`);
+    console.error(`[plugin] note: a fresh install allows no directories. On first run the server`);
+    console.error(`[plugin]       writes \${PLUGIN_DATA}/config.json and every refusal names that`);
+    console.error(`[plugin]       path; the user lists their folders there and restarts.`);
   } finally {
     rmSync(stagingDir, { recursive: true, force: true });
   }

--- a/scripts/test-suite-classification.mjs
+++ b/scripts/test-suite-classification.mjs
@@ -82,6 +82,7 @@ export const CHECKOUT_LOCAL_MUTATING_TEST_SUITES = Object.freeze([
   "test/mutation-input-limits.test.js",
   "test/path-handler-toctou.test.js",
   "test/pdfjs-worker-contract.test.js",
+  "test/plugin-data-config.test.js",
   "test/render-pdf-page.test.js",
   "test/sandbox-boundary-findings.test.js",
   "test/signatures.test.js",

--- a/server/index.js
+++ b/server/index.js
@@ -24,7 +24,7 @@ import {
   degrees as pdfDegrees,
 } from "pdf-lib";
 import { fileURLToPath } from "url";
-import { constants as fsConstants, existsSync, realpathSync } from "fs";
+import { constants as fsConstants, existsSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from "fs";
 import fs from "fs/promises";
 import path from "path";
 import { homedir, platform as osPlatform } from "os";
@@ -242,10 +242,14 @@ function assertPathAllowed(resolvedPath) {
     const error = new Error(
       ALLOWED_DIRECTORIES.length === 0
         ? "No allowed directories are configured, so this server refused the request. "
-          + "Set the allowed list where this server is configured. Hosts with a settings UI "
-          + "expose it as allowed_directories; otherwise set the --allowed-directories argument, "
-          + "which takes precedence, or the ALLOWED_DIRECTORIES environment variable, which "
-          + "applies only when that argument is absent."
+          + (PLUGIN_DATA_CONFIG_PATH
+            ? `List the folders you want reachable in ${PLUGIN_DATA_CONFIG_PATH}, under `
+              + "\"allowedDirectories\", then restart this server. That file is edited by you, "
+              + "not by the assistant."
+            : "Set the allowed list where this server is configured. Hosts with a settings UI "
+              + "expose it as allowed_directories; otherwise set the --allowed-directories argument, "
+              + "which takes precedence, or the ALLOWED_DIRECTORIES environment variable, which "
+              + "applies only when that argument is absent.")
         : `This server is only allowed to access: ${allowed}. ` +
           `Tried to access: ${resolvedPath}. ` +
           "The allowed list must be set where this server is configured, and it replaces " +
@@ -1400,14 +1404,95 @@ function parsePathListValue(value) {
 // user path rather than silently granting the home folders. Failing closed is
 // the point: an unexpanded template means we were never configured, which is
 // not a reason to choose a boundary on the user's behalf.
+// Agent Plugins 1.0.0 has no user-configuration mechanism and expands only
+// ${PLUGIN_ROOT} and ${PLUGIN_DATA}, so a plugin install can reach neither the
+// CLI flag nor the environment variable a host would otherwise set. PLUGIN_DATA
+// is the one location that specification guarantees exists, stays writable, and
+// survives plugin updates, which makes it the only place a stored allowed set
+// can live. It is the lowest layer: a host that does supply configuration is
+// stating an intent a stored file must not override.
+const PLUGIN_DATA_CONFIG_NAME = "config.json";
+
+function pluginDataConfigPath() {
+  const pluginData = process.env.PLUGIN_DATA;
+  if (!pluginData || pluginData.includes("${")) return null;
+  return path.join(path.resolve(pluginData), PLUGIN_DATA_CONFIG_NAME);
+}
+
+// A fresh install has nothing configured and must refuse every path. Writing
+// the template turns "configure the allowed directories somehow" into a named
+// file the user can open. Editing it is a human action the agent cannot
+// perform, which is what keeps widening off the agent's own authority.
+function ensurePluginDataConfigTemplate(configPath) {
+  if (!configPath || existsSync(configPath)) return;
+  try {
+    mkdirSync(path.dirname(configPath), { recursive: true });
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        _comment: "Folders this server may read and write. Absolute paths only. "
+          + "It replaces any built-in default rather than adding to it, so list every "
+          + "folder you need. Restart the server after editing.",
+        allowedDirectories: [],
+      }, null, 2) + "\n",
+      { mode: 0o600 },
+    );
+  } catch {
+    // A read-only or unwritable PLUGIN_DATA is the host's business. Failing to
+    // write a hint must never be louder than the refusal it was meant to explain.
+  }
+}
+
+// Returns the configured list, or null when this layer supplies nothing. A
+// malformed file returns an empty list rather than null, to say "configured,
+// badly" rather than "not configured". Today both end at an empty set because
+// this is the lowest layer, so the distinction is defensive rather than
+// observable; it matters the moment anything is added below it.
+function readPluginDataConfig(configPath) {
+  if (!configPath || !existsSync(configPath)) return null;
+  let parsed;
+  try {
+    parsed = JSON.parse(readFileSync(configPath, "utf8"));
+  } catch {
+    console.error(`[pdf-tools] ${configPath} is not valid JSON. No directories are allowed until it is fixed.`);
+    return [];
+  }
+  if (!parsed || typeof parsed !== "object" || !Array.isArray(parsed.allowedDirectories)) {
+    console.error(`[pdf-tools] ${configPath} needs an "allowedDirectories" array. No directories are allowed until it is fixed.`);
+    return [];
+  }
+  return parsed.allowedDirectories
+    .filter(entry => typeof entry === "string")
+    .map(entry => entry.trim())
+    .filter(entry => entry && !entry.includes("${"));
+}
+
+// A set that reaches the config file lets any write tool rewrite the sandbox on
+// the next launch. Refuse the whole set rather than dropping the entry, so the
+// operator learns the boundary is wrong instead of quietly losing one folder.
+function grantsAccessToOwnConfig(directories, configPath) {
+  if (!configPath) return false;
+  const canonicalConfig = canonicalizePathForPolicy(configPath);
+  return directories.some(directory => isPathInsideDirectory(canonicalConfig, directory.canonical));
+}
+
 function buildAllowedDirectories() {
+  const configPath = pluginDataConfigPath();
   const argumentDirectories = parseAllowedDirectoryArgs(process.argv.slice(2));
-  const configuredDirectories = argumentDirectories?.length
-    ? argumentDirectories
-    : parsePathListValue(process.env.ALLOWED_DIRECTORIES) ?? [];
+  const environmentDirectories = parsePathListValue(process.env.ALLOWED_DIRECTORIES);
+
+  let configuredDirectories;
+  if (argumentDirectories?.length) {
+    configuredDirectories = argumentDirectories;
+  } else if (environmentDirectories?.length) {
+    configuredDirectories = environmentDirectories;
+  } else {
+    ensurePluginDataConfigTemplate(configPath);
+    configuredDirectories = readPluginDataConfig(configPath) ?? [];
+  }
 
   const seen = new Set();
-  return configuredDirectories
+  const resolved = configuredDirectories
     .map((directory) => normalizeUserPath(directory))
     .map((directory) => ({
       display: directory,
@@ -1419,8 +1504,18 @@ function buildAllowedDirectories() {
       seen.add(key);
       return true;
     });
+
+  if (grantsAccessToOwnConfig(resolved, configPath)) {
+    console.error(
+      `[pdf-tools] The allowed directories reach ${configPath}, which would let this `
+      + "server rewrite its own boundary. No directories are allowed until that entry is removed.",
+    );
+    return [];
+  }
+  return resolved;
 }
 
+const PLUGIN_DATA_CONFIG_PATH = pluginDataConfigPath();
 const ALLOWED_DIRECTORIES = buildAllowedDirectories();
 
 // Where a tool browses when the caller names no directory. An explicitly

--- a/test/plugin-data-config.test.js
+++ b/test/plugin-data-config.test.js
@@ -1,0 +1,292 @@
+import fs from "fs/promises";
+import path from "path";
+import { fileURLToPath } from "url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { createTestTempDirectory, removeTestTempDirectory } from "./helpers/temp-directory.js";
+
+// Agent Plugins 1.0.0 supplies no user-configuration mechanism and expands only
+// ${PLUGIN_ROOT} and ${PLUGIN_DATA}, so a plugin install has no way to reach the
+// CLI flag or the environment variable a host would otherwise set. PLUGIN_DATA
+// is the one location the specification guarantees exists, is writable, and
+// survives updates, so it is where a plugin's allowed set is configured.
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.join(__dirname, "..");
+const SERVER_ENTRY = path.join(REPO_ROOT, "server", "index.js");
+const EXAMPLE_PDF = path.join(REPO_ROOT, "example-fw9.pdf");
+
+function textFromToolResult(result) {
+  return result.content?.map(item => item.type === "text" ? item.text : "").join(" ") || "";
+}
+
+function structuredErrorCode(result) {
+  return result.structuredContent?.error?.code;
+}
+
+async function connectServer({ args = [], env = {}, name }) {
+  const client = new Client({ name, version: "1.0.0" });
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [SERVER_ENTRY, ...args],
+    cwd: REPO_ROOT,
+    env: { PATH: process.env.PATH ?? "", ...env },
+    stderr: "pipe",
+  });
+  await client.connect(transport);
+  return { client, transport };
+}
+
+async function withServer(options, run) {
+  const { client, transport } = await connectServer(options);
+  try {
+    return await run(client);
+  } finally {
+    await transport.close();
+  }
+}
+
+describe("PLUGIN_DATA config file supplies the allowed set", () => {
+  let tempDirectory;
+  let pluginData;
+  let allowedDirectory;
+
+  beforeAll(async () => {
+    tempDirectory = await createTestTempDirectory(REPO_ROOT, "plugin-data-config");
+    pluginData = path.join(tempDirectory, "plugin-data");
+    allowedDirectory = path.join(tempDirectory, "documents");
+    await fs.mkdir(pluginData, { recursive: true });
+    await fs.mkdir(allowedDirectory, { recursive: true });
+    await fs.copyFile(EXAMPLE_PDF, path.join(allowedDirectory, "in-config.pdf"));
+  }, 30_000);
+
+  afterAll(async () => {
+    await removeTestTempDirectory(tempDirectory);
+  });
+
+  it("grants directories listed in the config file", async () => {
+    await fs.writeFile(
+      path.join(pluginData, "config.json"),
+      JSON.stringify({ allowedDirectories: [allowedDirectory] }),
+    );
+
+    const text = await withServer({
+      name: "plugin-data-config-grants",
+      env: { HOME: path.join(tempDirectory, "home"), PLUGIN_DATA: pluginData },
+    }, client => client
+      .callTool({ name: "list_pdfs", arguments: { directory: allowedDirectory } })
+      .then(textFromToolResult));
+
+    expect(text).toContain("in-config.pdf");
+  }, 30_000);
+
+  it("still refuses a directory the config file does not list", async () => {
+    await fs.writeFile(
+      path.join(pluginData, "config.json"),
+      JSON.stringify({ allowedDirectories: [allowedDirectory] }),
+    );
+
+    const result = await withServer({
+      name: "plugin-data-config-refuses",
+      env: { HOME: path.join(tempDirectory, "home"), PLUGIN_DATA: pluginData },
+    }, client => client.callTool({
+      name: "list_pdfs",
+      arguments: { directory: tempDirectory },
+    }));
+
+    expect(structuredErrorCode(result)).toBe("path_policy_denied");
+  }, 30_000);
+});
+
+describe("config file precedence", () => {
+  let tempDirectory;
+  let pluginData;
+  let configDirectory;
+  let envDirectory;
+
+  beforeAll(async () => {
+    tempDirectory = await createTestTempDirectory(REPO_ROOT, "plugin-data-precedence");
+    pluginData = path.join(tempDirectory, "plugin-data");
+    configDirectory = path.join(tempDirectory, "from-config");
+    envDirectory = path.join(tempDirectory, "from-env");
+    await fs.mkdir(pluginData, { recursive: true });
+    await fs.mkdir(configDirectory, { recursive: true });
+    await fs.mkdir(envDirectory, { recursive: true });
+    await fs.copyFile(EXAMPLE_PDF, path.join(configDirectory, "config-side.pdf"));
+    await fs.copyFile(EXAMPLE_PDF, path.join(envDirectory, "env-side.pdf"));
+    await fs.writeFile(
+      path.join(pluginData, "config.json"),
+      JSON.stringify({ allowedDirectories: [configDirectory] }),
+    );
+  }, 30_000);
+
+  afterAll(async () => {
+    await removeTestTempDirectory(tempDirectory);
+  });
+
+  it("lets the environment variable win over the config file", async () => {
+    // The config file is the lowest layer. A host that does supply configuration
+    // is stating an intent the stored file should not override.
+    const result = await withServer({
+      name: "plugin-data-env-wins",
+      env: {
+        HOME: path.join(tempDirectory, "home"),
+        PLUGIN_DATA: pluginData,
+        ALLOWED_DIRECTORIES: envDirectory,
+      },
+    }, client => client.callTool({
+      name: "list_pdfs",
+      arguments: { directory: configDirectory },
+    }));
+
+    expect(structuredErrorCode(result)).toBe("path_policy_denied");
+  }, 30_000);
+
+  it("does not merge the config file into a higher layer", async () => {
+    const text = await withServer({
+      name: "plugin-data-no-merge",
+      env: {
+        HOME: path.join(tempDirectory, "home"),
+        PLUGIN_DATA: pluginData,
+        ALLOWED_DIRECTORIES: envDirectory,
+      },
+    }, client => client
+      .callTool({ name: "list_pdfs", arguments: { directory: envDirectory } })
+      .then(textFromToolResult));
+
+    // A union across layers produces a boundary nobody chose.
+    expect(text).toContain("env-side.pdf");
+  }, 30_000);
+});
+
+describe("config file safety", () => {
+  let tempDirectory;
+
+  beforeAll(async () => {
+    tempDirectory = await createTestTempDirectory(REPO_ROOT, "plugin-data-safety");
+  }, 30_000);
+
+  afterAll(async () => {
+    await removeTestTempDirectory(tempDirectory);
+  });
+
+  it("refuses a config that would grant access to itself", async () => {
+    // If the allowed set contains the config file's own directory, an agent
+    // with a write tool can rewrite its own sandbox. That is escalation, and
+    // the right response is to refuse loudly rather than drop the entry.
+    const pluginData = path.join(tempDirectory, "self-granting");
+    await fs.mkdir(pluginData, { recursive: true });
+    await fs.writeFile(
+      path.join(pluginData, "config.json"),
+      JSON.stringify({ allowedDirectories: [pluginData] }),
+    );
+    await fs.copyFile(EXAMPLE_PDF, path.join(pluginData, "bait.pdf"));
+
+    const result = await withServer({
+      name: "plugin-data-self-grant",
+      env: { HOME: path.join(tempDirectory, "home"), PLUGIN_DATA: pluginData },
+    }, client => client.callTool({
+      name: "list_pdfs",
+      arguments: { directory: pluginData },
+    }));
+
+    expect(structuredErrorCode(result)).toBe("path_policy_denied");
+  }, 30_000);
+
+  it("fails closed on a malformed config rather than ignoring it", async () => {
+    const pluginData = path.join(tempDirectory, "malformed");
+    const documents = path.join(tempDirectory, "malformed-docs");
+    await fs.mkdir(pluginData, { recursive: true });
+    await fs.mkdir(documents, { recursive: true });
+    await fs.copyFile(EXAMPLE_PDF, path.join(documents, "doc.pdf"));
+    await fs.writeFile(path.join(pluginData, "config.json"), "{ this is not json");
+
+    const result = await withServer({
+      name: "plugin-data-malformed",
+      env: { HOME: path.join(tempDirectory, "home"), PLUGIN_DATA: pluginData },
+    }, client => client.callTool({
+      name: "list_pdfs",
+      arguments: { directory: documents },
+    }));
+
+    // Silently treating a broken config as "no configuration" is the same
+    // failure mode as the implicit home-folder grant that preceded it.
+    expect(structuredErrorCode(result)).toBe("path_policy_denied");
+  }, 30_000);
+
+  it("ignores a config entry that is an unexpanded placeholder", async () => {
+    const pluginData = path.join(tempDirectory, "placeholder");
+    await fs.mkdir(pluginData, { recursive: true });
+    await fs.writeFile(
+      path.join(pluginData, "config.json"),
+      JSON.stringify({ allowedDirectories: ["${user_config.allowed_directories}"] }),
+    );
+
+    const result = await withServer({
+      name: "plugin-data-placeholder",
+      env: { HOME: path.join(tempDirectory, "home"), PLUGIN_DATA: pluginData },
+    }, client => client.callTool({
+      name: "list_pdfs",
+      arguments: { directory: tempDirectory },
+    }));
+
+    expect(structuredErrorCode(result)).toBe("path_policy_denied");
+  }, 30_000);
+});
+
+describe("first-run bootstrap", () => {
+  let tempDirectory;
+
+  beforeAll(async () => {
+    tempDirectory = await createTestTempDirectory(REPO_ROOT, "plugin-data-bootstrap");
+  }, 30_000);
+
+  afterAll(async () => {
+    await removeTestTempDirectory(tempDirectory);
+  });
+
+  it("writes a template config on first run and names it in the refusal", async () => {
+    const pluginData = path.join(tempDirectory, "fresh-install");
+    await fs.mkdir(pluginData, { recursive: true });
+    const configPath = path.join(pluginData, "config.json");
+
+    const result = await withServer({
+      name: "plugin-data-bootstrap",
+      env: { HOME: path.join(tempDirectory, "home"), PLUGIN_DATA: pluginData },
+    }, client => client.callTool({
+      name: "list_pdfs",
+      arguments: { directory: tempDirectory },
+    }));
+
+    expect(structuredErrorCode(result)).toBe("path_policy_denied");
+    // A fresh install must not merely refuse; it must say where to fix it.
+    // Editing this file is a human action the agent cannot perform, which is
+    // what keeps widening off the agent's own authority.
+    expect(textFromToolResult(result)).toContain(configPath);
+
+    const written = JSON.parse(await fs.readFile(configPath, "utf8"));
+    expect(written.allowedDirectories).toEqual([]);
+  }, 30_000);
+
+  it("does not overwrite a config that already exists", async () => {
+    const pluginData = path.join(tempDirectory, "existing");
+    const documents = path.join(tempDirectory, "existing-docs");
+    await fs.mkdir(pluginData, { recursive: true });
+    await fs.mkdir(documents, { recursive: true });
+    await fs.copyFile(EXAMPLE_PDF, path.join(documents, "keep.pdf"));
+    const configPath = path.join(pluginData, "config.json");
+    await fs.writeFile(configPath, JSON.stringify({ allowedDirectories: [documents] }));
+
+    const text = await withServer({
+      name: "plugin-data-no-clobber",
+      env: { HOME: path.join(tempDirectory, "home"), PLUGIN_DATA: pluginData },
+    }, client => client
+      .callTool({ name: "list_pdfs", arguments: { directory: documents } })
+      .then(textFromToolResult));
+
+    expect(text).toContain("keep.pdf");
+    const after = JSON.parse(await fs.readFile(configPath, "utf8"));
+    expect(after.allowedDirectories).toEqual([documents]);
+  }, 30_000);
+});


### PR DESCRIPTION
## Summary

The bundle from #97 started, listed 42 tools, and then refused every file operation with no way to fix it. This closes that gap — the difference between "the packaging mechanism works" and "a person can install it and use it."

Agent Plugins 1.0.0 supplies no user-configuration mechanism and expands only `${PLUGIN_ROOT}` and `${PLUGIN_DATA}`, so a plugin install reaches neither the CLI flag nor the environment variable a host would otherwise set. `${PLUGIN_DATA}` is the one location the specification guarantees exists, stays writable, and survives updates, which makes it the only place a stored allowed set can live.

## Design

`${PLUGIN_DATA}/config.json` becomes the **lowest** precedence layer, below the argument and the environment variable. Layers are never merged — a host that does supply configuration is stating an intent a stored file must not override, and a union across sources produces a boundary nobody chose.

On first run the server writes a template with an empty list, and the empty-set refusal **names that exact path**. A fresh install is now actionable rather than only safe.

**Widening stays a human action.** The operator edits the file; no tool writes it. A tool that can widen its own sandbox is a privilege-escalation path, and document text is untrusted input this server already refuses to take instructions from (`server/index.js` prompt-injection guard). This is deliberate, and it is why there is no `add_allowed_directory`.

A set that reaches its own config file is **refused whole rather than trimmed**: such a set lets any write tool rewrite the boundary on the next launch, and quietly dropping the entry would leave the operator believing a broken boundary is intact.

## End-to-end verification

Against a real built plugin directory, simulating an install:

| Step | Result |
|---|---|
| Fresh `PLUGIN_DATA`, nothing configured | refused `path_policy_denied`, message names `config.json` |
| Template written by server | exists, `allowedDirectories: []` |
| Operator adds their Documents folder | `list_pdfs` works |
| Any other directory | still refused |

## Coverage, stated precisely

Nine cases; three failed before this change. The **self-escalation guard is mutation-verified** — disabling it fails its case.

The malformed-config case is **not** mutation-caught: returning "configured, badly" rather than "not configured" is currently indistinguishable, because this is the lowest layer and both paths end at an empty set. It is kept as defensive structure for the moment anything is added below it, and the code comment says exactly that rather than claiming coverage. (The test still proves the property that matters — a malformed config grants nothing.)

macOS ARM64, at `78bd4a1`:

```
Test Files  6 passed (6)
Tests       96 passed (96)
```

Covering `plugin-data-config`, `allowed-directories`, `sandbox-boundary-findings`, `path-handler-toctou`, `test-runner-contract`, and `mcp-contract`.

## Blast radius

**No new tools**, so the pinned tool count (`mcp-contract.test.js:374`) and the tool-contract digest are untouched. Mirrored into the share runtime and enrolled in `CHECKOUT_LOCAL_MUTATING_TEST_SUITES`.

Still deferred: a read-only tool reporting the active set and its source, runtime narrowing, and MCP roots intersection. The read-only tool is the next useful increment — it was kept out of this change because adding a tool moves the digest and the pinned count, which deserves its own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
