### PR TITLE
Bind the documented tool inventories to the registered tool set

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,9 @@ separate example to locate.
 - `example-fw9.pdf`: Sample form for smoke tests. Keep anonymized assets only.
 
 ### Tools currently shipped
-- `display_pdf`, `list_pdfs`, `read_pdf_fields`, `fill_pdf`, `bulk_fill_from_csv`, `save_profile`, `load_profile`, `list_profiles`, `fill_with_profile`, `extract_to_csv`, `validate_pdf`, `read_pdf_content`, `read_pdf_layout`, `convert_pdf_to_markdown`, `get_pdf_info`, `inspect_pdf_accessibility`, `compare_pdfs`, `render_pdf_page`, `render_pdf_region`, `get_pdf_resource_uri`, `read_pdf_bytes` (app-only).
+This is the complete registered set, not a selection.
+
+- `display_pdf`, `list_pdfs`, `read_pdf_fields`, `fill_pdf`, `bulk_fill_from_csv`, `save_profile`, `load_profile`, `list_profiles`, `fill_with_profile`, `extract_to_csv`, `validate_pdf`, `read_pdf_content`, `read_pdf_pages`, `read_pdf_layout`, `search_pdf_text`, `convert_pdf_to_markdown`, `get_pdf_identity`, `get_pdf_info`, `get_page_analysis`, `inspect_pdf_accessibility`, `compare_pdfs`, `render_pdf_page`, `render_pdf_region`, `fetch_pdf_from_url`, `merge_pdfs`, `split_pdf`, `rotate_pdf_pages`, `reorder_pdf_pages`, `apply_page_plan`, `create_signature`, `list_signatures`, `load_signature`, `detect_signature_zones`, `add_signature_field`, `prepare_signing_packet`, `apply_signature`, `apply_text`, `get_active_document`, `set_active_document`, `get_allowed_directories`, `get_pdf_resource_uri`, `reveal_in_finder`, `read_pdf_bytes` (app-only).
 
 `get_pdf_info` returns bounded source-bound observations. Widget annotations
 belong to form fields; ordinary annotations remain separate and their targets

--- a/README.md
+++ b/README.md
@@ -176,6 +176,10 @@ that same view and reports raw pixels unavailable.
 
 ## Core Tools
 
+This list is complete: it names every tool the server registers. One of them,
+`read_pdf_bytes`, is available only to the in-app viewer and is not packed into
+the `.mcpb` manifest that ordinary model workflows discover.
+
 ### Viewer and Reading
 
 - `display_pdf`
@@ -223,6 +227,7 @@ that same view and reports raw pixels unavailable.
 ### Extraction and Analysis
 
 - `extract_to_csv`
+- `compare_pdfs`
 - `get_pdf_identity`
 - `get_pdf_info`
 - `inspect_pdf_accessibility`
@@ -232,7 +237,7 @@ that same view and reports raw pixels unavailable.
 
 - `get_active_document`
 - `set_active_document`
-- `get_pdf_resource_uri`
+- `get_allowed_directories`
 - `read_pdf_bytes`
 - `reveal_in_finder`
 

--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -122,12 +122,31 @@ packaging, tests, and release evidence ship together.
 
 ## Tool inventory (current)
 
-Tools are listed in `CLAUDE.md` and in `server/index.js`. Keep the list
-stable and in sync across:
+`manifest.json` owns the registered tool set and `server/output-schemas.js`
+owns which of those tools advertise an `outputSchema`. Five documents write a
+tool inventory down, and "keep them in sync" was never an instruction anyone
+could follow, because three of the five are deliberately partial. Two rules
+apply instead, and `test/documentation-claims.test.js` enforces both.
 
-- `CLAUDE.md` tool list
-- README tool list
-- Actual tool registrations in `server/index.js`
+**An inventory that presents itself as complete must be complete.** These
+enumerate exactly the registered set, and adding a tool without adding it here
+turns the suite red:
+
+- `README.md`, under `## Core Tools`
+- `AGENTS.md`, under `### Tools currently shipped`
+- `docs/OUTPUT_SCHEMAS.md`, the discovery matrix, which enumerates exactly the
+  tools carrying an `outputSchema` plus a named text-only remainder
+
+**A partial inventory must say so, and must name no tool that does not exist.**
+These are selections by design and may lag the registered set, but a phantom
+name in either is a false capability claim and fails the suite:
+
+- `CLAUDE.md`, under `## Core Available Tools`
+- `pdf-toolkit-mcp-share/README.md`, under `## Tools Available`
+
+The selection marker is itself load-bearing. Delete the sentence that says a
+list is partial and the completeness rule starts applying to it, so a selection
+cannot quietly be promoted into a false claim of the whole surface.
 
 ## Zone coordinates and the viewer page box
 

