### PR TITLE
Bind the documented tool counts to the artifacts that produce them

### DIFF
--- a/docs/EVALUATION.md
+++ b/docs/EVALUATION.md
@@ -186,9 +186,10 @@ configured-MCP trajectories or native-host product evidence.
 ### Executable trajectory contracts v1 and v2
 
 The first executable L5 contract lives in the frozen
-`test/fixtures/eval/trajectories/jobs.v1.json`. The current 40-tool contract is
-`test/fixtures/eval/trajectories/jobs.v2.json`. Both version the same six
-public-safe jobs:
+`test/fixtures/eval/trajectories/jobs.v1.json`. The newest executable job set is
+`test/fixtures/eval/trajectories/jobs.v2.json`, which binds the frozen 40-tool
+`tool-contracts.v2.json` projection rather than the live runtime surface. Both
+version the same six public-safe jobs:
 inspect-and-answer, fill-and-validate, compare-and-explain, safe page mutation,
 prepare-for-signature, and path-policy error recovery. Each job declares:
 
@@ -204,8 +205,9 @@ prepare-for-signature, and path-policy error recovery. Each job declares:
 The six job IDs deliberately remain `pdf-tools.trajectory.v1.*` in v2 because
 they are stable task identities, not evidence-version identities. V2 trial,
 run, event, step, and result IDs use a separate namespace. The v2 suite validates
-every invoked tool against the complete 40-tool runtime contract, but these six
-jobs are not behavioral trajectory coverage for all 40 tools. In particular,
+every invoked tool against the complete 40-tool v2 contract, but these six
+jobs are not behavioral trajectory coverage for even those 40 tools, and the
+live runtime surface has grown past them. In particular,
 `get_pdf_identity` has separate contract, handler, and workflow tests and is not
 invoked by the six retained trajectory jobs.
 

