### PR TITLE
Read lowercase hex glyph-name escapes, and record the OT1 no-go

### DIFF
--- a/docs/evidence/legacy-tex-ligature-tounicode-2026-08.md
+++ b/docs/evidence/legacy-tex-ligature-tounicode-2026-08.md
@@ -1,0 +1,313 @@
+# Ligatures behind a demonstrably-wrong /ToUnicode, 2026-08
+
+## Outcome
+
+**The defect is real, it is in documents users can already read, and it is
+narrow: 725 occurrences on the one pinned corpus document that has it, and
+9,416 across 5 of 122 harvested documents. A producer writes a `/ToUnicode`
+that maps a drawn glyph to a C0 control character, and the character silently
+disappears. `Oflazer` renders as `O azer`; `defined` as `de ned`; `infinite`
+as `in nite`.**
+
+**One of four blockers to fixing it is removed and shipped in this change: the
+Type-3 linker could not identify these fonts at all, because pdf-lib leaves a
+lowercase `#hh` PDF name escape undecoded and every one of these producers
+names its glyphs after raw encoding bytes. astro-ph/9402001 goes from 7,019 to
+100,108 of its 100,114 drawn Type-3 occurrences attributable to a font
+dictionary, and from 11 to 32 recovered characters — all through the existing,
+unmodified generated-PK lane.**
+
+**The other three blockers are not removed, and the ligature override is not
+built. They are stated with numbers in §5–§7 so the next attempt starts from
+measurements rather than from this record's prose.** Shannon is unchanged at
+1,872 recoveries across all 70 registry ids with identical per-id counts.
+
+## What was measured, and against what
+
+- **Corpus.** The five pinned legacy documents plus the Shannon reference,
+  every page of each: 390,203 drawn Type-3 glyph occurrences.
+- **Wild.** 122 harvested documents, every page of each: 4,497,459 drawn
+  Type-3 glyph occurrences. Same harvest as
+  `docs/evidence/legacy-tex-ot1-text-no-go-2026-08.md`, and the same sample
+  bias applies.
+- **Attribution.** The shipped `rawType3Fonts` + `linkedRawType3Font` rules,
+  re-implemented without the `recoverable` filter so that fonts carrying a
+  `/ToUnicode` stay attributable and countable.
+- **Invalid.** A drawn glyph whose PDF.js Unicode contains a C0 control
+  (U+0000–U+001F), a C1 control or DEL, an unpaired surrogate, U+FFFD, or a
+  noncharacter. **TAB, LF and CR are counted as invalid here**, unlike in
+  running text: no glyph is a carriage return, and excluding them undercounts
+  astro-ph's ligature damage by exactly the 35 `fl` occurrences it maps to
+  U+000D.
+- **Provably wrong.** An invalid occurrence drawn from a font that actually
+  carries a `/ToUnicode`. This is the distinction the whole record turns on,
+  and it is not the same as "invalid".
+
+## 1. The defect, and what separates it from the one already recorded
+
+astro-ph/9402001 (`GPL Ghostscript GIT PRERELEASE 9.22`, `dvips 5.518`) embeds
+a `/ToUnicode` for 18 of its 22 Type-3 fonts. For its main text font, `134 0 R`
+— 86,547 occurrences, the body type of the whole paper — that CMap is the
+identity on the font's own byte codes. OT1 puts the ligatures at codes 11 to
+15, so the CMap says:
+
+| Code | OT1 character | Producer `/ToUnicode` target | Occurrences |
+| ---: | --- | --- | ---: |
+| 11 | `ff` | U+000B VERTICAL TAB | 140 |
+| 12 | `fi` | U+000C FORM FEED | 157 |
+| 13 | `fl` | U+000D CARRIAGE RETURN | 35 |
+| 14 | `ffi` | U+000E SHIFT OUT | 18 |
+| | | **Total** | **350** |
+
+Spread over 36 of the document's 37 pages. A reader gets `con ned` for
+`confined`, `e ects` for `effects`, `de ned` for `defined`, ` exible` for
+`flexible`, ` ducial` for `fiducial`.
+
+This is a **different defect** from the one
+`docs/evidence/legacy-tex-corpus-baseline-2026-08.md` records, and conflating
+them makes the problem look a hundred times bigger than it is. The four
+Ghostscript 6.52 papers also produce a million C0 code points between them —
+but their fonts carry no `/ToUnicode` at all, and what is being seen is PDF.js
+falling back to the raw byte because the producer supplied no mapping. That is
+missing information. What astro-ph has is *wrong* information, asserted by the
+producer, which the pipeline currently defers to precisely because it is
+asserted.
+
+The two are cleanly separable by whether the font dictionary has a `/ToUnicode`
+key, and every figure below uses that split.
+
+## 2. How much of it there is
+
+| Population | Documents | Drawn Type-3 occurrences | Invalid Unicode | …from a font that has a `/ToUnicode` | …at OT1 ligature slots 11–15 |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Pinned corpus | 6 | 390,203 | 80,972 | **725** | **470** |
+| Harvested wild | 122 | 4,497,459 | 1,136,921 | **9,416** | **1,098** |
+
+Two things to read off this.
+
+**The provably-wrong population is under 1% of the invalid one.** 725 of 80,972
+in the corpus (0.90%), 9,416 of 1,136,921 in the wild (0.83%). Nearly
+everything that looks like a
+broken mapping is the encoding-loss defect, which no `/ToUnicode` override can
+touch because there is no `/ToUnicode` to override.
+
+**Ligature slots are 65% of it in the corpus and 12% in the wild.** 470 of 725,
+and 1,098 of 9,416. The remaining provably-wrong occurrences sit at Greek
+capitals (codes 0–10), accents (18–24) and the `ß æ œ ø` block (25–31) in text
+fonts, and at math slots in math fonts — the same slots the OT1 no-go record
+declines to enroll. Ligatures are the part worth having because they fall
+inside words that are otherwise perfectly readable.
+
+**It is concentrated in five documents.** Only 1 of 6 corpus documents and 5 of
+122 harvested ones exhibit it at all:
+
+| Document | Pages | Attributed occurrences | Provably wrong | At ligature slots |
+| --- | ---: | ---: | ---: | ---: |
+| ias-GNW95.pdf | 27 | 50,103 | 6,990 | 693 |
+| CMU-CS-94-194.pdf | 19 | 34,678 | 2,117 | 273 |
+| astro-ph-9402001.pdf | 37 | 100,108 | 725 | 470 |
+| chao-dyn-9403001.pdf | 27 | 20,457 | 202 | 80 |
+| cmp-lg-9503001.pdf | 10 | 14,414 | 76 | 52 |
+| CMU-CS-94-135.pdf | 23 | 578 | 31 | 0 |
+
+All six are modern Ghostscript over dvips. The damage is visible in their text
+today: `Kemal O azer` on page 1 of `cmp-lg-9503001` (Oflazer), `de ned` and
+`the rst` throughout `ias-GNW95`, `ine cient` and `e ects` in
+`CMU-CS-94-194`, `in nite` in `chao-dyn-9403001`.
+
+## 3. The evidence bar
+
+The bar proposed for this work was: override a producer `/ToUnicode` only when
+it maps to a C0 control, **and** the glyph's raster matches a generated CM
+ligature digest exactly, **and** the existing safeguards pass. Two cleaner bars
+were tested against the documents first. Both fail, and the reasons are worth
+recording because they are the obvious things to try.
+
+**Rejected: trust the glyph name.** The standard extraction fallback when a
+`/ToUnicode` is absent or wrong is the PostScript glyph name via the Adobe
+Glyph List — a font whose `/Differences` says `/ff` is telling you the answer,
+and no raster evidence would be needed at all. It does not work here, because
+these producers do not use glyph names. dvips-era Ghostscript names every glyph
+after its own raw encoding byte: astro-ph's ligature slots are named `/#0b`,
+`/#0c`, `/#0d`, `/#0e`. The name carries exactly the same non-information as
+the `/ToUnicode`, from the same source, and it is wrong in exactly the same
+places. Of astro-ph's 112 distinct glyph names, 34 need `#`-escaping; the other
+78 are single printable bytes like `/a` and `/S`, which happen to coincide with
+AGL names only because those codes are ASCII already and need no recovery. Not
+one glyph that is actually mis-mapped carries a name that says what it is.
+
+**Rejected: infer from the surrounding word.** `con` + U+000B + `ned` is
+unambiguously `confined` to a reader, and a dictionary or a language model would
+say so. This is out of contract: the extraction lane is deterministic and local
+by construction, reports typed gaps rather than guesses, and runs no external
+model. A ligature restored by inference would be indistinguishable in the output
+from one restored by exact raster equality, which is the distinction the
+`qualification` field exists to preserve.
+
+**Accepted, with one strengthening: the proposed bar, plus a global-uniqueness
+requirement on the digest.** The proposed bar leaves the character to be decided
+by the (family, code) pair, and §6 shows the family pin is unavailable for
+exactly these fonts. Requiring instead that the digest identify exactly one
+`(face, code)` across the whole generated reference makes the raster decide the
+character on its own, and removes the need for a family. Measured on astro-ph's
+`134 0 R`, this holds:
+
+| Code | Digest entries in the 17,597-digest reference | Named face |
+| ---: | ---: | --- |
+| 11 | 1 | `cmr10@300-b0-f20-o60` |
+| 12 | 1 | `cmr10@300-b0-f20-o60` |
+| 13 | 1 | `cmr10@300-b0-f20-o60` |
+| 14 | 1 | `cmr10@300-b0-f20-o60` |
+
+All four are globally unique and all four name the same face, and 50 of the
+font's 92 slots key `cmr10` overall. The C0 test alone is a *trigger*, not
+evidence; the exact digest is the evidence; global uniqueness is what lets it
+stand without a family. No tolerance appears anywhere in this and none should.
+
+The `/ToUnicode` deferral stays intact for every valid mapping. The override
+would apply only where the producer asserted something no text can contain.
+
+## 4. What is fixed here: the linker could not see these fonts
+
+Before any of §3 can be reached, the pipeline has to know which font dictionary
+a drawn glyph came from. For these documents it did not.
+
+`linkedRawType3Font` re-identifies a font from its drawn `(code, width,
+CharProc name)` triples, comparing pdf-lib's `/Differences` name against
+PDF.js's CharProcs key. PDF names escape an irregular byte as `#` plus two
+hexadecimal digits and ISO 32000-1 7.3.5 allows either letter case, but
+pdf-lib's `decodeText()` unescapes with `/#([\dABCDEF]{2})/g` — digits and
+uppercase A–F only. Ghostscript writes lowercase. So pdf-lib reported the
+three-character string `#0b` where PDF.js reported the one-character name
+U+000B, the comparison failed, and the entire font went unlinked on every page
+where such a glyph was drawn.
+
+The cost was not confined to ligatures. It disabled recovery, classification
+and census reporting for the whole font:
+
+| Document | Occurrences attributable before | After | Of a total of |
+| --- | ---: | ---: | ---: |
+| astro-ph-9402001.pdf | 7,019 | 100,108 | 100,114 |
+| chao-dyn-9403001.pdf | 1,186 | 20,457 | 20,457 |
+| cmp-lg-9503001.pdf | 970 | 14,414 | 14,414 |
+| CMU-CS-94-230.pdf | 3,151 | 3,192 | 3,192 |
+
+`type3GlyphNameCandidates` in `server/layout-extraction.js` now offers the
+linker both readings of a name. The separation between them is exact rather
+than heuristic. pdf-lib has already consumed every escape whose two digits are
+`[0-9A-F]`, so a residual `#hh` can only be an escape it missed when one of the
+digits is lowercase `a-f`; `#0b` came from a raw `/#0b`, while `#0B`, `#28` and
+`#2328` could not have and are left alone. Both readings are offered rather than
+one being chosen, so a font is still only linked when the name PDF.js reports is
+one pdf-lib's bytes can actually produce, and a code whose two readings *both*
+name a real CharProcs entry is refused outright rather than guessed.
+
+This matters because the naive fix — unescape every residual `#hh` — breaks the
+Shannon reference document. Shannon's producer writes `/#230B`, an escaped
+hash, so its glyph really is named `#0B` and pdf-lib and PDF.js already agree.
+All 29 of Shannon's escaped Type-3 glyph names are of that form, and blanket
+re-unescaping drops its linked occurrences from 4,437 to 766. `CMU-CS-96-106`
+is the same case in the wild. Both are asserted in
+`test/read-pdf-layout.test.js`.
+
+**What it bought, and what it did not.** astro-ph's recoveries rise from 11 to
+32: 29 minus signs and 3 primes, all from font `247 0 R`, all through the
+existing generated-PK lane with its family pin, metric pin, digest match,
+witness match and complete-font footprint unchanged. No new evidence class, no
+new registry entry, no relaxed rule — the same font was simply invisible on most
+of its pages. **It recovered no ligature**, because ligature recovery needs
+§5–§7 as well. `test/legacy-tex-corpus-live.test.js` records the new baseline.
+
+## 5. Remaining blocker: recovery targets are single scalars
+
+`ff` is two characters and `ffi` is three. The registry's production site
+already computes `output_utf16_end` as `binding.source_utf16_start +
+registry.target_unicode.length`, which reads as if multi-scalar targets are
+supported. They are not. The semantic validator at
+`validatePdfLayoutSemantics` in `server/layout-extraction.js` asserts, in the
+single `semanticAssertion` that guards every glyph recovery's offsets,
+
+```
+recovery.target_unicode.length === 1
+&& recovery.output_utf16_end === recovery.output_utf16_start + 1
+```
+
+so any entry with a two-character target would fail validation and abort the
+extraction rather than emit a ligature.
+
+The survey's observation that no shipped entry emits more than one character is
+confirmed and is stronger than reported: all **6,379** entries have a
+`target_unicode` of length exactly 1 — 70 reviewed, 6,308 generated, 1 labelled
+reference — so the multi-scalar path has never executed and its correctness is
+unestablished, not merely untested. Relaxing the two assertions is necessary but
+not sufficient; the offset arithmetic they guard is consumed downstream by
+`server/markdown-conversion.js` and by the layout occurrence oracle, and each
+consumer needs its own evidence that a target longer than one code unit keeps
+`recoveredText === item.text` and keeps every subsequent offset aligned.
+
+## 6. Remaining blocker: these fonts pin no family
+
+`collectType3GlyphRecoveries` resolves a family from `/Widths` before it looks
+at a raster, and abandons the font when the answer is `null` or `unsupported:`.
+astro-ph's `134 0 R` returns `null`. It is cmr10 — its four ligature rasters are
+bit-exact to `cmr10@300-b0-f20-o60` — and 91 of its 92 positive widths fit
+cmr10's TFM inside the shipped ±0.5 tolerance. Code 109, `m`, is out by 1.33.
+One outlier empties the intersection of scale intervals and the font resolves
+to nothing.
+
+Widening the tolerance is the wrong response and is refused: the ±0.5 is what
+makes the fingerprint an identification rather than a guess, and it is shared
+with the math lane that Shannon depends on. The right response is §3's
+global-uniqueness requirement, which makes the family unnecessary for this lane
+rather than obtainable. `docs/evidence/legacy-tex-ot1-text-no-go-2026-08.md` §4
+records the same blocker from the other direction and measures it on three
+documents.
+
+## 7. Remaining blocker: no text encoding, and no text faces in the reference
+
+`CM_CODEPOINTS` covers three math families. There is no table saying OT1 code
+11 is `ff`, and no text face in `server/type3-cm-pk-reference.js` — its 34 face
+records and 470 digests are cmmi, cmsy, cmex and their bold variants only. Both
+would have to be generated, not written: `scripts/generate-type3-cm-reference.mjs`
+and `scripts/generate-type3-cm-pk-reference.mjs` are the only sanctioned
+sources, and the second needs a METAFONT run over the pinned CTAN archive.
+
+Two hazards for whoever does it. Text faces do not share one encoding: `cmtt`
+and `cmsltt` put arrows and inverted punctuation at codes 11–15 where `cmr` and
+`cmbx` put ligatures, so a per-family table is wrong and a per-face table is
+needed. And `generatedPkRecoveryEntries` builds a solo entry for every
+(code, witness) pair of a face; at 5 enrolled slots per text face that is
+manageable, but enrolling the whole OT1 range at 128 slots per face over 75
+faces is a combinatorial explosion that would have to be bounded deliberately.
+
+## 8. Verification
+
+- Both live oracles pass. Shannon: exactly 1,872 recoveries across all 70
+  registry ids, per-id counts identical to before this change.
+  `test/legacy-tex-corpus-live.test.js` baseline deliberately updated for
+  astro-ph (44→92 linked, 11→32 recovered); the other four documents are
+  unchanged to the occurrence.
+- `test/read-pdf-layout.test.js` gains four fixtures for hex-escaped glyph
+  names, two of which fail without the fix and two of which are the controls
+  that keep the naive fix from being written.
+- `npm test`: 2,192 passed. The 12 failures are the `source-identity`
+  clean-tree gate in `test/eval/agent-workflow-*`, which requires a committed
+  working tree; they pass on a clean tree and this change was not committed.
+- `npm run build:mcpb` reproducible (two byte-identical isolated builds) and
+  `npm run smoke:mcpb` passed on darwin/arm64.
+- `pdf-toolkit-mcp-share/server/` re-mirrored byte-identical; share contract
+  passed. Layout occurrence oracle regenerated — only the module digest binding
+  changed, no case content.
+
+## Conclusion
+
+The ligature override is worth building and is not built here. What is built is
+the prerequisite that made it look impossible: the affected fonts are now
+visible to the Type-3 subsystem at all, which is separately worth having because
+it recovers 21 further characters through the existing lane and repairs a census
+that was misreporting 93% of one document's Type-3 glyphs as unattributable.
+
+The next step is §3's bar behind a face-pinned lane, gated on a font carrying a
+`/ToUnicode` that maps a drawn glyph into C0 — a population of five documents
+in 122, disjoint at the font level from everything the math lane touches, so
+Shannon cannot be affected by construction.

