### PR TITLE
Repair the v0.10.0 aggregate: one stale guard, two stale identity pins

### DIFF
--- a/test/eval/markdown-bakeoff.test.js
+++ b/test/eval/markdown-bakeoff.test.js
@@ -117,20 +117,20 @@ process.stdin.on("data", chunk => {
 
 describe("Markdown bakeoff discovery binding", () => {
   const currentTools = [
-    ...Array.from({ length: 40 }, (_, index) => ({ name: `fixture_tool_${index}` })),
+    ...Array.from({ length: 41 }, (_, index) => ({ name: `fixture_tool_${index}` })),
     { name: "convert_pdf_to_markdown" },
     { name: "inspect_pdf_accessibility" },
   ];
 
-  it("accepts only the current 42-tool discovery", () => {
+  it("accepts only the current 43-tool discovery", () => {
     expect(() => validateMarkdownDiscovery(currentTools)).not.toThrow();
-    expect(() => validateMarkdownDiscovery(currentTools.slice(1))).toThrow(/42-tool contract/);
+    expect(() => validateMarkdownDiscovery(currentTools.slice(1))).toThrow(/43-tool contract/);
   });
 
   it("requires both current lane tools", () => {
     expect(() => validateMarkdownDiscovery(
       currentTools.map(tool => tool.name === "inspect_pdf_accessibility" ? { name: "stale_tool" } : tool),
-    )).toThrow(/42-tool contract/);
+    )).toThrow(/43-tool contract/);
   });
 });
 

--- a/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
+++ b/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
@@ -85,14 +85,14 @@
     {
       "role": "package_json",
       "path": "package.json",
-      "bytes": 2763,
-      "sha256": "e170d0085e34219558d1208cad22c8e06549a42d06fdfa74fef2bd098ec4df2f"
+      "bytes": 2764,
+      "sha256": "70923e8c36aa5183d64a77596cc3b4e19bec3cfb1672d5e412212a6cfe7355b5"
     },
     {
       "role": "package_lock",
       "path": "package-lock.json",
-      "bytes": 119051,
-      "sha256": "bf4f5392b56eac250b5342e6265cf94e3091876f8f5d601a5d4cd1554faa74a3"
+      "bytes": 119053,
+      "sha256": "a0d7d4fd28068386cb2940cbac8b17a55d4c2325410240538c18ad7b09b3e4d4"
     },
     {
       "role": "pdf_comparison_module",
@@ -119,7 +119,7 @@
       "sha256": "6e4429db62fcbe1dd73141d8c20a48b564d41f8bf8920d88775846995e1daf94"
     }
   ],
-  "validator_source_set_sha256": "6816279e7abf3ac0222de9c4a73b1d9a35bc758943880c8e10b3ad5ceb699f92",
+  "validator_source_set_sha256": "a27a546e015bbbe1095add00744ab08bc52690f3516d7657de708efbfceec0c9",
   "pdfjs_version": "5.4.624",
   "generation_contract": {
     "source_path": "source.pdf",

--- a/test/fixtures/eval/trajectories/tool-contracts.v3.json
+++ b/test/fixtures/eval/trajectories/tool-contracts.v3.json
@@ -3,7 +3,7 @@
   "contract_id": "pdf-tools.trajectory.tool-contracts.v3",
   "runtime": {
     "name": "pdf-tools",
-    "version": "0.9.6"
+    "version": "0.10.0"
   },
   "tools_sha256": "eeef340721ec2b52e05d01509e9e6698c79ee4323873677a7e72d03693fb87f9",
   "tools": [


### PR DESCRIPTION
## Summary

`npm run test:all` is **red at `ec3a975`** — 13 failed / 2143 passed / 91 skipped across 5 files. Found by the operator lane on Silverbook (macOS 26.6, arm64, node v26.3.1) from a clean checkout, deps via `npm ci`.

This gate had not been run at that head. The release evidence recorded `build:mcpb`, `smoke:mcpb` and `test:contract:share`, all of which pass — but "green on every automated gate" was not true, and this corrects it before the tag.

**All 13 are staleness. None are behavioural.**

## The three causes

**1. A stale guard `#107` missed (2 failures).** `#107` rebound three release scripts to the 43-tool contract and fixed `test/smoke-mcpb-contract.test.js`, whose fixture had encoded the same stale constant as the code it guards. `test/eval/markdown-bakeoff.test.js` is the *identical* pattern for `eval-run-markdown-bakeoff.mjs` and was not fixed — so the script moved to 43 while its guard still asserted 42. Same lesson, second instance: a test that hard-codes the same constant as its subject cannot fail with it.

**2. `tool-contracts.v3.json` pins `runtime.version` `0.9.6` (1 failure).** One line. `tools_sha256` is unchanged, so all 43 tool contracts are byte-identical — only the recorded runtime version moved.

**3. `layout-occurrence-oracle.v1.json` pins pre-bump source identity (10 failures, 3 suites).** The same rebinding `#104` performed, needed again one train later because the version bump rewrote two files the oracle binds.

## Verification of the oracle rebinding

Independently re-diffed rather than taken on trust — this is the fixture that must never be regenerated blindly:

```
differing leaves: 5
  /validator_source_set_sha256
  /validator_sources[8]  package_json   2763 -> 2764 bytes
  /validator_sources[9]  package_lock  119051 -> 119053 bytes
CASES IDENTICAL: True   (8 cases, 13 facts)
```

The byte deltas are arithmetic confirmation: `"0.9.6"` → `"0.10.0"` is +1 byte, written once in `package.json` and twice in the lock. **Every case, fact, occurrence and source span is unchanged** — the oracle is doing its job and catching a version-string rewrite, not a behavioural change in layout extraction.

## Effect

The 5 affected suites pass — 26 tests. Authored by the operator lane; pushed here because publishing is human-gated on that side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
