### PR TITLE
Stop promising password support the write paths cannot deliver

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ PDF Toolkit is a Claude Desktop extension (MCPB) and MCP server that enables aut
 - Read form fields from PDFs (text, checkboxes, dropdowns, radio buttons)
 - Fill PDF forms programmatically
 - Save filled PDFs to new files
-- Password-protected PDF support
+- Password-protected PDF reading through PDF.js only (see `## Password Support`); no pdf-lib path can decrypt
 - Bulk fill from CSV files
 - Profile system for reusable data
 - Extract data from PDFs to CSV
@@ -53,16 +53,41 @@ The project uses ES modules (`"type": "module"` in package.json):
 
 ## Password Support
 
-Password functionality for encrypted PDFs is implemented across all relevant tools:
-- `read_pdf_fields`
-- `fill_pdf`
-- `bulk_fill_from_csv`
-- `fill_with_profile`
-- `validate_pdf`
-- `read_pdf_layout`
-- `convert_pdf_to_markdown`
+**Only PDF.js decrypts. pdf-lib does not.** `pdf-lib` 1.17.1 ships no decryption
+of any kind: `PDFDocument.load` has no `password` option, it throws
+`EncryptedPDFError` on an encrypted document, and `{ ignoreEncryption: true }`
+returns an unusable document that fails on the first page access. Every tool
+that reaches pdf-lib therefore fails on an encrypted PDF regardless of the
+password supplied. `pdfjs-dist` 5.4.624 does accept `{ password }` and opens the
+same document correctly.
 
-Pass the optional `password` parameter when working with protected PDFs.
+Measured against an AES-256 PDF produced with
+`qpdf --encrypt --user-password=secret --owner-password=secret --bits=256`:
+
+| Tool | PDF reader | Password support |
+| --- | --- | --- |
+| `read_pdf_layout` | PDF.js | Real. Succeeds; reports a `RAW_PAGE_GEOMETRY_UNAVAILABLE` gap because raw geometry comes from pdf-lib. |
+| `convert_pdf_to_markdown` | PDF.js | Real. Same partial-coverage gap. |
+| `get_pdf_info` | PDF.js | Real. Same partial-coverage gap. |
+| `read_pdf_fields` | pdf-lib | None. Accepts `password`, cannot use it. |
+| `fill_pdf` | pdf-lib | None. Accepts `password`, cannot use it. |
+| `bulk_fill_from_csv` | pdf-lib | None. Accepts `password`, cannot use it. |
+| `fill_with_profile` | pdf-lib | None. Accepts `password`, cannot use it. |
+| `validate_pdf` | pdf-lib | None. Accepts `password`, cannot use it. |
+| `merge_pdfs`, `split_pdf`, `rotate_pdf_pages`, `reorder_pdf_pages`, `apply_page_plan` | pdf-lib worker | None. Accept `password`, cannot use it. |
+| `add_signature_field`, `apply_signature`, `prepare_signing_packet`, `apply_text` | pdf-lib worker | None. Accept `password`, cannot use it. |
+| `render_pdf_page`, `render_pdf_region`, `get_page_analysis` | PDF.js plus pdf-lib geometry | None in practice. PDF.js uses the password, but the pdf-lib geometry load still fails. |
+| `detect_signature_zones` | PDF.js plus pdf-lib geometry | None in practice. It degrades through `ignoreEncryption` and succeeds only on the committed header-malformed R4 oracle; a well-formed AES-128 or AES-256 file fails. |
+| `compare_pdfs` | PDF.js plus pdf-lib geometry | None. With `include_visual` it reports the pdf-lib limit; without it, the run still ends in `internal_validation_error` (pre-existing, unrelated to the password). |
+| `extract_to_csv` | pdf-lib | None. No `password` parameter exists. |
+| `read_pdf_content`, `read_pdf_pages`, `search_pdf_text` | PDF.js | None reachable. No `password` parameter exists, so an encrypted PDF cannot be opened. |
+| `inspect_pdf_accessibility` | pdf-lib | None, and it says so: it rejects a `password` argument outright. |
+
+Pass the optional `password` parameter only to `read_pdf_layout`,
+`convert_pdf_to_markdown`, and `get_pdf_info`. For anything else, decrypt the
+document first (for example with `qpdf --decrypt`) and operate on the plaintext
+copy. Adding decryption to the write paths means replacing or supplementing
+pdf-lib, which is an open dependency decision, not a bug fix.
 
 ## Development Commands
 
@@ -243,7 +268,8 @@ Reuse existing helpers in `server/index.js`:
 
 ### Error Handling
 - Provide clear, actionable error messages
-- Handle password-protected PDFs gracefully
+- Handle password-protected PDFs gracefully, and never tell a caller to supply a
+  password on a path that cannot use one (see `## Password Support`)
 - Guide users to correct tools (e.g., "use 'read_pdf_fields' to see available fields")
 
 ### Security
@@ -258,7 +284,11 @@ Reuse existing helpers in `server/index.js`:
 Ensure ESM syntax is used throughout (`import`/`export`). Check that `package.json` has `"type": "module"`.
 
 ### Password-protected PDF errors
-Pass the `password` parameter to relevant tools. The error message should indicate if a password is required.
+Pass the `password` parameter only to `read_pdf_layout`, `convert_pdf_to_markdown`,
+and `get_pdf_info`; they are the tools whose reader (PDF.js) can decrypt. Any
+other tool reaches pdf-lib and reports that it cannot decrypt the document no
+matter what password is supplied — decrypt the file first. The regression guard
+for this is `test/encrypted-pdf-password-truth.test.js`.
 
 ### MCPB not loading in Claude Desktop
 1. Ensure `npm run build:mcpb` and the platform's `npm run smoke:mcpb -- pdf-toolkit-mcp.mcpb` completed successfully

--- a/pdf-toolkit-mcp-share/server/helpers.js
+++ b/pdf-toolkit-mcp-share/server/helpers.js
@@ -20,6 +20,32 @@ import {
 } from "pdf-lib";
 
 const PDF_LIB_ENCRYPTED_ERROR_MESSAGE = new EncryptedPDFError().message;
+
+// pdf-lib 1.17.1 ships no decryption at all: PDFDocument.load has no password
+// option, and { ignoreEncryption: true } yields an unusable document. Any
+// operation that reaches pdf-lib therefore fails on an encrypted PDF no matter
+// what password the caller supplies, so the error must say that instead of
+// asking for the password again. PDF.js does decrypt, so the read tools that
+// route only through PDF.js are named as the working alternative.
+export const PDF_LIB_ENCRYPTED_MESSAGE =
+  "This PDF is encrypted and this operation cannot decrypt it: it reads the file with pdf-lib, "
+  + "which has no decryption support, so supplying a password here will not help. "
+  + "Decrypt the file first (for example with qpdf) and retry. "
+  + "To read an encrypted PDF as it is, use read_pdf_layout, convert_pdf_to_markdown, "
+  + "or get_pdf_info, which accept a password and decrypt with PDF.js.";
+
+// Parameter text for tools whose only PDF reader is pdf-lib. The argument is
+// still accepted so existing callers do not break, but it can never be used.
+export const PDF_LIB_UNUSABLE_PASSWORD_DESCRIPTION =
+  "Accepted but never used: this operation reads the PDF with pdf-lib, which cannot decrypt "
+  + "encrypted PDFs. Decrypt the document before calling this tool.";
+
+// Parameter text for tools that decrypt with PDF.js for one part of their work
+// but still load page geometry through pdf-lib, which stops on encryption.
+export const PDF_LIB_GEOMETRY_PASSWORD_DESCRIPTION =
+  "Password for encrypted PDFs. PDF.js uses it, but this operation also loads page geometry with "
+  + "pdf-lib, which cannot decrypt PDFs, so an encrypted document still fails with the correct password.";
+
 const PDF_FIELD_VALIDATION_SCHEMA_VERSION = "1.0";
 const UNSUPPORTED_DIRECTORY_FSYNC_ERRORS = new Set([
   "EINVAL",

--- a/pdf-toolkit-mcp-share/server/index.js
+++ b/pdf-toolkit-mcp-share/server/index.js
@@ -602,7 +602,7 @@ async function loadPdfBytes(pdfBytes, password = null) {
     pdfDoc = await PDFDocument.load(pdfBytes, password ? { password } : {});
   } catch (error) {
     if (error.message?.includes("password") || error.message?.includes("encrypt")) {
-      throw new Error("PDF is password-protected. Please provide the correct password using the 'password' parameter.");
+      throw new Error(PDF_LIB_ENCRYPTED_MESSAGE);
     }
     throw new Error(invalidPdfMessage, { cause: error });
   }
@@ -683,6 +683,9 @@ import {
   writePdfOutputsAtomic,
   MIN_TEXT_CHARS_WITH_IMAGES,
   openVerifiedRegularFile,
+  PDF_LIB_ENCRYPTED_MESSAGE,
+  PDF_LIB_GEOMETRY_PASSWORD_DESCRIPTION,
+  PDF_LIB_UNUSABLE_PASSWORD_DESCRIPTION,
 } from "./helpers.js";
 
 // Helper: validate profile name to prevent path traversal
@@ -2671,6 +2674,22 @@ async function fillPdfBytes(pdfBytes, fieldData, password = null) {
   return await fillPdfDocumentFields(await loadPdfBytes(pdfBytes, password), fieldData);
 }
 
+// read_pdf_content, read_pdf_pages, and search_pdf_text decrypt through PDF.js
+// but expose no password argument, so PDF.js's stock "provide it with the
+// password parameter" advice names an input those tools cannot accept. Name the
+// read tools that do take one instead.
+const PDFJS_NO_PASSWORD_ARGUMENT_MESSAGE =
+  "This PDF is encrypted and this tool accepts no password. Use read_pdf_layout, "
+  + "convert_pdf_to_markdown, or get_pdf_info, which do accept a password, or decrypt "
+  + "the file first (for example with qpdf) and retry.";
+
+function passwordlessReadError(error) {
+  if (!["PASSWORD_REQUIRED", "PASSWORD_INCORRECT"].includes(error?.code)) return error;
+  const replacement = new Error(PDFJS_NO_PASSWORD_ARGUMENT_MESSAGE);
+  replacement.code = error.code;
+  return replacement;
+}
+
 // List available tools
 server.setRequestHandler(ListToolsRequestSchema, async (request) => {
   rejectUnissuedCursor(request, "tools/list");
@@ -2713,7 +2732,7 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
             },
             password: {
               type: "string",
-              description: "Password for encrypted PDFs (optional)"
+              description: PDF_LIB_UNUSABLE_PASSWORD_DESCRIPTION,
             }
           },
           required: ["pdf_path"]
@@ -2751,7 +2770,7 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
             },
             password: {
               type: "string",
-              description: "Password for encrypted PDFs (optional)"
+              description: PDF_LIB_UNUSABLE_PASSWORD_DESCRIPTION,
             },
             force_xfa: {
               type: "boolean",
@@ -2793,7 +2812,7 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
             },
             password: {
               type: "string",
-              description: "Password for encrypted PDFs (optional)"
+              description: PDF_LIB_UNUSABLE_PASSWORD_DESCRIPTION,
             },
             force_xfa: {
               type: "boolean",
@@ -2896,7 +2915,7 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
             },
             password: {
               type: "string",
-              description: "Password for encrypted PDFs (optional)"
+              description: PDF_LIB_UNUSABLE_PASSWORD_DESCRIPTION,
             },
             expected_output_identity: EXPECTED_OUTPUT_IDENTITY_INPUT_SCHEMA
           },
