### PR TITLE
DRAFT, do not merge: configure_allowed_directories, blocked three times by adversarial review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,6 +130,7 @@ qualification. Then perform manual host runs against `example-fw9.pdf`:
 31. **prepare_signing_packet** - Fill form + add sign-here boxes in one pass
 32. **detect_signature_zones** - Locate signature, initials, printed-name, and date zones with coordinates. Use apply_signature for signatures and initials, and apply_text for names and dates.
 33. **get_allowed_directories** - Report the folders this server may reach, which configuration layer supplied them, and where the stored config file lives. Read-only; it cannot change the boundary.
+34. **configure_allowed_directories** - Add folders to the stored configuration on plugin-style installs, where the host offers no settings screen. Requires an explicit human intent statement naming each path. Writes the stored configuration only; the running session's boundary is never widened, so the change applies after a restart
 
 ### Current Extraction Boundary
 

--- a/docs/OUTPUT_SCHEMAS.md
+++ b/docs/OUTPUT_SCHEMAS.md
@@ -34,6 +34,7 @@ an `isError` result is never forced through a success schema.
 | `fill_pdf` | active document and field-fill outcome |
 | `fill_with_profile` | active document and profile-fill outcome |
 | `get_active_document` | empty or populated active-document state |
+| `configure_allowed_directories` | which folders were added, which were already present, the stored configuration path, whether a restart is required, and the unchanged active set |
 | `get_allowed_directories` | resolved directory list, whether any were configured, which configuration layer supplied them, and the stored configuration path |
 | `get_page_analysis` | bounded page analysis with explicit provenance, operator counts, and a `classification` rollup (`document_kind`, typed `pages_needing_vision`, explicit `pages_not_analyzed`) |
 | `get_pdf_identity` | parser-independent canonical path, byte length, and SHA-256 |

--- a/pdf-toolkit-mcp-share/server/index.js
+++ b/pdf-toolkit-mcp-share/server/index.js
@@ -29,7 +29,7 @@ import fs from "fs/promises";
 import path from "path";
 import { homedir, platform as osPlatform } from "os";
 import { spawn } from "child_process";
