### PR TITLE
Expand the host placeholders we can resolve, keep rejecting the rest

### DIFF
--- a/pdf-toolkit-mcp-share/server/helpers.js
+++ b/pdf-toolkit-mcp-share/server/helpers.js
@@ -596,6 +596,26 @@ export function failedPdfFormValidation({ pdfPath = null, fileName = null } = {}
 // separate command arguments. Keep the marker explicit so ordinary MCP hosts
 // can continue using environment variables without treating unrelated CLI
 // arguments as filesystem permissions.
+// A host may hand us a path that still contains a placeholder. Two kinds arrive
+// and they are not the same thing.
+//
+// `${HOME}` and `${USERPROFILE}` are *resolvable*: they name the running user's
+// home directory, which this process already knows. Claude Desktop expands them
+// in manifest-authored env strings but not inside `user_config` default values,
+// so a user who never opened the settings sends us a literal `${HOME}/Documents`
+// on every platform. Measured on Windows Claude Desktop 1.26832.0.
+//
+// `${user_config.*}` is *unresolvable*: it means the host did not substitute the
+// user's configuration and we genuinely do not know what was intended. That must
+// still be rejected, because guessing a boundary the user never chose is the
+// fail-open this replaced.
+export function expandHostPlaceholders(value) {
+  if (typeof value !== "string" || !value.includes("${")) return value;
+  return value
+    .replaceAll("${HOME}", homedir())
+    .replaceAll("${USERPROFILE}", homedir());
+}
+
 export function parseAllowedDirectoryArgs(argv = []) {
   const markerIndex = argv.indexOf("--allowed-directories");
   if (markerIndex === -1) return null;
@@ -606,7 +626,7 @@ export function parseAllowedDirectoryArgs(argv = []) {
     // Stop at the next option so an unrelated flag can never be mistaken for a
     // filesystem permission.
     if (argument.startsWith("--")) break;
-    const trimmed = argument.trim();
+    const trimmed = expandHostPlaceholders(argument.trim());
     if (!trimmed || trimmed.includes("${")) continue;
     values.push(trimmed);
   }

--- a/pdf-toolkit-mcp-share/server/index.js
+++ b/pdf-toolkit-mcp-share/server/index.js
@@ -670,6 +670,7 @@ import {
   assertXfaMutationAllowed,
   computeIoU,
   getRegionPixelRect,
+  expandHostPlaceholders,
   parseAllowedDirectoryArgs,
   validatePdfFormFields,
   failedPdfFormValidation,
@@ -1385,8 +1386,10 @@ const server = new Server(
 // "${user_config.X}" would reach us and break readdir. Treat any template-
 // shaped value as unset and fall through to the safe home-dir default.
 function envPathOrDefault(name, fallback) {
-  const val = process.env[name];
-  if (!val) return fallback;
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const val = expandHostPlaceholders(raw);
+  // Still templated after expansion means the host did not resolve it.
   if (val.includes("${")) return fallback;
   return val;
 }
@@ -1398,7 +1401,8 @@ const SIGNATURES_DIR = path.join(PROFILES_DIR, "signatures");
 const BACKUPS_DIR = path.join(PROFILES_DIR, "backups");
 const OLD_PROFILES_DIR = path.join(homedir(), ".pdf-filler-profiles");
 
-function parsePathListValue(value) {
+function parsePathListValue(rawValue) {
+  const value = expandHostPlaceholders(rawValue);
   if (!value || value.includes("${")) return null;
 
   const trimmed = value.trim();
@@ -1412,7 +1416,7 @@ function parsePathListValue(value) {
         // dropped rather than treated as a permission.
         return parsed
           .filter(item => typeof item === "string")
-          .map(item => item.trim())
+          .map(item => expandHostPlaceholders(item.trim()))
           .filter(item => item && !item.includes("${"));
       }
     } catch {}
@@ -1496,7 +1500,7 @@ function readPluginDataConfig(configPath) {
   }
   return parsed.allowedDirectories
     .filter(entry => typeof entry === "string")
-    .map(entry => entry.trim())
+    .map(entry => expandHostPlaceholders(entry.trim()))
     .filter(entry => entry && !entry.includes("${"));
 }
 

--- a/scripts/test-suite-classification.mjs
+++ b/scripts/test-suite-classification.mjs
@@ -77,6 +77,7 @@ export const CHECKOUT_LOCAL_MUTATING_TEST_SUITES = Object.freeze([
   "test/get-allowed-directories.test.js",
   "test/get-pdf-info.test.js",
   "test/golden-set-placement.test.js",
+  "test/host-placeholder-expansion.test.js",
   "test/integration.test.js",
   "test/list-pdfs-default-directory.test.js",
   "test/metadata-provenance.test.js",

--- a/server/helpers.js
+++ b/server/helpers.js
@@ -596,6 +596,26 @@ export function failedPdfFormValidation({ pdfPath = null, fileName = null } = {}
 // separate command arguments. Keep the marker explicit so ordinary MCP hosts
 // can continue using environment variables without treating unrelated CLI
 // arguments as filesystem permissions.
+// A host may hand us a path that still contains a placeholder. Two kinds arrive
+// and they are not the same thing.
+//
+// `${HOME}` and `${USERPROFILE}` are *resolvable*: they name the running user's
+// home directory, which this process already knows. Claude Desktop expands them
+// in manifest-authored env strings but not inside `user_config` default values,
+// so a user who never opened the settings sends us a literal `${HOME}/Documents`
+// on every platform. Measured on Windows Claude Desktop 1.26832.0.
+//
+// `${user_config.*}` is *unresolvable*: it means the host did not substitute the
+// user's configuration and we genuinely do not know what was intended. That must
+// still be rejected, because guessing a boundary the user never chose is the
+// fail-open this replaced.
+export function expandHostPlaceholders(value) {
+  if (typeof value !== "string" || !value.includes("${")) return value;
+  return value
+    .replaceAll("${HOME}", homedir())
+    .replaceAll("${USERPROFILE}", homedir());
+}
+
 export function parseAllowedDirectoryArgs(argv = []) {
   const markerIndex = argv.indexOf("--allowed-directories");
   if (markerIndex === -1) return null;
@@ -606,7 +626,7 @@ export function parseAllowedDirectoryArgs(argv = []) {
     // Stop at the next option so an unrelated flag can never be mistaken for a
     // filesystem permission.
     if (argument.startsWith("--")) break;
-    const trimmed = argument.trim();
+    const trimmed = expandHostPlaceholders(argument.trim());
     if (!trimmed || trimmed.includes("${")) continue;
     values.push(trimmed);
   }

--- a/server/index.js
+++ b/server/index.js
@@ -670,6 +670,7 @@ import {
   assertXfaMutationAllowed,
   computeIoU,
   getRegionPixelRect,
+  expandHostPlaceholders,
   parseAllowedDirectoryArgs,
   validatePdfFormFields,
   failedPdfFormValidation,
@@ -1385,8 +1386,10 @@ const server = new Server(
 // "${user_config.X}" would reach us and break readdir. Treat any template-
 // shaped value as unset and fall through to the safe home-dir default.
 function envPathOrDefault(name, fallback) {
-  const val = process.env[name];
-  if (!val) return fallback;
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const val = expandHostPlaceholders(raw);
+  // Still templated after expansion means the host did not resolve it.
   if (val.includes("${")) return fallback;
   return val;
 }
@@ -1398,7 +1401,8 @@ const SIGNATURES_DIR = path.join(PROFILES_DIR, "signatures");
 const BACKUPS_DIR = path.join(PROFILES_DIR, "backups");
 const OLD_PROFILES_DIR = path.join(homedir(), ".pdf-filler-profiles");
 
-function parsePathListValue(value) {
+function parsePathListValue(rawValue) {
+  const value = expandHostPlaceholders(rawValue);
   if (!value || value.includes("${")) return null;
 
   const trimmed = value.trim();
@@ -1412,7 +1416,7 @@ function parsePathListValue(value) {
         // dropped rather than treated as a permission.
         return parsed
           .filter(item => typeof item === "string")
-          .map(item => item.trim())
+          .map(item => expandHostPlaceholders(item.trim()))
           .filter(item => item && !item.includes("${"));
       }
     } catch {}
@@ -1496,7 +1500,7 @@ function readPluginDataConfig(configPath) {
   }
   return parsed.allowedDirectories
     .filter(entry => typeof entry === "string")
-    .map(entry => entry.trim())
+    .map(entry => expandHostPlaceholders(entry.trim()))
     .filter(entry => entry && !entry.includes("${"));
 }
 

--- a/test/host-placeholder-expansion.test.js
+++ b/test/host-placeholder-expansion.test.js
@@ -1,0 +1,166 @@
+import fs from "fs/promises";
+import path from "path";
+import { homedir } from "os";
+import { fileURLToPath } from "url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { expandHostPlaceholders, parseAllowedDirectoryArgs } from "../server/helpers.js";
+import { createTestTempDirectory, removeTestTempDirectory } from "./helpers/temp-directory.js";
+
+// Measured on Windows Claude Desktop 1.26832.0 with an MCPB install whose
+// allowed-directories setting the user had never opened:
+//
+//   argv = [..., "--allowed-directories",
+//           "${HOME}/Documents", "${HOME}/Downloads", "${HOME}/Desktop"]
+//   ALLOWED_DIRECTORIES = "${user_config.allowed_directories}"
+//   DEFAULT_PROFILES_DIR = "C:\Users\qa/.pdf-toolkit-files"
+//
+// The host expands ${HOME} in a manifest-authored env string but not inside a
+// user_config default value, so those three arrive literal. Rejecting them as
+// "unresolved" left the allowed set empty and refused every path, while the
+// removed home-folder fallback had been coincidentally reproducing the same
+// three directories and hiding it.
+//
+// ${HOME} is resolvable by this process. ${user_config.*} is not, and must stay
+// rejected: guessing a boundary the user never chose is the fail-open this
+// whole line of work removed.
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.join(__dirname, "..");
+const SERVER_ENTRY = path.join(REPO_ROOT, "server", "index.js");
+const EXAMPLE_PDF = path.join(REPO_ROOT, "example-fw9.pdf");
+
+function structuredErrorCode(result) {
+  return result.structuredContent?.error?.code;
+}
+
+async function withServer({ args = [], env = {}, name }, run) {
+  const client = new Client({ name, version: "1.0.0" });
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [SERVER_ENTRY, ...args],
+    cwd: REPO_ROOT,
+    env: { PATH: process.env.PATH ?? "", ...env },
+    stderr: "pipe",
+  });
+  await client.connect(transport);
+  try {
+    return await run(client);
+  } finally {
+    await transport.close();
+  }
+}
+
+describe("expandHostPlaceholders", () => {
+  it("resolves ${HOME} and ${USERPROFILE} to the running user's home", () => {
+    expect(expandHostPlaceholders("${HOME}/Documents")).toBe(`${homedir()}/Documents`);
+    expect(expandHostPlaceholders("${USERPROFILE}/Desktop")).toBe(`${homedir()}/Desktop`);
+  });
+
+  it("leaves an unresolvable host template alone", () => {
+    // We do not know what the user configured, so this must remain templated
+    // and be rejected downstream rather than guessed at.
+    expect(expandHostPlaceholders("${user_config.allowed_directories}"))
+      .toBe("${user_config.allowed_directories}");
+  });
+
+  it("passes ordinary paths through untouched", () => {
+    expect(expandHostPlaceholders("/srv/documents")).toBe("/srv/documents");
+    expect(expandHostPlaceholders("C:\\Users\\qa\\Documents")).toBe("C:\\Users\\qa\\Documents");
+  });
+});
+
+describe("parseAllowedDirectoryArgs with the argv Windows actually sends", () => {
+  it("accepts the unexpanded user_config defaults the host passes through", () => {
+    expect(parseAllowedDirectoryArgs([
+      "--allowed-directories",
+      "${HOME}/Documents",
+      "${HOME}/Downloads",
+      "${HOME}/Desktop",
+    ])).toEqual([
+      `${homedir()}/Documents`,
+      `${homedir()}/Downloads`,
+      `${homedir()}/Desktop`,
+    ]);
+  });
+
+  it("still rejects a template it cannot resolve", () => {
+    expect(parseAllowedDirectoryArgs([
+      "--allowed-directories",
+      "${user_config.allowed_directories}",
+    ])).toEqual([]);
+  });
+});
+
+describe("end to end: the Windows MCPB launch shape", () => {
+  let tempDirectory;
+  let fakeHome;
+  let documents;
+
+  beforeAll(async () => {
+    tempDirectory = await createTestTempDirectory(REPO_ROOT, "host-placeholder");
+    fakeHome = path.join(tempDirectory, "home");
+    documents = path.join(fakeHome, "Documents");
+    await fs.mkdir(documents, { recursive: true });
+    await fs.copyFile(EXAMPLE_PDF, path.join(documents, "w9.pdf"));
+  }, 30_000);
+
+  afterAll(async () => {
+    await removeTestTempDirectory(tempDirectory);
+  });
+
+  it("grants the folders the host named, reproducing the exact failing launch", async () => {
+    // Exactly what Claude Desktop passed on Windows: literal ${HOME} in argv,
+    // and an env var the host never substituted at all.
+    const text = await withServer({
+      name: "windows-launch-shape",
+      args: ["--allowed-directories", "${HOME}/Documents"],
+      env: {
+        HOME: fakeHome,
+        USERPROFILE: fakeHome,
+        ALLOWED_DIRECTORIES: "${user_config.allowed_directories}",
+        DEFAULT_PROFILES_DIR: path.join(tempDirectory, "profiles"),
+      },
+    }, client => client
+      .callTool({ name: "list_pdfs", arguments: { directory: documents } })
+      .then(r => r.content?.map(i => i.text).join(" ") ?? ""));
+
+    expect(text).toContain("w9.pdf");
+  }, 30_000);
+
+  it("reports the resolved directory, not the template it was handed", async () => {
+    const structured = await withServer({
+      name: "windows-launch-reported",
+      args: ["--allowed-directories", "${HOME}/Documents"],
+      env: {
+        HOME: fakeHome,
+        USERPROFILE: fakeHome,
+        DEFAULT_PROFILES_DIR: path.join(tempDirectory, "profiles"),
+      },
+    }, client => client
+      .callTool({ name: "get_allowed_directories", arguments: {} })
+      .then(r => r.structuredContent));
+
+    expect(structured.configured).toBe(true);
+    expect(structured.source).toBe("argument");
+    expect(structured.directories).toEqual([documents]);
+  }, 30_000);
+
+  it("still refuses when the host resolved nothing at all", async () => {
+    // Both channels unresolvable: this is genuinely unconfigured and must
+    // refuse rather than invent a boundary.
+    const result = await withServer({
+      name: "windows-unresolvable",
+      args: ["--allowed-directories", "${user_config.allowed_directories}"],
+      env: {
+        HOME: fakeHome,
+        USERPROFILE: fakeHome,
+        ALLOWED_DIRECTORIES: "${user_config.allowed_directories}",
+        DEFAULT_PROFILES_DIR: path.join(tempDirectory, "profiles"),
+      },
+    }, client => client.callTool({ name: "list_pdfs", arguments: { directory: documents } }));
+
+    expect(structuredErrorCode(result)).toBe("path_policy_denied");
+  }, 30_000);
+});


### PR DESCRIPTION
## Summary

`#94` made the allowed set come only from explicit configuration, so an unresolved `${...}` template means unconfigured and refuses everything. That is right in principle, and on Windows it refused *everything* — because the host legitimately hands us a placeholder we can resolve ourselves.

**Measured on Windows Claude Desktop 1.26832.0**, MCPB install, allowed-directories setting never opened by the user:

```
argv  … --allowed-directories ${HOME}/Documents ${HOME}/Downloads ${HOME}/Desktop
env   ALLOWED_DIRECTORIES = ${user_config.allowed_directories}
env   DEFAULT_PROFILES_DIR = C:\Users\qa/.pdf-toolkit-files
```

Three facts follow:

1. The `multiple: true` array expansion **works** — three separate argv entries.
2. The host expands `${HOME}` in a **manifest-authored env string** (see `DEFAULT_PROFILES_DIR`) but **not inside a `user_config` default value**, so those directories arrive as literal templates.
3. `user_config` substitution into **env does not happen at all**.

Rejecting every `${` therefore discarded all three and left the allowed set empty. The home-folder fallback that `#94` removed had been reproducing those same three directories by coincidence, hiding this the entire time.

## The distinction this adds

The two placeholder kinds are not equivalent:

- **`${HOME}` / `${USERPROFILE}` are resolvable.** They name the running user's home directory, which this process already knows.
- **`${user_config.*}` is unresolvable.** It means the host did not substitute the user's configuration and we genuinely do not know what was intended. Guessing there is exactly the fail-open this line of work removed, so it stays rejected.

`expandHostPlaceholders` resolves the first kind and leaves the second, and runs at every site that previously rejected on `${`: the argument parser, the environment path readers, the JSON list branch, and the `PLUGIN_DATA` config entries. **A value still templated after expansion is still refused.**

## Host evidence — the same machine, before and after

| | `get_allowed_directories` on Windows Claude Desktop 1.26832.0 |
|---|---|
| Before | *"No folders are allowed yet, and no configuration file location is available."* |
| After | `Allowed folders (argument): C:\Users\qa\Documents, C:\Users\qa\Downloads, C:\Users\qa\Desktop` |

Real conversation, real model, real tool call, approved interactively. The VM was restored to its original build afterwards with no residue.

## Test evidence

`test/host-placeholder-expansion.test.js` pins the exact failing launch shape — literal `${HOME}` in argv **and** the unsubstituted `ALLOWED_DIRECTORIES` env var — and asserts that a genuinely unresolvable configuration still refuses.

**Verified load-bearing by mutation:** disabling the expansion fails 4 of its 8 cases.

Full boundary regression, 7 files / 99 tests passing: `host-placeholder-expansion`, `allowed-directories`, `sandbox-boundary-findings`, `plugin-data-config`, `get-allowed-directories`, `test-runner-contract`, `mcp-contract`.

Mirrored into the share runtime and enrolled in `CHECKOUT_LOCAL_MUTATING_TEST_SUITES`.

## Why this gates the release

Without it, shipping `#94`–`#100` would give every Windows Claude Desktop user who never opened the setting an extension that refuses every path. macOS testing did not catch it because every macOS run supplied configuration explicitly; this VM's untouched-default state is the common real-world case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