@@ -2948,7 +2967,7 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
             },
             password: {
               type: "string",
-              description: "Password for encrypted PDFs (optional)"
+              description: PDF_LIB_UNUSABLE_PASSWORD_DESCRIPTION,
             }
           },
           required: ["pdf_path"]
@@ -3107,7 +3126,7 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
             },
             password: {
               type: "string",
-              description: "Password for encrypted PDFs (optional)."
+              description: PDF_LIB_GEOMETRY_PASSWORD_DESCRIPTION,
             }
           },
           required: ["pdf_path"],
@@ -3163,7 +3182,7 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
             },
             password: {
               type: "string",
-              description: "Password for encrypted PDFs (optional)."
+              description: PDF_LIB_GEOMETRY_PASSWORD_DESCRIPTION,
             }
           },
           required: ["pdf_path", "page", "x", "y", "width", "height"],
@@ -3414,7 +3433,7 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
             },
             password: {
               type: "string",
-              description: "Password for encrypted PDFs (optional, applied to all inputs)"
+              description: PDF_LIB_UNUSABLE_PASSWORD_DESCRIPTION,
             },
             expected_output_identity: EXPECTED_OUTPUT_IDENTITY_INPUT_SCHEMA
           },
@@ -3453,7 +3472,7 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
             },
             password: {
               type: "string",
-              description: "Password for encrypted PDFs (optional)"
+              description: PDF_LIB_UNUSABLE_PASSWORD_DESCRIPTION,
             },
             expected_output_identities: EXPECTED_OUTPUT_IDENTITIES_INPUT_SCHEMA
           },
@@ -3492,7 +3511,7 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
             },
             password: {
               type: "string",
-              description: "Password for encrypted PDFs (optional)"
+              description: PDF_LIB_UNUSABLE_PASSWORD_DESCRIPTION,
             },
             expected_output_identity: EXPECTED_OUTPUT_IDENTITY_INPUT_SCHEMA
           },
@@ -3532,7 +3551,7 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
             },
             password: {
               type: "string",
-              description: "Password for encrypted PDFs (optional)"
+              description: PDF_LIB_UNUSABLE_PASSWORD_DESCRIPTION,
             },
             expected_output_identity: EXPECTED_OUTPUT_IDENTITY_INPUT_SCHEMA
           },
@@ -3583,8 +3602,8 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
           properties: {
             before_pdf_path: { type: "string", description: "Absolute path to the earlier PDF." },
             after_pdf_path: { type: "string", description: "Absolute path to the later PDF." },
-            before_password: { type: "string", maxLength: 4096, description: "Optional password for the earlier PDF." },
-            after_password: { type: "string", maxLength: 4096, description: "Optional password for the later PDF." },
+            before_password: { type: "string", maxLength: 4096, description: `Optional password for the earlier PDF. ${PDF_LIB_GEOMETRY_PASSWORD_DESCRIPTION}` },
+            after_password: { type: "string", maxLength: 4096, description: `Optional password for the later PDF. ${PDF_LIB_GEOMETRY_PASSWORD_DESCRIPTION}` },
             mode: { type: "string", enum: ["default_material", "forensic"], description: "Presentation mode. Default: default_material." },
             max_pages: { type: "integer", minimum: 1, maximum: 20, description: "Whole-document page ceiling for each input. Default: 10." },
             include_visual: { type: "boolean", description: "Request canonical raw-pixel visual comparison. Default: true." },
@@ -3672,7 +3691,7 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
             },
             password: {
               type: "string",
-              description: "Password for encrypted PDFs (optional)"
+              description: PDF_LIB_UNUSABLE_PASSWORD_DESCRIPTION,
             },
             force_xfa: {
               type: "boolean",
@@ -3702,7 +3721,7 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
             },
             password: {
               type: "string",
-              description: "Password for encrypted PDFs (optional)"
+              description: PDF_LIB_GEOMETRY_PASSWORD_DESCRIPTION,
             }
           },
           required: ["pdf_path"]
@@ -3821,7 +3840,7 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
               type: "boolean",
               description: "Proceed even if the PDF already contains cryptographic signature fields (default: false). Warning: saving will invalidate any existing signatures."
             },
-            password: { type: "string", description: "Password for encrypted PDFs (optional)" },
+            password: { type: "string", description: PDF_LIB_UNUSABLE_PASSWORD_DESCRIPTION },
             force_xfa: { type: "boolean", description: "Proceed even if the PDF uses XFA forms (default: false). Warning: the XFA data will be stripped by pdf-lib." },
             expected_output_identity: EXPECTED_OUTPUT_IDENTITY_INPUT_SCHEMA
           },
@@ -3886,7 +3905,7 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
               type: "boolean",
               description: "Deprecated compatibility field. true is accepted as a no-op when the destination does not exist or output_path identifies the same canonical document as pdf_path. It never authorizes replacing a distinct existing output; that requires expected_output_identity."
             },
-            password: { type: "string", description: "Password for encrypted PDFs (optional)" },
+            password: { type: "string", description: PDF_LIB_UNUSABLE_PASSWORD_DESCRIPTION },
             expected_output_identity: EXPECTED_OUTPUT_IDENTITY_INPUT_SCHEMA
           },
           required: ["pdf_path", "output_path", "signature_name", "page", "x", "y", "width", "height", "user_intent_statement", "user_confirmed_at"]
@@ -3932,7 +3951,7 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
               type: "boolean",
               description: "Proceed even if the PDF already contains cryptographic signature fields (default: false). Warning: saving will invalidate any existing signatures."
             },
-            password: { type: "string", description: "Password for encrypted PDFs (optional)" },
+            password: { type: "string", description: PDF_LIB_UNUSABLE_PASSWORD_DESCRIPTION },
             force_xfa: { type: "boolean", description: "Proceed even if the PDF uses XFA forms (default: false). Warning: the XFA layer will be stripped." },
             expected_output_identity: EXPECTED_OUTPUT_IDENTITY_INPUT_SCHEMA
           },
@@ -3967,7 +3986,7 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
               type: "boolean",
               description: "Deprecated compatibility field. true is accepted as a no-op when the destination does not exist or output_path identifies the same canonical document as pdf_path. It never authorizes replacing a distinct existing output; that requires expected_output_identity."
             },
-            password: { type: "string", description: "Password for encrypted PDFs (optional)" },
+            password: { type: "string", description: PDF_LIB_UNUSABLE_PASSWORD_DESCRIPTION },
             expected_output_identity: EXPECTED_OUTPUT_IDENTITY_INPUT_SCHEMA
           },
           required: ["pdf_path", "output_path", "page", "x", "y", "width", "height", "text"]
@@ -3987,7 +4006,7 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
           type: "object",
           properties: {
             pdf_path: { type: "string", description: "Path to the PDF file" },
-            password: { type: "string", description: "Password for encrypted PDFs (optional)" }
+            password: { type: "string", description: PDF_LIB_GEOMETRY_PASSWORD_DESCRIPTION }
           },
           required: ["pdf_path"]
         },
@@ -4521,7 +4540,10 @@ async function handleToolCall(request) {
         for (const pdfPath of pdf_paths) {
           const resolvedPdfPath = resolvePath(pdfPath);
           const pdfBytes = await fs.readFile(resolvedPdfPath);
-          const pdfDoc = await PDFDocument.load(pdfBytes);
+          // Via loadPdfBytes so an encrypted input reports the honest pdf-lib
+          // limit instead of pdf-lib's raw "use ignoreEncryption" advice, which
+          // does not work on an encrypted document.
+          const pdfDoc = await loadPdfBytes(pdfBytes);
           const form = pdfDoc.getForm();
           const fields = form.getFields();
           
@@ -4888,6 +4910,7 @@ async function handleToolCall(request) {
               },
             });
           }