--- a/docs/OUTPUT_SCHEMAS.md
+++ b/docs/OUTPUT_SCHEMAS.md
@@ -34,6 +34,7 @@ an `isError` result is never forced through a success schema.
 | `fill_pdf` | active document and field-fill outcome |
 | `fill_with_profile` | active document and profile-fill outcome |
 | `get_active_document` | empty or populated active-document state |
+| `get_allowed_directories` | resolved directory list, whether any were configured, which configuration layer supplied them, and the stored configuration path |
 | `get_page_analysis` | bounded page analysis with explicit provenance, operator counts, and a `classification` rollup (`document_kind`, typed `pages_needing_vision`, explicit `pages_not_analyzed`) |
 | `get_pdf_identity` | parser-independent canonical path, byte length, and SHA-256 |
 | `get_pdf_info` | bounded source-bound page, metadata, form-widget, and inert annotation observations with typed coverage, exact accounting, and a full-envelope digest |
@@ -55,6 +56,7 @@ an `isError` result is never forced through a success schema.
 | `rotate_pdf_pages` | active output document and rotation outcome |
 | `search_pdf_text` | bounded page matches |
 | `set_active_document` | populated active-document state |
+| `split_pdf` | input path, output directory, and the page range and page count of every file written |
 | `validate_pdf` | versioned PDF field-validation result |
 
 The following four tools remain intentionally text-only and therefore do not
@@ -97,7 +99,7 @@ before loading the target PDF, writing output, or changing active-document
 state.
 
 The executable source of truth is `server/output-schemas.js`. The MCP contract
-tests assert this complete 38/4 matrix, compile every schema through the pinned
-SDK validator, reject newer unsupported JSON Schema keywords, exercise live
-success and error branches, and require byte-identical source/share runtime
-files.
+tests assert this complete matrix of 39 structured tools and four text-only
+tools, compile every schema through the pinned SDK validator, reject newer
+unsupported JSON Schema keywords, exercise live success and error branches, and
+require byte-identical source/share runtime files.

--- a/pdf-toolkit-mcp-share/README.md
+++ b/pdf-toolkit-mcp-share/README.md
@@ -95,6 +95,10 @@ Once installed, ask Claude in Cursor:
 - *"Rotate page 3 by 90 degrees"*
 
 ## Tools Available
+This page names a selection, not the whole surface: the server registers 43
+tools. The root `README.md` lists every one, and `docs/OUTPUT_SCHEMAS.md`
+carries their structured output contracts.
+
 - **display_pdf** - Interactive PDF viewer with search and form sidebar
 - **list_pdfs** - List PDF files in directories
 - **read_pdf_fields** - Read form fields from PDFs

