### PR TITLE
Stop the descendant-cleanup test racing its own fork

### DIFF
--- a/test/eval/accessibility-formal-v2.test.js
+++ b/test/eval/accessibility-formal-v2.test.js
@@ -460,10 +460,16 @@ describe.sequential("bounded process groups", () => {
   });
 
   it("kills and reports a stubborn descendant after its leader exits", async () => {
+    // The leader must not exit until the descendant actually exists. spawn() is
+    // asynchronous, so a fixed timer raced the fork: under a loaded parallel
+    // run the leader could exit first, leaving nothing for the cleanup path to
+    // observe and failing on descendant_observed_after_leader_close. Waiting
+    // for the spawn event removes the assumption rather than lengthening it.
     const script = [
       "const {spawn}=require('node:child_process');",
-      "spawn(process.execPath,['-e',\"process.on('SIGTERM',()=>{});setInterval(()=>{},1000)\"],{stdio:'ignore'});",
-      "setTimeout(()=>process.exit(0),200);",
+      "const child=spawn(process.execPath,['-e',\"process.on('SIGTERM',()=>{});setInterval(()=>{},1000)\"],{stdio:'ignore'});",
+      "child.on('spawn',()=>{setTimeout(()=>process.exit(0),50);});",
+      "child.on('error',()=>{process.exit(1);});",
     ].join("");
     const result = await runBoundedProcess(process.execPath, ["-e", script], {
       ...boundedOptions(),


### PR DESCRIPTION
## What

`test/eval/accessibility-formal-v2.test.js` — "kills and reports a stubborn
descendant after its leader exits" — had the leader exit on a fixed 200ms
timer, while `spawn()` is asynchronous. Under a loaded parallel run the leader
could exit before the OS had forked the descendant, leaving nothing for the
cleanup path to observe, so `descendant_observed_after_leader_close` came back
false and the test failed against a correct tree. Observed once in a full
parallel run.

The leader now exits on the child's `spawn` event rather than a timer, and a
spawn error fails loudly instead of presenting as a silently absent descendant.
This removes the assumption instead of lengthening the timeout.

## Honesty about the evidence

**I could not reproduce the original failure on demand** — 12 of 12 passes under
synthetic CPU load. The original was a 555-second full parallel run, a different
load profile. The race is plain on inspection and this eliminates it, but I am
not claiming a reproduced-then-fixed flake.

## Still strict

Verified the test has not been made permissive: mutating the leader to kill its
child before exiting makes it **fail**; restoring makes it pass. It still
detects a broken descendant-cleanup path.

## Verification

`npm test` — 2200 passed, 89 skipped, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)