+          error = passwordlessReadError(error);
           return createTypedToolError({
             message: `Error reading PDF file: ${error.message}`,
             content: [{
@@ -4975,6 +4998,7 @@ async function handleToolCall(request) {
           };
         } catch (error) {
           if (error?.code === PDF_RESOURCE_LIMIT_CODE) throw error;
+          error = passwordlessReadError(error);
           return createTypedToolError({
             message: `Error reading PDF pages: ${error.message}\n\nPlease ensure the file path is correct and the requested page range is valid.`,
           });
@@ -5399,6 +5423,7 @@ async function handleToolCall(request) {
           };
         } catch (error) {
           if (error?.code === PDF_RESOURCE_LIMIT_CODE) throw error;
+          error = passwordlessReadError(error);
           return createTypedToolError({
             message: `Error searching PDF text: ${error.message}\n\nPlease ensure the file path is correct and the query is valid.`,
           });
@@ -6034,6 +6059,19 @@ async function handleToolCall(request) {
             structuredContent: payload,
           };
         } catch (error) {
+          // The comparison classifier turns any unrecognized Error into
+          // "arguments or PDF inputs are invalid", which is false when the
+          // inputs were fine and only pdf-lib's inability to decrypt stopped
+          // the run. Say what actually happened.
+          // PDF_PARSE_FAILED is the closest code the sealed comparison error
+          // enum already carries; adding a new one would change an oracle-bound
+          // schema module. The message states the real cause either way.
+          if (error?.message === PDF_LIB_ENCRYPTED_MESSAGE) {
+            return createTypedToolError({
+              code: "PDF_PARSE_FAILED",
+              message: PDF_LIB_ENCRYPTED_MESSAGE,
+            });
+          }
           return createTypedToolError(publicPdfComparisonError(error));
         }
       }

--- a/pdf-toolkit-mcp-share/server/pdf-lib-worker.js
+++ b/pdf-toolkit-mcp-share/server/pdf-lib-worker.js
@@ -31,6 +31,7 @@ import {
   detectExistingSignatures,
   drawSignatureFieldOnPage,
   parsePageRanges,
+  PDF_LIB_ENCRYPTED_MESSAGE,
   stampSignatureOnPage,
   stampTextOnPage,
 } from "./helpers.js";
@@ -1665,7 +1666,7 @@ export async function loadPdfForMutation(bytes, password) {
     document = await PDFDocument.load(bytes, password ? { password } : {});
   } catch (error) {
     if (error.message?.includes("password") || error.message?.includes("encrypt")) {
-      throw new Error("PDF is password-protected. Please provide the correct password using the 'password' parameter.");
+      throw new Error(PDF_LIB_ENCRYPTED_MESSAGE);
     }
     throw new Error("Failed to load PDF: the file is malformed, incomplete, or unsupported.", { cause: error });
   }

--- a/pdf-toolkit-mcp-share/server/pdfjs-worker.js
+++ b/pdf-toolkit-mcp-share/server/pdfjs-worker.js
@@ -19,6 +19,7 @@ import {
   getPageBoxGeometry,
   getPageRenderScale,
   isPdfLibEncryptedError,
+  PDF_LIB_ENCRYPTED_MESSAGE,
   validatePdfRegionBox,
 } from "./helpers.js";
 import {
@@ -1510,8 +1511,22 @@ export async function runSystemCommand(command, args, {
   });
 }
 
+// Rendering and page analysis decrypt their text through PDF.js but still take
+// page geometry from pdf-lib, which cannot decrypt anything. Left raw, pdf-lib's
+// own error tells the caller to retry with { ignoreEncryption: true }, which
+// produces an unusable document — advice that cannot work. Report the real
+// limit instead.
+async function loadPdfLibGeometry(bytes, password) {
+  try {
+    return await PDFDocument.load(bytes, password ? { password } : {});
+  } catch (error) {
+    if (isPdfLibEncryptedError(error)) throw new Error(PDF_LIB_ENCRYPTED_MESSAGE);
+    throw error;
+  }
+}
+
 async function writeSinglePagePdf(bytes, pageNumber, password, targetPath, cropBox = null) {
-  const source = await PDFDocument.load(bytes, password ? { password } : {});
+  const source = await loadPdfLibGeometry(bytes, password);
   const target = await PDFDocument.create();
   const [page] = await target.copyPages(source, [pageNumber - 1]);
   if (cropBox !== null) {
@@ -1565,7 +1580,7 @@ async function systemRenderPage(bytes, password, options) {
   if (process.platform !== "darwin") {
     throw new Error("The macOS system PDF renderer is unavailable on this platform.");
   }
-  const geometryDocument = await PDFDocument.load(bytes, password ? { password } : {});
+  const geometryDocument = await loadPdfLibGeometry(bytes, password);
   if (options.page > geometryDocument.getPageCount()) {
     throw new Error(
       `Page ${options.page} is out of range (1-${geometryDocument.getPageCount()}).`,
@@ -1630,7 +1645,7 @@ async function systemRenderPage(bytes, password, options) {
 }
 
 async function nativeRenderPage(bytes, password, options) {
-  const geometryDocument = await PDFDocument.load(bytes, password ? { password } : {});
+  const geometryDocument = await loadPdfLibGeometry(bytes, password);
   if (options.page > geometryDocument.getPageCount()) {
     throw new Error(
       `Page ${options.page} is out of range (1-${geometryDocument.getPageCount()}).`,
@@ -1777,7 +1792,7 @@ async function renderComparisonPage(bytes, password, options) {
 }
 
 async function nativeRenderRegion(bytes, password, options) {
-  const geometryDocument = await PDFDocument.load(bytes, password ? { password } : {});
+  const geometryDocument = await loadPdfLibGeometry(bytes, password);
   if (options.page > geometryDocument.getPageCount()) {
     throw new Error(
       `Page ${options.page} is out of range (1-${geometryDocument.getPageCount()}).`,
@@ -1920,7 +1935,7 @@ async function renderRegion(bytes, password, options) {
 
 async function analyzePages(bytes, password, options) {
   const pdfjs = await loadPdfjs();
-  const pdfDocument = await PDFDocument.load(bytes, password ? { password } : {});
+  const pdfDocument = await loadPdfLibGeometry(bytes, password);
   return {
     analysis: await analyzePdfPages({
       pdfLibPages: pdfDocument.getPages(),
@@ -1953,31 +1968,46 @@ async function signatureZones(bytes, password) {
     scanAcroForm = false;
     recordWarning({ code: "ENCRYPTED_ACROFORM_SCAN_UNAVAILABLE" });
   }
-  const zones = await detectSignatureZones({
-    pdfDoc: pdfDocument,
-    pdfBytes: bytes,
-    pdfjsLib: pdfjs,
-    password,
-    onWarning: recordWarning,
-    scanAcroForm,
-  });
-  return {
-    page_geometry: pdfDocument.getPages().map((page, index) => {
-      const box = getPageBoxGeometry(page);
-      return {
-        height: box.height,
-        origin_x: box.originX,
-        origin_y: box.originY,
-        page: index + 1,
-        width: box.width,
-      };
-    }),
-    warning_counts: [...warningCounts.entries()].map(([code, occurrences]) => ({
-      code,
-      occurrences,
-    })),
-    zones,
+  const buildResult = async () => {
+    const zones = await detectSignatureZones({
+      pdfDoc: pdfDocument,
+      pdfBytes: bytes,
+      pdfjsLib: pdfjs,
+      password,
+      onWarning: recordWarning,
+      scanAcroForm,
+    });
+    return {
+      page_geometry: pdfDocument.getPages().map((page, index) => {
+        const box = getPageBoxGeometry(page);
+        return {
+          height: box.height,
+          origin_x: box.originX,
+          origin_y: box.originY,
+          page: index + 1,
+          width: box.width,
+        };
+      }),
+      warning_counts: [...warningCounts.entries()].map(([code, occurrences]) => ({
+        code,
+        occurrences,
+      })),
+      zones,
+    };
   };
+  if (scanAcroForm) return await buildResult();
+  // On the ignoreEncryption fallback pdf-lib may hand back a document whose
+  // page tree cannot be read at all — AES-256 fails with "Expected instance of
+  // PDFDict". Report the real limit rather than that internal detail.
+  try {
+    return await buildResult();
+  } catch (error) {
+    // A genuine PDF.js password failure still has to reach the caller as
+    // itself: a missing or wrong password is the one case where asking for the
+    // password is the correct advice.
+    if (error?.name === "PasswordException" || typeof error?.code === "string") throw error;
+    throw new Error(PDF_LIB_ENCRYPTED_MESSAGE);
+  }
 }
 
 async function performOperation(request, sourceBytes) {

--- a/scripts/test-suite-classification.mjs
+++ b/scripts/test-suite-classification.mjs
@@ -70,6 +70,7 @@ export const CHECKOUT_LOCAL_MUTATING_TEST_SUITES = Object.freeze([
   "test/csv-roundtrip.test.js",
   "test/deep-malformed-campaign.test.js",
   "test/detect-signature-zones-tool.test.js",
+  "test/encrypted-pdf-password-truth.test.js",
   "test/eval/codex-comparison-controller.test.js",
   "test/fetch-pdf-from-url.test.js",
   "test/fuzz-malformed-pdfs.test.js",

--- a/server/helpers.js
+++ b/server/helpers.js
@@ -20,6 +20,32 @@ import {
 } from "pdf-lib";
 
 const PDF_LIB_ENCRYPTED_ERROR_MESSAGE = new EncryptedPDFError().message;
+
+// pdf-lib 1.17.1 ships no decryption at all: PDFDocument.load has no password
+// option, and { ignoreEncryption: true } yields an unusable document. Any
+// operation that reaches pdf-lib therefore fails on an encrypted PDF no matter
+// what password the caller supplies, so the error must say that instead of
+// asking for the password again. PDF.js does decrypt, so the read tools that
+// route only through PDF.js are named as the working alternative.
+export const PDF_LIB_ENCRYPTED_MESSAGE =
+  "This PDF is encrypted and this operation cannot decrypt it: it reads the file with pdf-lib, "
+  + "which has no decryption support, so supplying a password here will not help. "
+  + "Decrypt the file first (for example with qpdf) and retry. "
+  + "To read an encrypted PDF as it is, use read_pdf_layout, convert_pdf_to_markdown, "
+  + "or get_pdf_info, which accept a password and decrypt with PDF.js.";
+
+// Parameter text for tools whose only PDF reader is pdf-lib. The argument is
+// still accepted so existing callers do not break, but it can never be used.
+export const PDF_LIB_UNUSABLE_PASSWORD_DESCRIPTION =
+  "Accepted but never used: this operation reads the PDF with pdf-lib, which cannot decrypt "
+  + "encrypted PDFs. Decrypt the document before calling this tool.";
+
+// Parameter text for tools that decrypt with PDF.js for one part of their work
+// but still load page geometry through pdf-lib, which stops on encryption.
+export const PDF_LIB_GEOMETRY_PASSWORD_DESCRIPTION =
+  "Password for encrypted PDFs. PDF.js uses it, but this operation also loads page geometry with "
+  + "pdf-lib, which cannot decrypt PDFs, so an encrypted document still fails with the correct password.";
+
 const PDF_FIELD_VALIDATION_SCHEMA_VERSION = "1.0";
 const UNSUPPORTED_DIRECTORY_FSYNC_ERRORS = new Set([
   "EINVAL",

--- a/server/index.js
+++ b/server/index.js
@@ -602,7 +602,7 @@ async function loadPdfBytes(pdfBytes, password = null) {
     pdfDoc = await PDFDocument.load(pdfBytes, password ? { password } : {});
   } catch (error) {
     if (error.message?.includes("password") || error.message?.includes("encrypt")) {
-      throw new Error("PDF is password-protected. Please provide the correct password using the 'password' parameter.");
+      throw new Error(PDF_LIB_ENCRYPTED_MESSAGE);
     }
     throw new Error(invalidPdfMessage, { cause: error });
   }
@@ -683,6 +683,9 @@ import {
   writePdfOutputsAtomic,
   MIN_TEXT_CHARS_WITH_IMAGES,
   openVerifiedRegularFile,
+  PDF_LIB_ENCRYPTED_MESSAGE,
+  PDF_LIB_GEOMETRY_PASSWORD_DESCRIPTION,
+  PDF_LIB_UNUSABLE_PASSWORD_DESCRIPTION,
 } from "./helpers.js";
 
 // Helper: validate profile name to prevent path traversal
@@ -2671,6 +2674,22 @@ async function fillPdfBytes(pdfBytes, fieldData, password = null) {
   return await fillPdfDocumentFields(await loadPdfBytes(pdfBytes, password), fieldData);
 }
 
+// read_pdf_content, read_pdf_pages, and search_pdf_text decrypt through PDF.js
+// but expose no password argument, so PDF.js's stock "provide it with the
+// password parameter" advice names an input those tools cannot accept. Name the
+// read tools that do take one instead.
+const PDFJS_NO_PASSWORD_ARGUMENT_MESSAGE =
+  "This PDF is encrypted and this tool accepts no password. Use read_pdf_layout, "
+  + "convert_pdf_to_markdown, or get_pdf_info, which do accept a password, or decrypt "
+  + "the file first (for example with qpdf) and retry.";
+
+function passwordlessReadError(error) {
+  if (!["PASSWORD_REQUIRED", "PASSWORD_INCORRECT"].includes(error?.code)) return error;
+  const replacement = new Error(PDFJS_NO_PASSWORD_ARGUMENT_MESSAGE);
+  replacement.code = error.code;
+  return replacement;
+}
+
 // List available tools
 server.setRequestHandler(ListToolsRequestSchema, async (request) => {
   rejectUnissuedCursor(request, "tools/list");
@@ -2713,7 +2732,7 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
             },
             password: {
               type: "string",
-              description: "Password for encrypted PDFs (optional)"
+              description: PDF_LIB_UNUSABLE_PASSWORD_DESCRIPTION,
             }
           },
           required: ["pdf_path"]
@@ -2751,7 +2770,7 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
             },
             password: {
               type: "string",
-              description: "Password for encrypted PDFs (optional)"
+              description: PDF_LIB_UNUSABLE_PASSWORD_DESCRIPTION,
             },
             force_xfa: {
               type: "boolean",
@@ -2793,7 +2812,7 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
             },
             password: {
               type: "string",
-              description: "Password for encrypted PDFs (optional)"
+              description: PDF_LIB_UNUSABLE_PASSWORD_DESCRIPTION,
             },
             force_xfa: {
               type: "boolean",
@@ -2896,7 +2915,7 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
             },
             password: {
               type: "string",
-              description: "Password for encrypted PDFs (optional)"
+              description: PDF_LIB_UNUSABLE_PASSWORD_DESCRIPTION,
             },
             expected_output_identity: EXPECTED_OUTPUT_IDENTITY_INPUT_SCHEMA
           },
@@ -2948,7 +2967,7 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
             },
             password: {
               type: "string",
-              description: "Password for encrypted PDFs (optional)"
+              description: PDF_LIB_UNUSABLE_PASSWORD_DESCRIPTION,
             }
           },
           required: ["pdf_path"]
@@ -3107,7 +3126,7 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
             },
             password: {
               type: "string",
-              description: "Password for encrypted PDFs (optional)."
+              description: PDF_LIB_GEOMETRY_PASSWORD_DESCRIPTION,
             }
           },
           required: ["pdf_path"],
@@ -3163,7 +3182,7 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
             },
             password: {
               type: "string",
-              description: "Password for encrypted PDFs (optional)."
+              description: PDF_LIB_GEOMETRY_PASSWORD_DESCRIPTION,
             }
           },
           required: ["pdf_path", "page", "x", "y", "width", "height"],
@@ -3414,7 +3433,7 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
             },
             password: {
               type: "string",
-              description: "Password for encrypted PDFs (optional, applied to all inputs)"
+              description: PDF_LIB_UNUSABLE_PASSWORD_DESCRIPTION,
             },
             expected_output_identity: EXPECTED_OUTPUT_IDENTITY_INPUT_SCHEMA
           },
@@ -3453,7 +3472,7 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
             },
             password: {
               type: "string",
-              description: "Password for encrypted PDFs (optional)"
+              description: PDF_LIB_UNUSABLE_PASSWORD_DESCRIPTION,
             },
             expected_output_identities: EXPECTED_OUTPUT_IDENTITIES_INPUT_SCHEMA
           },
@@ -3492,7 +3511,7 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
             },
             password: {
               type: "string",
-              description: "Password for encrypted PDFs (optional)"
+              description: PDF_LIB_UNUSABLE_PASSWORD_DESCRIPTION,
             },
             expected_output_identity: EXPECTED_OUTPUT_IDENTITY_INPUT_SCHEMA
           },
@@ -3532,7 +3551,7 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
             },
             password: {
               type: "string",
-              description: "Password for encrypted PDFs (optional)"
+              description: PDF_LIB_UNUSABLE_PASSWORD_DESCRIPTION,
             },
             expected_output_identity: EXPECTED_OUTPUT_IDENTITY_INPUT_SCHEMA
           },
@@ -3583,8 +3602,8 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
           properties: {
             before_pdf_path: { type: "string", description: "Absolute path to the earlier PDF." },
             after_pdf_path: { type: "string", description: "Absolute path to the later PDF." },
-            before_password: { type: "string", maxLength: 4096, description: "Optional password for the earlier PDF." },
-            after_password: { type: "string", maxLength: 4096, description: "Optional password for the later PDF." },
+            before_password: { type: "string", maxLength: 4096, description: `Optional password for the earlier PDF. ${PDF_LIB_GEOMETRY_PASSWORD_DESCRIPTION}` },
+            after_password: { type: "string", maxLength: 4096, description: `Optional password for the later PDF. ${PDF_LIB_GEOMETRY_PASSWORD_DESCRIPTION}` },
             mode: { type: "string", enum: ["default_material", "forensic"], description: "Presentation mode. Default: default_material." },
             max_pages: { type: "integer", minimum: 1, maximum: 20, description: "Whole-document page ceiling for each input. Default: 10." },
             include_visual: { type: "boolean", description: "Request canonical raw-pixel visual comparison. Default: true." },
@@ -3672,7 +3691,7 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
             },
             password: {
               type: "string",
-              description: "Password for encrypted PDFs (optional)"
+              description: PDF_LIB_UNUSABLE_PASSWORD_DESCRIPTION,
             },
             force_xfa: {
               type: "boolean",
@@ -3702,7 +3721,7 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
             },
             password: {
               type: "string",
-              description: "Password for encrypted PDFs (optional)"
+              description: PDF_LIB_GEOMETRY_PASSWORD_DESCRIPTION,
             }
           },
           required: ["pdf_path"]
@@ -3821,7 +3840,7 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
               type: "boolean",
               description: "Proceed even if the PDF already contains cryptographic signature fields (default: false). Warning: saving will invalidate any existing signatures."
             },
-            password: { type: "string", description: "Password for encrypted PDFs (optional)" },
+            password: { type: "string", description: PDF_LIB_UNUSABLE_PASSWORD_DESCRIPTION },
             force_xfa: { type: "boolean", description: "Proceed even if the PDF uses XFA forms (default: false). Warning: the XFA data will be stripped by pdf-lib." },
             expected_output_identity: EXPECTED_OUTPUT_IDENTITY_INPUT_SCHEMA
           },
@@ -3886,7 +3905,7 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
               type: "boolean",
               description: "Deprecated compatibility field. true is accepted as a no-op when the destination does not exist or output_path identifies the same canonical document as pdf_path. It never authorizes replacing a distinct existing output; that requires expected_output_identity."
             },
-            password: { type: "string", description: "Password for encrypted PDFs (optional)" },
+            password: { type: "string", description: PDF_LIB_UNUSABLE_PASSWORD_DESCRIPTION },
             expected_output_identity: EXPECTED_OUTPUT_IDENTITY_INPUT_SCHEMA
           },
           required: ["pdf_path", "output_path", "signature_name", "page", "x", "y", "width", "height", "user_intent_statement", "user_confirmed_at"]
@@ -3932,7 +3951,7 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
               type: "boolean",
               description: "Proceed even if the PDF already contains cryptographic signature fields (default: false). Warning: saving will invalidate any existing signatures."
             },
-            password: { type: "string", description: "Password for encrypted PDFs (optional)" },
+            password: { type: "string", description: PDF_LIB_UNUSABLE_PASSWORD_DESCRIPTION },
             force_xfa: { type: "boolean", description: "Proceed even if the PDF uses XFA forms (default: false). Warning: the XFA layer will be stripped." },
             expected_output_identity: EXPECTED_OUTPUT_IDENTITY_INPUT_SCHEMA
           },
