### PR TITLE
Report the filesystem boundary without having to trip it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,7 @@ qualification. Then perform manual host runs against `example-fw9.pdf`:
 30. **apply_signature** - Stamp a saved signature at a location (requires explicit human intent; see Signature Architecture below)
 31. **prepare_signing_packet** - Fill form + add sign-here boxes in one pass
 32. **detect_signature_zones** - Locate signature, initials, printed-name, and date zones with coordinates. Use apply_signature for signatures and initials, and apply_text for names and dates.
+33. **get_allowed_directories** - Report the folders this server may reach, which configuration layer supplied them, and where the stored config file lives. Read-only; it cannot change the boundary.
 
 ### Current Extraction Boundary
 

--- a/manifest.json
+++ b/manifest.json
@@ -18,7 +18,36 @@
   "documentation": "https://github.com/Open-Document-Alliance/PDF-Tools/blob/master/README.md",
   "support": "https://github.com/Open-Document-Alliance/PDF-Tools/issues",
   "license": "MIT",
-  "keywords": ["pdf", "markdown", "merge", "split", "rotate", "reorder", "viewer", "interactive", "search", "research", "academic", "analyze", "compare", "extract", "documentation", "contracts", "forms", "fill", "sign", "signature", "date", "url", "download", "render", "w9", "1099", "tax", "invoice"],
+  "keywords": [
+    "pdf",
+    "markdown",
+    "merge",
+    "split",
+    "rotate",
+    "reorder",
+    "viewer",
+    "interactive",
+    "search",
+    "research",
+    "academic",
+    "analyze",
+    "compare",
+    "extract",
+    "documentation",
+    "contracts",
+    "forms",
+    "fill",
+    "sign",
+    "signature",
+    "date",
+    "url",
+    "download",
+    "render",
+    "w9",
+    "1099",
+    "tax",
+    "invoice"
+  ],
   "icon": "icon.png",
   "tools": [
     {
@@ -150,6 +179,10 @@
       "description": "Save a reusable typed-name or image signature to ~/.pdf-toolkit-files/signatures/"
     },
     {
+      "name": "get_allowed_directories",
+      "description": "Report which folders this server may read and write, which configuration layer supplied them, and where the stored configuration file lives"
+    },
+    {
       "name": "list_signatures",
       "description": "List all saved signatures"
     },
@@ -194,43 +227,58 @@
     {
       "name": "view_and_analyze_pdf",
       "description": "Open and analyze any PDF document",
-      "arguments": ["focus"],
+      "arguments": [
+        "focus"
+      ],
       "text": "Use PDF Tools to open a PDF stored on this computer and analyze it, focusing on ${arguments.focus}. If I haven't given you a path, start by listing the PDFs you can see so I can pick one. Then extract key findings, summarize sections, answer questions about specific pages, pull out structured data, and identify form fields if present."
     },
     {
       "name": "research_paper_analysis",
       "description": "Analyze & summarize research papers",
-      "arguments": ["focus_area"],
+      "arguments": [
+        "focus_area"
+      ],
       "text": "Use PDF Tools to analyze a research paper stored on this computer, focusing on ${arguments.focus_area}. If I haven't given you a path, start by listing the PDFs you can see so I can pick one. Extract the key findings and methodology, identify research gaps, summarize it chapter by chapter, pull out the citations, and draft a literature review outline."
     },
     {
       "name": "contract_comparison",
       "description": "Compare legal documents & contracts",
-      "arguments": ["comparison_focus"],
+      "arguments": [
+        "comparison_focus"
+      ],
       "text": "Use PDF Tools to compare contracts or legal documents stored on this computer, focusing on ${arguments.comparison_focus}. If I haven't given you their paths, start by listing the PDFs you can see so I can pick them. Highlight changed clauses, modified terms, added or removed sections, pricing differences, and liability changes, then summarize the comparison."
     },
     {
       "name": "financial_report_extraction",
       "description": "Extract data from financial statements",
-      "arguments": ["output_format"],
+      "arguments": [
+        "output_format"
+      ],
       "text": "Use PDF Tools to extract and analyze data from financial PDFs stored on this computer, including tables and key metrics. If I haven't given you a path, start by listing the PDFs you can see so I can pick one. Convert what you extract to ${arguments.output_format} format, cite the page for the values you extract, and tell me plainly about anything you could not extract."
     },
     {
       "name": "document_qa_session",
       "description": "Interactive Q&A about your documents",
-      "arguments": ["initial_question"],
+      "arguments": [
+        "initial_question"
+      ],
       "text": "Use PDF Tools to open a PDF stored on this computer so we can discuss it. My first question is: ${arguments.initial_question}. If I haven't given you a path, start by listing the PDFs you can see so I can pick one. Find specific information, explain complex sections, cross-reference different parts, and quote passages with their page numbers."
     },
     {
       "name": "bulk_invoice_processing",
       "description": "Process multiple invoices into structured data",
-      "arguments": ["folder_path", "output_format"],
+      "arguments": [
+        "folder_path",
+        "output_format"
+      ],
       "text": "Use PDF Tools to process the invoice PDFs in the folder ${arguments.folder_path} on this computer and build a unified dataset in ${arguments.output_format} format. Start by listing the PDFs in that folder so I can see what you found. Extract vendor names, invoice numbers, dates, line items, totals, tax amounts, and payment terms, and tell me about any invoice you could not read."
     },
     {
       "name": "technical_documentation_summary",
       "description": "Summarize technical manuals & documentation",
-      "arguments": ["summary_type"],
+      "arguments": [
+        "summary_type"
+      ],
       "text": "Use PDF Tools to analyze technical documentation stored on this computer and create ${arguments.summary_type}. If I haven't given you a path, start by listing the PDFs you can see so I can pick one. Extract the code examples, build a reference guide, identify the implementation steps, and summarize the troubleshooting sections."
     },
     {

--- a/manifest.mcpb.json
+++ b/manifest.mcpb.json
@@ -18,7 +18,36 @@
   "documentation": "https://github.com/Open-Document-Alliance/PDF-Tools/blob/master/README.md",
   "support": "https://github.com/Open-Document-Alliance/PDF-Tools/issues",
   "license": "MIT",
-  "keywords": ["pdf", "markdown", "merge", "split", "rotate", "reorder", "viewer", "interactive", "search", "research", "academic", "analyze", "compare", "extract", "documentation", "contracts", "forms", "fill", "sign", "signature", "date", "url", "download", "render", "w9", "1099", "tax", "invoice"],
+  "keywords": [
+    "pdf",
+    "markdown",
+    "merge",
+    "split",
+    "rotate",
+    "reorder",
+    "viewer",
+    "interactive",
+    "search",
+    "research",
+    "academic",
+    "analyze",
+    "compare",
+    "extract",
+    "documentation",
+    "contracts",
+    "forms",
+    "fill",
+    "sign",
+    "signature",
+    "date",
+    "url",
+    "download",
+    "render",
+    "w9",
+    "1099",
+    "tax",
+    "invoice"
+  ],
   "icon": "icon.png",
   "tools": [
     {
@@ -146,6 +175,10 @@
       "description": "Save a reusable typed-name or image signature to ~/.pdf-toolkit-files/signatures/"
     },
     {
+      "name": "get_allowed_directories",
+      "description": "Report which folders this server may read and write, which configuration layer supplied them, and where the stored configuration file lives"
+    },
+    {
       "name": "list_signatures",
       "description": "List all saved signatures"
     },
@@ -191,43 +224,58 @@
     {
       "name": "view_and_analyze_pdf",
       "description": "Open and analyze any PDF document",
-      "arguments": ["focus"],
+      "arguments": [
+        "focus"
+      ],
       "text": "Use PDF Tools to open a PDF stored on this computer and analyze it, focusing on ${arguments.focus}. If I haven't given you a path, start by listing the PDFs you can see so I can pick one. Then extract key findings, summarize sections, answer questions about specific pages, pull out structured data, and identify form fields if present."
     },
     {
       "name": "research_paper_analysis",
       "description": "Analyze & summarize research papers",
-      "arguments": ["focus_area"],
+      "arguments": [
+        "focus_area"
+      ],
       "text": "Use PDF Tools to analyze a research paper stored on this computer, focusing on ${arguments.focus_area}. If I haven't given you a path, start by listing the PDFs you can see so I can pick one. Extract the key findings and methodology, identify research gaps, summarize it chapter by chapter, pull out the citations, and draft a literature review outline."
     },
     {
       "name": "contract_comparison",
       "description": "Compare legal documents & contracts",
-      "arguments": ["comparison_focus"],
+      "arguments": [
+        "comparison_focus"
+      ],
       "text": "Use PDF Tools to compare contracts or legal documents stored on this computer, focusing on ${arguments.comparison_focus}. If I haven't given you their paths, start by listing the PDFs you can see so I can pick them. Highlight changed clauses, modified terms, added or removed sections, pricing differences, and liability changes, then summarize the comparison."
     },
     {
       "name": "financial_report_extraction",
       "description": "Extract data from financial statements",
-      "arguments": ["output_format"],
+      "arguments": [
+        "output_format"
+      ],
       "text": "Use PDF Tools to extract and analyze data from financial PDFs stored on this computer, including tables and key metrics. If I haven't given you a path, start by listing the PDFs you can see so I can pick one. Convert what you extract to ${arguments.output_format} format, cite the page for the values you extract, and tell me plainly about anything you could not extract."
     },
     {
       "name": "document_qa_session",
       "description": "Interactive Q&A about your documents",
-      "arguments": ["initial_question"],
+      "arguments": [
+        "initial_question"
+      ],
       "text": "Use PDF Tools to open a PDF stored on this computer so we can discuss it. My first question is: ${arguments.initial_question}. If I haven't given you a path, start by listing the PDFs you can see so I can pick one. Find specific information, explain complex sections, cross-reference different parts, and quote passages with their page numbers."
     },
     {
       "name": "bulk_invoice_processing",
       "description": "Process multiple invoices into structured data",
-      "arguments": ["folder_path", "output_format"],
+      "arguments": [
+        "folder_path",
+        "output_format"
+      ],
       "text": "Use PDF Tools to process the invoice PDFs in the folder ${arguments.folder_path} on this computer and build a unified dataset in ${arguments.output_format} format. Start by listing the PDFs in that folder so I can see what you found. Extract vendor names, invoice numbers, dates, line items, totals, tax amounts, and payment terms, and tell me about any invoice you could not read."
     },
     {
       "name": "technical_documentation_summary",
       "description": "Summarize technical manuals & documentation",
-      "arguments": ["summary_type"],
+      "arguments": [
+        "summary_type"
+      ],
       "text": "Use PDF Tools to analyze technical documentation stored on this computer and create ${arguments.summary_type}. If I haven't given you a path, start by listing the PDFs you can see so I can pick one. Extract the code examples, build a reference guide, identify the implementation steps, and summarize the troubleshooting sections."
     },
     {

--- a/pdf-toolkit-mcp-share/server/index.js
+++ b/pdf-toolkit-mcp-share/server/index.js
@@ -1476,6 +1476,10 @@ function grantsAccessToOwnConfig(directories, configPath) {
   return directories.some(directory => isPathInsideDirectory(canonicalConfig, directory.canonical));
 }
 
+// Which precedence layer actually supplied the active set. Reported by
+// get_allowed_directories so an operator can tell where to change it.
+let ALLOWED_DIRECTORY_SOURCE = "none";
+
 function buildAllowedDirectories() {
   const configPath = pluginDataConfigPath();
   const argumentDirectories = parseAllowedDirectoryArgs(process.argv.slice(2));
@@ -1484,11 +1488,15 @@ function buildAllowedDirectories() {
   let configuredDirectories;
   if (argumentDirectories?.length) {
     configuredDirectories = argumentDirectories;
+    ALLOWED_DIRECTORY_SOURCE = "argument";
   } else if (environmentDirectories?.length) {
     configuredDirectories = environmentDirectories;
+    ALLOWED_DIRECTORY_SOURCE = "environment";
   } else {
     ensurePluginDataConfigTemplate(configPath);
-    configuredDirectories = readPluginDataConfig(configPath) ?? [];
+    const fromConfig = readPluginDataConfig(configPath);
+    configuredDirectories = fromConfig ?? [];
+    ALLOWED_DIRECTORY_SOURCE = fromConfig?.length ? "config_file" : "none";
   }
 
   const seen = new Set();
@@ -1510,6 +1518,7 @@ function buildAllowedDirectories() {
       `[pdf-tools] The allowed directories reach ${configPath}, which would let this `
       + "server rewrite its own boundary. No directories are allowed until that entry is removed.",
     );
+    ALLOWED_DIRECTORY_SOURCE = "refused_self_granting";
     return [];
   }
   return resolved;
@@ -3703,6 +3712,21 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
           readOnlyHint: false,
           destructiveHint: true,
           idempotentHint: false,
+          openWorldHint: false
+        }
+      },
+      {
+        name: "get_allowed_directories",
+        description: "Report which folders this server may read and write, which configuration layer supplied them, and where the stored configuration file lives. Answers without touching the filesystem, so it works before anything is configured. Use it to explain a path refusal or to tell the user where to change the boundary. It reports the boundary; it cannot change it.",
+        inputSchema: {
+          type: "object",
+          properties: {}
+        },
+        annotations: {
+          title: "Get Allowed Directories",
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: true,
           openWorldHint: false
         }
       },
@@ -6243,6 +6267,28 @@ async function handleToolCall(request) {
             style: signatureRecord.style,
             path: sigPath,
             bytes: bytesOnDisk,
+          },
+        };
+      }
+
+      case "get_allowed_directories": {
+        // Reporting the boundary is not reaching past it, so this answers even
+        // when nothing is configured — which is exactly when it is most needed.
+        const directories = ALLOWED_DIRECTORIES.map(directory => directory.display);
+        const configured = directories.length > 0;
+        const summary = configured
+          ? `Allowed folders (${ALLOWED_DIRECTORY_SOURCE.replace(/_/g, " ")}):\n${directories.join("\n")}`
+          : PLUGIN_DATA_CONFIG_PATH
+            ? `No folders are allowed yet. List them in ${PLUGIN_DATA_CONFIG_PATH} under "allowedDirectories", then restart this server.`
+            : "No folders are allowed yet, and no configuration file location is available. Set the --allowed-directories argument or the ALLOWED_DIRECTORIES environment variable where this server is configured.";
+
+        return {
+          content: [{ type: "text", text: summary }],
+          structuredContent: {
+            directories,
+            configured,
+            source: ALLOWED_DIRECTORY_SOURCE,
+            config_path: PLUGIN_DATA_CONFIG_PATH ?? null,
           },
         };
       }

--- a/pdf-toolkit-mcp-share/server/output-schemas.js
+++ b/pdf-toolkit-mcp-share/server/output-schemas.js
@@ -1289,6 +1289,12 @@ export const TOOL_SUCCESS_OUTPUT_SCHEMAS = Object.freeze({
     path: string,
     bytes: integer,
   }),
+  get_allowed_directories: object({
+    directories: arrayOf(string),
+    configured: { type: "boolean" },
+    source: enumString(["argument", "environment", "config_file", "none", "refused_self_granting"]),
+    config_path: nullable(string),
+  }),
   list_signatures: object({
     signatures: arrayOf(object({
       name: string,

--- a/scripts/test-suite-classification.mjs
+++ b/scripts/test-suite-classification.mjs
@@ -74,6 +74,7 @@ export const CHECKOUT_LOCAL_MUTATING_TEST_SUITES = Object.freeze([
   "test/fetch-pdf-from-url.test.js",
   "test/fuzz-malformed-pdfs.test.js",
   "test/get-page-analysis.test.js",
+  "test/get-allowed-directories.test.js",
   "test/get-pdf-info.test.js",
   "test/golden-set-placement.test.js",
   "test/integration.test.js",

--- a/server/index.js
+++ b/server/index.js
@@ -1476,6 +1476,10 @@ function grantsAccessToOwnConfig(directories, configPath) {
   return directories.some(directory => isPathInsideDirectory(canonicalConfig, directory.canonical));
 }
 
+// Which precedence layer actually supplied the active set. Reported by
+// get_allowed_directories so an operator can tell where to change it.
+let ALLOWED_DIRECTORY_SOURCE = "none";
+
 function buildAllowedDirectories() {
   const configPath = pluginDataConfigPath();
   const argumentDirectories = parseAllowedDirectoryArgs(process.argv.slice(2));
@@ -1484,11 +1488,15 @@ function buildAllowedDirectories() {
   let configuredDirectories;
   if (argumentDirectories?.length) {
     configuredDirectories = argumentDirectories;
+    ALLOWED_DIRECTORY_SOURCE = "argument";
   } else if (environmentDirectories?.length) {
     configuredDirectories = environmentDirectories;
+    ALLOWED_DIRECTORY_SOURCE = "environment";
   } else {
     ensurePluginDataConfigTemplate(configPath);
-    configuredDirectories = readPluginDataConfig(configPath) ?? [];
+    const fromConfig = readPluginDataConfig(configPath);
+    configuredDirectories = fromConfig ?? [];
+    ALLOWED_DIRECTORY_SOURCE = fromConfig?.length ? "config_file" : "none";
   }
 
   const seen = new Set();
@@ -1510,6 +1518,7 @@ function buildAllowedDirectories() {
       `[pdf-tools] The allowed directories reach ${configPath}, which would let this `
       + "server rewrite its own boundary. No directories are allowed until that entry is removed.",
     );
+    ALLOWED_DIRECTORY_SOURCE = "refused_self_granting";
     return [];
   }
   return resolved;
@@ -3703,6 +3712,21 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
           readOnlyHint: false,
           destructiveHint: true,
           idempotentHint: false,
+          openWorldHint: false
+        }
+      },
+      {
+        name: "get_allowed_directories",
+        description: "Report which folders this server may read and write, which configuration layer supplied them, and where the stored configuration file lives. Answers without touching the filesystem, so it works before anything is configured. Use it to explain a path refusal or to tell the user where to change the boundary. It reports the boundary; it cannot change it.",
+        inputSchema: {
+          type: "object",
+          properties: {}
+        },
+        annotations: {
+          title: "Get Allowed Directories",
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: true,
           openWorldHint: false
         }
       },
@@ -6243,6 +6267,28 @@ async function handleToolCall(request) {
             style: signatureRecord.style,
             path: sigPath,
             bytes: bytesOnDisk,
+          },
+        };
+      }
+
+      case "get_allowed_directories": {
+        // Reporting the boundary is not reaching past it, so this answers even
+        // when nothing is configured — which is exactly when it is most needed.
+        const directories = ALLOWED_DIRECTORIES.map(directory => directory.display);
+        const configured = directories.length > 0;
+        const summary = configured
+          ? `Allowed folders (${ALLOWED_DIRECTORY_SOURCE.replace(/_/g, " ")}):\n${directories.join("\n")}`
+          : PLUGIN_DATA_CONFIG_PATH
+            ? `No folders are allowed yet. List them in ${PLUGIN_DATA_CONFIG_PATH} under "allowedDirectories", then restart this server.`
+            : "No folders are allowed yet, and no configuration file location is available. Set the --allowed-directories argument or the ALLOWED_DIRECTORIES environment variable where this server is configured.";
+
+        return {
+          content: [{ type: "text", text: summary }],
+          structuredContent: {
+            directories,
+            configured,
+            source: ALLOWED_DIRECTORY_SOURCE,
+            config_path: PLUGIN_DATA_CONFIG_PATH ?? null,
           },
         };
       }

--- a/server/output-schemas.js
+++ b/server/output-schemas.js
@@ -1289,6 +1289,12 @@ export const TOOL_SUCCESS_OUTPUT_SCHEMAS = Object.freeze({
     path: string,
     bytes: integer,
   }),
+  get_allowed_directories: object({
+    directories: arrayOf(string),
+    configured: { type: "boolean" },
+    source: enumString(["argument", "environment", "config_file", "none", "refused_self_granting"]),
+    config_path: nullable(string),
+  }),
   list_signatures: object({
     signatures: arrayOf(object({
       name: string,

--- a/test/get-allowed-directories.test.js
+++ b/test/get-allowed-directories.test.js
@@ -1,0 +1,133 @@
+import fs from "fs/promises";
+import path from "path";
+import { fileURLToPath } from "url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { createTestTempDirectory, removeTestTempDirectory } from "./helpers/temp-directory.js";
+
+// Before this tool the only way to discover the boundary was to trip it: the
+// refusal message was the sole place the allowed set and the config path
+// appeared. Asking should not require failing first.
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.join(__dirname, "..");
+const SERVER_ENTRY = path.join(REPO_ROOT, "server", "index.js");
+
+async function withServer({ args = [], env = {}, name }, run) {
+  const client = new Client({ name, version: "1.0.0" });
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [SERVER_ENTRY, ...args],
+    cwd: REPO_ROOT,
+    env: { PATH: process.env.PATH ?? "", ...env },
+    stderr: "pipe",
+  });
+  await client.connect(transport);
+  try {
+    return await run(client);
+  } finally {
+    await transport.close();
+  }
+}
+
+describe("get_allowed_directories", () => {
+  let tempDirectory;
+  let pluginData;
+  let firstDirectory;
+  let secondDirectory;
+
+  beforeAll(async () => {
+    tempDirectory = await createTestTempDirectory(REPO_ROOT, "get-allowed-directories");
+    pluginData = path.join(tempDirectory, "plugin-data");
+    firstDirectory = path.join(tempDirectory, "first");
+    secondDirectory = path.join(tempDirectory, "second");
+    await fs.mkdir(pluginData, { recursive: true });
+    await fs.mkdir(firstDirectory, { recursive: true });
+    await fs.mkdir(secondDirectory, { recursive: true });
+  }, 30_000);
+
+  afterAll(async () => {
+    await removeTestTempDirectory(tempDirectory);
+  });
+
+  it("reports the configured directories and the layer that supplied them", async () => {
+    const result = await withServer({
+      name: "allowed-dirs-env",
+      env: {
+        HOME: path.join(tempDirectory, "home"),
+        ALLOWED_DIRECTORIES: [firstDirectory, secondDirectory].join(path.delimiter),
+        DEFAULT_PROFILES_DIR: path.join(tempDirectory, "profiles"),
+      },
+    }, client => client.callTool({ name: "get_allowed_directories", arguments: {} }));
+
+    const structured = result.structuredContent;
+    expect(structured.source).toBe("environment");
+    expect(structured.directories).toEqual([firstDirectory, secondDirectory]);
+    expect(structured.configured).toBe(true);
+  }, 30_000);
+
+  it("names the argument layer when the argument supplied the set", async () => {
+    const result = await withServer({
+      name: "allowed-dirs-argv",
+      args: ["--allowed-directories", firstDirectory],
+      env: {
+        HOME: path.join(tempDirectory, "home"),
+        ALLOWED_DIRECTORIES: secondDirectory,
+        DEFAULT_PROFILES_DIR: path.join(tempDirectory, "profiles"),
+      },
+    }, client => client.callTool({ name: "get_allowed_directories", arguments: {} }));
+
+    // The argument outranks the environment, and the report must say which one
+    // actually took effect rather than listing both.
+    expect(result.structuredContent.source).toBe("argument");
+    expect(result.structuredContent.directories).toEqual([firstDirectory]);
+  }, 30_000);
+
+  it("reports the config file and its path on a plugin install", async () => {
+    await fs.writeFile(
+      path.join(pluginData, "config.json"),
+      JSON.stringify({ allowedDirectories: [firstDirectory] }),
+    );
+
+    const result = await withServer({
+      name: "allowed-dirs-config",
+      env: { HOME: path.join(tempDirectory, "home"), PLUGIN_DATA: pluginData },
+    }, client => client.callTool({ name: "get_allowed_directories", arguments: {} }));
+
+    const structured = result.structuredContent;
+    expect(structured.source).toBe("config_file");
+    expect(structured.config_path).toBe(path.join(pluginData, "config.json"));
+    expect(structured.directories).toEqual([firstDirectory]);
+  }, 30_000);
+
+  it("answers without a refusal when nothing is configured", async () => {
+    const emptyPluginData = path.join(tempDirectory, "empty-plugin-data");
+    await fs.mkdir(emptyPluginData, { recursive: true });
+
+    const result = await withServer({
+      name: "allowed-dirs-empty",
+      env: { HOME: path.join(tempDirectory, "home"), PLUGIN_DATA: emptyPluginData },
+    }, client => client.callTool({ name: "get_allowed_directories", arguments: {} }));
+
+    // Reporting the boundary is not reaching past it, so an unconfigured
+    // server must still answer this question rather than deny it.
+    expect(result.isError).not.toBe(true);
+    expect(result.structuredContent.configured).toBe(false);
+    expect(result.structuredContent.directories).toEqual([]);
+    expect(result.structuredContent.config_path).toBe(path.join(emptyPluginData, "config.json"));
+  }, 30_000);
+
+  it("is annotated read-only and takes no arguments", async () => {
+    const tool = await withServer({
+      name: "allowed-dirs-annotations",
+      env: { HOME: path.join(tempDirectory, "home"), ALLOWED_DIRECTORIES: firstDirectory },
+    }, async client => (await client.listTools()).tools.find(t => t.name === "get_allowed_directories"));
+
+    expect(tool).toBeTruthy();
+    expect(tool.annotations.readOnlyHint).toBe(true);
+    expect(tool.annotations.destructiveHint).toBe(false);
+    // No arguments means nothing to point somewhere it should not go.
+    expect(tool.inputSchema.properties).toEqual({});
+  }, 30_000);
+});

--- a/test/mcp-contract.test.js
+++ b/test/mcp-contract.test.js
@@ -90,7 +90,7 @@ const EXAMPLE_PDF = path.join(REPO_ROOT, "example-fw9.pdf");
 // grid, with no matrix of any kind taking part, so every published digest
 // changed and the extraction IR went to 1.5.0. Previously
 // dafeaf19570eece1bb3901f883ea456216b7f46ea6872b80a9eb205c24b9e45f.
-const TOOL_CONTRACT_SHA256 = "b980fc09c3b9c886f01e08b82fe67df569e5cafa5471dd4c3e549ac6d8e26fc0";
+const TOOL_CONTRACT_SHA256 = "53d965e366b16adf2a0fa90dfe837ca98d29a8f41c1adf8b9e8f661ea3bb7d95";
 
 const CLOSED_READ = Object.freeze({
   readOnlyHint: true,
@@ -157,6 +157,7 @@ const TOOL_EFFECT_ANNOTATIONS = {
   apply_page_plan: CLOSED_IDEMPOTENT_OVERWRITE,
   get_page_analysis: CLOSED_READ,
   create_signature: CLOSED_NON_IDEMPOTENT_OVERWRITE,
+  get_allowed_directories: CLOSED_READ,
   list_signatures: CLOSED_READ,
   load_signature: CLOSED_READ,
   add_signature_field: CLOSED_NON_IDEMPOTENT_OVERWRITE,
@@ -371,7 +372,7 @@ describe.each(RUNTIMES)("$name runtime discovery", runtime => {
   });
 
   it("exposes the same uniquely named, fully annotated tool contract", () => {
-    expect(tools).toHaveLength(42);
+    expect(tools).toHaveLength(43);
     expect(new Set(names(tools)).size).toBe(tools.length);
     expect(sorted(names(tools))).toEqual(sorted(names(SOURCE_MANIFEST.tools)));
     expect(createHash("sha256").update(JSON.stringify(tools)).digest("hex"))

--- a/test/output-schema.test.js
+++ b/test/output-schema.test.js
@@ -34,6 +34,7 @@ const STRUCTURED_TOOLS = [
   "fill_pdf",
   "fill_with_profile",
   "get_active_document",
+  "get_allowed_directories",
   "get_page_analysis",
   "get_pdf_identity",
   "get_pdf_info",
@@ -144,11 +145,11 @@ describe("output schema definitions", () => {
     expect(rejected.structuredContent.error.code).toBe("internal_validation_error");
   });
 
-  it("covers the exact 38 structured tools and no text-only tool", () => {
+  it("covers the exact 39 structured tools and no text-only tool", () => {
     expect(Object.keys(TOOL_OUTPUT_SCHEMAS).sort()).toEqual(STRUCTURED_TOOLS);
     expect(Object.keys(TOOL_ERROR_OUTPUT_SCHEMAS).sort()).toEqual(STRUCTURED_TOOLS);
     expect(Object.keys(TOOL_SUCCESS_OUTPUT_SCHEMAS).sort()).toEqual(STRUCTURED_TOOLS);
-    expect(STRUCTURED_TOOLS).toHaveLength(38);
+    expect(STRUCTURED_TOOLS).toHaveLength(39);
     expect(TEXT_ONLY_TOOLS).toHaveLength(4);
   });
 


### PR DESCRIPTION
## Summary

Before this, the only way to learn which folders the server could reach — or where a plugin install's config file lives — was to request a path and read the refusal. Asking should not require failing first. On a fresh plugin install, where nothing is allowed yet, the refusal message was the *sole* place the config path appeared.

`get_allowed_directories` reports the active directories, which precedence layer supplied them (`argument`, `environment`, `config_file`, or `none`), and the `${PLUGIN_DATA}` config path when one exists.

It answers **even when nothing is configured**, which is exactly when it is most needed: reporting a boundary is not reaching past it.

## Why there is no counterpart that adds a directory

The asymmetry is deliberate. A tool that can widen its own sandbox is a privilege-escalation path, and document text is untrusted input this server already refuses to take instructions from. Widening remains a human editing a file; this tool tells them which file.

The tool takes **no arguments**, so it carries no path that could be aimed somewhere it should not go. It is read-only by construction and by annotation (`CLOSED_READ`).

## Registries updated

Adding a tool has a wide, mechanical blast radius in this repo. All of it is updated and verified:

| Registry | Change |
|---|---|
| `manifest.json` / `manifest.mcpb.json` | tool added to both |
| Pinned tool count (`mcp-contract.test.js`) | 42 → 43 |
| Tool-contract digest | re-pinned to `53d965e3…` |
| Effect-annotation table | `get_allowed_directories: CLOSED_READ` |
| Structured-tool inventory (`output-schema.test.js`) | 38 → 39 |
| `CLAUDE.md` tool list | documented |

The two manifests continue to differ by `read_pdf_bytes`, which is app-only by design and predates this change — verified against `HEAD` rather than assumed.

## Test evidence

`test/get-allowed-directories.test.js`, five cases: it reports the environment layer, the argument layer outranking the environment, the config-file layer with its path on a plugin install, a correct answer when nothing is configured, and its read-only annotations with an empty input schema.

macOS ARM64, at `fec8c02`:

```
Test Files  8 passed (8)
Tests       169 passed (169)
```

Covering `get-allowed-directories`, `mcp-contract` (including the re-pinned digest), `output-schema`, `plugin-data-config`, `allowed-directories`, `sandbox-boundary-findings`, `documentation-claims`, and `test-runner-contract`.

Mirrored into the share runtime and enrolled in `CHECKOUT_LOCAL_MUTATING_TEST_SUITES`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
