### PR TITLE
Reject hostile cross-reference stream byte widths before pdf-lib parses

### DIFF
--- a/pdf-toolkit-mcp-share/server/pdf-lib-worker.js
+++ b/pdf-toolkit-mcp-share/server/pdf-lib-worker.js
@@ -55,6 +55,24 @@ const MAX_STAGE_TOTAL_BYTES = 1024 * 1024 * 1024;
 const MAX_OUTPUTS = 1000;
 const MAX_REASONABLE_OBJECT_NUMBER = 2_000_000;
 const MAX_STRUCTURE_TOKEN_BYTES = 128;
+// ISO 32000-1:2008, Table 17: every element of a cross-reference stream's /W
+// array is the byte count of one cross-reference field. Eight bytes already
+// exceed the integer precision pdf-lib accumulates those bytes into, so no
+// conforming producer can need more.
+const MAX_XREF_FIELD_BYTES = 8;
+// pdf-lib's PDFXRefStreamParser consumes W[0] + W[1] + W[2] bytes per entry.
+const MAX_XREF_ENTRY_BYTES = 3 * MAX_XREF_FIELD_BYTES;
+// Only the first three /W elements ever become loop bounds, so retaining a
+// short prefix checks everything that matters and keeps a /W array with
+// millions of hostile elements from being materialized by this guard itself.
+const MAX_TRACKED_XREF_WIDTHS = 8;
+// A hostile file can nest dictionaries as deeply as its bytes allow, so the
+// per-dictionary tracking below keeps only a bounded window of open frames.
+const MAX_TRACKED_DICT_DEPTH = 512;
+// A PDF real, which pdf-lib will still coerce into a loop bound. The lexer
+// classifies anything containing a decimal point as a word, so byte widths
+// have to be recognized here rather than only from integer tokens.
+const PDF_REAL_NUMBER = /^[+-]?(?:\d+\.?\d*|\.\d+)$/;
 const MAX_STREAM_FILTER_CHAIN_LENGTH = 4;
 const MAX_EXPANDING_FILTER_STAGES = 2;
 const MAX_PARSED_DIRECT_DEPTH = 256;
@@ -369,12 +387,44 @@ function decodePdfName(bytes, start, end) {
   return value;
 }
 
+const PDF_ENDSTREAM_KEYWORD = Buffer.from("endstream", "ascii");
+
+// Resolve the end of one stream payload the way pdf-lib's own parser does:
+// trust a direct /Length only when the bytes it points past really are the
+// endstream keyword, and otherwise fall back to searching for that keyword.
+// A payload that misleads this also misleads pdf-lib, so the two views of a
+// document cannot be made to disagree about where structure resumes.
+function skipPdfStreamPayload(bytes, offset, declaredLength) {
+  let start = offset;
+  if (bytes[start] === 0x0d) start += 1;
+  if (bytes[start] === 0x0a) start += 1;
+  if (declaredLength !== null && start + declaredLength <= bytes.length) {
+    let probe = start + declaredLength;
+    while (probe < bytes.length && isPdfWhitespace(bytes[probe])) probe += 1;
+    if (bytes.subarray(probe, probe + PDF_ENDSTREAM_KEYWORD.length)
+      .equals(PDF_ENDSTREAM_KEYWORD)) {
+      return probe;
+    }
+  }
+  const found = bytes.indexOf(PDF_ENDSTREAM_KEYWORD, start);
+  return found < 0 ? bytes.length : found;
+}
+
 // This lexer retains only a bounded token and a handful of parser states. It
 // deliberately ignores comments and PDF string objects, where structural
 // spellings are data. Whitespace and comments may be arbitrarily long, so a
 // sparse declaration cannot evade the guard by crossing a fixed-size overlap.
