### PR TITLE
Rebind the layout oracle to its current source identity

### DIFF
--- a/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
+++ b/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
@@ -79,14 +79,14 @@
     {
       "role": "output_schemas_module",
       "path": "server/output-schemas.js",
-      "bytes": 51699,
-      "sha256": "774bb9590e1730062298e4f465b3f4db13dea571973614759133b745012b492f"
+      "bytes": 51948,
+      "sha256": "8c3972812cd9d8790919644d37965ef3a60e3753fa6c9143a258ec24aea75054"
     },
     {
       "role": "package_json",
       "path": "package.json",
-      "bytes": 2704,
-      "sha256": "8abd7cf4e5a12b4ebc251a4ee924c4a017770fcd53b4bd047aa8ddcb6b223cfc"
+      "bytes": 2763,
+      "sha256": "e170d0085e34219558d1208cad22c8e06549a42d06fdfa74fef2bd098ec4df2f"
     },
     {
       "role": "package_lock",
@@ -119,7 +119,7 @@
       "sha256": "6e4429db62fcbe1dd73141d8c20a48b564d41f8bf8920d88775846995e1daf94"
     }
   ],
-  "validator_source_set_sha256": "754bf2266dda1ab873c5841e0cfaf03f332112552740015d08265a900cc85fca",
+  "validator_source_set_sha256": "6816279e7abf3ac0222de9c4a73b1d9a35bc758943880c8e10b3ad5ceb699f92",
   "pdfjs_version": "5.4.624",
   "generation_contract": {
     "source_path": "source.pdf",


### PR DESCRIPTION
## Summary

The layout occurrence oracle has been red since `#97` and stayed red through the rest of that train, failing *"regenerates byte-identically with exact source, schema, package-lock, and PDF.js bindings"*. **This unblocks the release** — master is otherwise green.

It is **stale, not a behavioural regression**, and the regenerated fixture proves that rather than asserting it.

## The check that matters

Regenerating and diffing against the committed oracle changes **exactly five leaves, all source identity**:

```
validator_source_set_sha256
validator_sources[7]  output_schemas_module   51699 -> 51948 bytes
validator_sources[8]  package_json             2704 ->  2763 bytes
```

**Every case, fact, occurrence and source span is byte-identical** — 8 cases, 13 facts, unchanged. The oracle exists to prove layout extraction is deterministic against pinned PDF.js bindings, and it still does. What moved is the identity of two inputs it binds, neither of which reaches extraction at runtime.

## Both drifts accounted for

- **`#100`** added the `get_allowed_directories` output schema to `server/output-schemas.js`, which the oracle binds as `output_schemas_module` (+249 bytes).
- **`#97`** added one npm script line to `package.json`, which it binds as `package_json` (+59 bytes).

`#97` changed **no server code, no `package-lock.json`, and no dependency**, so the resolved PDF.js assets are identical to the last green commit. The bisect landing on `#97` reflects that package.json edit, not the bundle altering extraction — which was the open question, and the reason this was not regenerated blindly.

## Verification

The three previously failing extraction suites pass: `extraction-phase1-layout-evidence`, `extraction-phase1-scorer`, `extraction-phase1-generation-verifiers` — 20 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
