### PR TITLE
Align the share bundle to 0.10.0

### DIFF
--- a/pdf-toolkit-mcp-share/package-lock.json
+++ b/pdf-toolkit-mcp-share/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pdf-tools",
-  "version": "0.9.6",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pdf-tools",
-      "version": "0.9.6",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/pdf-toolkit-mcp-share/package.json
+++ b/pdf-toolkit-mcp-share/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdf-tools",
-  "version": "0.9.6",
+  "version": "0.10.0",
   "description": "PDF Tools MCP server for Cursor and other stdio MCP hosts",
   "type": "module",
   "main": "server/index.js",


### PR DESCRIPTION
## Summary

`npm run test:contract:share` — a required release gate — fails on the v0.10.0 candidate:

```
pdf-toolkit-mcp-share/package-lock.json is stale at packages[""].version.
Seed it from the reviewed root lock and prune it to the share manifest.
```

`package-for-friend.js` derives the share manifest's version from the **root** package at build time, so it reads `0.10.0`, while the committed share lock still recorded `0.9.6`. The reproducibility check compares the two and rejects the pair.

## Eight sites, not five

The release bump covered five: `package.json`, `manifest.json`, `manifest.mcpb.json`, the root `package-lock.json`, and the hardcoded `version` in `server/index.js`.

There are **eight**. The share bundle carries its own `package.json` and its own lock with a separate `packages[""]` record:

| | |
|---|---|
| `pdf-toolkit-mcp-share/package.json` | `version` |
| `pdf-toolkit-mcp-share/package-lock.json` | `version` |
| `pdf-toolkit-mcp-share/package-lock.json` | `packages[""].version` |

`CLAUDE.md` already requires versions aligned *"across `package.json`, `manifest.json`, and the share bundle"* — the share bundle half was simply not carried. All eight now read `0.10.0`.

## Verification

`npm run test:contract:share` passes:

```
Reproducible transactional share contract passed on linux/x64: 43 tools, 14 prompts,
112 SBOM components, native raster image,
SHA-256 34abe6b6170192d8db9e1fee485f707197d6c40a34f392ef2b7d9a37c1c056ac
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