-import { createHash, randomUUID } from "crypto";
+import { createHash, randomBytes, randomUUID } from "crypto";
 import {
   isUnavailableResourceError,
   pathToPdfResourceUri,
@@ -1458,8 +1458,22 @@ function pluginDataConfigPath() {
 
 // A fresh install has nothing configured and must refuse every path. Writing
 // the template turns "configure the allowed directories somehow" into a named
-// file the user can open. Editing it is a human action the agent cannot
-// perform, which is what keeps widening off the agent's own authority.
+// file the user can open.
+//
+// `configure_allowed_directories` can now write this file on the user's behalf,
+// because Agent Plugins defines no user-configuration surface at all and the
+// alternative was telling people to hand-edit JSON under a 64-character hex
+// path.
+//
+// Be precise about what that buys, because an adversarial review caught an
+// earlier comment here claiming more. What holds: the active set is read once
+// at startup and this tool never touches it, so a grant cannot widen the
+// session that asked for it. What does NOT hold: "a human approves it before it
+// takes effect." A host restarts this server on crash and on its own schedule,
+// so a persisted grant can become live with no human in the loop. The intent
+// statement is therefore an audit record of what was claimed, not proof that a
+// person agreed. Treat this as a convenience with provenance, and keep the
+// hand-edited file as the path for anyone who wants the stronger property.
 function ensurePluginDataConfigTemplate(configPath) {
   if (!configPath || existsSync(configPath)) return;
   try {
@@ -1502,6 +1516,134 @@ function readPluginDataConfig(configPath) {
     .filter(entry => typeof entry === "string")
     .map(entry => expandHostPlaceholders(entry.trim()))
     .filter(entry => entry && !entry.includes("${"));
+}
+
+// What this checks, stated honestly, because two adversarial reviews rejected
+// the earlier framing. The server receives a string from its caller. It cannot
+// know who wrote it, and it cannot tell agreement from refusal: "Do not allow
+// /x" satisfies every test below. So this is NOT consent, intent, or evidence
+// of a human decision, and nothing in this file should say it is.
+//
+// What it is: a caller-supplied justification that must name the exact folder
+// being granted, recorded in the configuration file so a person reading that
+// file later can see what was asserted when each folder was added. Requiring
+// the folder to appear as its own path token blocks the parent-escalation
+// route, where a sentence naming a child was reused to grant its parent. The
+// recency bound keeps a stale justification from being replayed indefinitely.
+// The real protection remains elsewhere: this cannot widen the running session,
+// and the folder itself must survive the overbroad and self-grant checks.
+const INTENT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+const ISO_8601_INSTANT = /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(:\d{2}(\.\d{1,9})?)?(Z|[+-]\d{2}:?\d{2})$/;
+
+// A substring test is not consent. An adversarial review broke the first draft
+// with it: the user says "allow /home/me/Documents/taxes/2025", the caller
+// submits "/home/me/Documents", and `includes` passes because the sentence
+// contains the parent as a prefix. The grant silently widens to everything in
+// Documents, using the user's own words as cover.
+//
+// So the statement is parsed into the paths it actually names, and the
+// requested directory has to be one of them. A path token ends at whitespace or
+// at punctuation that cannot appear mid-path in a sentence, and trailing
+// sentence punctuation is stripped.
+function pathsNamedIn(statement) {
+  const named = new Set();
+  for (const raw of statement.split(/[\s,;'"`()[\]{}<>]+/)) {
+    const token = raw.replace(/[.:!?]+$/, "");
+    if (!token || !path.isAbsolute(token)) continue;
+    named.add(token);
+    // A trailing separator is the same folder, not a different one.
+    if (token.length > 1 && token.endsWith(path.sep)) named.add(token.slice(0, -1));
+  }
+  return named;
+}
+
+function requireConfigurationIntent(statement, confirmedAt, directories, now) {
+  const trimmed = statement.trim();
+  if (trimmed.length < 12) {
+    throw new Error(
+      "'user_intent_statement' must be the user's own words asking for this folder, passed through verbatim. "
+      + "Ask them and pass their answer through verbatim; never write it for them.",
+    );
+  }
+  const named = pathsNamedIn(trimmed);
+  const missing = directories.filter(directory => {
+    const withoutTrailing = directory.length > 1 && directory.endsWith(path.sep)
+      ? directory.slice(0, -1)
+      : directory;
+    return !named.has(directory) && !named.has(withoutTrailing);
+  });
+  if (missing.length > 0) {
+    throw new Error(
+      `'user_intent_statement' must name each folder being allowed as its own path. Missing: ${missing.join(", ")}. `
+      + "A parent of a folder the user named does not count. Ask the user to confirm the exact folder, "
+      + "then pass their answer through verbatim.",
+    );
+  }
+  // Date.parse accepts a great deal that is not ISO-8601, including strings
+  // whose meaning depends on the host locale. The schema promises ISO-8601, so
+  // require it rather than accepting whatever parses.
+  if (!ISO_8601_INSTANT.test(confirmedAt.trim())) {
+    throw new Error(
+      "'user_confirmed_at' must be an ISO-8601 instant with a timezone, for example 2026-08-09T16:20:00Z.",
+    );
+  }
+  const confirmed = Date.parse(confirmedAt.trim());
+  if (Number.isNaN(confirmed)) {
+    throw new Error("'user_confirmed_at' is not a valid timestamp.");
+  }
+  if (confirmed > now) {
+    throw new Error("'user_confirmed_at' is in the future. Pass the time the user actually confirmed.");
+  }
+  if (now - confirmed > INTENT_MAX_AGE_MS) {
+    throw new Error("'user_confirmed_at' is more than 24 hours old. Ask the user to confirm again.");
+  }
+  return { statement: trimmed, confirmedAt: new Date(confirmed).toISOString() };
+}
+
+// Folders too broad to be a considered choice. Granting one of these is
+// indistinguishable from turning the boundary off, so refuse and make the
+// caller name something specific.
+//
+// The first draft recognised exactly two strings, the filesystem root and the
+// current user's home, which an adversarial review pointed out leaves /home,
+// /Users, /etc, /var, /usr and /tmp all reachable. Depth is the property that
+// actually matters: a directory shallow enough to contain other users' data or
+// the operating system is not a considered choice, whatever it is called.
+const OVERBROAD_ABSOLUTE_DIRECTORIES = new Set([
+  "/", "/home", "/Users", "/etc", "/var", "/usr", "/tmp", "/opt", "/srv", "/mnt", "/media",
+  "/private", "/System", "/Library", "/Applications", "/Volumes", "/bin", "/sbin", "/root", "/proc", "/dev",
+]);
+
+function rejectOverbroadDirectory(canonical) {
+  const parsed = path.parse(canonical);
+  if (canonical === parsed.root) {
+    throw new Error(`Refusing to allow the filesystem root (${canonical}). Name the specific folders you need.`);
+  }
+  const home = homedir();
+  if (home && canonicalizePathForPolicy(home) === canonical) {
+    throw new Error(
+      `Refusing to allow the whole home folder (${canonical}). Name the specific folders you need, `
+      + "such as its Documents or Desktop folder.",
+    );
+  }
+  const normalized = canonical.length > 1 && canonical.endsWith(path.sep)
+    ? canonical.slice(0, -1)
+    : canonical;
+  if (OVERBROAD_ABSOLUTE_DIRECTORIES.has(normalized)) {
+    throw new Error(
+      `Refusing to allow ${canonical}: it is a system or multi-user directory, which is not a considered choice. `
+      + "Name the specific folder you need inside it.",
+    );
+  }
+  // A one-segment directory on a Windows drive, C:\Users say, is the same
+  // problem in a different shape.
+  const depth = normalized.slice(parsed.root.length).split(/[\\/]+/).filter(Boolean).length;
+  if (depth <= 1 && home && !isPathInsideDirectory(normalized, canonicalizePathForPolicy(home))) {
+    throw new Error(
+      `Refusing to allow ${canonical}: a top-level directory outside your home folder is too broad. `
+      + "Name the specific folder you need inside it.",
+    );
+  }
 }
 
 // A set that reaches the config file lets any write tool rewrite the sandbox on
@@ -3751,6 +3893,34 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
           idempotentHint: false,
           openWorldHint: false
         }
+      },
+      {
+        name: "configure_allowed_directories",
+        description:
+          "Add folders to the stored configuration this server reads at startup. Requires explicit human intent and only works where a stored configuration file exists, which is plugin-style installs. "
+          + "IT DOES NOT WIDEN THE CURRENT SESSION. The active boundary was read at startup and is not changed, so the folders you add apply only to a later run. Tell the user that plainly, and tell them a restart will apply it, because a restart is not necessarily something they perform.\n\n"
+          + "ASK THE USER FIRST AND PASS THEIR ANSWER THROUGH VERBATIM. The server cannot tell your words from theirs, so this is recorded as a claim, not verified as consent: it is written into the configuration file for a person to audit later. Never invent it. The statement must name each folder as its own path. "
+          + "On hosts that provide their own settings screen, such as Claude Desktop, this tool refuses and the user should use that screen instead.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            directories: {
+              type: "array",
+              items: { type: "string" },
+              minItems: 1,
+              description: "Absolute paths of existing folders to add. Existing entries are kept; nothing is removed.",
+            },
+            user_intent_statement: {
+              type: "string",
+              description: "The user's own words asking for these folders, passed through verbatim. Must name each folder as its own path. Recorded for audit; the server cannot verify who wrote it, so never invent it.",
+            },
+            user_confirmed_at: {
+              type: "string",
+              description: "ISO-8601 instant with a timezone, when the user asked, within the last 24 hours.",
+            },
+          },
+          required: ["directories", "user_intent_statement", "user_confirmed_at"],
+        },
       },
       {
         name: "get_allowed_directories",
@@ -6311,6 +6481,225 @@ async function handleToolCall(request) {
         };
       }
 
+      case "configure_allowed_directories": {
+        if (!PLUGIN_DATA_CONFIG_PATH) {
+          throw new Error(
+            "There is no stored configuration file for this install, so this tool cannot change anything. "
+            + "This host configures the boundary itself: in Claude Desktop open Settings, then Extensions, "
+            + "then this extension, and edit Allowed PDF Directories. Otherwise set the --allowed-directories "
+            + "argument or the ALLOWED_DIRECTORIES environment variable where this server is configured.",
+          );
+        }
+
+        const args = requireArgumentObject(request.params.arguments, "configure_allowed_directories");
+        if (!Array.isArray(args.directories) || args.directories.length === 0) {
+          throw new Error("'directories' must be a non-empty array of absolute folder paths.");
+        }
+
+        const requested = args.directories.map((entry, index) => {
+          if (typeof entry !== "string" || !entry.trim()) {
+            throw new Error(`'directories[${index}]' must be a non-empty string.`);
+          }
+          const expanded = expandHostPlaceholders(entry.trim());
+          if (expanded.includes("${")) {
+            throw new Error(`'directories[${index}]' still contains an unresolved placeholder: ${entry}`);
+          }
+          if (!path.isAbsolute(expanded)) {
+            throw new Error(`'directories[${index}]' must be an absolute path. Got: ${entry}`);
+          }
+          return expanded;
+        });
+
+        // Intent is checked against what the user typed, before anything on disk
+        // is touched, so a refusal never leaves a half-written boundary.
+        requireConfigurationIntent(
+          requireStringArgument(args.user_intent_statement, "user_intent_statement"),
+          requireStringArgument(args.user_confirmed_at, "user_confirmed_at"),
+          requested,
+          Date.now(),
+        );
+
+        const canonicalConfig = canonicalizePathForPolicy(PLUGIN_DATA_CONFIG_PATH);
+        let configIdentity = null;
+        try {
+          const configStats = await fs.stat(PLUGIN_DATA_CONFIG_PATH);
+          configIdentity = { dev: configStats.dev, ino: configStats.ino };
+        } catch { /* not written yet; the pathname check below still applies */ }
+
+        const additions = [];
+        for (const directory of requested) {
+          let stats;
+          try {
+            stats = await fs.stat(directory);
+          } catch {
+            throw new Error(`Folder does not exist: ${directory}. Create it first, or check the path.`);
+          }
+          if (!stats.isDirectory()) throw new Error(`Not a folder: ${directory}`);
+
+          // Store what the checks below actually inspected. The first draft
+          // validated the canonical path and then wrote the requested one, so a
+          // symlink approved while pointing somewhere harmless could be
+          // repointed at / afterwards and the next startup would follow it.
+          // Persisting the resolved target means a later swap of the original
+          // name changes nothing about what was granted.
+          const canonical = canonicalizePathForPolicy(directory);
+          rejectOverbroadDirectory(canonical);
+          if (isPathInsideDirectory(canonicalConfig, canonical)) {
+            throw new Error(
+              `Refusing ${directory}: it contains this server's own configuration file, which would let any `
+              + "write tool rewrite the boundary on the next launch.",
+            );
+          }
+          // A pathname check alone misses a hard link: a second name for the
+          // same file inside an otherwise innocent folder is still that file.
+          //
+          // Granting a directory grants its descendants, so this walks the tree
+          // rather than the immediate children, which an earlier draft did.
+          // It fails closed: a subtree that cannot be read, or one too large to
+          // scan within the bound, is refused rather than assumed innocent,
+          // because a security check that cannot complete has not passed.
+          if (configIdentity) {
+            const MAX_ENTRIES_SCANNED = 20000;
+            let scanned = 0;
+            const pending = [canonical];
+            while (pending.length > 0) {
+              const current = pending.pop();
+              let entries;
+              try {
+                entries = await fs.readdir(current, { withFileTypes: true });
+              } catch (error) {
+                throw new Error(
+                  `Refusing ${directory}: cannot verify that it does not contain this server's own `
+                  + `configuration file, because ${current} could not be read (${error.code ?? "unreadable"}).`,
+                );
+              }
+              for (const entry of entries) {
+                if (++scanned > MAX_ENTRIES_SCANNED) {
+                  throw new Error(
+                    `Refusing ${directory}: it is too large to verify that it does not contain this server's `
+                    + "own configuration file. Name a smaller, more specific folder.",
+                  );
+                }
+                const child = path.join(current, entry.name);
+                if (entry.isDirectory()) {
+                  pending.push(child);
+                  continue;
+                }
+                // lstat, so a symlink is inspected rather than followed.
+                const candidate = await fs.lstat(child).catch(() => null);
+                if (candidate?.isFile()
+                  && candidate.dev === configIdentity.dev
+                  && candidate.ino === configIdentity.ino) {
+                  throw new Error(
+                    `Refusing ${directory}: ${child} is another name for this server's own configuration `
+                    + "file, which would let any write tool rewrite the boundary on the next launch.",
+                  );
+                }
+              }
+            }
+          }
+          additions.push({ requested: directory, canonical });
+        }
+
+        ensurePluginDataConfigTemplate(PLUGIN_DATA_CONFIG_PATH);
+        let stored;
+        try {
+          stored = JSON.parse(await fs.readFile(PLUGIN_DATA_CONFIG_PATH, "utf8"));
+        } catch {
+          throw new Error(
+            `${PLUGIN_DATA_CONFIG_PATH} is not valid JSON. Fix or delete it, then try again. `
+            + "Refusing to overwrite a file that may hold folders you configured by hand.",
+          );
+        }
+        if (!stored || typeof stored !== "object" || Array.isArray(stored)) {
+          throw new Error(`${PLUGIN_DATA_CONFIG_PATH} must contain a JSON object.`);
+        }
+
+        // Refuse rather than rewrite. Dropping entries we do not recognise
+        // would silently delete folders the user configured by hand, and a
+        // configuration tool that quietly narrows the boundary is as wrong as
+        // one that quietly widens it.
+        if (stored.allowedDirectories !== undefined && !Array.isArray(stored.allowedDirectories)) {
+          throw new Error(
+            `${PLUGIN_DATA_CONFIG_PATH} has an "allowedDirectories" that is not a list. `
+            + "Fix it by hand; refusing to replace a value you may have written deliberately.",
+          );
+        }
+        const existing = stored.allowedDirectories ?? [];
+        const unsupported = existing.filter(entry => typeof entry !== "string");
+        if (unsupported.length > 0) {
+          throw new Error(
+            `${PLUGIN_DATA_CONFIG_PATH} contains ${unsupported.length} entr${unsupported.length === 1 ? "y" : "ies"} `
+            + "that are not plain paths. Fix them by hand; refusing to drop entries you may have written deliberately.",
+          );
+        }
+
+        const already = new Set(existing.map(entry => canonicalizePathForPolicy(expandHostPlaceholders(entry))));
+        const accepted = additions.filter(entry => !already.has(entry.canonical));
+        const added = accepted.map(entry => entry.canonical);
+
+        stored.allowedDirectories = [...existing, ...added];
+        // Append rather than replace. The first draft kept only the most recent
+        // statement, so a later innocuous call erased the consent that had
+        // actually granted a sensitive folder. Nothing that only reports "no
+        // change" is recorded at all.
+        if (added.length > 0) {
+          const history = Array.isArray(stored._configurationHistory) ? stored._configurationHistory : [];
+          history.push({
+            user_intent_statement: String(args.user_intent_statement).trim(),
+            user_confirmed_at: new Date(Date.parse(String(args.user_confirmed_at).trim())).toISOString(),
+            requested: accepted.map(entry => entry.requested),
+            added,
+          });
+          stored._configurationHistory = history;
+        }
+
+        // Write through a temporary file and rename, so an interrupted write
+        // cannot leave the boundary unreadable.
+        //
+        // The name must be unpredictable and created exclusively. A review of
+        // the previous draft, which used `${config}.${pid}.tmp`, pointed out
+        // that a deterministic name lets a local actor pre-create it as a
+        // symlink: writeFile follows the link and truncates whatever it points
+        // at, before the rename ever runs. `wx` refuses to open an existing
+        // path of any kind, which closes that.
+        const temporary = `${PLUGIN_DATA_CONFIG_PATH}.${randomBytes(12).toString("hex")}.tmp`;
+        let handle;
+        try {
+          handle = await fs.open(temporary, "wx", 0o600);
+          await handle.writeFile(JSON.stringify(stored, null, 2) + "\n");
+          // Durability has to reach the disk before the rename claims it.
+          await handle.sync();
+        } finally {
+          await handle?.close().catch(() => {});
+        }
+        try {
+          await fs.rename(temporary, PLUGIN_DATA_CONFIG_PATH);
+        } catch (error) {
+          await fs.unlink(temporary).catch(() => {});
+          throw error;
+        }
+
+        // Deliberately not touching ALLOWED_DIRECTORIES. The boundary this
+        // session enforces stays exactly as the user last launched it.
+        const summary = added.length === 0
+          ? `Already configured, nothing changed. The stored configuration at ${PLUGIN_DATA_CONFIG_PATH} already lists: ${requested.join(", ")}.`
+          : `Added to ${PLUGIN_DATA_CONFIG_PATH}:\n${added.join("\n")}\n\n`
+            + "This does NOT affect the current session. Restart the server, then these folders will be reachable.";
+
+        return {
+          content: [{ type: "text", text: summary }],
+          structuredContent: {
+            added,
+            already_configured: requested.filter(directory => !added.includes(directory)),
+            config_path: PLUGIN_DATA_CONFIG_PATH,
+            restart_required: added.length > 0,
+            active_directories_unchanged: true,
+            active_directories: ALLOWED_DIRECTORIES.map(directory => directory.display),
+          },
+        };
+      }
+
       case "get_allowed_directories": {
         // Reporting the boundary is not reaching past it, so this answers even
         // when nothing is configured — which is exactly when it is most needed.
@@ -6319,7 +6708,15 @@ async function handleToolCall(request) {
         const summary = configured
           ? `Allowed folders (${ALLOWED_DIRECTORY_SOURCE.replace(/_/g, " ")}):\n${directories.join("\n")}`
           : PLUGIN_DATA_CONFIG_PATH
-            ? `No folders are allowed yet. List them in ${PLUGIN_DATA_CONFIG_PATH} under "allowedDirectories", then restart this server.`
+            // Deliberately not a paste-ready shell command. An adversarial
+            // review of an earlier draft pointed out two problems with one: a
+            // quote anywhere in PLUGIN_DATA_CONFIG_PATH turns the generated
+            // line into shell injection, and handing users a command that
+            // appends straight to allowedDirectories teaches them to bypass
+            // every check the configuration path applies. The file is the
+            // instruction; the user edits it themselves.
+            ? `No folders are allowed yet. Open this file and list the folders you want under "allowedDirectories", then restart:\n\n  ${PLUGIN_DATA_CONFIG_PATH}\n\n`
+              + `Absolute paths only. It replaces any default rather than adding to one, so list every folder you need.`
             : "No folders are allowed yet, and no configuration file location is available. Set the --allowed-directories argument or the ALLOWED_DIRECTORIES environment variable where this server is configured.";
 
         return {

--- a/pdf-toolkit-mcp-share/server/output-schemas.js
+++ b/pdf-toolkit-mcp-share/server/output-schemas.js
@@ -1289,6 +1289,17 @@ export const TOOL_SUCCESS_OUTPUT_SCHEMAS = Object.freeze({
     path: string,
     bytes: integer,
   }),
+  configure_allowed_directories: object({
+    added: arrayOf(string),
+    already_configured: arrayOf(string),
+    config_path: string,
+    restart_required: { type: "boolean" },
+    // Always true. Declared so a caller can read the promise off the contract
+    // rather than the prose: writing the stored configuration never widens the
+    // boundary the running session enforces.
+    active_directories_unchanged: { type: "boolean" },
+    active_directories: arrayOf(string),
+  }),
   get_allowed_directories: object({
     directories: arrayOf(string),
     configured: { type: "boolean" },

--- a/server/index.js
+++ b/server/index.js
@@ -29,7 +29,7 @@ import fs from "fs/promises";
 import path from "path";
 import { homedir, platform as osPlatform } from "os";
 import { spawn } from "child_process";
-import { createHash, randomUUID } from "crypto";
+import { createHash, randomBytes, randomUUID } from "crypto";
 import {
   isUnavailableResourceError,
   pathToPdfResourceUri,
@@ -1458,8 +1458,22 @@ function pluginDataConfigPath() {
 
 // A fresh install has nothing configured and must refuse every path. Writing
 // the template turns "configure the allowed directories somehow" into a named
-// file the user can open. Editing it is a human action the agent cannot
-// perform, which is what keeps widening off the agent's own authority.
+// file the user can open.
+//
+// `configure_allowed_directories` can now write this file on the user's behalf,
+// because Agent Plugins defines no user-configuration surface at all and the
+// alternative was telling people to hand-edit JSON under a 64-character hex
+// path.
+//
+// Be precise about what that buys, because an adversarial review caught an
+// earlier comment here claiming more. What holds: the active set is read once
+// at startup and this tool never touches it, so a grant cannot widen the
+// session that asked for it. What does NOT hold: "a human approves it before it
+// takes effect." A host restarts this server on crash and on its own schedule,
+// so a persisted grant can become live with no human in the loop. The intent
+// statement is therefore an audit record of what was claimed, not proof that a
+// person agreed. Treat this as a convenience with provenance, and keep the
+// hand-edited file as the path for anyone who wants the stronger property.
 function ensurePluginDataConfigTemplate(configPath) {
   if (!configPath || existsSync(configPath)) return;
   try {
@@ -1502,6 +1516,134 @@ function readPluginDataConfig(configPath) {
     .filter(entry => typeof entry === "string")
     .map(entry => expandHostPlaceholders(entry.trim()))
     .filter(entry => entry && !entry.includes("${"));
+}
+
+// What this checks, stated honestly, because two adversarial reviews rejected
+// the earlier framing. The server receives a string from its caller. It cannot
+// know who wrote it, and it cannot tell agreement from refusal: "Do not allow
+// /x" satisfies every test below. So this is NOT consent, intent, or evidence
+// of a human decision, and nothing in this file should say it is.
+//
+// What it is: a caller-supplied justification that must name the exact folder
+// being granted, recorded in the configuration file so a person reading that
+// file later can see what was asserted when each folder was added. Requiring
+// the folder to appear as its own path token blocks the parent-escalation
+// route, where a sentence naming a child was reused to grant its parent. The
+// recency bound keeps a stale justification from being replayed indefinitely.
+// The real protection remains elsewhere: this cannot widen the running session,
+// and the folder itself must survive the overbroad and self-grant checks.
+const INTENT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+const ISO_8601_INSTANT = /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(:\d{2}(\.\d{1,9})?)?(Z|[+-]\d{2}:?\d{2})$/;
+
+// A substring test is not consent. An adversarial review broke the first draft
+// with it: the user says "allow /home/me/Documents/taxes/2025", the caller
+// submits "/home/me/Documents", and `includes` passes because the sentence
+// contains the parent as a prefix. The grant silently widens to everything in
+// Documents, using the user's own words as cover.
+//
+// So the statement is parsed into the paths it actually names, and the
+// requested directory has to be one of them. A path token ends at whitespace or
+// at punctuation that cannot appear mid-path in a sentence, and trailing
+// sentence punctuation is stripped.
+function pathsNamedIn(statement) {
+  const named = new Set();
+  for (const raw of statement.split(/[\s,;'"`()[\]{}<>]+/)) {
+    const token = raw.replace(/[.:!?]+$/, "");
+    if (!token || !path.isAbsolute(token)) continue;
+    named.add(token);
+    // A trailing separator is the same folder, not a different one.
+    if (token.length > 1 && token.endsWith(path.sep)) named.add(token.slice(0, -1));
+  }
+  return named;
+}
+
+function requireConfigurationIntent(statement, confirmedAt, directories, now) {
+  const trimmed = statement.trim();
+  if (trimmed.length < 12) {
+    throw new Error(
+      "'user_intent_statement' must be the user's own words asking for this folder, passed through verbatim. "
+      + "Ask them and pass their answer through verbatim; never write it for them.",
+    );
+  }
+  const named = pathsNamedIn(trimmed);
+  const missing = directories.filter(directory => {
+    const withoutTrailing = directory.length > 1 && directory.endsWith(path.sep)
+      ? directory.slice(0, -1)
+      : directory;
+    return !named.has(directory) && !named.has(withoutTrailing);
+  });
+  if (missing.length > 0) {
+    throw new Error(
+      `'user_intent_statement' must name each folder being allowed as its own path. Missing: ${missing.join(", ")}. `
+      + "A parent of a folder the user named does not count. Ask the user to confirm the exact folder, "
+      + "then pass their answer through verbatim.",
+    );
+  }
+  // Date.parse accepts a great deal that is not ISO-8601, including strings
+  // whose meaning depends on the host locale. The schema promises ISO-8601, so
+  // require it rather than accepting whatever parses.
+  if (!ISO_8601_INSTANT.test(confirmedAt.trim())) {
+    throw new Error(
+      "'user_confirmed_at' must be an ISO-8601 instant with a timezone, for example 2026-08-09T16:20:00Z.",
+    );
+  }
+  const confirmed = Date.parse(confirmedAt.trim());
+  if (Number.isNaN(confirmed)) {
+    throw new Error("'user_confirmed_at' is not a valid timestamp.");
+  }
+  if (confirmed > now) {
+    throw new Error("'user_confirmed_at' is in the future. Pass the time the user actually confirmed.");
+  }
+  if (now - confirmed > INTENT_MAX_AGE_MS) {
+    throw new Error("'user_confirmed_at' is more than 24 hours old. Ask the user to confirm again.");
+  }
+  return { statement: trimmed, confirmedAt: new Date(confirmed).toISOString() };
+}
+
+// Folders too broad to be a considered choice. Granting one of these is
+// indistinguishable from turning the boundary off, so refuse and make the
+// caller name something specific.
+//
+// The first draft recognised exactly two strings, the filesystem root and the
+// current user's home, which an adversarial review pointed out leaves /home,
+// /Users, /etc, /var, /usr and /tmp all reachable. Depth is the property that
+// actually matters: a directory shallow enough to contain other users' data or
+// the operating system is not a considered choice, whatever it is called.
+const OVERBROAD_ABSOLUTE_DIRECTORIES = new Set([
+  "/", "/home", "/Users", "/etc", "/var", "/usr", "/tmp", "/opt", "/srv", "/mnt", "/media",
+  "/private", "/System", "/Library", "/Applications", "/Volumes", "/bin", "/sbin", "/root", "/proc", "/dev",
+]);
+
+function rejectOverbroadDirectory(canonical) {
+  const parsed = path.parse(canonical);
+  if (canonical === parsed.root) {
+    throw new Error(`Refusing to allow the filesystem root (${canonical}). Name the specific folders you need.`);
+  }
+  const home = homedir();
+  if (home && canonicalizePathForPolicy(home) === canonical) {
+    throw new Error(
+      `Refusing to allow the whole home folder (${canonical}). Name the specific folders you need, `
+      + "such as its Documents or Desktop folder.",
+    );
+  }
+  const normalized = canonical.length > 1 && canonical.endsWith(path.sep)
+    ? canonical.slice(0, -1)
+    : canonical;
+  if (OVERBROAD_ABSOLUTE_DIRECTORIES.has(normalized)) {
+    throw new Error(
+      `Refusing to allow ${canonical}: it is a system or multi-user directory, which is not a considered choice. `
+      + "Name the specific folder you need inside it.",
+    );
+  }
+  // A one-segment directory on a Windows drive, C:\Users say, is the same
+  // problem in a different shape.
+  const depth = normalized.slice(parsed.root.length).split(/[\\/]+/).filter(Boolean).length;
+  if (depth <= 1 && home && !isPathInsideDirectory(normalized, canonicalizePathForPolicy(home))) {
+    throw new Error(
+      `Refusing to allow ${canonical}: a top-level directory outside your home folder is too broad. `
+      + "Name the specific folder you need inside it.",
+    );
+  }
 }
 
 // A set that reaches the config file lets any write tool rewrite the sandbox on
@@ -3751,6 +3893,34 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
           idempotentHint: false,
           openWorldHint: false
         }
+      },
+      {
+        name: "configure_allowed_directories",
+        description:
+          "Add folders to the stored configuration this server reads at startup. Requires explicit human intent and only works where a stored configuration file exists, which is plugin-style installs. "
+          + "IT DOES NOT WIDEN THE CURRENT SESSION. The active boundary was read at startup and is not changed, so the folders you add apply only to a later run. Tell the user that plainly, and tell them a restart will apply it, because a restart is not necessarily something they perform.\n\n"
+          + "ASK THE USER FIRST AND PASS THEIR ANSWER THROUGH VERBATIM. The server cannot tell your words from theirs, so this is recorded as a claim, not verified as consent: it is written into the configuration file for a person to audit later. Never invent it. The statement must name each folder as its own path. "
+          + "On hosts that provide their own settings screen, such as Claude Desktop, this tool refuses and the user should use that screen instead.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            directories: {
+              type: "array",
+              items: { type: "string" },
+              minItems: 1,
+              description: "Absolute paths of existing folders to add. Existing entries are kept; nothing is removed.",
+            },
+            user_intent_statement: {
+              type: "string",
+              description: "The user's own words asking for these folders, passed through verbatim. Must name each folder as its own path. Recorded for audit; the server cannot verify who wrote it, so never invent it.",
+            },
+            user_confirmed_at: {
+              type: "string",
+              description: "ISO-8601 instant with a timezone, when the user asked, within the last 24 hours.",
+            },
+          },
+          required: ["directories", "user_intent_statement", "user_confirmed_at"],
+        },
       },
       {
         name: "get_allowed_directories",
@@ -6311,6 +6481,225 @@ async function handleToolCall(request) {
         };
       }
 
+      case "configure_allowed_directories": {
+        if (!PLUGIN_DATA_CONFIG_PATH) {
+          throw new Error(
+            "There is no stored configuration file for this install, so this tool cannot change anything. "
+            + "This host configures the boundary itself: in Claude Desktop open Settings, then Extensions, "
+            + "then this extension, and edit Allowed PDF Directories. Otherwise set the --allowed-directories "
+            + "argument or the ALLOWED_DIRECTORIES environment variable where this server is configured.",
+          );
+        }
+
+        const args = requireArgumentObject(request.params.arguments, "configure_allowed_directories");
+        if (!Array.isArray(args.directories) || args.directories.length === 0) {
+          throw new Error("'directories' must be a non-empty array of absolute folder paths.");
+        }
+
+        const requested = args.directories.map((entry, index) => {
+          if (typeof entry !== "string" || !entry.trim()) {
+            throw new Error(`'directories[${index}]' must be a non-empty string.`);
+          }
+          const expanded = expandHostPlaceholders(entry.trim());
+          if (expanded.includes("${")) {
+            throw new Error(`'directories[${index}]' still contains an unresolved placeholder: ${entry}`);
+          }
+          if (!path.isAbsolute(expanded)) {
+            throw new Error(`'directories[${index}]' must be an absolute path. Got: ${entry}`);
+          }
+          return expanded;
+        });
+
+        // Intent is checked against what the user typed, before anything on disk
+        // is touched, so a refusal never leaves a half-written boundary.
+        requireConfigurationIntent(
+          requireStringArgument(args.user_intent_statement, "user_intent_statement"),
+          requireStringArgument(args.user_confirmed_at, "user_confirmed_at"),
+          requested,
+          Date.now(),
+        );
+
+        const canonicalConfig = canonicalizePathForPolicy(PLUGIN_DATA_CONFIG_PATH);
+        let configIdentity = null;
+        try {
+          const configStats = await fs.stat(PLUGIN_DATA_CONFIG_PATH);
+          configIdentity = { dev: configStats.dev, ino: configStats.ino };
+        } catch { /* not written yet; the pathname check below still applies */ }
+
+        const additions = [];
+        for (const directory of requested) {
+          let stats;
+          try {
+            stats = await fs.stat(directory);
+          } catch {
+            throw new Error(`Folder does not exist: ${directory}. Create it first, or check the path.`);
+          }
+          if (!stats.isDirectory()) throw new Error(`Not a folder: ${directory}`);
+
+          // Store what the checks below actually inspected. The first draft
+          // validated the canonical path and then wrote the requested one, so a
+          // symlink approved while pointing somewhere harmless could be
+          // repointed at / afterwards and the next startup would follow it.
+          // Persisting the resolved target means a later swap of the original
+          // name changes nothing about what was granted.
+          const canonical = canonicalizePathForPolicy(directory);
+          rejectOverbroadDirectory(canonical);
+          if (isPathInsideDirectory(canonicalConfig, canonical)) {
+            throw new Error(
+              `Refusing ${directory}: it contains this server's own configuration file, which would let any `
+              + "write tool rewrite the boundary on the next launch.",
+            );
+          }
+          // A pathname check alone misses a hard link: a second name for the
+          // same file inside an otherwise innocent folder is still that file.
+          //
+          // Granting a directory grants its descendants, so this walks the tree
+          // rather than the immediate children, which an earlier draft did.
+          // It fails closed: a subtree that cannot be read, or one too large to
+          // scan within the bound, is refused rather than assumed innocent,
+          // because a security check that cannot complete has not passed.
+          if (configIdentity) {
+            const MAX_ENTRIES_SCANNED = 20000;
+            let scanned = 0;
+            const pending = [canonical];
+            while (pending.length > 0) {
+              const current = pending.pop();
+              let entries;
+              try {
+                entries = await fs.readdir(current, { withFileTypes: true });
+              } catch (error) {
+                throw new Error(
+                  `Refusing ${directory}: cannot verify that it does not contain this server's own `
+                  + `configuration file, because ${current} could not be read (${error.code ?? "unreadable"}).`,
+                );
+              }
+              for (const entry of entries) {
+                if (++scanned > MAX_ENTRIES_SCANNED) {
+                  throw new Error(
+                    `Refusing ${directory}: it is too large to verify that it does not contain this server's `
+                    + "own configuration file. Name a smaller, more specific folder.",
+                  );
+                }
+                const child = path.join(current, entry.name);
+                if (entry.isDirectory()) {
+                  pending.push(child);
+                  continue;
+                }
+                // lstat, so a symlink is inspected rather than followed.
+                const candidate = await fs.lstat(child).catch(() => null);
+                if (candidate?.isFile()
+                  && candidate.dev === configIdentity.dev
+                  && candidate.ino === configIdentity.ino) {
+                  throw new Error(
+                    `Refusing ${directory}: ${child} is another name for this server's own configuration `
+                    + "file, which would let any write tool rewrite the boundary on the next launch.",
+                  );
+                }
+              }
+            }
+          }
+          additions.push({ requested: directory, canonical });
+        }
+
+        ensurePluginDataConfigTemplate(PLUGIN_DATA_CONFIG_PATH);
+        let stored;
+        try {
+          stored = JSON.parse(await fs.readFile(PLUGIN_DATA_CONFIG_PATH, "utf8"));
+        } catch {
+          throw new Error(
+            `${PLUGIN_DATA_CONFIG_PATH} is not valid JSON. Fix or delete it, then try again. `
+            + "Refusing to overwrite a file that may hold folders you configured by hand.",
+          );
+        }
+        if (!stored || typeof stored !== "object" || Array.isArray(stored)) {
+          throw new Error(`${PLUGIN_DATA_CONFIG_PATH} must contain a JSON object.`);
+        }
+
+        // Refuse rather than rewrite. Dropping entries we do not recognise
+        // would silently delete folders the user configured by hand, and a
+        // configuration tool that quietly narrows the boundary is as wrong as
+        // one that quietly widens it.
+        if (stored.allowedDirectories !== undefined && !Array.isArray(stored.allowedDirectories)) {
+          throw new Error(
+            `${PLUGIN_DATA_CONFIG_PATH} has an "allowedDirectories" that is not a list. `
+            + "Fix it by hand; refusing to replace a value you may have written deliberately.",
+          );
+        }
+        const existing = stored.allowedDirectories ?? [];
+        const unsupported = existing.filter(entry => typeof entry !== "string");
+        if (unsupported.length > 0) {
+          throw new Error(
+            `${PLUGIN_DATA_CONFIG_PATH} contains ${unsupported.length} entr${unsupported.length === 1 ? "y" : "ies"} `
+            + "that are not plain paths. Fix them by hand; refusing to drop entries you may have written deliberately.",
+          );
+        }
+
+        const already = new Set(existing.map(entry => canonicalizePathForPolicy(expandHostPlaceholders(entry))));
+        const accepted = additions.filter(entry => !already.has(entry.canonical));
+        const added = accepted.map(entry => entry.canonical);
+
+        stored.allowedDirectories = [...existing, ...added];
+        // Append rather than replace. The first draft kept only the most recent
+        // statement, so a later innocuous call erased the consent that had
+        // actually granted a sensitive folder. Nothing that only reports "no
+        // change" is recorded at all.
+        if (added.length > 0) {
+          const history = Array.isArray(stored._configurationHistory) ? stored._configurationHistory : [];
+          history.push({
+            user_intent_statement: String(args.user_intent_statement).trim(),
+            user_confirmed_at: new Date(Date.parse(String(args.user_confirmed_at).trim())).toISOString(),
+            requested: accepted.map(entry => entry.requested),
+            added,
+          });
+          stored._configurationHistory = history;
+        }
+
+        // Write through a temporary file and rename, so an interrupted write
+        // cannot leave the boundary unreadable.
+        //
+        // The name must be unpredictable and created exclusively. A review of
+        // the previous draft, which used `${config}.${pid}.tmp`, pointed out
+        // that a deterministic name lets a local actor pre-create it as a
+        // symlink: writeFile follows the link and truncates whatever it points
+        // at, before the rename ever runs. `wx` refuses to open an existing
+        // path of any kind, which closes that.
+        const temporary = `${PLUGIN_DATA_CONFIG_PATH}.${randomBytes(12).toString("hex")}.tmp`;
+        let handle;
+        try {
+          handle = await fs.open(temporary, "wx", 0o600);
+          await handle.writeFile(JSON.stringify(stored, null, 2) + "\n");
+          // Durability has to reach the disk before the rename claims it.
+          await handle.sync();
+        } finally {
+          await handle?.close().catch(() => {});
+        }
+        try {
+          await fs.rename(temporary, PLUGIN_DATA_CONFIG_PATH);
+        } catch (error) {
+          await fs.unlink(temporary).catch(() => {});
+          throw error;
+        }
+
+        // Deliberately not touching ALLOWED_DIRECTORIES. The boundary this
+        // session enforces stays exactly as the user last launched it.
+        const summary = added.length === 0
+          ? `Already configured, nothing changed. The stored configuration at ${PLUGIN_DATA_CONFIG_PATH} already lists: ${requested.join(", ")}.`
+          : `Added to ${PLUGIN_DATA_CONFIG_PATH}:\n${added.join("\n")}\n\n`
+            + "This does NOT affect the current session. Restart the server, then these folders will be reachable.";
+
+        return {
+          content: [{ type: "text", text: summary }],
+          structuredContent: {
+            added,
+            already_configured: requested.filter(directory => !added.includes(directory)),
+            config_path: PLUGIN_DATA_CONFIG_PATH,
+            restart_required: added.length > 0,
+            active_directories_unchanged: true,
+            active_directories: ALLOWED_DIRECTORIES.map(directory => directory.display),
+          },
+        };
+      }
+
       case "get_allowed_directories": {
         // Reporting the boundary is not reaching past it, so this answers even
         // when nothing is configured — which is exactly when it is most needed.
@@ -6319,7 +6708,15 @@ async function handleToolCall(request) {
         const summary = configured
           ? `Allowed folders (${ALLOWED_DIRECTORY_SOURCE.replace(/_/g, " ")}):\n${directories.join("\n")}`
           : PLUGIN_DATA_CONFIG_PATH
-            ? `No folders are allowed yet. List them in ${PLUGIN_DATA_CONFIG_PATH} under "allowedDirectories", then restart this server.`
+            // Deliberately not a paste-ready shell command. An adversarial
+            // review of an earlier draft pointed out two problems with one: a
+            // quote anywhere in PLUGIN_DATA_CONFIG_PATH turns the generated
+            // line into shell injection, and handing users a command that
+            // appends straight to allowedDirectories teaches them to bypass
+            // every check the configuration path applies. The file is the
+            // instruction; the user edits it themselves.
+            ? `No folders are allowed yet. Open this file and list the folders you want under "allowedDirectories", then restart:\n\n  ${PLUGIN_DATA_CONFIG_PATH}\n\n`
+              + `Absolute paths only. It replaces any default rather than adding to one, so list every folder you need.`
             : "No folders are allowed yet, and no configuration file location is available. Set the --allowed-directories argument or the ALLOWED_DIRECTORIES environment variable where this server is configured.";
 
         return {

--- a/server/output-schemas.js
+++ b/server/output-schemas.js
@@ -1289,6 +1289,17 @@ export const TOOL_SUCCESS_OUTPUT_SCHEMAS = Object.freeze({
     path: string,
     bytes: integer,
   }),
+  configure_allowed_directories: object({
+    added: arrayOf(string),
+    already_configured: arrayOf(string),
+    config_path: string,
+    restart_required: { type: "boolean" },
+    // Always true. Declared so a caller can read the promise off the contract
+    // rather than the prose: writing the stored configuration never widens the
+    // boundary the running session enforces.
+    active_directories_unchanged: { type: "boolean" },
+    active_directories: arrayOf(string),
+  }),
   get_allowed_directories: object({
     directories: arrayOf(string),
     configured: { type: "boolean" },

--- a/test/configure-allowed-directories.test.js
+++ b/test/configure-allowed-directories.test.js
@@ -1,0 +1,332 @@
+// configure_allowed_directories widens a security boundary, so these tests are
+// written against the guards rather than the happy path. The property that
+// matters most is the last one: writing the file must not change what the
+// running session is allowed to touch.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, mkdirSync, symlinkSync, linkSync, realpathSync, existsSync } from "fs";
+import { tmpdir, homedir } from "os";
+import path from "path";
+import { spawn } from "child_process";
+import { fileURLToPath } from "url";
+
+const SERVER = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "server", "index.js");
+
+// Holds one server process open across several calls. The first version of
+// this file killed the server after a single call, which made the property that
+// matters untestable: you cannot show that configuring did not widen access
+// without then asking the SAME process to read something.
+function openSession(pluginData, extraEnv = {}) {
+  const child = spawn(process.execPath, [SERVER], {
+    env: { PATH: process.env.PATH ?? "", PLUGIN_DATA: pluginData, ...extraEnv },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  let buffer = "";
+  const waiting = new Map();
+  child.stdout.on("data", chunk => {
+    buffer += chunk.toString();
+    let index;
+    while ((index = buffer.indexOf("\n")) >= 0) {
+      const line = buffer.slice(0, index).trim();
+      buffer = buffer.slice(index + 1);
+      if (!line) continue;
+      try {
+        const message = JSON.parse(line);
+        if (message.id && waiting.has(message.id)) {
+          waiting.get(message.id)(message);
+          waiting.delete(message.id);
+        }
+      } catch { /* the server may log non-JSON; ignore */ }
+    }
+  });
+
+  let nextId = 1;
+  const send = (method, params) => new Promise((resolve, reject) => {
+    const id = ++nextId;
+    waiting.set(id, resolve);
+    const timer = setTimeout(() => reject(new Error(`timeout on ${method}`)), 25000);
+    waiting.set(id, message => { clearTimeout(timer); resolve(message); });
+    child.stdin.write(JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n");
+  });
+
+  const ready = (async () => {
+    await send("initialize", {
+      protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "t", version: "1" },
+    });
+    child.stdin.write(JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }) + "\n");
+  })();
+
+  return {
+    async call(name, args) {
+      await ready;
+      return send("tools/call", { name, arguments: args });
+    },
+    close() { child.kill("SIGKILL"); },
+  };
+}
+
+// Single-call convenience for the rejection cases.
+async function callTool(pluginData, name, args, extraEnv = {}) {
+  const session = openSession(pluginData, extraEnv);
+  try {
+    return await session.call(name, args);
+  } finally {
+    session.close();
+  }
+}
+
+const nowIso = () => new Date().toISOString();
+
+describe("configure_allowed_directories", () => {
+  let pluginData;
+  let target;
+
+  beforeEach(() => {
+    pluginData = mkdtempSync(path.join(tmpdir(), "pdf-plugin-data-"));
+    target = mkdtempSync(path.join(tmpdir(), "pdf-target-"));
+  });
+  afterEach(() => {
+    rmSync(pluginData, { recursive: true, force: true });
+    rmSync(target, { recursive: true, force: true });
+  });
+
+  const configPath = () => path.join(pluginData, "config.json");
+  const readConfig = () => JSON.parse(readFileSync(configPath(), "utf8"));
+
+  // The property this whole design rests on. Asserting the handler's own
+  // `active_directories_unchanged` boolean proves nothing: it is hard-coded
+  // true, so it would keep saying true while access widened underneath it. An
+  // adversarial review named that as the central weakness of the first version
+  // of this test. So configure, then ask the SAME process to read a file in the
+  // folder just granted, and require it to still refuse.
+  it("does not widen the running session: a real read still refuses after configuring", async () => {
+    const pdf = path.join(target, "probe.pdf");
+    writeFileSync(pdf, "%PDF-1.4\n%%EOF\n");
+    const session = openSession(pluginData);
+    try {
+      const before = await session.call("list_pdfs", { directory: target });
+      expect(JSON.stringify(before)).toMatch(/allowed|not permitted|access/i);
+
+      const configured = await session.call("configure_allowed_directories", {
+        directories: [target],
+        user_intent_statement: `Please allow ${target} so you can read my files there.`,
+        user_confirmed_at: nowIso(),
+      });
+      expect(configured.error).toBeUndefined();
+      expect(configured.result.structuredContent.restart_required).toBe(true);
+      expect(readConfig().allowedDirectories).toContain(target);
+
+      // The file is on disk and readable; only the boundary should stop this.
+      const after = await session.call("list_pdfs", { directory: target });
+      expect(JSON.stringify(after)).toMatch(/allowed|not permitted|access/i);
+      expect(JSON.stringify(after)).not.toContain("probe.pdf");
+    } finally {
+      session.close();
+    }
+  });
+
+  it("stores the resolved target so retargeting the symlink later cannot widen it", async () => {
+    const benign = path.join(target, "benign");
+    const forbidden = path.join(target, "forbidden");
+    mkdirSync(benign); mkdirSync(forbidden);
+    const link = path.join(target, "link");
+    symlinkSync(benign, link);
+
+    const result = await callTool(pluginData, "configure_allowed_directories", {
+      directories: [link],
+      user_intent_statement: `Please allow ${link} for me.`,
+      user_confirmed_at: nowIso(),
+    });
+    expect(result.error).toBeUndefined();
+
+    // Repointing the name must not move the grant.
+    rmSync(link); symlinkSync(forbidden, link);
+    const stored = readConfig().allowedDirectories.map(entry => realpathSync(entry));
+    expect(stored).toContain(realpathSync(benign));
+    expect(stored).not.toContain(realpathSync(forbidden));
+  });
+
+  it("refuses a parent of the folder the user named", async () => {
+    const child = path.join(target, "taxes", "2025");
+    mkdirSync(child, { recursive: true });
+    const result = await callTool(pluginData, "configure_allowed_directories", {
+      directories: [target],
+      user_intent_statement: `Please allow ${child} so you can read my return.`,
+      user_confirmed_at: nowIso(),
+    });
+    expect(JSON.stringify(result)).toMatch(/must name each folder/i);
+    expect(existsSync(configPath()) ? readConfig().allowedDirectories : []).not.toContain(target);
+  });
+
+  it("refuses shallow system directories, not just root and home", async () => {
+    for (const directory of ["/etc", "/var", "/usr"]) {
+      const result = await callTool(pluginData, "configure_allowed_directories", {
+        directories: [directory],
+        user_intent_statement: `Please allow ${directory} for me.`,
+        user_confirmed_at: nowIso(),
+      });
+      expect(JSON.stringify(result)).toMatch(/too broad|system or multi-user|filesystem root/i);
+    }
+  });
+
+  it("refuses a folder holding a second hard link to its own config file", async () => {
+    const result0 = await callTool(pluginData, "configure_allowed_directories", {
+      directories: [target],
+      user_intent_statement: `Please allow ${target} for me.`,
+      user_confirmed_at: nowIso(),
+    });
+    expect(result0.error).toBeUndefined();
+    linkSync(configPath(), path.join(target, "alias.json"));
+    const result = await callTool(pluginData, "configure_allowed_directories", {
+      directories: [target],
+      user_intent_statement: `Please allow ${target} again for me.`,
+      user_confirmed_at: nowIso(),
+    });
+    expect(JSON.stringify(result)).toMatch(/another name for this server's own configuration/i);
+  });
+
+  it("rejects a non-ISO timestamp that Date.parse would otherwise accept", async () => {
+    const result = await callTool(pluginData, "configure_allowed_directories", {
+      directories: [target],
+      user_intent_statement: `Please allow ${target} for me.`,
+      user_confirmed_at: "August 9, 2026 16:20 UTC",
+    });
+    expect(JSON.stringify(result)).toMatch(/ISO-8601/i);
+  });
+
+  it("refuses when the intent statement does not name the folder", async () => {
+    const result = await callTool(pluginData, "configure_allowed_directories", {
+      directories: [target],
+      user_intent_statement: "Yes, go ahead and allow that folder, that is fine by me.",
+      user_confirmed_at: nowIso(),
+    });
+    expect(JSON.stringify(result)).toMatch(/must name each folder/i);
+  });
+
+  it("refuses a confirmation older than a day, and one from the future", async () => {
+    const stale = await callTool(pluginData, "configure_allowed_directories", {
+      directories: [target],
+      user_intent_statement: `Allow ${target} please.`,
+      user_confirmed_at: new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString(),
+    });
+    expect(JSON.stringify(stale)).toMatch(/24 hours/i);
+
+    const future = await callTool(pluginData, "configure_allowed_directories", {
+      directories: [target],
+      user_intent_statement: `Allow ${target} please.`,
+      user_confirmed_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+    });
+    expect(JSON.stringify(future)).toMatch(/future/i);
+  });
+
+  it("refuses the home folder and the filesystem root", async () => {
+    const home = await callTool(pluginData, "configure_allowed_directories", {
+      directories: [homedir()],
+      user_intent_statement: `Allow ${homedir()} please.`,
+      user_confirmed_at: nowIso(),
+    });
+    expect(JSON.stringify(home)).toMatch(/home folder/i);
+
+    const root = path.parse(process.cwd()).root;
+    const rootResult = await callTool(pluginData, "configure_allowed_directories", {
+      directories: [root],
+      user_intent_statement: `Allow ${root} please.`,
+      user_confirmed_at: nowIso(),
+    });
+    expect(JSON.stringify(rootResult)).toMatch(/filesystem root/i);
+  });
+
+  it("refuses a folder that contains its own configuration file", async () => {
+    const result = await callTool(pluginData, "configure_allowed_directories", {
+      directories: [pluginData],
+      user_intent_statement: `Allow ${pluginData} please.`,
+      user_confirmed_at: nowIso(),
+    });
+    expect(JSON.stringify(result)).toMatch(/own configuration file/i);
+  });
+
+  it("refuses a folder that does not exist rather than creating one", async () => {
+    const missing = path.join(target, "not-here");
+    const result = await callTool(pluginData, "configure_allowed_directories", {
+      directories: [missing],
+      user_intent_statement: `Allow ${missing} please.`,
+      user_confirmed_at: nowIso(),
+    });
+    expect(JSON.stringify(result)).toMatch(/does not exist/i);
+  });
+
+  it("keeps folders the user configured by hand instead of replacing them", async () => {
+    const handWritten = mkdtempSync(path.join(tmpdir(), "pdf-hand-"));
+    try {
+      mkdirSync(pluginData, { recursive: true });
+      writeFileSync(configPath(), JSON.stringify({ allowedDirectories: [handWritten] }, null, 2));
+      await callTool(pluginData, "configure_allowed_directories", {
+        directories: [target],
+        user_intent_statement: `Also allow ${target} please.`,
+        user_confirmed_at: nowIso(),
+      });
+      const stored = readConfig().allowedDirectories;
+      expect(stored).toContain(handWritten);
+      expect(stored).toContain(target);
+    } finally {
+      rmSync(handWritten, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses to overwrite a configuration file it cannot parse", async () => {
+    mkdirSync(pluginData, { recursive: true });
+    writeFileSync(configPath(), "{ this is not json");
+    const result = await callTool(pluginData, "configure_allowed_directories", {
+      directories: [target],
+      user_intent_statement: `Allow ${target} please.`,
+      user_confirmed_at: nowIso(),
+    });
+    expect(JSON.stringify(result)).toMatch(/not valid JSON/i);
+    expect(readFileSync(configPath(), "utf8")).toBe("{ this is not json");
+  });
+
+  it("appends consent history rather than overwriting it", async () => {
+    const second = mkdtempSync(path.join(tmpdir(), "pdf-second-"));
+    try {
+      const first = `I want you to be able to read ${target}, please allow it.`;
+      await callTool(pluginData, "configure_allowed_directories", {
+        directories: [target], user_intent_statement: first, user_confirmed_at: nowIso(),
+      });
+      await callTool(pluginData, "configure_allowed_directories", {
+        directories: [second],
+        user_intent_statement: `Also allow ${second} please.`,
+        user_confirmed_at: nowIso(),
+      });
+      const history = readConfig()._configurationHistory;
+      expect(history).toHaveLength(2);
+      // The consent that granted the first folder must survive the second call.
+      expect(history[0].user_intent_statement).toBe(first);
+    } finally {
+      rmSync(second, { recursive: true, force: true });
+    }
+  });
+
+  it("records nothing when a call adds nothing", async () => {
+    const statement = `Please allow ${target} for me.`;
+    await callTool(pluginData, "configure_allowed_directories", {
+      directories: [target], user_intent_statement: statement, user_confirmed_at: nowIso(),
+    });
+    await callTool(pluginData, "configure_allowed_directories", {
+      directories: [target],
+      user_intent_statement: `Something bland about ${target}.`,
+      user_confirmed_at: nowIso(),
+    });
+    const history = readConfig()._configurationHistory;
+    expect(history).toHaveLength(1);
+    expect(history[0].user_intent_statement).toBe(statement);
+  });
+
+  it("refuses entirely where the host owns the settings, writing nothing", async () => {
+    const result = await callTool("", "configure_allowed_directories", {
+      directories: [target],
+      user_intent_statement: `Allow ${target} please.`,
+      user_confirmed_at: nowIso(),
+    }, { ALLOWED_DIRECTORIES: target });
+    expect(JSON.stringify(result)).toMatch(/no stored configuration file/i);
+  });
+});


### PR DESCRIPTION
**Do not merge.** Opened as a record of a design that was tried and rejected, so the next person does not rediscover it from scratch.

## What it does

Agent Plugins defines no user-configuration surface, so on plugin installs the only way to widen the filesystem boundary is hand-editing JSON under a 64-character hex path. This adds a tool that writes that file.

## Why it is blocked

Three independent adversarial reviews. The first two found implementation defects, all since fixed: a symlink validated and then stored by its unresolved name, a substring intent check that allowed parent escalation, an overbroad list that knew only root and home, a pathname-only self-grant check defeated by a hard link, a predictable temporary filename open to symlink clobbering, destructive audit records, and a central test that asserted a hard-coded boolean and would have passed even if access had widened.

The third review identified the problem as conceptual rather than fixable:

> The subject constrained by the filesystem boundary can call a tool that persists a wider boundary for its own future execution. A delayed effect is not an authorization control, especially when the host may restart automatically.

That is right. The server receives a string from its caller. It cannot know who wrote it, and it cannot tell agreement from refusal: `Do not allow /x` satisfies every check. No amount of string inspection turns a caller-supplied value into consent.

## What is still true and worth keeping

- It genuinely cannot widen the session that calls it, and there is a test that proves it by configuring a folder and then requiring `list_pdfs` to still refuse in the same process.
- The subtree self-grant scan, the exclusive temporary-file create, and the ISO-8601 timestamp handling are sound improvements in isolation.

## If someone picks this up

The gap is real and worth solving; this shape is not the solution. A workable design needs authorization the server can actually verify, which likely means something outside the agent's reach: a host-provided consent surface, a one-time out-of-band token, or a file the user touches themselves. Until then the hand-edited configuration file is the honest mechanism, because the human action is the edit itself.

Known unfixed here: concurrent writers can lose an update; the subtree scan has a TOCTOU window; `lstat` failures fail open.