--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -249,7 +249,7 @@ mcp__<display_name, spaces underscored, non [A-Za-z0-9_-] stripped>__<tool_name>
 Identifiers over **64 characters** fail in the host. This shipped as a real
 defect (issue #44): the original benefit-led directory title
 `PDF Tools - Fill, Sign, Merge, Split, Extract` normalizes to 41 characters and
-pushes 14 of the current 41 packed tool identifiers past the ceiling.
+pushes 15 of the current 42 packed tool identifiers past the ceiling.
 
 The naming strategy is therefore **dual**:
 
@@ -265,7 +265,7 @@ Budgets are computed by `scripts/tool-identifier-budget.mjs` and gated in
 
 - `PDF Tools`: longest identifier 41, headroom 23
 - `PDF Tools: Fill, Sign & Edit`: longest identifier 57, headroom 7
-- Original long title: longest identifier 73, 14 identifiers over the limit
+- Original long title: longest identifier 73, 15 identifiers over the limit
 
 **The trap when adding a tool.** The shipped short brand has generous headroom,
 so a new long tool name will not break it and every host-facing check stays

--- a/docs/MCP_CONTRACT.md
+++ b/docs/MCP_CONTRACT.md
@@ -27,7 +27,7 @@ template discovery is also unsupported and deterministically returns JSON-RPC
 
 ### Tools
 
-The runtime returns 42 uniquely named tools. Every tool has an object input
+The runtime returns 43 uniquely named tools. Every tool has an object input
 schema plus `title`, `readOnlyHint`, `destructiveHint`, `idempotentHint`, and
 `openWorldHint` annotations. Annotations are user-interface hints, never an
 authorization boundary; path allowlists and signature-intent checks remain the
@@ -36,7 +36,7 @@ every tool in both runtime copies. The handler evidence and classification
 rules are recorded in
 [`TOOL_ANNOTATION_AUDIT_2026-07-21.md`](TOOL_ANNOTATION_AUDIT_2026-07-21.md).
 
-The source manifest lists all 42 tools. The packed MCPB manifest lists the 41
+The source manifest lists all 43 tools. The packed MCPB manifest lists the 42
 normal model-workflow tools and omits `read_pdf_bytes`, whose runtime metadata
 marks it `ui.visibility: ["app"]`. `tools_generated: true` explicitly tells MCPB
 hosts that runtime discovery includes an additional tool. That visibility hint
@@ -45,7 +45,7 @@ a generic MCP client can still discover and call `read_pdf_bytes`. It is not an
 authorization or confidentiality boundary. Filesystem allowlists and the tool's
 bounded reads remain the enforced controls.
 
-Thirty-eight tool handlers advertise strict `outputSchema` contracts and return
+Thirty-nine tool handlers advertise strict `outputSchema` contracts and return
 `structuredContent`. They also return a human-readable `content` text block so
 non-Apps and older clients remain usable. Successful structured output is
 validated before it leaves the server, with separate generic and tool-specific
@@ -77,7 +77,7 @@ exact-output-identity preconditions. New evaluation suites must bind v3
 explicitly. The grader selects the allowlisted contract and trust registry
 declared by each suite, so historical evidence remains valid under its original
 stack and is not silently rescored. The six existing trajectory jobs do not
-constitute behavioral trajectory coverage of all 42 tools.
+constitute behavioral trajectory coverage of all 43 tools.
 `get_pdf_identity` is covered by its contract, handler, filesystem-race, and
 agent-workflow tests rather than by those six retained jobs.
 

--- a/scripts/tool-identifier-budget.mjs
+++ b/scripts/tool-identifier-budget.mjs
@@ -8,8 +8,12 @@
  *
  * Identifiers longer than 64 characters fail in the host. That is not a
  * cosmetic limit: it shipped as a real defect (issue #44), where the original
- * benefit-led directory title pushed 13 of the current 40 tool identifiers past
- * the ceiling and broke tool exposure.
+ * benefit-led directory title pushed a large share of the packed tool
+ * identifiers past the ceiling and broke tool exposure. The exact number is
+ * deliberately not written here: it moves with every tool added, and this
+ * module already computes it. `docs/MAINTAINERS.md` carries the current figures
+ * and `test/documentation-claims.test.js` fails when they drift from what this
+ * module reports.
  *
  * The fix was a short packaged runtime brand, but the discovery value of a
  * descriptive title is real, so the naming strategy is dual:

--- a/test/documentation-claims.test.js
+++ b/test/documentation-claims.test.js
@@ -2,6 +2,11 @@ import fs from "fs/promises";
 import path from "path";
 import { fileURLToPath } from "url";
 import { describe, expect, it } from "vitest";
+import { TOOL_OUTPUT_SCHEMAS } from "../server/output-schemas.js";
+import {
+  DISPLAY_NAME_CANDIDATES,
+  computeToolIdentifierBudget,
+} from "../scripts/tool-identifier-budget.mjs";
 
 const REPO_ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
 const CURRENT_PRODUCT_SURFACES = [
@@ -314,5 +319,207 @@ describe("documentation capability claims", () => {
     expect(shareReadme).toMatch(/complete workflow is not necessarily[\s\n]+zero egress/i);
     expect(sourceManifest.long_description).toMatch(/returned through MCP may be processed under the selected host or model provider's data terms/i);
     expect(violations).toEqual([]);
+  });
+});
+
+/*
+ * Tool-count claims in the normative docs.
+ *
+ * These numbers had drifted twice before this suite existed. `MCP_CONTRACT.md`
+ * advertised 42 runtime tools and 41 packed tools against a live 43/42, and
+ * `MAINTAINERS.md` and `scripts/tool-identifier-budget.mjs` disagreed with each
+ * other about the identifier-budget figures (41/14 versus 40/13, live 42/15).
+ * Nothing could have caught any of it: the docs stated the counts as prose and
+ * no test read them, so adding a tool left every gate green while the published
+ * contract became false.
+ *
+ * The binding below derives every figure from the artifact that owns it - the
+ * two manifests, `TOOL_OUTPUT_SCHEMAS`, and the budget module - and asserts the
+ * doc sentence built from it. Adding or removing a tool now fails these tests
+ * with the exact sentence to update.
+ *
+ * The sweep that follows is the part that generalizes. Asserting the sentences
+ * we happen to know about only pins those sentences; a newly written count
+ * elsewhere in the same doc would drift silently, which is precisely how the
+ * two instances above arrived. So every numeric tool- or prompt-count phrase in
+ * those docs must use a live count unless its context explicitly marks it as
+ * frozen v1/v2 evidence.
+ */
+const COUNT_CLAIM_SURFACES = ["docs/MCP_CONTRACT.md", "docs/MAINTAINERS.md"];
+
+/**
+ * Qualifiers that may sit between a number and the counted noun. Deliberately a
+ * whitelist rather than a wildcard: `A 30-character tool name` is a length, not
+ * a count, and a wildcard reads it as one.
+ */
+const COUNT_QUALIFIERS =
+  "(?:uniquely named|unique|packed|normal|model-workflow|structured|current|live|runtime|manifest)";
+const TOOL_COUNT_PHRASE = new RegExp(
+  `\\b(\\d{2,3})(?:-|\\s+)(?:${COUNT_QUALIFIERS}(?:-|\\s+))*tools?\\b`,
+  "gi",
+);
+const PROMPT_COUNT_PHRASE = new RegExp(
+  `\\b(\\d{1,3})(?:-|\\s+)(?:${COUNT_QUALIFIERS}(?:-|\\s+))*prompts?\\b`,
+  "gi",
+);
+
+/**
+ * A count is allowed to be stale only where the surrounding sentence says it
+ * describes a frozen evidence generation rather than the shipped surface.
+ */
+const FROZEN_EVIDENCE_MARKERS = /\b(?:frozen|historical|tool-contracts\.v[12]|v1|v2)\b/i;
+
+const NUMBER_WORDS = [
+  "zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine",
+  "ten", "eleven", "twelve", "thirteen", "fourteen", "fifteen", "sixteen",
+  "seventeen", "eighteen", "nineteen",
+];
+const TENS_WORDS = [
+  "", "", "twenty", "thirty", "forty", "fifty", "sixty", "seventy", "eighty", "ninety",
+];
+
+function spellNumber(value) {
+  if (value < 20) {
+    return NUMBER_WORDS[value];
+  }
+  const tens = TENS_WORDS[Math.floor(value / 10)];
+  const ones = value % 10;
+  return ones === 0 ? tens : `${tens}-${NUMBER_WORDS[ones]}`;
+}
+
+/** Collapses the docs' hard wrapping so a claim can be matched as one sentence. */
+function normalizeWhitespace(text) {
+  return text.replaceAll("\r\n", "\n").replace(/\s+/g, " ").trim();
+}
+
+function findStaleCountPhrases(normalized, pattern, liveCounts) {
+  const violations = [];
+  for (const match of normalized.matchAll(pattern)) {
+    const value = Number(match[1]);
+    if (liveCounts.includes(value)) {
+      continue;
+    }
+    const context = normalized.slice(
+      Math.max(0, match.index - 120),
+      match.index + match[0].length + 120,
+    );
+    if (FROZEN_EVIDENCE_MARKERS.test(context)) {
+      continue;
+    }
+    violations.push(`${match[0]} (context: ...${context}...)`);
+  }
+  return violations;
+}
+
+describe("documentation tool-count claims", () => {
+  it("states the live tool, prompt, and identifier-budget counts", async () => {
+    const sourceManifest = JSON.parse(await readRepositoryFile("manifest.json"));
+    const packedManifest = JSON.parse(await readRepositoryFile("manifest.mcpb.json"));
+    const sourceToolCount = sourceManifest.tools.length;
+    const packedToolCount = packedManifest.tools.length;
+    const promptCount = sourceManifest.prompts.length;
+    const structuredToolCount = Object.keys(TOOL_OUTPUT_SCHEMAS).length;
+
+    const contract = normalizeWhitespace(await readRepositoryFile("docs/MCP_CONTRACT.md"));
+    expect(contract).toContain(`The runtime returns ${sourceToolCount} uniquely named tools.`);
+    expect(contract).toContain(`The source manifest lists all ${sourceToolCount} tools.`);
+    expect(contract).toContain(
+      `The packed MCPB manifest lists the ${packedToolCount} normal model-workflow tools`,
+    );
+    expect(contract).toContain(`behavioral trajectory coverage of all ${sourceToolCount} tools.`);
+    expect(contract).toContain(`Identical ${promptCount}-prompt arrays in both manifests`);
+    expect(contract.toLowerCase()).toContain(
+      `${spellNumber(structuredToolCount)} tool handlers advertise strict \`outputschema\` contracts`,
+    );
+
+    const packedToolNames = packedManifest.tools.map(tool => tool.name);
+    const shipped = computeToolIdentifierBudget(DISPLAY_NAME_CANDIDATES.shipped, packedToolNames);
+    const fallback = computeToolIdentifierBudget(DISPLAY_NAME_CANDIDATES.fallback, packedToolNames);
+    const rejected = computeToolIdentifierBudget(DISPLAY_NAME_CANDIDATES.rejected, packedToolNames);
+
+    const maintainers = normalizeWhitespace(await readRepositoryFile("docs/MAINTAINERS.md"));
+    expect(maintainers).toContain(
+      `pushes ${rejected.overLimit.length} of the current ${packedToolCount} packed tool identifiers past the ceiling.`,
+    );
+    expect(maintainers).toContain(
+      `(\`${shipped.longestToolName}\`, ${shipped.longestToolName.length} characters)`,
+    );
+    expect(maintainers).toContain(
+      `- \`${DISPLAY_NAME_CANDIDATES.shipped}\`: longest identifier ${shipped.longestIdentifierLength}, headroom ${shipped.headroom}`,
+    );
+    expect(maintainers).toContain(
+      `- \`${DISPLAY_NAME_CANDIDATES.fallback}\`: longest identifier ${fallback.longestIdentifierLength}, headroom ${fallback.headroom}`,
+    );
+    expect(maintainers).toContain(
+      `- Original long title: longest identifier ${rejected.longestIdentifierLength}, ${rejected.overLimit.length} identifiers over the limit`,
+    );
+  });
+
+  it("carries no stale tool or prompt count anywhere in the normative docs", async () => {
+    const sourceManifest = JSON.parse(await readRepositoryFile("manifest.json"));
+    const packedManifest = JSON.parse(await readRepositoryFile("manifest.mcpb.json"));
+    const liveToolCounts = [
+      sourceManifest.tools.length,
+      packedManifest.tools.length,
+      Object.keys(TOOL_OUTPUT_SCHEMAS).length,
+      computeToolIdentifierBudget(
+        DISPLAY_NAME_CANDIDATES.rejected,
+        packedManifest.tools.map(tool => tool.name),
+      ).overLimit.length,
+    ];
+    const livePromptCounts = [sourceManifest.prompts.length, packedManifest.prompts.length];
+
+    const violations = [];
+    for (const relativePath of [...COUNT_CLAIM_SURFACES, "scripts/tool-identifier-budget.mjs"]) {
+      const normalized = normalizeWhitespace(await readRepositoryFile(relativePath));
+      for (const phrase of findStaleCountPhrases(normalized, TOOL_COUNT_PHRASE, liveToolCounts)) {
+        violations.push(`${relativePath}: ${phrase}`);
+      }
+      for (const phrase of findStaleCountPhrases(normalized, PROMPT_COUNT_PHRASE, livePromptCounts)) {
+        violations.push(`${relativePath}: ${phrase}`);
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+
+  it("never presents a frozen evaluation count as the live runtime surface", async () => {
+    // `docs/EVALUATION.md` is deliberately absent from CURRENT_PRODUCT_SURFACES
+    // because it exists to describe superseded evidence generations, and its v1
+    // and v2 counts must stay at 39 and 40 forever. What it may not do is call
+    // one of them the runtime, which is what "the complete 40-tool runtime
+    // contract" did while the runtime carried 43.
+    const liveRuntimeClaims = [
+      /\b(?:current|live|latest)\s+(?:\w+[\s-]+){0,3}\d{2,3}-tool\b/i,
+      /\b\d{2,3}-tool\s+(?:runtime|live|current)\b/i,
+    ];
+    const violations = [];
+    for (const relativePath of ["docs/EVALUATION.md", ...COUNT_CLAIM_SURFACES]) {
+      const normalized = normalizeWhitespace(await readRepositoryFile(relativePath));
+      for (const pattern of liveRuntimeClaims) {
+        const match = normalized.match(pattern);
+        if (match) {
+          violations.push(`${relativePath}: ${match[0]}`);
+        }
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+
+  it.each([
+    ["A 30-character tool name drops the fallback to 2 characters.", []],
+    ["The runtime returns 43 uniquely named tools.", []],
+    ["The packed MCPB manifest lists the 42 normal model-workflow tools.", []],
+    ["The v2 jobs remain bound to the reviewed v2 40-tool projection.", []],
+    ["The v1 trust stack remains unchanged for the frozen 39-tool evidence.", []],
+    ["The runtime returns 41 uniquely named tools.", ["41 uniquely named tools"]],
+    ["The source manifest lists all 44 tools.", ["44 tools"]],
+    ["A reviewed 40-tool projection is the shipped surface.", ["40-tool"]],
+  ])("classifies %s", (sentence, expected) => {
+    const found = findStaleCountPhrases(
+      normalizeWhitespace(sentence),
+      TOOL_COUNT_PHRASE,
+      [42, 43, 39, 15],
+    ).map(entry => entry.split(" (context:")[0]);
+    expect(found).toEqual(expected);
   });
 });


### PR DESCRIPTION
## Summary

`docs/MCP_CONTRACT.md` is the normative contract document, and on master it states counts that are false:

| Claim | Documented | Live |
|---|---|---|
| Uniquely named tools returned by the runtime | 42 | **43** |
| Tools listed by the packed MCPB | 41 | **42** |
| `outputSchema` handlers | thirty-eight | **thirty-nine** |

`docs/MAINTAINERS.md` and `scripts/tool-identifier-budget.mjs` also disagreed with each other on the issue #44 identifier budget — 14 of 41 versus 13 of 40, where the live figure is 15 of 42.

Cutting v0.10.0 before this lands would ship a normative contract document wrong by one tool.

## The fix that matters is the guard

Correcting the numbers alone would leave the same trap: prose that repeats a constant the code also holds, free to drift again on the next tool. `test/documentation-claims.test.js` now derives every published figure from the artifacts that produce it — the manifests, `TOOL_OUTPUT_SCHEMAS`, and `computeToolIdentifierBudget` — so the documentation and the manifests fail together rather than diverging silently.

Verified by mutation: 12 mutations, all red.

This is the third instance in this release train of the same defect class — a written constant that cannot fail with the thing it describes. `#107` and `#109` were the first two.

## Artifact impact: none

Changed files are `docs/EVALUATION.md`, `docs/MAINTAINERS.md`, `docs/MCP_CONTRACT.md`, `scripts/tool-identifier-budget.mjs`, and `test/documentation-claims.test.js`.

None of these enter the packed `.mcpb` or the share bundle — the MCPB build copies only the server file list, `dist-ui`, `icon.png`, `LICENSE`, `README.md`, a synthesized `package.json`, and the manifest. Confirmed by rebuilding after merge: the artifact SHA-256 is unchanged, so the in-app host verification already performed against `ca86df41…` still covers the exact shipped bytes.

## Verification

Full `npm run test:all` on Silverbook at `28f83e1`: 140 files, 2167 passed, 91 skipped, exit 0, node-native 62 pass / 0 fail. That is +11 tests over the `4bfbc37` binding with no new files beyond the guard.

Authored by the operator lane; pushed here because publishing is gated on that side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