--- a/test/documentation-claims.test.js
+++ b/test/documentation-claims.test.js
@@ -345,7 +345,15 @@ describe("documentation capability claims", () => {
  * those docs must use a live count unless its context explicitly marks it as
  * frozen v1/v2 evidence.
  */
-const COUNT_CLAIM_SURFACES = ["docs/MCP_CONTRACT.md", "docs/MAINTAINERS.md"];
+const COUNT_CLAIM_SURFACES = [
+  "docs/MCP_CONTRACT.md",
+  "docs/MAINTAINERS.md",
+  // Added after `docs/OUTPUT_SCHEMAS.md` was found claiming "this complete 38/4
+  // matrix" over a 37-row table against a live 39/4. Scoping the original sweep
+  // to the two files that had already drifted left the next one unguarded.
+  "docs/OUTPUT_SCHEMAS.md",
+  "pdf-toolkit-mcp-share/README.md",
+];
 
 /**
  * Qualifiers that may sit between a number and the counted noun. Deliberately a
@@ -521,5 +529,258 @@ describe("documentation tool-count claims", () => {
       [42, 43, 39, 15],
     ).map(entry => entry.split(" (context:")[0]);
     expect(found).toEqual(expected);
+  });
+});
+
+/*
+ * Tool-name inventories.
+ *
+ * The count binding above stops a documented *number* from drifting. It says
+ * nothing about the lists themselves, and the lists had drifted further than
+ * the numbers had. `docs/OUTPUT_SCHEMAS.md` presents a "Discovery matrix" and
+ * calls it complete; it omitted `get_allowed_directories` and `split_pdf`, so
+ * the normative statement of the wire contract told a host integrator that two
+ * shipped tools return no `structuredContent` when both advertise a schema.
+ * `README.md` omitted two tools and listed a third twice, and `AGENTS.md` said
+ * "Tools currently shipped" over twenty-one of forty-three.
+ *
+ * `docs/MAINTAINERS.md` did carry an instruction to keep the lists in sync, and
+ * it was unfollowable: it named two of the five inventories, and three of the
+ * five are deliberately partial, so "in sync" was not a property any of them
+ * could have had.
+ *
+ * The rule below replaces it. A partial inventory is legitimate but must say it
+ * is partial, and may never name a tool that does not exist. Everything else is
+ * read as a claim about the whole surface and must be exactly the registered
+ * set. The selection marker is load-bearing in both directions: deleting the
+ * sentence that declares a list partial promotes it into a completeness claim
+ * and the same test then requires it to be complete, so a selection cannot be
+ * quietly upgraded into a false one.
+ */
+const TOOL_INVENTORIES = [
+  {
+    label: "README.md `## Core Tools`",
+    file: "README.md",
+    start: "## Core Tools",
+    end: "## Build From Source",
+    // Bullets only. `### Viewer and Reading` and the trailing prose on the
+    // `convert_pdf_to_markdown` line must not be read as entries.
+    entry: /^-\s+`([a-z_][a-z0-9_]*)`/gm,
+    completenessStatement: /this list is complete/i,
+  },
+  {
+    label: "AGENTS.md `### Tools currently shipped`",
+    file: "AGENTS.md",
+    start: "### Tools currently shipped",
+    end: "## Build, Test, and Development Commands",
+    // The paragraphs after the list discuss individual tools in backticks;
+    // anchoring to the bullet keeps those out of the inventory.
+    entry: /^-\s+(?:`([a-z_][a-z0-9_]*)`(?:,\s*)?)+/gm,
+    entryWithin: /`([a-z_][a-z0-9_]*)`/g,
+    completenessStatement: /not a selection/i,
+  },
+  {
+    label: "docs/OUTPUT_SCHEMAS.md discovery matrix",
+    file: "docs/OUTPUT_SCHEMAS.md",
+    start: "## Discovery matrix",
+    end: "The executable source of truth",
+    entry: /^\|\s+`([a-z_][a-z0-9_]*)`\s+\|/gm,
+    // The matrix enumerates the tools that advertise a schema, not every tool.
+    registeredKey: "structured",
+    completenessStatement: /this complete matrix of/i,
+  },
+  {
+    label: "CLAUDE.md `## Core Available Tools`",
+    file: "CLAUDE.md",
+    start: "## Core Available Tools",
+    end: "### Current Extraction Boundary",
+    entry: /^\d+\.\s+\*\*([a-z_][a-z0-9_]*)\*\*/gm,
+    selectionMarker: /\(selected;/i,
+  },
+  {
+    label: "pdf-toolkit-mcp-share/README.md `## Tools Available`",
+    file: "pdf-toolkit-mcp-share/README.md",
+    start: "## Tools Available",
+    end: "### Current Extraction Boundary",
+    entry: /^-\s+(?:\*\*([a-z_][a-z0-9_]*)\*\*(?:\s*\/\s*)?)+/gm,
+    entryWithin: /\*\*([a-z_][a-z0-9_]*)\*\*/g,
+    selectionMarker: /names a selection, not the whole surface/i,
+  },
+];
+
+function inventorySection({ file, start, end }, contents) {
+  const startIndex = contents.indexOf(start);
+  if (startIndex === -1) {
+    throw new Error(`${file}: inventory heading ${JSON.stringify(start)} is gone`);
+  }
+  const endIndex = contents.indexOf(end, startIndex + start.length);
+  if (endIndex === -1) {
+    throw new Error(`${file}: inventory terminator ${JSON.stringify(end)} is gone`);
+  }
+  return contents.slice(startIndex + start.length, endIndex);
+}
+
+function inventoryEntries(inventory, section) {
+  const names = [];
+  for (const match of section.matchAll(inventory.entry)) {
+    if (inventory.entryWithin) {
+      for (const inner of match[0].matchAll(inventory.entryWithin)) {
+        names.push(inner[1]);
+      }
+    } else {
+      names.push(match[1]);
+    }
+  }
+  return names;
+}
+
+/**
+ * The whole rule, as one function, so the table-driven test below can falsify
+ * it directly instead of only through the five live documents.
+ */
+function inventoryViolations({ label, names, registered, declaresSelection }) {
+  const violations = [];
+
+  const duplicates = [...new Set(names.filter((name, index) => names.indexOf(name) !== index))];
+  if (duplicates.length > 0) {
+    violations.push(`${label}: lists ${duplicates.join(", ")} more than once`);
+  }
+
+  const phantom = names.filter(name => !registered.includes(name));
+  if (phantom.length > 0) {
+    violations.push(`${label}: names unregistered tools ${phantom.join(", ")}`);
+  }
+
+  if (!declaresSelection) {
+    const missing = registered.filter(name => !names.includes(name));
+    if (missing.length > 0) {
+      violations.push(`${label}: presents a complete inventory but omits ${missing.join(", ")}`);
+    }
+  }
+
+  return violations;
+}
+
+describe("documented tool inventories", () => {
+  async function liveInventoryInputs() {
+    const sourceManifest = JSON.parse(await readRepositoryFile("manifest.json"));
+    const packedManifest = JSON.parse(await readRepositoryFile("manifest.mcpb.json"));
+    const registered = sourceManifest.tools.map(tool => tool.name);
+    const structured = Object.keys(TOOL_OUTPUT_SCHEMAS);
+    return {
+      registered,
+      structured,
+      textOnly: registered.filter(name => !structured.includes(name)),
+      appOnly: registered.filter(
+        name => !packedManifest.tools.some(tool => tool.name === name),
+      ),
+    };
+  }
+
+  it("keeps every documented inventory complete, or declared partial and free of phantom tools", async () => {
+    const { registered, structured } = await liveInventoryInputs();
+    const violations = [];
+
+    for (const inventory of TOOL_INVENTORIES) {
+      const contents = await readRepositoryFile(inventory.file);
+      const section = inventorySection(inventory, contents);
+      const names = inventoryEntries(inventory, section);
+
+      expect(names.length, `${inventory.label}: matched no entries`).toBeGreaterThan(0);
+
+      // Read from the document, not from this config, so the marker is
+      // load-bearing in the way `docs/MAINTAINERS.md` says it is: delete the
+      // sentence declaring a list partial and the completeness rule applies to
+      // it on the next run.
+      const declaresSelection = Boolean(inventory.selectionMarker)
+        && inventory.selectionMarker.test(contents);
+
+      if (inventory.completenessStatement) {
+        expect(contents, `${inventory.label}: completeness statement is gone`)
+          .toMatch(inventory.completenessStatement);
+      }
+
+      violations.push(...inventoryViolations({
+        label: inventory.label,
+        names,
+        registered: inventory.registeredKey === "structured" ? structured : registered,
+        declaresSelection,
+      }));
+    }
+
+    expect(violations).toEqual([]);
+  });
+
+  it("states the live structured and text-only split in the output-schema contract", async () => {
+    const { structured, textOnly } = await liveInventoryInputs();
+    const outputSchemas = normalizeWhitespace(await readRepositoryFile("docs/OUTPUT_SCHEMAS.md"));
+
+    expect(outputSchemas).toContain(
+      `this complete matrix of ${structured.length} structured tools and ${spellNumber(textOnly.length)} text-only tools`,
+    );
+    expect(outputSchemas).toContain(
+      `The following ${spellNumber(textOnly.length)} tools remain intentionally text-only`,
+    );
+
+    // The named remainder must be exactly the tools with no advertised schema.
+    // A tool that quietly loses its schema would otherwise appear in neither
+    // half of a document that claims to cover both.
+    const declared = [...outputSchemas
+      .slice(outputSchemas.indexOf("remain intentionally text-only"))
+      .slice(0, 240)
+      .matchAll(/`([a-z_][a-z0-9_]*)`/g)]
+      .map(match => match[1]);
+    expect([...declared].sort()).toEqual([...textOnly].sort());
+  });
+
+  it("states the live app-only tool count where CLAUDE.md declares its selection", async () => {
+    const { appOnly } = await liveInventoryInputs();
+    const developmentGuide = await readRepositoryFile("CLAUDE.md");
+    expect(developmentGuide).toContain(`(selected; ${appOnly.length} app-only)`);
+  });
+
+  it("keeps the maintainer rule pointing at every inventory it governs", async () => {
+    // The previous instruction named two of the five lists. A rule that governs
+    // an inventory nobody wrote down is how the OUTPUT_SCHEMAS matrix drifted.
+    const maintainers = await readRepositoryFile("docs/MAINTAINERS.md");
+    const missing = TOOL_INVENTORIES
+      .filter(inventory => !maintainers.includes(inventory.file))
+      .map(inventory => inventory.file);
+    expect(missing).toEqual([]);
+  });
+
+  it.each([
+    [
+      "complete inventory that is complete",
+      { names: ["a", "b"], registered: ["a", "b"], declaresSelection: false },
+      [],
+    ],
+    [
+      "complete inventory missing a registered tool",
+      { names: ["a"], registered: ["a", "b"], declaresSelection: false },
+      ["x: presents a complete inventory but omits b"],
+    ],
+    [
+      "declared selection missing a registered tool",
+      { names: ["a"], registered: ["a", "b"], declaresSelection: true },
+      [],
+    ],
+    [
+      "selection promoted to a completeness claim by dropping its marker",
+      { names: ["a"], registered: ["a", "b"], declaresSelection: false },
+      ["x: presents a complete inventory but omits b"],
+    ],
+    [
+      "declared selection naming a tool that does not exist",
+      { names: ["a", "ghost"], registered: ["a", "b"], declaresSelection: true },
+      ["x: names unregistered tools ghost"],
+    ],
+    [
+      "inventory listing the same tool twice",
+      { names: ["a", "b", "a"], registered: ["a", "b"], declaresSelection: false },
+      ["x: lists a more than once"],
+    ],
+  ])("%s", (_label, input, expected) => {
+    expect(inventoryViolations({ label: "x", ...input })).toEqual(expected);
   });
 });


### PR DESCRIPTION
## Summary

`docs/OUTPUT_SCHEMAS.md` is the normative structured-output contract. It presents a table it calls the complete Discovery matrix, and that table was **missing `get_allowed_directories` and `split_pdf`**, summarising itself as 38/4 against a live 39/4.

Alongside it: `README.md` omitted `compare_pdfs` and `get_allowed_directories` and listed `get_pdf_resource_uri` twice, and `AGENTS.md` said "Tools currently shipped" over 21 of 43.

Cutting v0.10.0 before this lands publishes a structured-output contract missing two tools.

## Bound, not just corrected

`test/documentation-claims.test.js` now derives these inventories from the registered tool set, so a documented list and the tools that exist fail together rather than drifting. This is the fourth instance in this release train of one defect class — a written inventory that cannot fail with the thing it describes — after `#107`, `#109`, and `#110`.

## Artifact impact — real, and worth stating precisely

The commit message scope was "no server code, no manifest, nothing under `pdf-toolkit-mcp-share/server/`", which is accurate but incomplete: **`README.md` is packaged inside the `.mcpb`** (12,620 bytes in the archive), and `pdf-toolkit-mcp-share/README.md` ships in the `.zip`. So both artifact hashes move.

What does **not** move is the runtime. No file under `server/` changes, so the executable payload is byte-identical to the artifact already verified in-app on Windows Claude Desktop; the delta is README prose. That equality is verified below rather than asserted.

## Verification

Full `npm run test:all` on Silverbook at `1293235`: 140 files, 2177 passed, 91 skipped, exit 0, node-native 62 pass / 0 fail — +10 tests over the `c031696` binding.

Authored by the operator lane; pushed here because publishing is gated on that side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