-function* pdfStructureTokens(bytes) {
+//
+// By default stream payloads are tokenized too, because pdf-lib resynchronizes
+// inside a payload whose /Length lies and will parse object headers out of it.
+// skipStreamPayloads is for the cross-reference byte-width pass, which needs
+// the structural view pdf-lib's parser itself acts on: a single unpaired "<"
+// or "(" in compressed payload bytes otherwise swallows every following token
+// up to the next ">" or ")", which is enough to hide a whole xref dictionary.
+function* pdfStructureTokens(bytes, { skipStreamPayloads = false } = {}) {
   let offset = 0;
+  let expectLengthValue = false;
+  let declaredLength = null;
   while (offset < bytes.length) {
     const byte = bytes[offset];
     if (isPdfWhitespace(byte)) {
@@ -411,11 +461,15 @@ function* pdfStructureTokens(bytes) {
       while (offset < bytes.length && !isPdfWhitespace(bytes[offset]) && !isPdfDelimiter(bytes[offset])) {
         offset += 1;
       }
-      yield {
+      const nameToken = {
         type: "name",
         value: decodePdfName(bytes, start, offset),
         overlong: offset - start > MAX_STRUCTURE_TOKEN_BYTES,
       };
+      yield nameToken;
+      if (skipStreamPayloads) {
+        expectLengthValue = !nameToken.overlong && nameToken.value === "Length";
+      }
       continue;
     }
     if (isPdfDelimiter(byte)) {
@@ -439,16 +493,160 @@ function* pdfStructureTokens(bytes) {
     }
     const length = offset - start;
     if (digitLength === 0) allDigits = false;
-    yield {
+    const token = {
       type: allDigits ? "integer" : "word",
       value: bytes.subarray(start, Math.min(offset, start + MAX_STRUCTURE_TOKEN_BYTES)).toString("latin1"),
       overlong: length > MAX_STRUCTURE_TOKEN_BYTES,
       digitLength: allDigits ? digitLength : 0,
     };
+    yield token;
+    if (!skipStreamPayloads) continue;
+    if (expectLengthValue) {
+      expectLengthValue = false;
+      const value = token.type === "integer" && token.digitLength <= 15
+        ? Number(token.value)
+        : null;
+      declaredLength = Number.isSafeInteger(value) && value >= 0 ? value : null;
+      continue;
+    }
+    if (token.type === "word" && !token.overlong && token.value === "stream") {
+      offset = skipPdfStreamPayload(bytes, offset, declaredLength);
+      declaredLength = null;
+    }
+  }
+}
+
+// pdf-lib 1.17.1 reads a cross-reference stream's /W byte widths straight
+// into the loop bounds of PDFXRefStreamParser.parseEntries without any range
+// check, so /W [1 2000000000 1] spins that loop for billions of iterations on
+// a one-kilobyte file while resident memory stays flat. The RSS monitor cannot
+// see a flat-memory spin, which leaves only the subprocess deadline between a
+// hostile document and a wedged worker. The defect is Hopding/pdf-lib#1776
+// (CWE-190); the fix in PR #1781 is unmerged and the issue was closed
+// untouched by a stale bot, so the bound has to live on our side of the
+// parser. The reasoning ported from that PR is the ISO 32000-1:2008 Table 17
+// range check below; the premature end-of-stream handling it also adds is not
+// reproducible from here, because a bounded /W can never read past a bounded
+// entry count.
+function assertBoundedXRefStreamByteWidths(bytes) {
+  const rejectByteWidth = detail => {
+    throw resourceError(
+      "unsafe_xref_byte_width",
+      `PDF declares an unsafe cross-reference stream byte width (${detail}); `
+      + "mutation was stopped before parsing.",
+    );
+  };
+  // The loop bound pdf-lib derives is the numeric magnitude, so magnitude is
+  // what has to be bounded. A non-canonical spelling such as 1.0 stays
+  // acceptable; 2000000000.0 does not.
+  const byteWidthNumber = token => {
+    if (token.overlong) return Number.POSITIVE_INFINITY;
+    if (token.type === "integer") return Number(token.value);
+    if (token.type === "word" && PDF_REAL_NUMBER.test(token.value)) return Number(token.value);
+    return null;
+  };
+  const assertByteWidths = widths => {
+    let entryBytes = 0;
+    for (let index = 0; index < widths.length; index += 1) {
+      const { raw, value } = widths[index];
+      if (!Number.isFinite(value) || value < 0 || value > MAX_XREF_FIELD_BYTES) {
+        rejectByteWidth(`/W[${index}] = ${raw}`);
+      }
+      if (index < 3) entryBytes += value;
+    }
+    if (entryBytes > MAX_XREF_ENTRY_BYTES) {
+      rejectByteWidth(`/W implies a ${entryBytes}-byte entry`);
+    }
+  };
+  const dictStack = [];
+  let untrackedDictDepth = 0;
+  let expectTypeValue = false;
+  let widthState = "idle";
+  let widthFrame = null;
+  let widthDepth = 0;
+  let widthValues = null;
+  let widthMalformed = false;
+  const resetWidthCollection = () => {
+    widthState = "idle";
+    widthFrame = null;
+    widthDepth = 0;
+    widthValues = null;
+    widthMalformed = false;
+  };
+
+  for (const token of pdfStructureTokens(bytes, { skipStreamPayloads: true })) {
+    // Bind each /W array to the dictionary that declares it so a CIDFont /W
+    // glyph-width array, whose legitimate elements are far larger than eight,
+    // is never mistaken for a cross-reference stream's byte widths. The widths
+    // are checked when the dictionary closes, because /Type /XRef may be
+    // written after /W.
+    if (expectTypeValue) {
+      if (token.type === "name" && !token.overlong && token.value === "XRef") {
+        const frame = dictStack.at(-1);
+        if (frame) frame.xrefStream = true;
+      }
+      expectTypeValue = false;
+    }
+    if (widthState === "bracket") {
+      if (token.type === "delimiter" && token.value === "[") {
+        widthState = "collect";
+        widthDepth = 1;
+        widthValues = [];
+        widthMalformed = false;
+      } else {
+        resetWidthCollection();
+      }
+    } else if (widthState === "collect") {
+      if (token.type === "delimiter" && token.value === "[") {
+        widthDepth += 1;
+        widthMalformed = true;
+      } else if (token.type === "delimiter" && token.value === "]") {
+        widthDepth -= 1;
+        if (widthDepth === 0) {
+          if (widthFrame && !widthMalformed) widthFrame.widths = widthValues;
+          resetWidthCollection();
+        }
+      } else if (widthDepth === 1) {
+        // A non-numeric element makes pdf-lib's own W.lookup(idx, PDFNumber)
+        // throw inside the constructor, before parseEntries runs, so such an
+        // array needs no bound from here.
+        const value = byteWidthNumber(token);
+        if (value === null) widthMalformed = true;
+        else if (widthValues.length < MAX_TRACKED_XREF_WIDTHS) {
+          widthValues.push({ raw: token.value, value });
+        }
+      }
+    }
+    if (token.type === "delimiter" && token.value === "<<") {
+      if (dictStack.length < MAX_TRACKED_DICT_DEPTH) {
+        dictStack.push({ xrefStream: false, widths: null });
+      } else {
+        untrackedDictDepth += 1;
+      }
+    } else if (token.type === "delimiter" && token.value === ">>") {
+      if (untrackedDictDepth > 0) {
+        untrackedDictDepth -= 1;
+      } else {
+        const frame = dictStack.pop();
+        if (frame === widthFrame) resetWidthCollection();
+        if (frame?.xrefStream && frame.widths) assertByteWidths(frame.widths);
+      }
+    }
+    if (token.type === "name" && !token.overlong) {
+      if (token.value === "Type") expectTypeValue = true;
+      if (token.value === "W" && dictStack.length > 0) {
+        widthState = "bracket";
+        widthFrame = dictStack.at(-1);
+        widthDepth = 0;
+        widthValues = null;
+        widthMalformed = false;
+      }
+    }
   }
 }
 
 export function assertBoundedPdfStructure(bytes) {
+  assertBoundedXRefStreamByteWidths(bytes);
   const densityLimit = Math.min(
     MAX_REASONABLE_OBJECT_NUMBER,
     Math.max(100_000, bytes.length * 32),

--- a/server/pdf-lib-worker.js
+++ b/server/pdf-lib-worker.js
@@ -55,6 +55,24 @@ const MAX_STAGE_TOTAL_BYTES = 1024 * 1024 * 1024;
 const MAX_OUTPUTS = 1000;
 const MAX_REASONABLE_OBJECT_NUMBER = 2_000_000;
 const MAX_STRUCTURE_TOKEN_BYTES = 128;
+// ISO 32000-1:2008, Table 17: every element of a cross-reference stream's /W
+// array is the byte count of one cross-reference field. Eight bytes already
+// exceed the integer precision pdf-lib accumulates those bytes into, so no
+// conforming producer can need more.
+const MAX_XREF_FIELD_BYTES = 8;
+// pdf-lib's PDFXRefStreamParser consumes W[0] + W[1] + W[2] bytes per entry.
+const MAX_XREF_ENTRY_BYTES = 3 * MAX_XREF_FIELD_BYTES;
+// Only the first three /W elements ever become loop bounds, so retaining a
+// short prefix checks everything that matters and keeps a /W array with
+// millions of hostile elements from being materialized by this guard itself.
+const MAX_TRACKED_XREF_WIDTHS = 8;
+// A hostile file can nest dictionaries as deeply as its bytes allow, so the
+// per-dictionary tracking below keeps only a bounded window of open frames.
+const MAX_TRACKED_DICT_DEPTH = 512;
+// A PDF real, which pdf-lib will still coerce into a loop bound. The lexer
+// classifies anything containing a decimal point as a word, so byte widths
+// have to be recognized here rather than only from integer tokens.
+const PDF_REAL_NUMBER = /^[+-]?(?:\d+\.?\d*|\.\d+)$/;
 const MAX_STREAM_FILTER_CHAIN_LENGTH = 4;
 const MAX_EXPANDING_FILTER_STAGES = 2;
 const MAX_PARSED_DIRECT_DEPTH = 256;
@@ -369,12 +387,44 @@ function decodePdfName(bytes, start, end) {
   return value;
 }
 
+const PDF_ENDSTREAM_KEYWORD = Buffer.from("endstream", "ascii");
+
+// Resolve the end of one stream payload the way pdf-lib's own parser does:
+// trust a direct /Length only when the bytes it points past really are the
+// endstream keyword, and otherwise fall back to searching for that keyword.
+// A payload that misleads this also misleads pdf-lib, so the two views of a
+// document cannot be made to disagree about where structure resumes.
+function skipPdfStreamPayload(bytes, offset, declaredLength) {
+  let start = offset;
+  if (bytes[start] === 0x0d) start += 1;
+  if (bytes[start] === 0x0a) start += 1;
+  if (declaredLength !== null && start + declaredLength <= bytes.length) {
+    let probe = start + declaredLength;
+    while (probe < bytes.length && isPdfWhitespace(bytes[probe])) probe += 1;
+    if (bytes.subarray(probe, probe + PDF_ENDSTREAM_KEYWORD.length)
+      .equals(PDF_ENDSTREAM_KEYWORD)) {
+      return probe;
+    }
+  }
+  const found = bytes.indexOf(PDF_ENDSTREAM_KEYWORD, start);
+  return found < 0 ? bytes.length : found;
+}
+
 // This lexer retains only a bounded token and a handful of parser states. It
 // deliberately ignores comments and PDF string objects, where structural
 // spellings are data. Whitespace and comments may be arbitrarily long, so a
 // sparse declaration cannot evade the guard by crossing a fixed-size overlap.
-function* pdfStructureTokens(bytes) {
+//
+// By default stream payloads are tokenized too, because pdf-lib resynchronizes
+// inside a payload whose /Length lies and will parse object headers out of it.
+// skipStreamPayloads is for the cross-reference byte-width pass, which needs
+// the structural view pdf-lib's parser itself acts on: a single unpaired "<"
+// or "(" in compressed payload bytes otherwise swallows every following token
+// up to the next ">" or ")", which is enough to hide a whole xref dictionary.
+function* pdfStructureTokens(bytes, { skipStreamPayloads = false } = {}) {
   let offset = 0;
+  let expectLengthValue = false;
+  let declaredLength = null;
   while (offset < bytes.length) {
     const byte = bytes[offset];
     if (isPdfWhitespace(byte)) {
@@ -411,11 +461,15 @@ function* pdfStructureTokens(bytes) {
       while (offset < bytes.length && !isPdfWhitespace(bytes[offset]) && !isPdfDelimiter(bytes[offset])) {
         offset += 1;
       }
-      yield {
+      const nameToken = {
         type: "name",
         value: decodePdfName(bytes, start, offset),
         overlong: offset - start > MAX_STRUCTURE_TOKEN_BYTES,
       };
+      yield nameToken;
+      if (skipStreamPayloads) {
+        expectLengthValue = !nameToken.overlong && nameToken.value === "Length";
+      }
       continue;
     }
     if (isPdfDelimiter(byte)) {
@@ -439,16 +493,160 @@ function* pdfStructureTokens(bytes) {
     }
     const length = offset - start;
     if (digitLength === 0) allDigits = false;
-    yield {
+    const token = {
       type: allDigits ? "integer" : "word",
       value: bytes.subarray(start, Math.min(offset, start + MAX_STRUCTURE_TOKEN_BYTES)).toString("latin1"),
       overlong: length > MAX_STRUCTURE_TOKEN_BYTES,
       digitLength: allDigits ? digitLength : 0,
     };
+    yield token;
+    if (!skipStreamPayloads) continue;
+    if (expectLengthValue) {
+      expectLengthValue = false;
+      const value = token.type === "integer" && token.digitLength <= 15
+        ? Number(token.value)
+        : null;
+      declaredLength = Number.isSafeInteger(value) && value >= 0 ? value : null;
+      continue;
+    }
+    if (token.type === "word" && !token.overlong && token.value === "stream") {
+      offset = skipPdfStreamPayload(bytes, offset, declaredLength);
+      declaredLength = null;
+    }
+  }
+}
+
+// pdf-lib 1.17.1 reads a cross-reference stream's /W byte widths straight
+// into the loop bounds of PDFXRefStreamParser.parseEntries without any range
+// check, so /W [1 2000000000 1] spins that loop for billions of iterations on
+// a one-kilobyte file while resident memory stays flat. The RSS monitor cannot
+// see a flat-memory spin, which leaves only the subprocess deadline between a
+// hostile document and a wedged worker. The defect is Hopding/pdf-lib#1776
+// (CWE-190); the fix in PR #1781 is unmerged and the issue was closed
+// untouched by a stale bot, so the bound has to live on our side of the
+// parser. The reasoning ported from that PR is the ISO 32000-1:2008 Table 17
+// range check below; the premature end-of-stream handling it also adds is not
+// reproducible from here, because a bounded /W can never read past a bounded
+// entry count.
+function assertBoundedXRefStreamByteWidths(bytes) {
+  const rejectByteWidth = detail => {
+    throw resourceError(
+      "unsafe_xref_byte_width",
+      `PDF declares an unsafe cross-reference stream byte width (${detail}); `
+      + "mutation was stopped before parsing.",
+    );
+  };
+  // The loop bound pdf-lib derives is the numeric magnitude, so magnitude is
+  // what has to be bounded. A non-canonical spelling such as 1.0 stays
+  // acceptable; 2000000000.0 does not.
+  const byteWidthNumber = token => {
+    if (token.overlong) return Number.POSITIVE_INFINITY;
+    if (token.type === "integer") return Number(token.value);
+    if (token.type === "word" && PDF_REAL_NUMBER.test(token.value)) return Number(token.value);
+    return null;
+  };
+  const assertByteWidths = widths => {
+    let entryBytes = 0;
+    for (let index = 0; index < widths.length; index += 1) {
+      const { raw, value } = widths[index];
+      if (!Number.isFinite(value) || value < 0 || value > MAX_XREF_FIELD_BYTES) {
+        rejectByteWidth(`/W[${index}] = ${raw}`);
+      }
+      if (index < 3) entryBytes += value;
+    }
+    if (entryBytes > MAX_XREF_ENTRY_BYTES) {
+      rejectByteWidth(`/W implies a ${entryBytes}-byte entry`);
+    }
+  };
+  const dictStack = [];
+  let untrackedDictDepth = 0;
+  let expectTypeValue = false;
+  let widthState = "idle";
+  let widthFrame = null;
+  let widthDepth = 0;
+  let widthValues = null;
+  let widthMalformed = false;
+  const resetWidthCollection = () => {
+    widthState = "idle";
+    widthFrame = null;
+    widthDepth = 0;
+    widthValues = null;
+    widthMalformed = false;
+  };
+
+  for (const token of pdfStructureTokens(bytes, { skipStreamPayloads: true })) {
+    // Bind each /W array to the dictionary that declares it so a CIDFont /W
+    // glyph-width array, whose legitimate elements are far larger than eight,
+    // is never mistaken for a cross-reference stream's byte widths. The widths
+    // are checked when the dictionary closes, because /Type /XRef may be
+    // written after /W.
+    if (expectTypeValue) {
+      if (token.type === "name" && !token.overlong && token.value === "XRef") {
+        const frame = dictStack.at(-1);
+        if (frame) frame.xrefStream = true;
+      }
+      expectTypeValue = false;
+    }
+    if (widthState === "bracket") {
+      if (token.type === "delimiter" && token.value === "[") {
+        widthState = "collect";
+        widthDepth = 1;
+        widthValues = [];
+        widthMalformed = false;
+      } else {
+        resetWidthCollection();
+      }
+    } else if (widthState === "collect") {
+      if (token.type === "delimiter" && token.value === "[") {
+        widthDepth += 1;
+        widthMalformed = true;
+      } else if (token.type === "delimiter" && token.value === "]") {
+        widthDepth -= 1;
+        if (widthDepth === 0) {
+          if (widthFrame && !widthMalformed) widthFrame.widths = widthValues;
+          resetWidthCollection();
+        }
+      } else if (widthDepth === 1) {
+        // A non-numeric element makes pdf-lib's own W.lookup(idx, PDFNumber)
+        // throw inside the constructor, before parseEntries runs, so such an
+        // array needs no bound from here.
+        const value = byteWidthNumber(token);
+        if (value === null) widthMalformed = true;
+        else if (widthValues.length < MAX_TRACKED_XREF_WIDTHS) {
+          widthValues.push({ raw: token.value, value });
+        }
+      }
+    }
+    if (token.type === "delimiter" && token.value === "<<") {
+      if (dictStack.length < MAX_TRACKED_DICT_DEPTH) {
+        dictStack.push({ xrefStream: false, widths: null });
+      } else {
+        untrackedDictDepth += 1;
+      }
+    } else if (token.type === "delimiter" && token.value === ">>") {
+      if (untrackedDictDepth > 0) {
+        untrackedDictDepth -= 1;
+      } else {
+        const frame = dictStack.pop();
+        if (frame === widthFrame) resetWidthCollection();
+        if (frame?.xrefStream && frame.widths) assertByteWidths(frame.widths);
+      }
+    }
+    if (token.type === "name" && !token.overlong) {
+      if (token.value === "Type") expectTypeValue = true;
+      if (token.value === "W" && dictStack.length > 0) {
+        widthState = "bracket";
+        widthFrame = dictStack.at(-1);
+        widthDepth = 0;
+        widthValues = null;
+        widthMalformed = false;
+      }
+    }
   }
 }
 
 export function assertBoundedPdfStructure(bytes) {
+  assertBoundedXRefStreamByteWidths(bytes);
   const densityLimit = Math.min(
     MAX_REASONABLE_OBJECT_NUMBER,
     Math.max(100_000, bytes.length * 32),

--- a/test/pdf-lib-worker-contract.test.js
+++ b/test/pdf-lib-worker-contract.test.js
@@ -42,6 +42,23 @@ const typedSlot = (...segments) => segments
   .join("\n")
   + (segments.length > 0 ? "\n" : "");
 
+// Build the cross-reference-stream fixture in the test rather than committing
+// a binary: pdf-lib's own object-stream writer emits a conforming /Type /XRef
+// dictionary, and only its /W array is rewritten. The /W array sits after the
+// byte offset that startxref points at, so rewriting it cannot disturb any
+// other structure the parser depends on.
+async function xrefStreamPdfWithByteWidths(widths) {
+  const document = await PDFDocument.create();
+  document.addPage([200, 200]);
+  const written = Buffer.from(await document.save({ useObjectStreams: true }));
+  const text = written.toString("latin1");
+  if (!/\/Type\s*\/XRef/.test(text) || !/\/W\s*\[[^\]]*\]/.test(text)) {
+    throw new Error("pdf-lib no longer writes a cross-reference stream with a /W array.");
+  }
+  if (widths === null) return written;
+  return Buffer.from(text.replace(/\/W\s*\[[^\]]*\]/, widths), "latin1");
+}
+
 function sparseDeclarationAcrossBoundary(prefix, suffix) {
   const header = Buffer.from("%PDF-1.7\n", "ascii");
   const declarationPrefix = Buffer.from(prefix, "ascii");
@@ -243,6 +260,126 @@ endobj
 %%EOF
 `, "ascii");
     expect(() => assertBoundedPdfStructure(bytes)).not.toThrow();
+  });
+
+  // Hopding/pdf-lib#1776 (CWE-190): PDFXRefStreamParser copies /W straight
+  // into its per-entry read loops. The upstream fix (PR #1781) is unmerged and
+  // the issue was closed by a stale bot, so the bound is ours to enforce.
+  // Measured against the pinned pdf-lib 1.17.1: on a ~1 KiB file, /W [1 2e8 1]
+  // holds PDFDocument.load for 3.9s, /W [1 1e9 1] for 198s, and /W [1 2e9 1]
+  // for over 400s, with resident memory flat near 160 MiB throughout. A
+  // flat-memory spin is invisible to the RSS monitor, so before this bound the
+  // only thing between a hostile document and a wedged worker was the 30s
+  // subprocess deadline.
+  describe("cross-reference stream byte widths", () => {
+    it.each([
+      ["a width beyond the Table 17 field size", "/W [100 100 100]"],
+      ["a width that overflows the accumulator", "/W [1 2000000000 1]"],
+      ["a width beyond safe integer precision", "/W [1 9007199254740991 1]"],
+      ["a hostile width spelled as a PDF real", "/W [1 2000000000.0 1]"],
+      ["a width longer than one structure token", `/W [1 ${"9".repeat(300)} 1]`],
+      ["a negative width", "/W [-1 -1 -1]"],
+      ["a width one byte past the field bound", "/W [1 9 2]"],
+    ])("rejects %s before pdf-lib parsing", async (_kind, hostileWidths) => {
+      const bytes = await xrefStreamPdfWithByteWidths(hostileWidths);
+      expect(() => assertBoundedPdfStructure(bytes)).toThrow(expect.objectContaining({
+        code: "PDF_RESOURCE_LIMIT_EXCEEDED",
+        reason: "unsafe_xref_byte_width",
+      }));
+      await expect(loadPdfForMutation(bytes)).rejects.toThrow(expect.objectContaining({
+        reason: "unsafe_xref_byte_width",
+      }));
+    });
+
+    it("checks the widths when /Type /XRef is written after /W", () => {
+      const bytes = Buffer.from(`%PDF-1.7
+2 0 obj
+<< /W [ 1 2000000000 1 ] /Size 3 /Index [0 3] /Type /XRef /Length 0 >>
+stream
+endstream
+endobj
+%%EOF
+`, "ascii");
+      expect(() => assertBoundedPdfStructure(bytes)).toThrow(expect.objectContaining({
+        reason: "unsafe_xref_byte_width",
+      }));
+    });
+
+    it("accepts the real cross-reference stream widths this repository ships", async () => {
+      const fw9 = await fs.readFile(path.join(REPO_ROOT, "example-fw9.pdf"));
+      expect(fw9.toString("latin1")).toMatch(/\/Type\s*\/XRef/);
+      expect(fw9.toString("latin1")).toMatch(/\/W\s*\[\s*1 3 2\s*\]/);
+      expect(() => assertBoundedPdfStructure(fw9)).not.toThrow();
+      await expect(loadPdfForMutation(fw9)).resolves.toBeDefined();
+
+      const written = await xrefStreamPdfWithByteWidths(null);
+      expect(() => assertBoundedPdfStructure(written)).not.toThrow();
+    });
+
+    it.each([
+      ["the widest conforming entry", "/W [8 8 8]"],
+      ["a non-canonical real spelling", "/W [1.0 4.0 2.0]"],
+      ["a short width array", "/W [1 2]"],
+    ])("accepts %s", async (_kind, widths) => {
+      const bytes = await xrefStreamPdfWithByteWidths(widths);
+      expect(() => assertBoundedPdfStructure(bytes)).not.toThrow();
+    });
+
+    // The shared structure lexer treats an unpaired "<" or "(" as the start of
+    // a hex or literal string and skips to the next ">" or ")". Compressed
+    // payload bytes contain those characters routinely, which silently
+    // swallowed the following cross-reference dictionary until the byte-width
+    // pass was given its own stream-skipping view of the file.
+    it.each([
+      ["an unpaired hex-string opener", "<"],
+      ["an unpaired literal-string opener", "("],
+      ["a comment opener", "%"],
+    ])("still sees the widths behind a payload containing %s", (_kind, opener) => {
+      const payload = Buffer.from(`${opener}${"·".repeat(40)}`, "latin1");
+      const bytes = Buffer.concat([
+        Buffer.from(`%PDF-1.7\n1 0 obj\n<< /Length ${payload.length} >>\nstream\n`, "ascii"),
+        payload,
+        Buffer.from(`\nendstream\nendobj\n2 0 obj
+<< /Type /XRef /W [ 1 2000000000 1 ] /Size 3 /Index [0 3] /Length 0 >>
+stream
+endstream
+endobj
+%%EOF
+`, "ascii"),
+      ]);
+      expect(() => assertBoundedPdfStructure(bytes)).toThrow(expect.objectContaining({
+        reason: "unsafe_xref_byte_width",
+      }));
+    });
+
+    it("is not desynchronized by a dictionary-closing spelling inside a string value", () => {
+      const bytes = Buffer.from(`%PDF-1.7
+2 0 obj
+<< /Type /XRef /Note (>> << >>) /W [ 1 2000000000 1 ] /Size 3 /Index [0 3] /Length 0 >>
+stream
+endstream
+endobj
+%%EOF
+`, "ascii");
+      expect(() => assertBoundedPdfStructure(bytes)).toThrow(expect.objectContaining({
+        reason: "unsafe_xref_byte_width",
+      }));
+    });
+
+    it("does not mistake a CIDFont glyph-width array for cross-reference byte widths", () => {
+      const bytes = Buffer.from(`%PDF-1.7
+1 0 obj
+<< /Type /Font /Subtype /CIDFontType2 /W [ 120 [ 400 325 500 ] 200 300 722 ] >>
+endobj
+2 0 obj
+<< /Type /XRef /W [ 1 2 1 ] /Size 3 /Index [0 3] /Length 0 >>
+stream
+endstream
+endobj
+%%EOF
+`, "ascii");
+      expect(() => assertBoundedPdfStructure(bytes)).not.toThrow();
+    });
   });
 
   it("inspects parsed stream dictionaries, not comments, strings, or raw payload spellings", async () => {


### PR DESCRIPTION
## The defect

pdf-lib copies an xref stream's `/W` array straight into loop bounds with no
range check. Our pinned 1.17.1 is character-for-character the code in upstream
[#1776](https://github.com/Hopding/pdf-lib/issues/1776) — which
`github-actions[bot]` marked stale after 14 days and **closed after 16, with no
human comment**. That repo has no `SECURITY.md` and private vulnerability
reporting is disabled, so there is no escalation channel and no reason to expect
a fix.

## Reproduced, on a 1 KiB file

Built with pdf-lib's own writer; only `/W` altered.

| `/W` | elapsed | peak RSS |
|---|---:|---|
| `[1 2 2]` (control) | 3 ms | flat |
| `[1 200000000 1]` | 3.9 s | flat |
| `[1 1000000000 1]` | **198 s** | 158 MiB |
| `[1 2000000000 1]` | **>400 s** (killed) | flat |

**Resident memory stays flat**, so the RSS monitor never fires. The only
containment was the 30-second subprocess timeout — one wedged worker burning a
core per hostile document. `assertBoundedPdfStructure` accepted all of them.

## One correction to the upstream report

In 1.17.1 this is **CPU exhaustion, not memory corruption**. `PDFParser` discards
the parser's return value, so corrupted entries never reach the context.

## What the guard does

Bounds each `/W` element to 8 bytes (ISO 32000-1 Table 17) at our boundary,
before pdf-lib sees the bytes. Rejects with `PDF_RESOURCE_LIMIT_EXCEEDED` /
`unsafe_xref_byte_width`.

It bounds **magnitude, not integrality** — the loop bound pdf-lib derives is
`Number(value)`, so `/W [1 2000000000.0 1]` is hostile while `[1.0 4.0 2.0]` is
benign. The upstream patch's integer check would have missed the real-spelled
variant. Widths bind to their enclosing dictionary, so a CIDFont `/W` array is
never mistaken for xref widths. The patch's undefined-read guard is deliberately
**not** ported: with widths bounded, no bounded entry count can read past the
payload, and I could not reproduce it.

## How close this came to shipping broken

The first version reused the shared structure lexer, which treats an unpaired `<`
as a hex-string opener and skips to the next `>` — so one such byte in a
preceding compressed payload swallowed the following xref dictionary. **It passed
one verification run and failed the next**: the guard was silently absent on real
documents depending on their compressed bytes. Payload skipping is now opt-in,
leaving the existing pass byte-for-byte unchanged. Stable across 40 generated
documents, all 33 PDFs in the repo, and the Shannon source.

## Tests

17 new, in an existing file, fixture built in-test. **12 fail without the guard.**
The 5 acceptance controls — a genuine xref-stream PDF, pdf-lib's own output,
`/W [8 8 8]`, `/W [1.0 4.0 2.0]`, and a CIDFont width array — pass either way, so
they are not vacuously coupled.

`npm test` — 2221 passed, 0 failed. Shannon unchanged at 1,872 across 70 ids.
Guard cost ~1.6 ms/MiB.

## Separately open: decompression bomb

A 1 MB object stream inflating to 1 GB drove peak RSS to **3.1 GiB — 6× its
ceiling — in a single allocation** a 25 ms sampler cannot pre-empt. Different
mechanism (RSS *does* move, so the monitor fires), deserves its own reproduction
and bound rather than being bolted onto this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)