@@ -3967,7 +3986,7 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
               type: "boolean",
               description: "Deprecated compatibility field. true is accepted as a no-op when the destination does not exist or output_path identifies the same canonical document as pdf_path. It never authorizes replacing a distinct existing output; that requires expected_output_identity."
             },
-            password: { type: "string", description: "Password for encrypted PDFs (optional)" },
+            password: { type: "string", description: PDF_LIB_UNUSABLE_PASSWORD_DESCRIPTION },
             expected_output_identity: EXPECTED_OUTPUT_IDENTITY_INPUT_SCHEMA
           },
           required: ["pdf_path", "output_path", "page", "x", "y", "width", "height", "text"]
@@ -3987,7 +4006,7 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
           type: "object",
           properties: {
             pdf_path: { type: "string", description: "Path to the PDF file" },
-            password: { type: "string", description: "Password for encrypted PDFs (optional)" }
+            password: { type: "string", description: PDF_LIB_GEOMETRY_PASSWORD_DESCRIPTION }
           },
           required: ["pdf_path"]
         },
@@ -4521,7 +4540,10 @@ async function handleToolCall(request) {
         for (const pdfPath of pdf_paths) {
           const resolvedPdfPath = resolvePath(pdfPath);
           const pdfBytes = await fs.readFile(resolvedPdfPath);
-          const pdfDoc = await PDFDocument.load(pdfBytes);
+          // Via loadPdfBytes so an encrypted input reports the honest pdf-lib
+          // limit instead of pdf-lib's raw "use ignoreEncryption" advice, which
+          // does not work on an encrypted document.
+          const pdfDoc = await loadPdfBytes(pdfBytes);
           const form = pdfDoc.getForm();
           const fields = form.getFields();
           
@@ -4888,6 +4910,7 @@ async function handleToolCall(request) {
               },
             });
           }