--- a/docs/evidence/legacy-tex-ot1-text-no-go-2026-08.md
+++ b/docs/evidence/legacy-tex-ot1-text-no-go-2026-08.md
@@ -1,0 +1,201 @@
+# Legacy dvips-era Type-3 text — OT1 enrollment is not worth building, 2026-08
+
+## Outcome
+
+**Enrolling the OT1 text encoding would gain 72 characters across every
+document this repository has ever pinned, and 0.25% of eligible occurrences in
+the wild. The reason is not that the work is hard. It is that the documents
+where a Computer Modern text raster can be recovered and the documents where
+the text is unreadable without recovery are, across all three dvips producer
+regimes present, disjoint populations.**
+
+`docs/evidence/legacy-tex-corpus-baseline-2026-08.md` and
+`docs/evidence/legacy-tex-metric-routes-closed-2026-08.md` closed the shape and
+metric routes to the four Ghostscript 6.52 papers. This record answers a
+different question, asked after the generated Computer Modern PK reference made
+a labelled bitmap ground truth available for the first time: now that
+`ctan-cm-metafont-generated-pk-v1` exists, is it worth extending
+`CM_CODEPOINTS` past the three math families to the OT1 text encoding — the
+Greek capitals at 0–10, the `ff fi fl ffi ffl` ligatures at 11–15, the dotless
+letters and accents at 16–24, and `ß æ œ ø Æ Œ Ø` at 25–31?
+
+No. Not because of a tolerance that needs loosening or a reference that needs
+more faces, but because of a structural anti-correlation described in §1 and a
+second, independent blocker described in §4 that would require replacing the
+family pin the math lane depends on.
+
+This is a decision about the *text* lane. It says nothing about the math lane,
+which recovers 1,872 occurrences on the Shannon reference document and is
+untouched by any of it.
+
+## What was measured, and against what
+
+- **Generated reference.** Every Computer Modern face in the pinned CTAN
+  `cm/mf.zip` (SHA-256 `b22c69034d…`), rasterised by METAFONT at both settings
+  the shipped reference pins — 600 dpi `blacker .25 fillin 0 o_correction 1`,
+  and 300 dpi `blacker 0 fillin .2 o_correction .6` — and keyed with the
+  shipped mask-lane key `type3MaskGridSha256`. 76 faces, 152 face-profile
+  builds, **17,597 distinct digests**, zero build failures. This is 37 times the
+  470 digests the shipped `server/type3-cm-pk-reference.js` carries, because
+  the shipped one keys only the three supported families' enrolled slots.
+- **Eligibility.** The shipped gate, unchanged: a Type-3 font with no
+  `/ToUnicode`, `LastChar <= 127`, at least one positive width, uniquely
+  linkable from its drawn `(code, width)` pairs. An occurrence is *eligible*
+  when its font clears that gate.
+- **Match.** Exact SHA-256 equality between the document's decoded glyph mask
+  and a generated raster. No tolerance, no similarity score, at any point in
+  this record.
+- **Gained.** An eligible occurrence that matches exactly *and* whose OT1 slot
+  disagrees with the Unicode PDF.js reports for it today. An occurrence that
+  already reads correctly is not a gain.
+- **Corpus.** The five pinned legacy documents plus the Shannon reference,
+  every page of each.
+- **Wild.** 122 documents harvested from arXiv, ECCC, CMU CS technical reports
+  and IAS/TUG mirrors; 110 produced a screen row, the other 12 failed to fetch
+  or parse. The wild screen reads the **first three pages** of each document,
+  so its absolute counts are a sample and only its rates are comparable to the
+  corpus figures.
+
+## 1. The two populations do not overlap
+
+Three dvips-era producer regimes appear in everything harvested, and each one
+fails the trade in its own way.
+
+| Regime | Documents | Eligible occurrences | Exact matches | Gained |
+| --- | ---: | ---: | ---: | ---: |
+| Acrobat Distiller (Shannon) | 1 | 4,437 | 4,083 | 66 |
+| GNU Ghostscript 6.52 (m3, nfscircuit, pippenger, sf) | 4 | 52,768 | 11 | 6 |
+| GPL Ghostscript 9.22 (astro-ph/9402001) | 1 | 92 | 63 | 0 |
+| **Corpus total** | **6** | **57,297** | **4,157** | **72** |
+
+Read down the "gained" column and then read the mechanism for each row.
+
+**Distiller preserves both the raster and the encoding, so its text is already
+readable.** Shannon's rasters match the generated reference 4,083 times — a
+92% hit rate, the highest anywhere in this investigation, and the direct proof
+that the reference is good and the key is right. It converts to 66 gained
+characters, and all 66 are *math* slots that no family currently enrolls, not
+OT1 text. Shannon's running text is Type-1, extracts correctly today, and OT1
+enrollment would not touch a character of it.
+
+**Ghostscript 6.52 renumbers the codes and re-rasterises, so nothing matches.**
+The four cr.yp.to papers offer 52,768 eligible occurrences — 92% of the
+corpus's eligible population, and the only large body of genuinely unreadable
+legacy text here. They yield **11** exact matches, of which 6 are gains. Their
+glyph names are repacked to `/a0 /a1 /a2 …`, their `/Widths` are zero for every
+inked code, and their bitmaps are the producer's own re-rasterisation rather
+than the PK bytes dvips passed through. The two earlier records establish that
+no metric or shape route reaches them; this one adds that no *raster* route
+does either, at 17,597 candidate digests.
+
+**Modern Ghostscript writes a `/ToUnicode`, so its glyphs are not eligible and
+its text is already mapped.** astro-ph/9402001 draws 100,114 Type-3 glyph
+occurrences and offers 92 eligible ones — 0.09% — because 18 of its 22 Type-3
+fonts carry a producer mapping that the pipeline deliberately defers to. Of
+those 92, 63 match exactly and **none** is a gain: every one already reads
+correctly.
+
+That is the whole finding. Recoverable-by-PK and unreadable-without-recovery
+are anti-correlated by construction: a producer that preserves the METAFONT
+raster well enough to match also preserved the encoding, and a producer that
+destroyed the encoding also destroyed the raster.
+
+## 2. The wild sample says the same thing, at scale
+
+Of 110 documents screened, 71 offer at least one eligible occurrence. Across
+those 71:
+
+- **41,840** eligible occurrences.
+- **105** exact matches against the 17,597-digest reference — **0.251%**.
+- 99 of the 105 sit at an OT1 text slot; **92** are gains.
+- The best single document is `eccc-1998-012.pdf` with **16** matches. No
+  document exceeds 16 on its three-page sample; scaled to full length the best
+  case is on the order of a hundred characters in a nineteen-page paper, in a
+  document whose remaining fourteen thousand eligible occurrences would still
+  be unrecovered.
+
+A 0.25% hit rate is not a coverage problem that more faces or more profiles
+fix. It is what §1 predicts: 70 of the 122 harvested documents are ESP
+Ghostscript 7.05, which behaves like 6.52 — it re-rasterises, so its glyphs
+miss — and most of the rest are modern Ghostscript, which writes a `/ToUnicode`,
+so its glyphs are ineligible.
+
+## 3. What OT1 enrollment would have to buy to be worth it
+
+72 characters across six pinned documents. For comparison, the math lane the
+same reference already serves recovers 1,872 occurrences on Shannon alone. The
+text lane would cost a new encoding table, text faces added to the generated PK
+reference, and — per §4 — a replacement for the family pin, in exchange for
+less than 4% of the recoveries the existing lane already makes on one document.
+
+## 4. The independent blocker: text faces pin no family
+
+Even granting §1 were wrong, the matcher could not be reached.
+
+`collectType3GlyphRecoveries` resolves a font's family from its `/Widths` with
+`uniqueComputerModernFamily` before it looks at any raster, and abandons the
+font when the answer is `null` or begins with `unsupported:`. Of the 75 faces in
+`CM_TFM_METRICS`, exactly three carry a supported family label; every text face
+— `cmr10`, `cmbx10`, `cmti10`, `cmss10`, `cmtt10`, `cmcsc10` and the rest — is
+labelled `unsupported:<face>` by `encodingFamily` in
+`scripts/generate-type3-cm-reference.mjs`, and `CM_CODEPOINTS` has no entry for
+any of them.
+
+Measured on real documents, the fingerprint does not merely fail to name a text
+family — it returns nothing at all:
+
+| Document | Type-3 fonts | Pin a supported math family | Pin any family | Pin a text family |
+| --- | ---: | ---: | ---: | ---: |
+| shannon-entropy.pdf | 24 | 11 | 11 | **0 of 13** |
+| ias-GNW95.pdf | 29 | 0 | 0 | **0 of 29** |
+| eccc1997-020.pdf | 25 | 0 | 0 | **0 of 25** |
+
+Every non-math Type-3 font in all three documents returns `null` — not an
+`unsupported:` label that a new encoding table could be attached to, but no
+answer. Nine of Shannon's thirteen have two or more positive widths, so they are
+not being refused by the `widths.size < 2` guard; their width vectors simply
+admit either several Computer Modern faces or none.
+
+astro-ph/9402001 shows how close and how unfixable this is. Its main text font
+`134 0 R` is cmr10 — its ligature rasters are bit-exact to
+`cmr10@300-b0-f20-o60` — and 91 of its 92 positive widths fit that face's TFM
+inside the shipped ±0.5. One slot, code 109 (`m`), is out by 1.33, and one
+outlier is enough: the scale intervals fail to intersect and the font resolves
+to no family.
+
+So an OT1 text lane cannot be an extension of the existing matcher. It would
+need a different pin — a face identified from its rasters rather than a family
+identified from its metrics — which means replacing, for text, the very
+mechanism the math lane's safety argument rests on. That is a large change to
+the most invariant-dense code in the repository, in service of §3's 72
+characters.
+
+## 5. Sample bias, stated plainly
+
+The evidence above is real but it is not a random sample of the world's legacy
+TeX PDFs, and three limits should be read alongside it.
+
+- **Two producer families dominate.** 74 of the 122 harvested documents are
+  Ghostscript 7.05 (ESP or GNU) and 19 more are modern GPL Ghostscript. A third
+  regime that preserved the PK raster *and* dropped the encoding would break the
+  anti-correlation in §1, and nothing here proves one does not exist. It is
+  simply absent from everything reachable.
+- **The corpora are computer science.** arXiv `cs`/`astro-ph`, ECCC, CMU CS
+  technical reports. Mathematics, physics and humanities archives of the same
+  era were not sampled, and their `dvips` invocations may differ.
+- **Two intended sources were unreachable.** The IACR eprint archive and
+  CiteSeerX did not serve documents during the harvest, so the sample has no
+  cryptography preprints and no broad-crawl population at all.
+
+## Conclusion
+
+Do not build OT1 text enrollment. If the question is reopened, the thing to
+look for first is a producer regime that keeps METAFONT's rasters while losing
+the encoding — that is the population this lane would serve, and this
+investigation found none. The generated reference itself is not the problem and
+should be kept: at 17,597 digests it matches Shannon's rasters 4,083 times, and
+it is what proved the text lane empty rather than merely unattempted.
+
+The user-visible defect in this space is not a missing encoding at all. It is a
+producer `/ToUnicode` that is present and wrong; see
+`docs/evidence/legacy-tex-ligature-tounicode-2026-08.md`.

