### PR TITLE
Rebind the release gates to the 43-tool contract

### DIFF
--- a/scripts/eval-run-markdown-bakeoff.mjs
+++ b/scripts/eval-run-markdown-bakeoff.mjs
@@ -41,10 +41,10 @@ const REQUIRED_OPTIONS = [
 
 export function validateMarkdownDiscovery(tools) {
   if (!Array.isArray(tools)
-    || tools.length !== 42
+    || tools.length !== 43
     || !tools.some(tool => tool.name === "convert_pdf_to_markdown")
     || !tools.some(tool => tool.name === "inspect_pdf_accessibility")) {
-    throw new Error("Packed Markdown bakeoff discovery differs from the current 42-tool contract");
+    throw new Error("Packed Markdown bakeoff discovery differs from the current 43-tool contract");
   }
 }
 

--- a/scripts/smoke-mcpb.mjs
+++ b/scripts/smoke-mcpb.mjs
@@ -68,11 +68,11 @@ async function expectMcpError(operation, code) {
 
 export function validatePackedDiscovery(tools) {
   if (!Array.isArray(tools)
-    || tools.length !== 42
+    || tools.length !== 43
     || !tools.some(tool => tool.name === "render_pdf_page")
     || !tools.some(tool => tool.name === "compare_pdfs")
     || !tools.some(tool => tool.name === "inspect_pdf_accessibility")) {
-    throw new Error("Packed server discovery differs from the current 42-tool contract");
+    throw new Error("Packed server discovery differs from the current 43-tool contract");
   }
 }
 

--- a/scripts/test-share-contract.mjs
+++ b/scripts/test-share-contract.mjs
@@ -803,7 +803,7 @@ async function main() {
     const { tools } = await client.listTools();
     const { prompts } = await client.listPrompts();
     const { resources } = await client.listResources();
-    if (tools.length !== 42 || prompts.length !== 14 || resources.length !== 1) {
+    if (tools.length !== 43 || prompts.length !== 14 || resources.length !== 1) {
       throw new Error(
         `Unexpected discovery counts: ${tools.length} tools, ${prompts.length} prompts, ${resources.length} resources`,
       );

--- a/test/smoke-mcpb-contract.test.js
+++ b/test/smoke-mcpb-contract.test.js
@@ -11,22 +11,22 @@ const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..
 
 describe("packed MCPB discovery binding", () => {
   const currentTools = [
-    ...Array.from({ length: 39 }, (_, index) => ({ name: `fixture_tool_${index}` })),
+    ...Array.from({ length: 40 }, (_, index) => ({ name: `fixture_tool_${index}` })),
     { name: "render_pdf_page" },
     { name: "compare_pdfs" },
     { name: "inspect_pdf_accessibility" },
   ];
 
-  it("accepts only the current 42-tool discovery", () => {
+  it("accepts only the current 43-tool discovery", () => {
     expect(() => validatePackedDiscovery(currentTools)).not.toThrow();
-    expect(() => validatePackedDiscovery(currentTools.slice(1))).toThrow(/42-tool contract/);
+    expect(() => validatePackedDiscovery(currentTools.slice(1))).toThrow(/43-tool contract/);
   });
 
   it("requires every smoke-critical tool", () => {
     for (const required of ["render_pdf_page", "compare_pdfs", "inspect_pdf_accessibility"]) {
       expect(() => validatePackedDiscovery(
         currentTools.map(tool => tool.name === required ? { name: "stale_tool" } : tool),
-      )).toThrow(/42-tool contract/);
+      )).toThrow(/43-tool contract/);
     }
   });
 });


### PR DESCRIPTION
## Summary

`npm run smoke:mcpb` **fails on the v0.10.0 artifact**:

```
Packed MCPB smoke failed: Packed server discovery differs from the current 42-tool contract
```

The tool count moved to 43 when `#100` added `get_allowed_directories`. Three release-gate scripts still assert 42, so **the release cannot be cut at `1509d4d`** — that commit fails its own gate.

## Rebound

- `scripts/smoke-mcpb.mjs` — the packed MCPB smoke gate
- `scripts/eval-run-markdown-bakeoff.mjs`
- `scripts/test-share-contract.mjs` — the `test:contract:share` gate

## The fourth one is the interesting one

`test/smoke-mcpb-contract.test.js` guards the smoke validator — and **it pinned 42 as well**, building a 39-tool fixture list plus three named tools and asserting the validator rejects anything else.

So the guard encoded the same stale constant as the code it checks. It passed happily while the actual release gate was broken, which is why five merges and a full aggregate went by without surfacing this. A test that hard-codes the same wrong number as its subject cannot fail with it. Its fixture is now 40 plus the same three named tools.

These scripts run only at release time; that is the reason the gap survived.

## Verification

`npm run smoke:mcpb` against the built v0.10.0 artifact now passes:

```
Packed MCPB smoke passed on linux/x64: 43 tools, 14 prompts, canonical resources,
verified PDF-lib mutation, source-bound accessibility and compare_pdfs, native raster image.
```

`test/smoke-mcpb-contract.test.js` — 5 tests pass.

Artifact under test: `73,726,636` bytes, SHA-256 `ca86df4197feda718dcfd7a6c6d9aad511fefb1c639dc55f01643486dcd7a345`, two clean isolated builds byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