+          error = passwordlessReadError(error);
           return createTypedToolError({
             message: `Error reading PDF file: ${error.message}`,
             content: [{
@@ -4975,6 +4998,7 @@ async function handleToolCall(request) {
           };
         } catch (error) {
           if (error?.code === PDF_RESOURCE_LIMIT_CODE) throw error;
+          error = passwordlessReadError(error);
           return createTypedToolError({
             message: `Error reading PDF pages: ${error.message}\n\nPlease ensure the file path is correct and the requested page range is valid.`,
           });
@@ -5399,6 +5423,7 @@ async function handleToolCall(request) {
           };
         } catch (error) {
           if (error?.code === PDF_RESOURCE_LIMIT_CODE) throw error;
+          error = passwordlessReadError(error);
           return createTypedToolError({
             message: `Error searching PDF text: ${error.message}\n\nPlease ensure the file path is correct and the query is valid.`,
           });
@@ -6034,6 +6059,19 @@ async function handleToolCall(request) {
             structuredContent: payload,
           };
         } catch (error) {
+          // The comparison classifier turns any unrecognized Error into
+          // "arguments or PDF inputs are invalid", which is false when the
+          // inputs were fine and only pdf-lib's inability to decrypt stopped
+          // the run. Say what actually happened.
+          // PDF_PARSE_FAILED is the closest code the sealed comparison error
+          // enum already carries; adding a new one would change an oracle-bound
+          // schema module. The message states the real cause either way.
+          if (error?.message === PDF_LIB_ENCRYPTED_MESSAGE) {
+            return createTypedToolError({
+              code: "PDF_PARSE_FAILED",
+              message: PDF_LIB_ENCRYPTED_MESSAGE,
+            });
+          }
           return createTypedToolError(publicPdfComparisonError(error));
         }
       }

--- a/server/pdf-lib-worker.js
+++ b/server/pdf-lib-worker.js
@@ -31,6 +31,7 @@ import {
   detectExistingSignatures,
   drawSignatureFieldOnPage,
   parsePageRanges,
+  PDF_LIB_ENCRYPTED_MESSAGE,
   stampSignatureOnPage,
   stampTextOnPage,
 } from "./helpers.js";
@@ -1665,7 +1666,7 @@ export async function loadPdfForMutation(bytes, password) {
     document = await PDFDocument.load(bytes, password ? { password } : {});
   } catch (error) {
     if (error.message?.includes("password") || error.message?.includes("encrypt")) {
-      throw new Error("PDF is password-protected. Please provide the correct password using the 'password' parameter.");
+      throw new Error(PDF_LIB_ENCRYPTED_MESSAGE);
     }
     throw new Error("Failed to load PDF: the file is malformed, incomplete, or unsupported.", { cause: error });
   }

--- a/server/pdfjs-worker.js
+++ b/server/pdfjs-worker.js
@@ -19,6 +19,7 @@ import {
   getPageBoxGeometry,
   getPageRenderScale,
   isPdfLibEncryptedError,
+  PDF_LIB_ENCRYPTED_MESSAGE,
   validatePdfRegionBox,
 } from "./helpers.js";
 import {
@@ -1510,8 +1511,22 @@ export async function runSystemCommand(command, args, {
   });
 }
 
+// Rendering and page analysis decrypt their text through PDF.js but still take
+// page geometry from pdf-lib, which cannot decrypt anything. Left raw, pdf-lib's
+// own error tells the caller to retry with { ignoreEncryption: true }, which
+// produces an unusable document — advice that cannot work. Report the real
+// limit instead.
+async function loadPdfLibGeometry(bytes, password) {
+  try {
+    return await PDFDocument.load(bytes, password ? { password } : {});
+  } catch (error) {
+    if (isPdfLibEncryptedError(error)) throw new Error(PDF_LIB_ENCRYPTED_MESSAGE);
+    throw error;
+  }
+}
+
 async function writeSinglePagePdf(bytes, pageNumber, password, targetPath, cropBox = null) {
-  const source = await PDFDocument.load(bytes, password ? { password } : {});
+  const source = await loadPdfLibGeometry(bytes, password);
   const target = await PDFDocument.create();
   const [page] = await target.copyPages(source, [pageNumber - 1]);
   if (cropBox !== null) {
@@ -1565,7 +1580,7 @@ async function systemRenderPage(bytes, password, options) {
   if (process.platform !== "darwin") {
     throw new Error("The macOS system PDF renderer is unavailable on this platform.");
   }
-  const geometryDocument = await PDFDocument.load(bytes, password ? { password } : {});
+  const geometryDocument = await loadPdfLibGeometry(bytes, password);
   if (options.page > geometryDocument.getPageCount()) {
     throw new Error(
       `Page ${options.page} is out of range (1-${geometryDocument.getPageCount()}).`,
@@ -1630,7 +1645,7 @@ async function systemRenderPage(bytes, password, options) {
 }
 
 async function nativeRenderPage(bytes, password, options) {
-  const geometryDocument = await PDFDocument.load(bytes, password ? { password } : {});
+  const geometryDocument = await loadPdfLibGeometry(bytes, password);
   if (options.page > geometryDocument.getPageCount()) {
     throw new Error(
       `Page ${options.page} is out of range (1-${geometryDocument.getPageCount()}).`,
@@ -1777,7 +1792,7 @@ async function renderComparisonPage(bytes, password, options) {
 }
 
 async function nativeRenderRegion(bytes, password, options) {
-  const geometryDocument = await PDFDocument.load(bytes, password ? { password } : {});
+  const geometryDocument = await loadPdfLibGeometry(bytes, password);
   if (options.page > geometryDocument.getPageCount()) {
     throw new Error(
       `Page ${options.page} is out of range (1-${geometryDocument.getPageCount()}).`,
@@ -1920,7 +1935,7 @@ async function renderRegion(bytes, password, options) {
 
 async function analyzePages(bytes, password, options) {
   const pdfjs = await loadPdfjs();
-  const pdfDocument = await PDFDocument.load(bytes, password ? { password } : {});
+  const pdfDocument = await loadPdfLibGeometry(bytes, password);
   return {
     analysis: await analyzePdfPages({
       pdfLibPages: pdfDocument.getPages(),
@@ -1953,31 +1968,46 @@ async function signatureZones(bytes, password) {
     scanAcroForm = false;
     recordWarning({ code: "ENCRYPTED_ACROFORM_SCAN_UNAVAILABLE" });
   }
-  const zones = await detectSignatureZones({
-    pdfDoc: pdfDocument,
-    pdfBytes: bytes,
-    pdfjsLib: pdfjs,
-    password,
-    onWarning: recordWarning,
-    scanAcroForm,
-  });
-  return {
-    page_geometry: pdfDocument.getPages().map((page, index) => {
-      const box = getPageBoxGeometry(page);
-      return {
-        height: box.height,
-        origin_x: box.originX,
-        origin_y: box.originY,
-        page: index + 1,
-        width: box.width,
-      };
-    }),
-    warning_counts: [...warningCounts.entries()].map(([code, occurrences]) => ({
-      code,
-      occurrences,
-    })),
-    zones,
+  const buildResult = async () => {
+    const zones = await detectSignatureZones({
+      pdfDoc: pdfDocument,
+      pdfBytes: bytes,
+      pdfjsLib: pdfjs,
+      password,
+      onWarning: recordWarning,
+      scanAcroForm,
+    });
+    return {
+      page_geometry: pdfDocument.getPages().map((page, index) => {
+        const box = getPageBoxGeometry(page);
+        return {
+          height: box.height,
+          origin_x: box.originX,
+          origin_y: box.originY,
+          page: index + 1,
+          width: box.width,
+        };
+      }),
+      warning_counts: [...warningCounts.entries()].map(([code, occurrences]) => ({
+        code,
+        occurrences,
+      })),
+      zones,
+    };
   };
+  if (scanAcroForm) return await buildResult();
+  // On the ignoreEncryption fallback pdf-lib may hand back a document whose
+  // page tree cannot be read at all — AES-256 fails with "Expected instance of
+  // PDFDict". Report the real limit rather than that internal detail.
+  try {
+    return await buildResult();
+  } catch (error) {
+    // A genuine PDF.js password failure still has to reach the caller as
+    // itself: a missing or wrong password is the one case where asking for the
+    // password is the correct advice.
+    if (error?.name === "PasswordException" || typeof error?.code === "string") throw error;
+    throw new Error(PDF_LIB_ENCRYPTED_MESSAGE);
+  }
 }
 
 async function performOperation(request, sourceBytes) {

--- a/test/encrypted-pdf-password-truth.test.js
+++ b/test/encrypted-pdf-password-truth.test.js
@@ -1,0 +1,245 @@
+// Truthfulness guard for encrypted PDFs.
+//
+// pdf-lib 1.17.1 has no decryption at all, so every tool whose reader is
+// pdf-lib fails on an encrypted document no matter what password the caller
+// sends. PDF.js does decrypt. This suite builds a real AES-256 PDF with qpdf at
+// run time (no encrypted binary is committed for it), then proves three things
+// that keep the product honest:
+//
+//   1. the two libraries really do behave that way, so the claim is measured
+//      here rather than asserted from documentation;
+//   2. a pdf-lib path reports that it cannot decrypt, and never tells the
+//      caller to supply a password it cannot use;
+//   3. every tool the honest message points at genuinely opens the same
+//      document with the same password.
+//
+// (3) is what stops the message from drifting into naming a tool that does not
+// work, and (2) is what stops the old "please provide the correct password"
+// advice from coming back.
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { PDFDocument } from "pdf-lib";
+import { PDF_LIB_ENCRYPTED_MESSAGE } from "../server/helpers.js";
+import { createTestTempDirectory, removeTestTempDirectory } from "./helpers/temp-directory.js";
+
+const REPO_ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
+const PLAINTEXT_PDF = path.join(REPO_ROOT, "example-fw9.pdf");
+const USER_PASSWORD = "encrypted-truth-user-2026";
+const WRONG_PASSWORD = "encrypted-truth-wrong-2026";
+
+// Every tool that advertises a `password` argument and reads only through
+// PDF.js. The honest pdf-lib message is allowed to name these and nothing else.
+const PDFJS_PASSWORD_TOOLS = Object.freeze(["convert_pdf_to_markdown", "get_pdf_info", "read_pdf_layout"]);
+
+function probeQpdf() {
+  try {
+    const probe = spawnSync("qpdf", ["--version"], { encoding: "utf8" });
+    if (probe.error || probe.status !== 0) {
+      return { available: false, reason: probe.error ? probe.error.message : `qpdf --version exited ${probe.status}` };
+    }
+    return { available: true, version: probe.stdout.split("\n")[0].trim() };
+  } catch (error) {
+    return { available: false, reason: error.message };
+  }
+}
+
+const QPDF = probeQpdf();
+
+describe("encrypted PDF password truthfulness", () => {
+  // Always runs, so the report states the guard's status instead of quietly
+  // omitting it. A skipped encryption guard must be loud: a silent skip is how
+  // a truthfulness regression reaches a release unnoticed.
+  it("reports whether the qpdf-backed encryption guard could run", () => {
+    expect(typeof QPDF.available).toBe("boolean");
+    if (QPDF.available) return;
+    expect(QPDF.reason, "a skip must carry its reason").toEqual(expect.any(String));
+    expect(QPDF.reason.length).toBeGreaterThan(0);
+    const banner = `[encrypted-pdf-password-truth] SKIPPED: qpdf is unavailable (${QPDF.reason}). `
+      + "The encrypted-PDF password-truthfulness guard did NOT run. Install qpdf to enforce it.";
+    process.stderr.write(`\n${"!".repeat(78)}\n${banner}\n${"!".repeat(78)}\n\n`);
+    console.warn(banner);
+  });
+});
+
+describe.skipIf(!QPDF.available)("encrypted PDF password truthfulness (qpdf present)", () => {
+  let client;
+  let transport;
+  let tempDirectory;
+  let encryptedPath;
+  let encryptedBytes;
+
+  const callTool = async (name, args) => await client.callTool({ name, arguments: args });
+  const toolText = result => result.content?.map(part => part.text ?? "").join("\n") ?? "";
+
+  beforeAll(async () => {
+    tempDirectory = await createTestTempDirectory(REPO_ROOT, "encrypted-password-truth");
+    encryptedPath = path.join(tempDirectory, "aes256-encrypted.pdf");
+    const encrypt = spawnSync("qpdf", [
+      "--encrypt",
+      `--user-password=${USER_PASSWORD}`,
+      `--owner-password=${USER_PASSWORD}`,
+      "--bits=256",
+      "--",
+      PLAINTEXT_PDF,
+      encryptedPath,
+    ], { encoding: "utf8" });
+    if (encrypt.status !== 0) {
+      throw new Error(`qpdf encryption failed (${encrypt.status}): ${encrypt.stderr}`);
+    }
+    encryptedBytes = await fs.readFile(encryptedPath);
+
+    client = new Client({ name: "encrypted-password-truth-test", version: "1.0.0" });
+    transport = new StdioClientTransport({
+      command: process.execPath,
+      args: [path.join(REPO_ROOT, "server/index.js")],
+      cwd: REPO_ROOT,
+      env: { ALLOWED_DIRECTORIES: [REPO_ROOT, tempDirectory].join(path.delimiter) },
+      stderr: "ignore",
+    });
+    await client.connect(transport);
+  }, 60_000);
+
+  afterAll(async () => {
+    try {
+      await client?.close();
+      await transport?.close();
+    } finally {
+      await removeTestTempDirectory(tempDirectory);
+    }
+  });
+
+  it("measures that pdf-lib cannot decrypt and PDF.js can", async () => {
+    // The premise of every other assertion in this file, checked against the
+    // pinned libraries instead of taken on trust.
+    await expect(PDFDocument.load(encryptedBytes, { password: USER_PASSWORD }))
+      .rejects.toThrow(/encrypted/i);
+    await expect(PDFDocument.load(encryptedBytes)).rejects.toThrow(/encrypted/i);
+    // pdf-lib's own suggested escape hatch produces a document that cannot be
+    // used, which is why the error must not repeat that advice either.
+    let ignoredEncryptionFailure = null;
+    try {
+      const ignored = await PDFDocument.load(encryptedBytes, { ignoreEncryption: true });
+      ignored.getPages();
+    } catch (error) {
+      ignoredEncryptionFailure = error;
+    }
+    expect(ignoredEncryptionFailure, "ignoreEncryption must not yield a usable document").not.toBeNull();
+
+    const pdfjs = await import("pdfjs-dist/legacy/build/pdf.mjs");
+    const task = pdfjs.getDocument({
+      data: new Uint8Array(encryptedBytes),
+      password: USER_PASSWORD,
+      isEvalSupported: false,
+      useSystemFonts: false,
+    });
+    const document = await task.promise;
+    try {
+      expect(document.numPages).toBeGreaterThan(0);
+    } finally {
+      await task.destroy();
+    }
+  }, 60_000);
+
+  it("states the pdf-lib limit instead of asking for a password it cannot use", () => {
+    // Derived from the message itself, so rewording it cannot smuggle the old
+    // instruction back in.
+    const message = PDF_LIB_ENCRYPTED_MESSAGE;
+    expect(message).toMatch(/cannot decrypt|no decryption/i);
+    expect(message).toMatch(/pdf-lib/);
+    expect(message).not.toMatch(/provide the correct password/i);
+    expect(message).not.toMatch(/using the '?password'? parameter/i);
+    expect(message).not.toMatch(/ignoreEncryption/);
+    // It must direct the caller somewhere that works, and only there.
+    const namedTools = PDFJS_PASSWORD_TOOLS.filter(tool => message.includes(tool));
+    expect(namedTools).toEqual([...PDFJS_PASSWORD_TOOLS]);
+  });
+
+  it("fails every pdf-lib reader identically whether or not a password is sent", async () => {
+    // read_pdf_fields loads in-process; fill_pdf loads inside the pdf-lib
+    // worker subprocess. Both copies of the loader must tell the same truth.
+    const attempts = [
+      { name: "read_pdf_fields", base: { pdf_path: encryptedPath } },
+      {
+        name: "fill_pdf",
+        base: { pdf_path: encryptedPath, field_data: {}, output_path: path.join(tempDirectory, "filled.pdf") },
+      },
+    ];
+    for (const attempt of attempts) {
+      for (const password of [undefined, WRONG_PASSWORD, USER_PASSWORD]) {
+        const result = await callTool(attempt.name, {
+          ...attempt.base,
+          ...(password === undefined ? {} : { password }),
+        });
+        const label = `${attempt.name} password=${password ?? "(omitted)"}`;
+        expect(result.isError, label).toBe(true);
+        expect(toolText(result), label).toBe(`Error: ${PDF_LIB_ENCRYPTED_MESSAGE}`);
+        if (password !== undefined) {
+          expect(toolText(result), label).not.toContain(password);
+        }
+      }
+    }
+    // The correct password must not have produced an output file either.
+    await expect(fs.access(path.join(tempDirectory, "filled.pdf"))).rejects.toThrow();
+  }, 90_000);
+
+  it("opens the same document with the same password on every tool the message names", async () => {
+    // Binds the advice to behavior: if one of these stops working, the message
+    // is no longer true and this test fails.
+    const invocations = {
+      convert_pdf_to_markdown: { pdf_path: encryptedPath, password: USER_PASSWORD, start_page: 1, end_page: 1 },
+      get_pdf_info: { pdf_path: encryptedPath, password: USER_PASSWORD },
+      read_pdf_layout: { pdf_path: encryptedPath, password: USER_PASSWORD, start_page: 1, end_page: 1 },
+    };
+    expect(Object.keys(invocations).sort()).toEqual([...PDFJS_PASSWORD_TOOLS].sort());
+    for (const tool of PDFJS_PASSWORD_TOOLS) {
+      const result = await callTool(tool, invocations[tool]);
+      expect(result.isError, `${tool} with the correct password`).not.toBe(true);
+      expect(toolText(result), `${tool} must not echo the password`).not.toContain(USER_PASSWORD);
+    }
+  }, 120_000);
+
+  it("does not point a password-less read tool at a password parameter it lacks", async () => {
+    // read_pdf_content and its siblings decrypt through PDF.js but expose no
+    // password argument, so the advice must name tools that do accept one.
+    const { tools } = await client.listTools();
+    const byName = new Map(tools.map(tool => [tool.name, tool]));
+    for (const tool of ["read_pdf_content", "read_pdf_pages", "search_pdf_text"]) {
+      expect(Object.keys(byName.get(tool).inputSchema.properties), `${tool} schema`)
+        .not.toContain("password");
+    }
+    const readArguments = {
+      read_pdf_content: { pdf_path: encryptedPath },
+      read_pdf_pages: { pdf_path: encryptedPath, start_page: 1, end_page: 1 },
+      search_pdf_text: { pdf_path: encryptedPath, query: "name" },
+    };
+    for (const [tool, args] of Object.entries(readArguments)) {
+      const result = await callTool(tool, args);
+      const text = toolText(result);
+      expect(result.isError, tool).toBe(true);
+      expect(text, tool).not.toMatch(/provide it with the password parameter/i);
+      expect(PDFJS_PASSWORD_TOOLS.filter(named => text.includes(named)), tool)
+        .toEqual([...PDFJS_PASSWORD_TOOLS]);
+    }
+  }, 90_000);
+
+  it("never advertises a usable password on a pdf-lib-backed tool", async () => {
+    // The schema text is the other place the claim can drift.
+    const { tools } = await client.listTools();
+    for (const tool of tools) {
+      const description = tool.inputSchema?.properties?.password?.description;
+      if (typeof description !== "string") continue;
+      if (PDFJS_PASSWORD_TOOLS.includes(tool.name)) {
+        expect(description, `${tool.name} password description`).not.toMatch(/pdf-lib/);
+        continue;
+      }
+      expect(description, `${tool.name} password description`).toMatch(/pdf-lib/);
+      expect(description, `${tool.name} password description`).toMatch(/cannot decrypt/i);
+    }
+  }, 30_000);
+});

--- a/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
+++ b/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
@@ -91,8 +91,8 @@
     {
       "role": "package_json",
       "path": "package.json",
-      "bytes": 2764,
-      "sha256": "70923e8c36aa5183d64a77596cc3b4e19bec3cfb1672d5e412212a6cfe7355b5"
+      "bytes": 2827,
+      "sha256": "e7bab0462ca87a92c7833868bbe1de66150ce97094773fdb2a18bc13ccaba84f"
     },
     {
       "role": "package_lock",
@@ -125,7 +125,7 @@
       "sha256": "6e4429db62fcbe1dd73141d8c20a48b564d41f8bf8920d88775846995e1daf94"
     }
   ],
-  "validator_source_set_sha256": "fc0e84b5d30cb80d8b416f4782ee9d1f5289a87999c5fe67eec3c41d8fdf7635",
+  "validator_source_set_sha256": "279631d26e1be3d10f90973c31b91ba24a3ed901ad69224f97c62be35e22570e",
   "pdfjs_version": "5.4.624",
   "generation_contract": {
     "source_path": "source.pdf",

--- a/test/fixtures/eval/trajectories/tool-contracts.v3.json
+++ b/test/fixtures/eval/trajectories/tool-contracts.v3.json
@@ -5,7 +5,7 @@
     "name": "pdf-tools",
     "version": "0.10.0"
   },
-  "tools_sha256": "eeef340721ec2b52e05d01509e9e6698c79ee4323873677a7e72d03693fb87f9",
+  "tools_sha256": "53c4f2e1bd63613694f7ca93fe2387219e1e04e3beceaaeeb2faf1cd1f0b69ee",
   "tools": [
     {
       "name": "add_signature_field",
@@ -50,7 +50,7 @@
           },
           "password": {
             "type": "string",
-            "description": "Password for encrypted PDFs (optional)"
+            "description": "Accepted but never used: this operation reads the PDF with pdf-lib, which cannot decrypt encrypted PDFs. Decrypt the document before calling this tool."
           },
           "force_xfa": {
             "type": "boolean",
@@ -132,7 +132,7 @@
           },
           "password": {
             "type": "string",
-            "description": "Password for encrypted PDFs (optional)"
+            "description": "Accepted but never used: this operation reads the PDF with pdf-lib, which cannot decrypt encrypted PDFs. Decrypt the document before calling this tool."
           },
           "force_xfa": {
             "type": "boolean",
@@ -243,7 +243,7 @@
           },
           "password": {
             "type": "string",
-            "description": "Password for encrypted PDFs (optional)"
+            "description": "Accepted but never used: this operation reads the PDF with pdf-lib, which cannot decrypt encrypted PDFs. Decrypt the document before calling this tool."
           },
           "expected_output_identity": {
             "type": "object",
@@ -345,7 +345,7 @@
           },
           "password": {
             "type": "string",
-            "description": "Password for encrypted PDFs (optional)"
+            "description": "Accepted but never used: this operation reads the PDF with pdf-lib, which cannot decrypt encrypted PDFs. Decrypt the document before calling this tool."
           },
           "expected_output_identity": {
             "type": "object",
@@ -409,7 +409,7 @@
           },
           "password": {
             "type": "string",
-            "description": "Password for encrypted PDFs (optional)"
+            "description": "Accepted but never used: this operation reads the PDF with pdf-lib, which cannot decrypt encrypted PDFs. Decrypt the document before calling this tool."
           },
           "force_xfa": {
             "type": "boolean",
@@ -474,12 +474,12 @@
           "before_password": {
             "type": "string",
             "maxLength": 4096,
-            "description": "Optional password for the earlier PDF."
+            "description": "Optional password for the earlier PDF. Password for encrypted PDFs. PDF.js uses it, but this operation also loads page geometry with pdf-lib, which cannot decrypt PDFs, so an encrypted document still fails with the correct password."
           },
           "after_password": {
             "type": "string",
             "maxLength": 4096,
-            "description": "Optional password for the later PDF."
+            "description": "Optional password for the later PDF. Password for encrypted PDFs. PDF.js uses it, but this operation also loads page geometry with pdf-lib, which cannot decrypt PDFs, so an encrypted document still fails with the correct password."
           },
           "mode": {
             "type": "string",
@@ -645,7 +645,7 @@
           },
           "password": {
             "type": "string",
-            "description": "Password for encrypted PDFs (optional)"
+            "description": "Password for encrypted PDFs. PDF.js uses it, but this operation also loads page geometry with pdf-lib, which cannot decrypt PDFs, so an encrypted document still fails with the correct password."
           }
         },
         "required": [
@@ -788,7 +788,7 @@
           },
           "password": {
             "type": "string",
-            "description": "Password for encrypted PDFs (optional)"
+            "description": "Accepted but never used: this operation reads the PDF with pdf-lib, which cannot decrypt encrypted PDFs. Decrypt the document before calling this tool."
           },
           "force_xfa": {
             "type": "boolean",
@@ -851,7 +851,7 @@
           },
           "password": {
             "type": "string",
-            "description": "Password for encrypted PDFs (optional)"
+            "description": "Accepted but never used: this operation reads the PDF with pdf-lib, which cannot decrypt encrypted PDFs. Decrypt the document before calling this tool."
           },
           "expected_output_identity": {
             "type": "object",
@@ -912,7 +912,7 @@
           },
           "password": {
             "type": "string",
-            "description": "Password for encrypted PDFs (optional)"
+            "description": "Password for encrypted PDFs. PDF.js uses it, but this operation also loads page geometry with pdf-lib, which cannot decrypt PDFs, so an encrypted document still fails with the correct password."
           }
         },
         "required": [
@@ -1089,7 +1089,7 @@
           },
           "password": {
             "type": "string",
-            "description": "Password for encrypted PDFs (optional, applied to all inputs)"
+            "description": "Accepted but never used: this operation reads the PDF with pdf-lib, which cannot decrypt encrypted PDFs. Decrypt the document before calling this tool."
           },
           "expected_output_identity": {
             "type": "object",
@@ -1183,7 +1183,7 @@
           },
           "password": {
             "type": "string",
-            "description": "Password for encrypted PDFs (optional)"
+            "description": "Accepted but never used: this operation reads the PDF with pdf-lib, which cannot decrypt encrypted PDFs. Decrypt the document before calling this tool."
           },
           "force_xfa": {
             "type": "boolean",
@@ -1283,7 +1283,7 @@
           },
           "password": {
             "type": "string",
-            "description": "Password for encrypted PDFs (optional)"
+            "description": "Accepted but never used: this operation reads the PDF with pdf-lib, which cannot decrypt encrypted PDFs. Decrypt the document before calling this tool."
           }
         },
         "required": [
@@ -1392,7 +1392,7 @@
           },
           "password": {
             "type": "string",
-            "description": "Password for encrypted PDFs (optional)."
+            "description": "Password for encrypted PDFs. PDF.js uses it, but this operation also loads page geometry with pdf-lib, which cannot decrypt PDFs, so an encrypted document still fails with the correct password."
           }
         },
         "required": [
@@ -1442,7 +1442,7 @@
           },
           "password": {
             "type": "string",
-            "description": "Password for encrypted PDFs (optional)."
+            "description": "Password for encrypted PDFs. PDF.js uses it, but this operation also loads page geometry with pdf-lib, which cannot decrypt PDFs, so an encrypted document still fails with the correct password."
           }
         },
         "required": [
@@ -1488,7 +1488,7 @@
           },
           "password": {
             "type": "string",
-            "description": "Password for encrypted PDFs (optional)"
+            "description": "Accepted but never used: this operation reads the PDF with pdf-lib, which cannot decrypt encrypted PDFs. Decrypt the document before calling this tool."
           },
           "expected_output_identity": {
             "type": "object",
@@ -1565,7 +1565,7 @@
           },
           "password": {
             "type": "string",
-            "description": "Password for encrypted PDFs (optional)"
+            "description": "Accepted but never used: this operation reads the PDF with pdf-lib, which cannot decrypt encrypted PDFs. Decrypt the document before calling this tool."
           },
           "expected_output_identity": {
             "type": "object",
@@ -1702,7 +1702,7 @@
           },
           "password": {
             "type": "string",
-            "description": "Password for encrypted PDFs (optional)"
+            "description": "Accepted but never used: this operation reads the PDF with pdf-lib, which cannot decrypt encrypted PDFs. Decrypt the document before calling this tool."
           },
           "expected_output_identities": {
             "type": "array",
@@ -1758,7 +1758,7 @@
           },
           "password": {
             "type": "string",
-            "description": "Password for encrypted PDFs (optional)"
+            "description": "Accepted but never used: this operation reads the PDF with pdf-lib, which cannot decrypt encrypted PDFs. Decrypt the document before calling this tool."
           }
         },
         "required": [

--- a/test/fuzz-malformed-pdfs.test.js
+++ b/test/fuzz-malformed-pdfs.test.js
@@ -6,6 +6,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { PDFDocument } from "pdf-lib";
+import { PDF_LIB_ENCRYPTED_MESSAGE } from "../server/helpers.js";
 import {
   createTestTempDirectory,
   removeTestTempDirectory,
@@ -833,9 +834,10 @@ describe.each(RUNTIMES)("$name malformed PDF containment", ({ root }) => {
         },
       });
       expect(result.isError, "encrypted password behavior").toBe(true);
-      expect(result.content?.[0]?.text).toBe(
-        "Error: PDF is password-protected. Please provide the correct password using the 'password' parameter.",
-      );
+      // pdf-lib cannot decrypt, so the same honest refusal is correct for a
+      // missing, wrong, and correct password. test/encrypted-pdf-password-truth
+      // .test.js owns the wording; this only pins that the three cases agree.
+      expect(result.content?.[0]?.text).toBe(`Error: ${PDF_LIB_ENCRYPTED_MESSAGE}`);
       if (password !== undefined) {
         expect(result.content?.[0]?.text).not.toContain(password);
       }

--- a/test/mcp-contract.test.js
+++ b/test/mcp-contract.test.js
@@ -90,7 +90,14 @@ const EXAMPLE_PDF = path.join(REPO_ROOT, "example-fw9.pdf");
 // grid, with no matrix of any kind taking part, so every published digest
 // changed and the extraction IR went to 1.5.0. Previously
 // dafeaf19570eece1bb3901f883ea456216b7f46ea6872b80a9eb205c24b9e45f.
-const TOOL_CONTRACT_SHA256 = "53d965e366b16adf2a0fa90dfe837ca98d29a8f41c1adf8b9e8f661ea3bb7d95";
+// 2026-08-09: every `password` argument now states what its own tool can do
+// with it. pdf-lib 1.17.1 has no decryption, so the tools that read only
+// through pdf-lib say the argument is accepted but never used, and the tools
+// that decrypt with PDF.js but still load geometry through pdf-lib say the
+// document fails anyway. Only read_pdf_layout, convert_pdf_to_markdown, and
+// get_pdf_info keep an unqualified password parameter, because only they work.
+// Previously 53d965e366b16adf2a0fa90dfe837ca98d29a8f41c1adf8b9e8f661ea3bb7d95.
+const TOOL_CONTRACT_SHA256 = "59af94a52312b299f57f9f5ab8e18b5de626d2502aa18f47438d7a1ce66e2c1c";
 
 const CLOSED_READ = Object.freeze({
   readOnlyHint: true,


### PR DESCRIPTION
## The defect

`pdf-lib` ships **no decryption at all**. Every tool that reads through it fails
on an encrypted file regardless of the password supplied — and the error told the
user to *"provide the correct password using the 'password' parameter"*, which is
exactly what they had just done.

Three read tools went further: `read_pdf_content`, `read_pdf_pages` and
`search_pdf_text` returned *"Provide it with the password parameter and try
again"* — on tools that **do not declare a password parameter**. There was no
action the user could take.

## Measured blast radius

Probed through a live MCP server against `qpdf --encrypt` AES-256 and AES-128
copies of `example-fw9.pdf`, **with the correct password**.

| Reader | Tools | Password support |
|---|---|---|
| PDF.js | `read_pdf_layout`, `convert_pdf_to_markdown`, `get_pdf_info` | **Real** |
| pdf-lib | `fill_pdf`, `bulk_fill_from_csv`, `fill_with_profile`, `read_pdf_fields`, `validate_pdf`, `merge_pdfs`, `split_pdf`, `rotate_pdf_pages`, `reorder_pdf_pages`, `apply_page_plan`, `add_signature_field`, `apply_signature`, `prepare_signing_packet`, `apply_text`, `extract_to_csv` | **Absent** |
| Mixed | `render_pdf_page`, `render_pdf_region`, `get_page_analysis`, `detect_signature_zones`, `compare_pdfs` | **Absent in practice** — PDF.js accepts the password, a pdf-lib geometry load then kills it |
| PDF.js, no param | `read_pdf_content`, `read_pdf_pages`, `search_pdf_text` | **Unreachable advice** |

Sixteen tools advertised a parameter that could not work. Also found five
unguarded `PDFDocument.load` calls in `pdfjs-worker.js` that nobody had counted.

## Before / after

`fill_pdf`, AES-256, correct password:

- **Before:** `PDF is password-protected. Please provide the correct password using the 'password' parameter.`
- **After:** `This PDF is encrypted and this operation cannot decrypt it: it reads the file with pdf-lib, which has no decryption support, so supplying a password here will not help. Decrypt the file first (for example with qpdf) and retry. To read an encrypted PDF as it is, use read_pdf_layout, convert_pdf_to_markdown, or get_pdf_info, which accept a password and decrypt with PDF.js.`

Preserved: a genuine PDF.js `PASSWORD_REQUIRED`/`PASSWORD_INCORRECT` on a tool
that *does* take a password still says to provide one — a typed-error test caught
an over-broad catch that had lost that distinction.

## Why it should not rot

- The message and the parameter descriptions are **shared constants**, so the
  three loaders cannot drift apart.
- The test asserts every tool the message **recommends** actually opens the
  document with that password, so the advice cannot go stale.
- `test/encrypted-pdf-password-truth.test.js` builds AES-256 with qpdf at run
  time (no committed binary), measures pdf-lib's three failure modes and PDF.js's
  success directly, and asserts no schema advertises a usable password on a
  pdf-lib path. Skip is loud.

## Deliberately not done

No decryption added, no dependency swapped. The real fix is decrypting outside
pdf-lib — verified working end to end (qpdf decrypt → pdf-lib fills 22 fields →
qpdf re-encrypt → output refuses without the password, filled value intact) — but
that is a feature, and plaintext handling plus encryption-parameter preservation
deserve their own scoping.

Pre-existing and untouched: `compare_pdfs` with `include_visual: false` ends in
`internal_validation_error` on encrypted input, reproduced before any edit here.

## Verification

`npm test` — **2239 passed, 89 skipped, 0 failed**. `test:contract:share` passed;
`build:mcpb` reproducible + `smoke:mcpb` passed. Share mirror byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)