--- a/pdf-toolkit-mcp-share/server/layout-extraction.js
+++ b/pdf-toolkit-mcp-share/server/layout-extraction.js
@@ -1570,6 +1570,51 @@ export function type3GlyphEvidenceSha256(charProc, fontMatrix, ops, fontPaintOri
   return grid;
 }
 
+/*
+ * The glyph name a /Differences entry really carries, as PDF.js sees it.
+ *
+ * PDF names escape an irregular byte as `#` plus two hexadecimal digits, and
+ * ISO 32000-1 7.3.5 allows either letter case. pdf-lib's `decodeText()`
+ * unescapes with `/#([\dABCDEF]{2})/g` — digits and UPPERCASE A-F only — so a
+ * producer that writes lowercase hex leaves the escape sitting in the decoded
+ * string. dvips-era Ghostscript names each Computer Modern glyph after its own
+ * raw encoding byte, so a text font's ligature slots arrive as `/#0b`, `/#0c`,
+ * `/#0d`, `/#0e` and pdf-lib reports the three-character strings `#0b`, `#0c`,
+ * … while PDF.js keys the same CharProcs entries by the one-character names
+ * U+000B, U+000C, and so on. `linkedRawType3Font` compares the two and the
+ * whole font fails to link, which costs it every recovery and every census
+ * row it would otherwise have.
+ *
+ * A residual escape cannot simply be unescaped again, because the same
+ * three characters can be the glyph's real name. A producer that means the
+ * literal name `#0B` writes `/#230B`; pdf-lib decodes the `#23` to `#` and
+ * stops, and PDF.js decodes it exactly the same way, so both agree on `#0B`
+ * and unescaping once more would break a font that links today. The Shannon
+ * reference document is that case: all 29 of its escaped Type-3 glyph names
+ * are `/#23`-prefixed, and blanket re-unescaping drops its linked occurrences
+ * from 4,437 to 766.
+ *
+ * The two cases are separated exactly, not heuristically. pdf-lib already
+ * consumed every escape whose digits are `[0-9A-F]`, so a residual `#hh` can
+ * only be an escape pdf-lib missed when at least one of its digits is
+ * lowercase `a-f`. `#0b` therefore came from a raw `/#0b`; `#0B`, `#28` and
+ * `#2328` could not have, and are left alone. Both readings are offered to the
+ * linker rather than one being chosen, so a font is still only linked when the
+ * name PDF.js reports is one pdf-lib's bytes can actually produce.
+ *
+ * Measured on the corpus: astro-ph/9402001 goes from 7,019 to 100,108 of its
+ * 100,114 drawn Type-3 occurrences attributable to a font dictionary, and
+ * three further harvested documents recover in the same way, while Shannon and
+ * the four Ghostscript 6.52 documents are unchanged to the occurrence.
+ */
+function type3GlyphNameCandidates(decodedName) {
+  const unescaped = decodedName.replace(
+    /#(?=[0-9a-fA-F]{2})([0-9a-fA-F]{2})/gu,
+    (escape, digits) => (/[a-f]/u.test(digits) ? String.fromCharCode(Number.parseInt(digits, 16)) : escape),
+  );
+  return unescaped === decodedName ? Object.freeze([decodedName]) : Object.freeze([decodedName, unescaped]);
+}
+
 function fontEncodingDifferences(font, context) {
   const encoding = context.lookup(font.get(PDFName.of("Encoding")), PDFDict);
   const differences = encoding?.lookup(PDFName.of("Differences"), PDFArray);
@@ -1581,7 +1626,7 @@ function fontEncodingDifferences(font, context) {
     if (value instanceof PDFNumber) {
       code = value.asNumber();
     } else if (value instanceof PDFName && Number.isSafeInteger(code) && code >= 0 && code <= 255) {
-      codeToGlyph.set(code, value.decodeText());
+      codeToGlyph.set(code, type3GlyphNameCandidates(value.decodeText()));
       code += 1;
     } else {
       return null;
@@ -2000,7 +2045,7 @@ function linkedRawType3Font(fontId, fontTokens, rawFonts) {
     if (typeof glyph.operatorListId === "string") glyphIds.set(glyph.originalCharCode, glyph.operatorListId);
   }
   const candidates = rawFonts.filter(raw => [...observed].every(([code, width]) => raw.widths.get(code) === width)
-    && [...glyphIds].every(([code, glyphId]) => raw.codeToGlyph.get(code) === glyphId));
+    && [...glyphIds].every(([code, glyphId]) => raw.codeToGlyph.get(code)?.includes(glyphId) === true));
   if (candidates.length !== 1 || !candidates[0].recoverable) return null;
   return candidates[0];
 }
@@ -2087,9 +2132,16 @@ export function type3FontPaintOrientation(font, ops) {
 }
 
 function type3GlyphEvidenceForCode(font, rawFont, code, ops) {
-  const glyphId = rawFont.codeToGlyph.get(code);
-  if (typeof glyphId !== "string") return null;
-  const charProc = font?.charProcOperatorList?.[glyphId];
+  // A /Differences name has one reading unless pdf-lib left a lowercase hex
+  // escape in it (see `type3GlyphNameCandidates`), in which case the second
+  // reading is the escape resolved. Whichever one names a real CharProcs entry
+  // is the glyph PDF.js drew; if both do, the font gives one name two meanings
+  // and there is nothing honest to key on.
+  const names = (rawFont.codeToGlyph.get(code) ?? [])
+    .filter(name => typeof name === "string" && typeof font?.charProcOperatorList?.[name] === "object" && font.charProcOperatorList[name] !== null);
+  if (names.length !== 1) return null;
+  const glyphId = names[0];
+  const charProc = font.charProcOperatorList[glyphId];
   if (!charProc || typeof charProc !== "object") return null;
   let byGlyphId = type3GlyphEvidenceCache.get(font);
   if (byGlyphId === undefined) {

--- a/server/layout-extraction.js
+++ b/server/layout-extraction.js
@@ -1570,6 +1570,51 @@ export function type3GlyphEvidenceSha256(charProc, fontMatrix, ops, fontPaintOri
   return grid;
 }
 
+/*
+ * The glyph name a /Differences entry really carries, as PDF.js sees it.
+ *
+ * PDF names escape an irregular byte as `#` plus two hexadecimal digits, and
+ * ISO 32000-1 7.3.5 allows either letter case. pdf-lib's `decodeText()`
+ * unescapes with `/#([\dABCDEF]{2})/g` — digits and UPPERCASE A-F only — so a
+ * producer that writes lowercase hex leaves the escape sitting in the decoded
+ * string. dvips-era Ghostscript names each Computer Modern glyph after its own
+ * raw encoding byte, so a text font's ligature slots arrive as `/#0b`, `/#0c`,
+ * `/#0d`, `/#0e` and pdf-lib reports the three-character strings `#0b`, `#0c`,
+ * … while PDF.js keys the same CharProcs entries by the one-character names
+ * U+000B, U+000C, and so on. `linkedRawType3Font` compares the two and the
+ * whole font fails to link, which costs it every recovery and every census
+ * row it would otherwise have.
+ *
+ * A residual escape cannot simply be unescaped again, because the same
+ * three characters can be the glyph's real name. A producer that means the
+ * literal name `#0B` writes `/#230B`; pdf-lib decodes the `#23` to `#` and
+ * stops, and PDF.js decodes it exactly the same way, so both agree on `#0B`
+ * and unescaping once more would break a font that links today. The Shannon
+ * reference document is that case: all 29 of its escaped Type-3 glyph names
+ * are `/#23`-prefixed, and blanket re-unescaping drops its linked occurrences
+ * from 4,437 to 766.
+ *
+ * The two cases are separated exactly, not heuristically. pdf-lib already
+ * consumed every escape whose digits are `[0-9A-F]`, so a residual `#hh` can
+ * only be an escape pdf-lib missed when at least one of its digits is
+ * lowercase `a-f`. `#0b` therefore came from a raw `/#0b`; `#0B`, `#28` and
+ * `#2328` could not have, and are left alone. Both readings are offered to the
+ * linker rather than one being chosen, so a font is still only linked when the
+ * name PDF.js reports is one pdf-lib's bytes can actually produce.
+ *
+ * Measured on the corpus: astro-ph/9402001 goes from 7,019 to 100,108 of its
+ * 100,114 drawn Type-3 occurrences attributable to a font dictionary, and
+ * three further harvested documents recover in the same way, while Shannon and
+ * the four Ghostscript 6.52 documents are unchanged to the occurrence.
+ */
+function type3GlyphNameCandidates(decodedName) {
+  const unescaped = decodedName.replace(
+    /#(?=[0-9a-fA-F]{2})([0-9a-fA-F]{2})/gu,
+    (escape, digits) => (/[a-f]/u.test(digits) ? String.fromCharCode(Number.parseInt(digits, 16)) : escape),
+  );
+  return unescaped === decodedName ? Object.freeze([decodedName]) : Object.freeze([decodedName, unescaped]);
+}
+
 function fontEncodingDifferences(font, context) {
   const encoding = context.lookup(font.get(PDFName.of("Encoding")), PDFDict);
   const differences = encoding?.lookup(PDFName.of("Differences"), PDFArray);
@@ -1581,7 +1626,7 @@ function fontEncodingDifferences(font, context) {
     if (value instanceof PDFNumber) {
       code = value.asNumber();
     } else if (value instanceof PDFName && Number.isSafeInteger(code) && code >= 0 && code <= 255) {
-      codeToGlyph.set(code, value.decodeText());
+      codeToGlyph.set(code, type3GlyphNameCandidates(value.decodeText()));
       code += 1;
     } else {
       return null;
@@ -2000,7 +2045,7 @@ function linkedRawType3Font(fontId, fontTokens, rawFonts) {
     if (typeof glyph.operatorListId === "string") glyphIds.set(glyph.originalCharCode, glyph.operatorListId);
   }
   const candidates = rawFonts.filter(raw => [...observed].every(([code, width]) => raw.widths.get(code) === width)
-    && [...glyphIds].every(([code, glyphId]) => raw.codeToGlyph.get(code) === glyphId));
+    && [...glyphIds].every(([code, glyphId]) => raw.codeToGlyph.get(code)?.includes(glyphId) === true));
   if (candidates.length !== 1 || !candidates[0].recoverable) return null;
   return candidates[0];
 }
@@ -2087,9 +2132,16 @@ export function type3FontPaintOrientation(font, ops) {
 }
 
 function type3GlyphEvidenceForCode(font, rawFont, code, ops) {
-  const glyphId = rawFont.codeToGlyph.get(code);
-  if (typeof glyphId !== "string") return null;
-  const charProc = font?.charProcOperatorList?.[glyphId];
+  // A /Differences name has one reading unless pdf-lib left a lowercase hex
+  // escape in it (see `type3GlyphNameCandidates`), in which case the second
+  // reading is the escape resolved. Whichever one names a real CharProcs entry
+  // is the glyph PDF.js drew; if both do, the font gives one name two meanings
+  // and there is nothing honest to key on.
+  const names = (rawFont.codeToGlyph.get(code) ?? [])
+    .filter(name => typeof name === "string" && typeof font?.charProcOperatorList?.[name] === "object" && font.charProcOperatorList[name] !== null);
+  if (names.length !== 1) return null;
+  const glyphId = names[0];
+  const charProc = font.charProcOperatorList[glyphId];
   if (!charProc || typeof charProc !== "object") return null;
   let byGlyphId = type3GlyphEvidenceCache.get(font);
   if (byGlyphId === undefined) {

--- a/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
+++ b/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
@@ -55,8 +55,8 @@
     {
       "role": "layout_extraction_module",
       "path": "server/layout-extraction.js",
-      "bytes": 260732,
-      "sha256": "4ec9d63d624ac92a395a52fb9336f0ac16343818dd1396f857573c5c7d4e73ee"
+      "bytes": 263962,
+      "sha256": "c381515a4154dac58ce7555342443c55a9b1d64571242d9dc13cfb1edd6ac6b9"
     },
     {
       "role": "type3_cm_reference_module",
@@ -125,7 +125,7 @@
       "sha256": "6e4429db62fcbe1dd73141d8c20a48b564d41f8bf8920d88775846995e1daf94"
     }
   ],
-  "validator_source_set_sha256": "587e0c07c616c778a848947d1e3c00a3f4f1bbc300f686830b1cfab825df623a",
+  "validator_source_set_sha256": "fc0e84b5d30cb80d8b416f4782ee9d1f5289a87999c5fe67eec3c41d8fdf7635",
   "pdfjs_version": "5.4.624",
   "generation_contract": {
     "source_path": "source.pdf",

--- a/test/legacy-tex-corpus-live.test.js
+++ b/test/legacy-tex-corpus-live.test.js
@@ -226,6 +226,22 @@ import { uniqueComputerModernFamily } from "../server/layout-extraction.js";
  * reason in (a). With (a) closed it recovers, and its remaining ceiling is
  * the /ToUnicode deferral rather than any shortage of enrolled shapes.
  *
+ *   h. Extending the reference past the three math families to the OT1 text
+ *      encoding was measured and refused. At 17,597 generated digests over 76
+ *      faces it would gain 72 characters across this corpus and the Shannon
+ *      document together, and 0.25% of eligible occurrences over 110 harvested
+ *      wild documents, because the producers whose rasters match are the ones
+ *      that also kept their encoding. See
+ *      `docs/evidence/legacy-tex-ot1-text-no-go-2026-08.md`.
+ *   i. astro-ph's own figures below rose from 44 linked / 11 recovered when
+ *      the linker learned to read a lowercase `#hh` PDF name escape that
+ *      pdf-lib's `decodeText()` leaves undecoded. That is a linking fix, not a
+ *      new evidence class; the recovered characters are still only cmsy7's
+ *      minus and prime. The defect it exposes underneath — a producer
+ *      /ToUnicode that maps ligature glyphs into C0 — is recorded with its
+ *      measurements in `docs/evidence/legacy-tex-ligature-tounicode-2026-08.md`
+ *      and is NOT fixed.
+ *
  * Interface: one directory variable, `PDF_TOOLS_LEGACY_CORPUS_DIR`, holding
  * all five documents under the fixed basenames listed in DOCUMENTS. A single
  * variable was chosen over five because five separate variables permit a
@@ -369,11 +385,25 @@ const BASELINE = Object.freeze({
     // to cmsy7 as METAFONT builds it from the pinned CTAN sources at 300 dpi
     // with blacker 0, fillin .2, o_correction .6. That is finding (a) below
     // being answered rather than worked around: the external labelled bitmap
-    // reference now exists, generated and pinned, so the eleven minus signs
-    // recover through the ordinary two-glyph corroboration rule under
-    // `ctan-cm-metafont-generated-pk-v1`. The remaining 100,070 omitted
-    // occurrences are the /ToUnicode deferral, which is a safeguard rather
-    // than a gap, and no amount of reference coverage will change it.
+    // reference now exists, generated and pinned, so the minus signs and
+    // primes recover through the ordinary two-glyph corroboration rule under
+    // `ctan-cm-metafont-generated-pk-v1`.
+    //
+    // The figures below rose from 44 linked / 11 recovered when
+    // `type3GlyphNameCandidates` taught the linker to read a lowercase `#hh`
+    // PDF name escape that pdf-lib's `decodeText()` leaves undecoded. This
+    // producer names each glyph after its own raw encoding byte, so `247 0 R`
+    // writes `/#00` and `/#30`; the linker used to compare pdf-lib's literal
+    // `#00` against PDF.js's one-character name and reject the font on every
+    // page where a glyph with such a name was drawn. Nothing about the
+    // evidence changed — the same font, the same two bit-exact cmsy7 rasters,
+    // the same registry entries — only how many of the document's pages the
+    // font could be identified on. The recovered characters are still only
+    // `−` and `′`.
+    //
+    // The remaining 100,022 omitted occurrences are the /ToUnicode deferral,
+    // which is a safeguard rather than a gap, and no amount of reference
+    // coverage will change it.
     producer: "GPL Ghostscript GIT PRERELEASE 9.22",
     creator: "dvips 5.518",
     page_count: 37,
@@ -382,12 +412,12 @@ const BASELINE = Object.freeze({
     layout_admissible_font_count: 4,
     computer_modern_family_font_count: 10,
     observed_type3_occurrence_count: 100114,
-    linked_type3_occurrence_count: 44,
-    omitted_type3_occurrence_count: 100070,
-    classified_occurrence_count: 12,
-    officially_named_occurrence_count: 11,
-    registry_evidence_occurrence_count: 11,
-    strict_recovery_count: 11,
+    linked_type3_occurrence_count: 92,
+    omitted_type3_occurrence_count: 100022,
+    classified_occurrence_count: 60,
+    officially_named_occurrence_count: 32,
+    registry_evidence_occurrence_count: 32,
+    strict_recovery_count: 32,
     abstention_reasons: Object.freeze(["raw_type3_font_link_ambiguous_or_unavailable"]),
   }),
 });
@@ -569,7 +599,7 @@ describe.runIf(Boolean(CORPUS_DIR))("legacy dvips-era Computer Modern Type-3 cor
    * Corpus-level statement of the gap, so the headline claim is asserted once
    * rather than only implied by five per-document blocks.
    */
-  it("recovers only astro-ph's eleven minus signs across the whole corpus", async () => {
+  it("recovers only astro-ph's cmsy7 minus signs and primes across the whole corpus", async () => {
     const measured = [];
     for (const document of DOCUMENTS) measured.push((await measureDocument(document)).measured);
     expect(measured).toHaveLength(DOCUMENTS.length);
@@ -580,7 +610,8 @@ describe.runIf(Boolean(CORPUS_DIR))("legacy dvips-era Computer Modern Type-3 cor
     expect(total("type3_font_count")).toBeGreaterThan(50);
 
     /*
-     * Eleven, and all eleven from one document. Every other recovery-shaped
+     * Thirty-two, and all thirty-two from one document: 29 minus signs and 3
+     * primes, all from astro-ph's `247 0 R`. Every other recovery-shaped
      * figure in this corpus is still zero, so the corpus remains a record of
      * the gap rather than of the fix. Moving this number in either direction
      * is a deliberate, reviewable edit: down is a regression in the generated
@@ -590,7 +621,7 @@ describe.runIf(Boolean(CORPUS_DIR))("legacy dvips-era Computer Modern Type-3 cor
     expect(
       total("strict_recovery_count"),
       "the legacy corpus recovery total moved: this is the tracked defect being fixed, so update the recorded baseline deliberately",
-    ).toBe(11);
+    ).toBe(32);
     expect(
       measured.filter(entry => entry.strict_recovery_count > 0),
       "more than one corpus document now recovers: update the recorded baseline deliberately",

--- a/test/read-pdf-layout.test.js
+++ b/test/read-pdf-layout.test.js
@@ -689,6 +689,127 @@ describe("qualified legacy Type-3 glyph evidence", () => {
     }
   });
 
+  /**
+   * A /Differences glyph name is bytes, and PDF names escape an irregular byte
+   * as `#` plus two hexadecimal digits in either letter case. pdf-lib's
+   * `decodeText()` unescapes digits and UPPERCASE A-F only, so the linker sees
+   * a different string from PDF.js exactly when a producer wrote lowercase hex
+   * — which dvips-era Ghostscript does for every Computer Modern glyph it
+   * names after its own raw encoding byte.
+   *
+   * Both readings are asserted, because they pull in opposite directions and a
+   * fix for one is the obvious way to break the other. `/#0b` is an escape
+   * pdf-lib missed and its glyph is really U+000B; `/#230b` is an escaped
+   * `#` and its glyph is really the three-character name `#0b`, which pdf-lib
+   * and PDF.js already agree on. Unescaping every residual `#hh` would link
+   * the first and break the second.
+   */
+  describe("hex-escaped Type-3 glyph names", () => {
+    const MASK_ROWS = Object.freeze([0xfe, 0x80, 0x80, 0xf8, 0x80, 0x80, 0x80, 0x80]);
+    const escapedCharProc = Buffer.concat([
+      Buffer.from("1000 0 0 0 800 800 d1\nq 800 0 0 800 0 0 cm\n"
+        + "BI /IM true /W 8 /H 8 /BPC 1 ID ", "latin1"),
+      Buffer.from(MASK_ROWS.map(row => ~row & 0xff)),
+      Buffer.from("\nEI\nQ\n", "latin1"),
+    ]);
+
+    /**
+     * One page, one Type-3 font, two drawn codes, and `names` written verbatim
+     * into both the /Differences array and the /CharProcs dictionary so the
+     * fixture varies nothing but the on-disk spelling of the glyph name.
+     */
+    function buildEscapedNamePdf(names) {
+      return assemblePdf([
+        Buffer.from("<< /Type /Catalog /Pages 2 0 R >>", "latin1"),
+        Buffer.from("<< /Type /Pages /Kids [3 0 R] /Count 1 >>", "latin1"),
+        Buffer.from("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] "
+          + "/Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>", "latin1"),
+        streamObject(Buffer.from("BT /F1 1 Tf 1 0 0 1 20 60 Tm <4142> Tj ET\n", "latin1")),
+        Buffer.from("<< /Type /Font /Subtype /Type3 /FontBBox [0 0 8 8] "
+          + "/FontMatrix [0.01 0 0 0.01 0 0] /CharProcs 6 0 R "
+          + `/Encoding << /Type /Encoding /Differences [65 /${names[0]} /${names[1]}] >> `
+          + "/FirstChar 65 /LastChar 66 /Widths [10 10] /Resources << >> >>", "latin1"),
+        Buffer.from(`<< /${names[0]} 7 0 R /${names[1]} 7 0 R >>`, "latin1"),
+        streamObject(escapedCharProc),
+      ]);
+    }
+
+    async function inspectEscapedNames(names) {
+      const bytes = buildEscapedNamePdf(names);
+      const pdfLibDocument = await PDFDocument.load(bytes, { ignoreEncryption: true, updateMetadata: false });
+      const packageDirectory = path.dirname(require.resolve("pdfjs-dist/package.json"));
+      const pdfjsLib = await import("pdfjs-dist/legacy/build/pdf.mjs");
+      const document = await pdfjsLib.getDocument({
+        data: bytes,
+        useWorkerFetch: false,
+        isEvalSupported: false,
+        cMapUrl: pdfjsFactoryDirectory(path.join(packageDirectory, "cmaps")),
+        cMapPacked: true,
+        standardFontDataUrl: pdfjsFactoryDirectory(path.join(packageDirectory, "standard_fonts")),
+      }).promise;
+      try {
+        const page = await document.getPage(1);
+        const [textContent, operators] = await Promise.all([
+          page.getTextContent({ includeMarkedContent: false, disableNormalization: false }),
+          page.getOperatorList(),
+        ]);
+        const inventory = inspectType3GlyphEvidenceForPage({
+          textContent,
+          operators,
+          pdfjsPage: page,
+          pdfLibPage: pdfLibDocument.getPage(0),
+          pdfjsLib,
+        });
+        return {
+          occurrence_count: inventory.occurrences.length,
+          digests: inventory.occurrences.map(occurrence => occurrence.glyph_sha256),
+          unlinked: inventory.omissions
+            .filter(omission => omission.reason === "raw_type3_font_link_ambiguous_or_unavailable")
+            .reduce((total, omission) => total + omission.count, 0),
+        };
+      } finally {
+        await document.destroy();
+      }
+    }
+
+    it("links a font whose names are plain and keys both drawn glyphs", async () => {
+      // Positive control: no escape anywhere, so nothing below can pass
+      // because the fixture never links in the first place.
+      const plain = await inspectEscapedNames(["upright", "sibling"]);
+      expect(plain.unlinked).toBe(0);
+      expect(plain.occurrence_count).toBe(2);
+      expect(plain.digests.every(digest => typeof digest === "string" && digest.length === 64)).toBe(true);
+    });
+
+    it("links a font whose names are lowercase hex escapes pdf-lib leaves undecoded", async () => {
+      const escaped = await inspectEscapedNames(["#0b", "#0c"]);
+      expect(escaped.unlinked).toBe(0);
+      expect(escaped.occurrence_count).toBe(2);
+      // Same font, same rasters: resolving the name must not change what the
+      // glyph keys to, only whether the font can be found at all.
+      const plain = await inspectEscapedNames(["upright", "sibling"]);
+      expect(escaped.digests).toEqual(plain.digests);
+    });
+
+    it("links a font whose names really are three characters beginning with a hash", async () => {
+      // `/#230b` is an escaped hash, so the glyph's name is `#0b`. pdf-lib and
+      // PDF.js already agree here; re-unescaping the residual would break it.
+      const literal = await inspectEscapedNames(["#230b", "#230c"]);
+      expect(literal.unlinked).toBe(0);
+      expect(literal.occurrence_count).toBe(2);
+    });
+
+    it("keys nothing when one code's two readings both name a CharProcs entry", async () => {
+      // A font that writes /#230b for one code and /#0b for another gives
+      // pdf-lib the same string, `#0b`, for the first, whose two readings then
+      // both exist in /CharProcs. Which raster belongs to the code is no longer
+      // decidable, so no digest is offered for it.
+      const collided = await inspectEscapedNames(["#230b", "#0b"]);
+      expect(collided.occurrence_count).toBe(2);
+      expect(collided.digests[0]).toBeNull();
+    });
+  });
+
   it("keeps ordinary punctuation and already-correct Unicode byte-for-byte unchanged", async () => {
     const { result } = await runFake([{ items: [textItem({ text: "!:=,-−", x: 20, top: 20 })] }]);
     const item = result.pages[0].raw_items[0];


### PR DESCRIPTION
## The bug

`pdf-lib`'s `decodeName` unescapes **uppercase hex only** (`/#([\dABCDEF]{2})/g`),
while Ghostscript writes names like `/#0b`. pdf-lib reported the literal `#0b`
where PDF.js reported `U+000B`, the two disagreed, and **the whole font failed
to link** — every glyph in it unattributable.

`astro-ph/9402001`: **7,019 → 100,108** of 100,114 occurrences attributable.
Strict recoveries **11 → 32**, through the existing lane with no change to
matching and no safeguard relaxed. Three wild documents recover the same way.

## The obvious fix is wrong, and the tests now say so

Unescaping every `#hh` in a single reading **breaks Shannon**: 4,437 linked
occurrences → 766, because a glyph name can legitimately contain that sequence.

The linker instead offers both readings as candidates, and the separation is
**exact, not heuristic**: pdf-lib has already consumed every `[0-9A-F]` escape,
so a residual containing a lowercase hex digit provably came from an escape it
missed. Two of the four new tests are the controls that fail under the naive
version.

## OT1 text enrollment: recorded as a no-go

`docs/evidence/legacy-tex-ot1-text-no-go-2026-08.md`. Recoverable-by-PK and
unreadable-without-recovery are **anti-correlated across the three dvips
producer regimes**:

| pipeline | bitmaps | encoding | outcome |
|---|---|---|---|
| dvips → Distiller | survive | survives | already readable |
| dvips → Ghostscript 6.52/7.05 | re-rasterised | destroyed | unreadable, unmatchable |
| dvips → modern Ghostscript | kept | `/ToUnicode` | already readable |

The entire pinned corpus would gain **72 characters**, and 66 of those are math
slots in Shannon rather than text. Across 122 wild documents, 71 in class,
41,840 eligible occurrences yielded **105 exact matches (0.251%)**; best single
document 16.

A separate blocker sits underneath: text faces pin **no family at all** — 0 of
Shannon's 13, 0 of 29 on ias-GNW95, 0 of 25 on eccc1997-020 — returning `null`
rather than an `unsupported:` label, so an encoding table would have nothing to
attach to. OT1 would require replacing the family pin the math lane depends on.

Sample bias recorded: 74 of 122 documents are Ghostscript 7.05, CS/TCS archives
only, IACR ePrint and CiteSeerX unreachable.

## The ligature override: measured, deliberately not built

The real user-visible defect is confirmed — astro-ph maps ff/fi/fl/ffi to
U+000B–U+000E, **350 occurrences over 36 pages**, which reads as "Formal
Specication" in extracted text. Only 6 documents of 128 exhibit it.

Not built, for three measured reasons: all **6,379** registry entries target a
single character and `validatePdfLayoutSemantics` hard-asserts
`target_unicode.length === 1`, so the multi-scalar path has never executed;
astro-ph's own text font pins no family; and the reference carries no text
faces. Recorded rather than half-built.

## Verification

- `npm test` — **2204 passed, 89 skipped, 0 failed**
- Shannon live oracle — **1,872 across all 70 ids, per-id identical**
- Corpus live oracle — astro-ph deliberately raised to 32 with reasoning inline;
  the other four documents unchanged to the occurrence
- `build:mcpb` reproducible, `smoke:mcpb` passed, share mirror byte-identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)