### PR TITLE
Read allowed folders from ~/.pdf-tools/config.json

### DIFF
--- a/pdf-toolkit-mcp-share/server/index.js
+++ b/pdf-toolkit-mcp-share/server/index.js
@@ -242,14 +242,13 @@ function assertPathAllowed(resolvedPath) {
     const error = new Error(
       ALLOWED_DIRECTORIES.length === 0
         ? "No allowed directories are configured, so this server refused the request. "
+          + `List the folders you want reachable in ${HOME_CONFIG_PATH}, under `
+          + "\"allowedDirectories\", then restart this server. "
           + (PLUGIN_DATA_CONFIG_PATH
-            ? `List the folders you want reachable in ${PLUGIN_DATA_CONFIG_PATH}, under `
-              + "\"allowedDirectories\", then restart this server. That file is edited by you, "
-              + "not by the assistant."
-            : "Set the allowed list where this server is configured. Hosts with a settings UI "
-              + "expose it as allowed_directories; otherwise set the --allowed-directories argument, "
-              + "which takes precedence, or the ALLOWED_DIRECTORIES environment variable, which "
-              + "applies only when that argument is absent.")
+            ? `A plugin-specific file at ${PLUGIN_DATA_CONFIG_PATH} takes precedence when present. `
+            : "")
+          + "Hosts with a settings UI may instead set --allowed-directories or the "
+          + "ALLOWED_DIRECTORIES environment variable."
         : `This server is only allowed to access: ${allowed}. ` +
           `Tried to access: ${resolvedPath}. ` +
           "The allowed list must be set where this server is configured, and it replaces " +
@@ -1447,16 +1446,20 @@ function parsePathListValue(rawValue) {
 // Agent Plugins 1.0.0 has no user-configuration mechanism and expands only
 // ${PLUGIN_ROOT} and ${PLUGIN_DATA}, so a plugin install can reach neither the
 // CLI flag nor the environment variable a host would otherwise set. PLUGIN_DATA
-// is the one location that specification guarantees exists, stays writable, and
-// survives plugin updates, which makes it the only place a stored allowed set
-// can live. It is the lowest layer: a host that does supply configuration is
-// stating an intent a stored file must not override.
+// is one location that specification guarantees exists, stays writable, and
+// survives plugin updates. A plugin data file outranks the well-known home file,
+// while host-supplied argument or environment configuration outranks both.
 const PLUGIN_DATA_CONFIG_NAME = "config.json";
+const HOME_CONFIG_DIRECTORY_NAME = ".pdf-tools";
 
 function pluginDataConfigPath() {
   const pluginData = process.env.PLUGIN_DATA;
   if (!pluginData || pluginData.includes("${")) return null;
   return path.join(path.resolve(pluginData), PLUGIN_DATA_CONFIG_NAME);
+}
+
+function homeConfigPath() {
+  return path.join(homedir(), HOME_CONFIG_DIRECTORY_NAME, PLUGIN_DATA_CONFIG_NAME);
 }
 
 // A fresh install has nothing configured and must refuse every path. Writing
@@ -1483,28 +1486,51 @@ function ensurePluginDataConfigTemplate(configPath) {
   }
 }
 
+// Create the discoverable template only when no higher layer supplied a value.
+// Resolve the target through existing ancestors before writing so a symlinked
+// .pdf-tools directory cannot redirect first-run setup outside the home folder.
+function ensureHomeConfigTemplate(configPath) {
+  if (!configPath || existsSync(configPath)) return;
+  const canonicalHome = canonicalizePathForPolicy(homedir());
+  const canonicalConfig = canonicalizePathForPolicy(configPath);
+  if (!isPathInsideDirectory(canonicalConfig, canonicalHome)) {
+    console.error(`[pdf-tools] Refusing to create ${configPath} because it resolves outside the home directory.`);
+    return;
+  }
+  ensurePluginDataConfigTemplate(configPath);
+}
+
 // Returns the configured list, or null when this layer supplies nothing. A
-// malformed file returns an empty list rather than null, to say "configured,
-// badly" rather than "not configured". Today both end at an empty set because
-// this is the lowest layer, so the distinction is defensive rather than
-// observable; it matters the moment anything is added below it.
-function readPluginDataConfig(configPath) {
-  if (!configPath || !existsSync(configPath)) return null;
+// malformed file returns an empty list rather than null, to say "present,
+// badly" rather than "not present". That distinction prevents a malformed or
+// empty higher-precedence file from falling through to a lower layer.
+// Three outcomes, not two. Collapsing "present but unusable" and "present and
+// deliberately empty" into one empty list forces a single precedence answer for
+// two different situations, and either answer is wrong for the other:
+//
+//   malformed  -> authoritative, fail closed. Falling through to a lower layer
+//                 would silently paper over a file the user needs to fix.
+//   valid+empty -> not a configuration. It must NOT shadow a lower layer, or
+//                 anyone upgrading from a version that wrote an empty template
+//                 finds the friendlier file they just edited silently ignored.
+function readAllowedDirectoriesConfig(configPath) {
+  if (!configPath || !existsSync(configPath)) return { status: "absent", directories: [] };
   let parsed;
   try {
     parsed = JSON.parse(readFileSync(configPath, "utf8"));
   } catch {
     console.error(`[pdf-tools] ${configPath} is not valid JSON. No directories are allowed until it is fixed.`);
-    return [];
+    return { status: "malformed", directories: [] };
   }
   if (!parsed || typeof parsed !== "object" || !Array.isArray(parsed.allowedDirectories)) {
     console.error(`[pdf-tools] ${configPath} needs an "allowedDirectories" array. No directories are allowed until it is fixed.`);
-    return [];
+    return { status: "malformed", directories: [] };
   }
-  return parsed.allowedDirectories
+  const directories = parsed.allowedDirectories
     .filter(entry => typeof entry === "string")
     .map(entry => expandHostPlaceholders(entry.trim()))
     .filter(entry => entry && !entry.includes("${"));
+  return { status: "ok", directories };
 }
 
 // A set that reaches the config file lets any write tool rewrite the sandbox on
@@ -1519,13 +1545,18 @@ function grantsAccessToOwnConfig(directories, configPath) {
 // Which precedence layer actually supplied the active set. Reported by
 // get_allowed_directories so an operator can tell where to change it.
 let ALLOWED_DIRECTORY_SOURCE = "none";
+const PLUGIN_DATA_CONFIG_PATH = pluginDataConfigPath();
+const HOME_CONFIG_PATH = homeConfigPath();
+let ALLOWED_DIRECTORY_CONFIG_PATH = PLUGIN_DATA_CONFIG_PATH;
 
 function buildAllowedDirectories() {
-  const configPath = pluginDataConfigPath();
+  const pluginConfigPath = PLUGIN_DATA_CONFIG_PATH;
+  const userHomeConfigPath = HOME_CONFIG_PATH;
   const argumentDirectories = parseAllowedDirectoryArgs(process.argv.slice(2));
   const environmentDirectories = parsePathListValue(process.env.ALLOWED_DIRECTORIES);
 
   let configuredDirectories;
+  let boundaryConfigPath = pluginConfigPath;
   if (argumentDirectories?.length) {
     configuredDirectories = argumentDirectories;
     ALLOWED_DIRECTORY_SOURCE = "argument";
@@ -1533,10 +1564,25 @@ function buildAllowedDirectories() {
     configuredDirectories = environmentDirectories;
     ALLOWED_DIRECTORY_SOURCE = "environment";
   } else {
-    ensurePluginDataConfigTemplate(configPath);
-    const fromConfig = readPluginDataConfig(configPath);
-    configuredDirectories = fromConfig ?? [];
-    ALLOWED_DIRECTORY_SOURCE = fromConfig?.length ? "config_file" : "none";
+    const fromPluginConfig = readAllowedDirectoriesConfig(pluginConfigPath);
+    if (fromPluginConfig.status === "malformed" || fromPluginConfig.directories.length > 0) {
+      configuredDirectories = fromPluginConfig.directories;
+      boundaryConfigPath = pluginConfigPath;
+      ALLOWED_DIRECTORY_CONFIG_PATH = pluginConfigPath;
+      ALLOWED_DIRECTORY_SOURCE = fromPluginConfig.directories.length ? "config_file" : "none";
+    } else {
+      const fromHomeConfig = readAllowedDirectoriesConfig(userHomeConfigPath);
+      boundaryConfigPath = userHomeConfigPath;
+      ALLOWED_DIRECTORY_CONFIG_PATH = userHomeConfigPath;
+      if (fromHomeConfig.status !== "absent") {
+        configuredDirectories = fromHomeConfig.directories;
+        ALLOWED_DIRECTORY_SOURCE = fromHomeConfig.directories.length ? "home_config_file" : "none";
+      } else {
+        configuredDirectories = [];
+        ALLOWED_DIRECTORY_SOURCE = "none";
+        ensureHomeConfigTemplate(userHomeConfigPath);
+      }
+    }
   }
 
   const seen = new Set();
@@ -1553,9 +1599,9 @@ function buildAllowedDirectories() {
       return true;
     });
 
-  if (grantsAccessToOwnConfig(resolved, configPath)) {
+  if (grantsAccessToOwnConfig(resolved, boundaryConfigPath)) {
     console.error(
-      `[pdf-tools] The allowed directories reach ${configPath}, which would let this `
+      `[pdf-tools] The allowed directories reach ${boundaryConfigPath}, which would let this `
       + "server rewrite its own boundary. No directories are allowed until that entry is removed.",
     );
     ALLOWED_DIRECTORY_SOURCE = "refused_self_granting";
@@ -1564,7 +1610,6 @@ function buildAllowedDirectories() {
   return resolved;
 }
 
-const PLUGIN_DATA_CONFIG_PATH = pluginDataConfigPath();
 const ALLOWED_DIRECTORIES = buildAllowedDirectories();
 
 // Where a tool browses when the caller names no directory. An explicitly
@@ -6356,9 +6401,10 @@ async function handleToolCall(request) {
         const configured = directories.length > 0;
         const summary = configured
           ? `Allowed folders (${ALLOWED_DIRECTORY_SOURCE.replace(/_/g, " ")}):\n${directories.join("\n")}`
-          : PLUGIN_DATA_CONFIG_PATH
-            ? `No folders are allowed yet. List them in ${PLUGIN_DATA_CONFIG_PATH} under "allowedDirectories", then restart this server.`
-            : "No folders are allowed yet, and no configuration file location is available. Set the --allowed-directories argument or the ALLOWED_DIRECTORIES environment variable where this server is configured.";
+          : `No folders are allowed yet. List them in ${HOME_CONFIG_PATH} under "allowedDirectories", then restart this server.`
+            + (PLUGIN_DATA_CONFIG_PATH
+              ? ` A plugin-specific file at ${PLUGIN_DATA_CONFIG_PATH} takes precedence when present.`
+              : "");
 
         return {
           content: [{ type: "text", text: summary }],
@@ -6366,7 +6412,7 @@ async function handleToolCall(request) {
             directories,
             configured,
             source: ALLOWED_DIRECTORY_SOURCE,
-            config_path: PLUGIN_DATA_CONFIG_PATH ?? null,
+            config_path: ALLOWED_DIRECTORY_CONFIG_PATH ?? null,
           },
         };
       }

--- a/pdf-toolkit-mcp-share/server/output-schemas.js
+++ b/pdf-toolkit-mcp-share/server/output-schemas.js
@@ -1292,7 +1292,7 @@ export const TOOL_SUCCESS_OUTPUT_SCHEMAS = Object.freeze({
   get_allowed_directories: object({
     directories: arrayOf(string),
     configured: { type: "boolean" },
-    source: enumString(["argument", "environment", "config_file", "none", "refused_self_granting"]),
+    source: enumString(["argument", "environment", "config_file", "home_config_file", "none", "refused_self_granting"]),
     config_path: nullable(string),
   }),
   list_signatures: object({

--- a/server/index.js
+++ b/server/index.js
@@ -242,14 +242,13 @@ function assertPathAllowed(resolvedPath) {
     const error = new Error(
       ALLOWED_DIRECTORIES.length === 0
         ? "No allowed directories are configured, so this server refused the request. "
+          + `List the folders you want reachable in ${HOME_CONFIG_PATH}, under `
+          + "\"allowedDirectories\", then restart this server. "
           + (PLUGIN_DATA_CONFIG_PATH
-            ? `List the folders you want reachable in ${PLUGIN_DATA_CONFIG_PATH}, under `
-              + "\"allowedDirectories\", then restart this server. That file is edited by you, "
-              + "not by the assistant."
-            : "Set the allowed list where this server is configured. Hosts with a settings UI "
-              + "expose it as allowed_directories; otherwise set the --allowed-directories argument, "
-              + "which takes precedence, or the ALLOWED_DIRECTORIES environment variable, which "
-              + "applies only when that argument is absent.")
+            ? `A plugin-specific file at ${PLUGIN_DATA_CONFIG_PATH} takes precedence when present. `
+            : "")
+          + "Hosts with a settings UI may instead set --allowed-directories or the "
+          + "ALLOWED_DIRECTORIES environment variable."
         : `This server is only allowed to access: ${allowed}. ` +
           `Tried to access: ${resolvedPath}. ` +
           "The allowed list must be set where this server is configured, and it replaces " +
@@ -1447,16 +1446,20 @@ function parsePathListValue(rawValue) {
 // Agent Plugins 1.0.0 has no user-configuration mechanism and expands only
 // ${PLUGIN_ROOT} and ${PLUGIN_DATA}, so a plugin install can reach neither the
 // CLI flag nor the environment variable a host would otherwise set. PLUGIN_DATA
-// is the one location that specification guarantees exists, stays writable, and
-// survives plugin updates, which makes it the only place a stored allowed set
-// can live. It is the lowest layer: a host that does supply configuration is
-// stating an intent a stored file must not override.
+// is one location that specification guarantees exists, stays writable, and
+// survives plugin updates. A plugin data file outranks the well-known home file,
+// while host-supplied argument or environment configuration outranks both.
 const PLUGIN_DATA_CONFIG_NAME = "config.json";
+const HOME_CONFIG_DIRECTORY_NAME = ".pdf-tools";
 
 function pluginDataConfigPath() {
   const pluginData = process.env.PLUGIN_DATA;
   if (!pluginData || pluginData.includes("${")) return null;
   return path.join(path.resolve(pluginData), PLUGIN_DATA_CONFIG_NAME);
+}
+
+function homeConfigPath() {
+  return path.join(homedir(), HOME_CONFIG_DIRECTORY_NAME, PLUGIN_DATA_CONFIG_NAME);
 }
 
 // A fresh install has nothing configured and must refuse every path. Writing
@@ -1483,28 +1486,51 @@ function ensurePluginDataConfigTemplate(configPath) {
   }
 }
 
+// Create the discoverable template only when no higher layer supplied a value.
+// Resolve the target through existing ancestors before writing so a symlinked
+// .pdf-tools directory cannot redirect first-run setup outside the home folder.
+function ensureHomeConfigTemplate(configPath) {
+  if (!configPath || existsSync(configPath)) return;
+  const canonicalHome = canonicalizePathForPolicy(homedir());
+  const canonicalConfig = canonicalizePathForPolicy(configPath);
+  if (!isPathInsideDirectory(canonicalConfig, canonicalHome)) {
+    console.error(`[pdf-tools] Refusing to create ${configPath} because it resolves outside the home directory.`);
+    return;
+  }
+  ensurePluginDataConfigTemplate(configPath);
+}
+
 // Returns the configured list, or null when this layer supplies nothing. A
-// malformed file returns an empty list rather than null, to say "configured,
-// badly" rather than "not configured". Today both end at an empty set because
-// this is the lowest layer, so the distinction is defensive rather than
-// observable; it matters the moment anything is added below it.
-function readPluginDataConfig(configPath) {
-  if (!configPath || !existsSync(configPath)) return null;
+// malformed file returns an empty list rather than null, to say "present,
+// badly" rather than "not present". That distinction prevents a malformed or
+// empty higher-precedence file from falling through to a lower layer.
+// Three outcomes, not two. Collapsing "present but unusable" and "present and
+// deliberately empty" into one empty list forces a single precedence answer for
+// two different situations, and either answer is wrong for the other:
+//
+//   malformed  -> authoritative, fail closed. Falling through to a lower layer
+//                 would silently paper over a file the user needs to fix.
+//   valid+empty -> not a configuration. It must NOT shadow a lower layer, or
+//                 anyone upgrading from a version that wrote an empty template
+//                 finds the friendlier file they just edited silently ignored.
+function readAllowedDirectoriesConfig(configPath) {
+  if (!configPath || !existsSync(configPath)) return { status: "absent", directories: [] };
   let parsed;
   try {
     parsed = JSON.parse(readFileSync(configPath, "utf8"));
   } catch {
     console.error(`[pdf-tools] ${configPath} is not valid JSON. No directories are allowed until it is fixed.`);
-    return [];
+    return { status: "malformed", directories: [] };
   }
   if (!parsed || typeof parsed !== "object" || !Array.isArray(parsed.allowedDirectories)) {
     console.error(`[pdf-tools] ${configPath} needs an "allowedDirectories" array. No directories are allowed until it is fixed.`);
-    return [];
+    return { status: "malformed", directories: [] };
   }
-  return parsed.allowedDirectories
+  const directories = parsed.allowedDirectories
     .filter(entry => typeof entry === "string")
     .map(entry => expandHostPlaceholders(entry.trim()))
     .filter(entry => entry && !entry.includes("${"));
+  return { status: "ok", directories };
 }
 
 // A set that reaches the config file lets any write tool rewrite the sandbox on
@@ -1519,13 +1545,18 @@ function grantsAccessToOwnConfig(directories, configPath) {
 // Which precedence layer actually supplied the active set. Reported by
 // get_allowed_directories so an operator can tell where to change it.
 let ALLOWED_DIRECTORY_SOURCE = "none";
+const PLUGIN_DATA_CONFIG_PATH = pluginDataConfigPath();
+const HOME_CONFIG_PATH = homeConfigPath();
+let ALLOWED_DIRECTORY_CONFIG_PATH = PLUGIN_DATA_CONFIG_PATH;
 
 function buildAllowedDirectories() {
-  const configPath = pluginDataConfigPath();
+  const pluginConfigPath = PLUGIN_DATA_CONFIG_PATH;
+  const userHomeConfigPath = HOME_CONFIG_PATH;
   const argumentDirectories = parseAllowedDirectoryArgs(process.argv.slice(2));
   const environmentDirectories = parsePathListValue(process.env.ALLOWED_DIRECTORIES);
 
   let configuredDirectories;
+  let boundaryConfigPath = pluginConfigPath;
   if (argumentDirectories?.length) {
     configuredDirectories = argumentDirectories;
     ALLOWED_DIRECTORY_SOURCE = "argument";
@@ -1533,10 +1564,25 @@ function buildAllowedDirectories() {
     configuredDirectories = environmentDirectories;
     ALLOWED_DIRECTORY_SOURCE = "environment";
   } else {
-    ensurePluginDataConfigTemplate(configPath);
-    const fromConfig = readPluginDataConfig(configPath);
-    configuredDirectories = fromConfig ?? [];
-    ALLOWED_DIRECTORY_SOURCE = fromConfig?.length ? "config_file" : "none";
+    const fromPluginConfig = readAllowedDirectoriesConfig(pluginConfigPath);
+    if (fromPluginConfig.status === "malformed" || fromPluginConfig.directories.length > 0) {
+      configuredDirectories = fromPluginConfig.directories;
+      boundaryConfigPath = pluginConfigPath;
+      ALLOWED_DIRECTORY_CONFIG_PATH = pluginConfigPath;
+      ALLOWED_DIRECTORY_SOURCE = fromPluginConfig.directories.length ? "config_file" : "none";
+    } else {
+      const fromHomeConfig = readAllowedDirectoriesConfig(userHomeConfigPath);
+      boundaryConfigPath = userHomeConfigPath;
+      ALLOWED_DIRECTORY_CONFIG_PATH = userHomeConfigPath;
+      if (fromHomeConfig.status !== "absent") {
+        configuredDirectories = fromHomeConfig.directories;
+        ALLOWED_DIRECTORY_SOURCE = fromHomeConfig.directories.length ? "home_config_file" : "none";
+      } else {
+        configuredDirectories = [];
+        ALLOWED_DIRECTORY_SOURCE = "none";
+        ensureHomeConfigTemplate(userHomeConfigPath);
+      }
+    }
   }
 
   const seen = new Set();
@@ -1553,9 +1599,9 @@ function buildAllowedDirectories() {
       return true;
     });
 
-  if (grantsAccessToOwnConfig(resolved, configPath)) {
+  if (grantsAccessToOwnConfig(resolved, boundaryConfigPath)) {
     console.error(
-      `[pdf-tools] The allowed directories reach ${configPath}, which would let this `
+      `[pdf-tools] The allowed directories reach ${boundaryConfigPath}, which would let this `
       + "server rewrite its own boundary. No directories are allowed until that entry is removed.",
     );
     ALLOWED_DIRECTORY_SOURCE = "refused_self_granting";
@@ -1564,7 +1610,6 @@ function buildAllowedDirectories() {
   return resolved;
 }
 
-const PLUGIN_DATA_CONFIG_PATH = pluginDataConfigPath();
 const ALLOWED_DIRECTORIES = buildAllowedDirectories();
 
 // Where a tool browses when the caller names no directory. An explicitly
@@ -6356,9 +6401,10 @@ async function handleToolCall(request) {
         const configured = directories.length > 0;
         const summary = configured
           ? `Allowed folders (${ALLOWED_DIRECTORY_SOURCE.replace(/_/g, " ")}):\n${directories.join("\n")}`
-          : PLUGIN_DATA_CONFIG_PATH
-            ? `No folders are allowed yet. List them in ${PLUGIN_DATA_CONFIG_PATH} under "allowedDirectories", then restart this server.`
-            : "No folders are allowed yet, and no configuration file location is available. Set the --allowed-directories argument or the ALLOWED_DIRECTORIES environment variable where this server is configured.";
+          : `No folders are allowed yet. List them in ${HOME_CONFIG_PATH} under "allowedDirectories", then restart this server.`
+            + (PLUGIN_DATA_CONFIG_PATH
+              ? ` A plugin-specific file at ${PLUGIN_DATA_CONFIG_PATH} takes precedence when present.`
+              : "");
 
         return {
           content: [{ type: "text", text: summary }],
@@ -6366,7 +6412,7 @@ async function handleToolCall(request) {
             directories,
             configured,
             source: ALLOWED_DIRECTORY_SOURCE,
-            config_path: PLUGIN_DATA_CONFIG_PATH ?? null,
+            config_path: ALLOWED_DIRECTORY_CONFIG_PATH ?? null,
           },
         };
       }

--- a/server/output-schemas.js
+++ b/server/output-schemas.js
@@ -1292,7 +1292,7 @@ export const TOOL_SUCCESS_OUTPUT_SCHEMAS = Object.freeze({
   get_allowed_directories: object({
     directories: arrayOf(string),
     configured: { type: "boolean" },
-    source: enumString(["argument", "environment", "config_file", "none", "refused_self_granting"]),
+    source: enumString(["argument", "environment", "config_file", "home_config_file", "none", "refused_self_granting"]),
     config_path: nullable(string),
   }),
   list_signatures: object({

--- a/test/get-allowed-directories.test.js
+++ b/test/get-allowed-directories.test.js
@@ -115,7 +115,9 @@ describe("get_allowed_directories", () => {
     expect(result.isError).not.toBe(true);
     expect(result.structuredContent.configured).toBe(false);
     expect(result.structuredContent.directories).toEqual([]);
-    expect(result.structuredContent.config_path).toBe(path.join(emptyPluginData, "config.json"));
+    expect(result.structuredContent.config_path).toBe(
+      path.join(tempDirectory, "home", ".pdf-tools", "config.json"),
+    );
   }, 30_000);
 
   it("is annotated read-only and takes no arguments", async () => {

--- a/test/home-config-location.test.js
+++ b/test/home-config-location.test.js
@@ -1,0 +1,364 @@
+import fs from "fs/promises";
+import path from "path";
+import { fileURLToPath } from "url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { createTestTempDirectory, removeTestTempDirectory } from "./helpers/temp-directory.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.join(__dirname, "..");
+const SERVER_ENTRY = path.join(REPO_ROOT, "server", "index.js");
+const EXAMPLE_PDF = path.join(REPO_ROOT, "example-fw9.pdf");
+
+function textFromToolResult(result) {
+  return result.content?.map(item => item.type === "text" ? item.text : "").join(" ") || "";
+}
+
+function structuredErrorCode(result) {
+  return result.structuredContent?.error?.code;
+}
+
+async function withServer({ args = [], env = {}, name }, run) {
+  const client = new Client({ name, version: "1.0.0" });
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [SERVER_ENTRY, ...args],
+    cwd: REPO_ROOT,
+    env: { PATH: process.env.PATH ?? "", ...env },
+    stderr: "pipe",
+  });
+  await client.connect(transport);
+  try {
+    return await run(client);
+  } finally {
+    await transport.close();
+  }
+}
+
+function homeConfigPath(home) {
+  return path.join(home, ".pdf-tools", "config.json");
+}
+
+async function writeHomeConfig(home, allowedDirectories) {
+  const configPath = homeConfigPath(home);
+  await fs.mkdir(path.dirname(configPath), { recursive: true });
+  await fs.writeFile(configPath, JSON.stringify({ allowedDirectories }));
+  return configPath;
+}
+
+describe("well-known home allowed-directories configuration", () => {
+  let tempDirectory;
+
+  beforeAll(async () => {
+    tempDirectory = await createTestTempDirectory(REPO_ROOT, "home-config-location");
+  }, 30_000);
+
+  afterAll(async () => {
+    await removeTestTempDirectory(tempDirectory);
+  });
+
+  it("uses the home file and reports that layer and exact path", async () => {
+    const home = path.join(tempDirectory, "reported-home");
+    const documents = path.join(tempDirectory, "reported-documents");
+    await fs.mkdir(documents, { recursive: true });
+    await fs.copyFile(EXAMPLE_PDF, path.join(documents, "from-home.pdf"));
+    const configPath = await writeHomeConfig(home, [documents]);
+
+    const { listing, boundary } = await withServer({
+      name: "home-config-reported",
+      env: { HOME: home },
+    }, async client => ({
+      listing: await client.callTool({ name: "list_pdfs", arguments: { directory: documents } }),
+      boundary: await client.callTool({ name: "get_allowed_directories", arguments: {} }),
+    }));
+
+    expect(textFromToolResult(listing)).toContain("from-home.pdf");
+    expect(boundary.structuredContent).toMatchObject({
+      directories: [documents],
+      configured: true,
+      source: "home_config_file",
+      config_path: configPath,
+    });
+  }, 30_000);
+
+  it.each([
+    ["argument", ["--allowed-directories", "WINNER"], {}],
+    ["environment", [], { ALLOWED_DIRECTORIES: "WINNER" }],
+  ])("keeps the %s layer above the home file without merging it", async (source, rawArgs, rawEnv) => {
+    const home = path.join(tempDirectory, `${source}-home`);
+    const homeDocuments = path.join(tempDirectory, `${source}-home-documents`);
+    const winner = path.join(tempDirectory, `${source}-winner`);
+    await fs.mkdir(homeDocuments, { recursive: true });
+    await fs.mkdir(winner, { recursive: true });
+    await fs.copyFile(EXAMPLE_PDF, path.join(homeDocuments, "lower-layer.pdf"));
+    await fs.copyFile(EXAMPLE_PDF, path.join(winner, "winner.pdf"));
+    await writeHomeConfig(home, [homeDocuments]);
+    const args = rawArgs.map(value => value === "WINNER" ? winner : value);
+    const env = Object.fromEntries(Object.entries(rawEnv).map(([key, value]) => [
+      key,
+      value === "WINNER" ? winner : value,
+    ]));
+
+    const observed = await withServer({
+      name: `home-config-${source}-precedence`,
+      args,
+      env: { HOME: home, ...env },
+    }, async client => ({
+      winner: await client.callTool({ name: "list_pdfs", arguments: { directory: winner } }),
+      lower: await client.callTool({ name: "list_pdfs", arguments: { directory: homeDocuments } }),
+      boundary: await client.callTool({ name: "get_allowed_directories", arguments: {} }),
+    }));
+
+    expect(textFromToolResult(observed.winner)).toContain("winner.pdf");
+    expect(structuredErrorCode(observed.lower)).toBe("path_policy_denied");
+    expect(observed.boundary.structuredContent.source).toBe(source);
+    expect(observed.boundary.structuredContent.directories).toEqual([winner]);
+  }, 30_000);
+
+  it("keeps an existing plugin data file above the home file", async () => {
+    const home = path.join(tempDirectory, "plugin-precedence-home");
+    const pluginData = path.join(tempDirectory, "plugin-precedence-data");
+    const homeDocuments = path.join(tempDirectory, "plugin-precedence-home-documents");
+    const pluginDocuments = path.join(tempDirectory, "plugin-precedence-plugin-documents");
+    await fs.mkdir(pluginData, { recursive: true });
+    await fs.mkdir(homeDocuments, { recursive: true });
+    await fs.mkdir(pluginDocuments, { recursive: true });
+    await fs.copyFile(EXAMPLE_PDF, path.join(homeDocuments, "lower-layer.pdf"));
+    await fs.copyFile(EXAMPLE_PDF, path.join(pluginDocuments, "plugin-layer.pdf"));
+    await writeHomeConfig(home, [homeDocuments]);
+    await fs.writeFile(
+      path.join(pluginData, "config.json"),
+      JSON.stringify({ allowedDirectories: [pluginDocuments] }),
+    );
+
+    const observed = await withServer({
+      name: "home-config-plugin-precedence",
+      env: { HOME: home, PLUGIN_DATA: pluginData },
+    }, async client => ({
+      plugin: await client.callTool({ name: "list_pdfs", arguments: { directory: pluginDocuments } }),
+      lower: await client.callTool({ name: "list_pdfs", arguments: { directory: homeDocuments } }),
+      boundary: await client.callTool({ name: "get_allowed_directories", arguments: {} }),
+    }));
+
+    expect(textFromToolResult(observed.plugin)).toContain("plugin-layer.pdf");
+    expect(structuredErrorCode(observed.lower)).toBe("path_policy_denied");
+    expect(observed.boundary.structuredContent.source).toBe("config_file");
+    expect(observed.boundary.structuredContent.config_path).toBe(path.join(pluginData, "config.json"));
+  }, 30_000);
+
+  // Only a malformed plugin file blocks the home file. A valid but empty one
+  // must fall through: versions up to 0.10.0 wrote exactly that empty template
+  // on first run, so treating it as authoritative would mean everyone upgrading
+  // edits the friendlier home file and silently sees nothing happen. A file
+  // that configures nothing is not a configuration; a file nobody can parse is
+  // a problem the user has to see.
+  it.each([
+    ["malformed", "{ not json"],
+  ])("does not fall through a %s plugin data file to the home file", async (kind, pluginContents) => {
+    const home = path.join(tempDirectory, `plugin-${kind}-home`);
+    const pluginData = path.join(tempDirectory, `plugin-${kind}-data`);
+    const homeDocuments = path.join(home, "Documents");
+    await fs.mkdir(pluginData, { recursive: true });
+    await fs.mkdir(homeDocuments, { recursive: true });
+    await fs.copyFile(EXAMPLE_PDF, path.join(homeDocuments, "must-stay-hidden.pdf"));
+    await writeHomeConfig(home, [homeDocuments]);
+    await fs.writeFile(path.join(pluginData, "config.json"), pluginContents);
+
+    const observed = await withServer({
+      name: `home-config-plugin-${kind}`,
+      env: { HOME: home, PLUGIN_DATA: pluginData },
+    }, async client => ({
+      listing: await client.callTool({ name: "list_pdfs", arguments: { directory: homeDocuments } }),
+      boundary: await client.callTool({ name: "get_allowed_directories", arguments: {} }),
+    }));
+
+    expect(structuredErrorCode(observed.listing)).toBe("path_policy_denied");
+    expect(textFromToolResult(observed.listing)).not.toContain("must-stay-hidden.pdf");
+    expect(observed.boundary.structuredContent).toMatchObject({
+      directories: [],
+      configured: false,
+      source: "none",
+      config_path: path.join(pluginData, "config.json"),
+    });
+  }, 30_000);
+
+  it("falls through an empty plugin data file so an upgraded install still works", async () => {
+    const home = path.join(tempDirectory, "plugin-empty-falls-through-home");
+    const pluginData = path.join(tempDirectory, "plugin-empty-falls-through-data");
+    const homeDocuments = path.join(home, "Documents");
+    await fs.mkdir(pluginData, { recursive: true });
+    await fs.mkdir(homeDocuments, { recursive: true });
+    await fs.copyFile(EXAMPLE_PDF, path.join(homeDocuments, "reachable.pdf"));
+    await writeHomeConfig(home, [homeDocuments]);
+    // Exactly what 0.10.0 wrote on first run.
+    await fs.writeFile(path.join(pluginData, "config.json"), JSON.stringify({ allowedDirectories: [] }));
+
+    const observed = await withServer({
+      name: "home-config-plugin-empty-falls-through",
+      env: { HOME: home, PLUGIN_DATA: pluginData },
+    }, async client => ({
+      listing: await client.callTool({ name: "list_pdfs", arguments: { directory: homeDocuments } }),
+      boundary: await client.callTool({ name: "get_allowed_directories", arguments: {} }),
+    }));
+
+    expect(structuredErrorCode(observed.listing)).toBeUndefined();
+    expect(textFromToolResult(observed.listing)).toContain("reachable.pdf");
+    expect(observed.boundary.structuredContent).toMatchObject({
+      configured: true,
+      source: "home_config_file",
+      config_path: path.join(home, ".pdf-tools", "config.json"),
+    });
+  }, 30_000);
+
+  it.each([
+    ["missing", null],
+    ["malformed", "{ not json"],
+    ["empty-file", ""],
+    ["empty-list", JSON.stringify({ allowedDirectories: [] })],
+  ])("fails closed when the home file is %s", async (kind, contents) => {
+    const home = path.join(tempDirectory, `${kind}-home`);
+    const documents = path.join(home, "Documents");
+    const configPath = homeConfigPath(home);
+    await fs.mkdir(documents, { recursive: true });
+    await fs.copyFile(EXAMPLE_PDF, path.join(documents, "must-stay-hidden.pdf"));
+    if (contents !== null) {
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.writeFile(configPath, contents);
+    }
+
+    const observed = await withServer({
+      name: `home-config-${kind}`,
+      env: { HOME: home },
+    }, async client => ({
+      listing: await client.callTool({ name: "list_pdfs", arguments: { directory: documents } }),
+      boundary: await client.callTool({ name: "get_allowed_directories", arguments: {} }),
+    }));
+
+    expect(structuredErrorCode(observed.listing)).toBe("path_policy_denied");
+    expect(textFromToolResult(observed.listing)).not.toContain("must-stay-hidden.pdf");
+    expect(observed.boundary.structuredContent).toMatchObject({
+      directories: [],
+      configured: false,
+      source: "none",
+      config_path: configPath,
+    });
+    if (kind === "missing") {
+      const template = JSON.parse(await fs.readFile(configPath, "utf8"));
+      expect(template.allowedDirectories).toEqual([]);
+    }
+  }, 30_000);
+
+  it("refuses a home configuration that reaches its own file", async () => {
+    const home = path.join(tempDirectory, "self-grant-home");
+    const configDirectory = path.join(home, ".pdf-tools");
+    await fs.mkdir(configDirectory, { recursive: true });
+    await fs.copyFile(EXAMPLE_PDF, path.join(configDirectory, "bait.pdf"));
+    await writeHomeConfig(home, [configDirectory]);
+
+    const observed = await withServer({
+      name: "home-config-self-grant",
+      env: { HOME: home },
+    }, async client => ({
+      listing: await client.callTool({ name: "list_pdfs", arguments: { directory: configDirectory } }),
+      boundary: await client.callTool({ name: "get_allowed_directories", arguments: {} }),
+    }));
+
+    expect(structuredErrorCode(observed.listing)).toBe("path_policy_denied");
+    expect(textFromToolResult(observed.listing)).not.toContain("bait.pdf");
+    expect(observed.boundary.structuredContent.source).toBe("refused_self_granting");
+    expect(observed.boundary.structuredContent.directories).toEqual([]);
+    expect(observed.boundary.structuredContent.config_path).toBe(homeConfigPath(home));
+  }, 30_000);
+
+  it("expands ${HOME} and rejects unresolved placeholders like the existing layers", async () => {
+    const expandedHome = path.join(tempDirectory, "expanded-placeholder-home");
+    const documents = path.join(expandedHome, "Documents");
+    await fs.mkdir(documents, { recursive: true });
+    await fs.copyFile(EXAMPLE_PDF, path.join(documents, "expanded.pdf"));
+    await writeHomeConfig(expandedHome, ["${HOME}/Documents"]);
+
+    const expanded = await withServer({
+      name: "home-config-expanded-placeholder",
+      env: { HOME: expandedHome },
+    }, client => client.callTool({ name: "get_allowed_directories", arguments: {} }));
+    expect(expanded.structuredContent.source).toBe("home_config_file");
+    expect(expanded.structuredContent.directories).toEqual([documents]);
+
+    const unresolvedHome = path.join(tempDirectory, "unresolved-placeholder-home");
+    await writeHomeConfig(unresolvedHome, ["${user_config.allowed_directories}"]);
+    const unresolved = await withServer({
+      name: "home-config-unresolved-placeholder",
+      env: { HOME: unresolvedHome },
+    }, client => client.callTool({ name: "get_allowed_directories", arguments: {} }));
+    expect(unresolved.structuredContent.source).toBe("none");
+    expect(unresolved.structuredContent.directories).toEqual([]);
+  }, 30_000);
+
+  it("does not create the home template when a higher layer supplied directories", async () => {
+    const home = path.join(tempDirectory, "no-template-home");
+    const documents = path.join(tempDirectory, "no-template-documents");
+    await fs.mkdir(documents, { recursive: true });
+
+    await withServer({
+      name: "home-config-no-template",
+      env: { HOME: home, ALLOWED_DIRECTORIES: documents },
+    }, client => client.callTool({ name: "get_allowed_directories", arguments: {} }));
+
+    await expect(fs.stat(homeConfigPath(home))).rejects.toMatchObject({ code: "ENOENT" });
+  }, 30_000);
+
+  it("fails closed when the home config path cannot be read as a file", async () => {
+    const home = path.join(tempDirectory, "unreadable-home");
+    const documents = path.join(home, "Documents");
+    const configPath = homeConfigPath(home);
+    await fs.mkdir(documents, { recursive: true });
+    await fs.mkdir(configPath, { recursive: true });
+    await fs.copyFile(EXAMPLE_PDF, path.join(documents, "must-stay-hidden.pdf"));
+
+    const result = await withServer({
+      name: "home-config-unreadable",
+      env: { HOME: home },
+    }, client => client.callTool({ name: "list_pdfs", arguments: { directory: documents } }));
+
+    expect(structuredErrorCode(result)).toBe("path_policy_denied");
+    expect(textFromToolResult(result)).not.toContain("must-stay-hidden.pdf");
+  }, 30_000);
+
+  it("does not follow a home config-directory symlink outside the home when creating a template", async () => {
+    const home = path.join(tempDirectory, "symlink-home");
+    const outside = path.join(tempDirectory, "symlink-outside");
+    await fs.mkdir(home, { recursive: true });
+    await fs.mkdir(outside, { recursive: true });
+    await fs.symlink(
+      outside,
+      path.join(home, ".pdf-tools"),
+      process.platform === "win32" ? "junction" : "dir",
+    );
+
+    const boundary = await withServer({
+      name: "home-config-symlink-template",
+      env: { HOME: home },
+    }, client => client.callTool({ name: "get_allowed_directories", arguments: {} }));
+
+    expect(boundary.structuredContent.configured).toBe(false);
+    expect(boundary.structuredContent.config_path).toBe(homeConfigPath(home));
+    await expect(fs.stat(path.join(outside, "config.json"))).rejects.toMatchObject({ code: "ENOENT" });
+  }, 30_000);
+
+  it("names the friendly path before plugin data and emits no shell recipe", async () => {
+    const home = path.join(tempDirectory, "refusal-home");
+    const pluginData = path.join(tempDirectory, "refusal-plugin-data");
+    await fs.mkdir(pluginData, { recursive: true });
+
+    const refusal = await withServer({
+      name: "home-config-refusal",
+      env: { HOME: home, PLUGIN_DATA: pluginData },
+    }, client => client.callTool({ name: "list_pdfs", arguments: { directory: tempDirectory } }));
+
+    const text = textFromToolResult(refusal);
+    expect(text.indexOf(homeConfigPath(home))).toBeGreaterThanOrEqual(0);
+    expect(text.indexOf(homeConfigPath(home))).toBeLessThan(text.indexOf(path.join(pluginData, "config.json")));
+    expect(text).not.toMatch(/(?:^|\s)(?:cat|echo|printf|mkdir|tee)\s/);
+  }, 30_000);
+});

--- a/test/mcp-contract.test.js
+++ b/test/mcp-contract.test.js
@@ -97,7 +97,7 @@ const EXAMPLE_PDF = path.join(REPO_ROOT, "example-fw9.pdf");
 // document fails anyway. Only read_pdf_layout, convert_pdf_to_markdown, and
 // get_pdf_info keep an unqualified password parameter, because only they work.
 // Previously 53d965e366b16adf2a0fa90dfe837ca98d29a8f41c1adf8b9e8f661ea3bb7d95.
-const TOOL_CONTRACT_SHA256 = "59af94a52312b299f57f9f5ab8e18b5de626d2502aa18f47438d7a1ce66e2c1c";
+const TOOL_CONTRACT_SHA256 = "fef092d0e306a33839f249d0cf121519d723981aaf3872119d8668d2001cb62f";
 
 const CLOSED_READ = Object.freeze({
   readOnlyHint: true,

--- a/test/plugin-data-config.test.js
+++ b/test/plugin-data-config.test.js
@@ -126,8 +126,7 @@ describe("config file precedence", () => {
   });
 
   it("lets the environment variable win over the config file", async () => {
-    // The config file is the lowest layer. A host that does supply configuration
-    // is stating an intent the stored file should not override.
+    // A host-supplied value outranks stored configuration.
     const result = await withServer({
       name: "plugin-data-env-wins",
       env: {
@@ -246,27 +245,28 @@ describe("first-run bootstrap", () => {
     await removeTestTempDirectory(tempDirectory);
   });
 
-  it("writes a template config on first run and names it in the refusal", async () => {
+  it("writes the well-known home template on first run and names it in the refusal", async () => {
     const pluginData = path.join(tempDirectory, "fresh-install");
+    const home = path.join(tempDirectory, "home");
     await fs.mkdir(pluginData, { recursive: true });
-    const configPath = path.join(pluginData, "config.json");
+    const pluginConfigPath = path.join(pluginData, "config.json");
+    const configPath = path.join(home, ".pdf-tools", "config.json");
 
     const result = await withServer({
       name: "plugin-data-bootstrap",
-      env: { HOME: path.join(tempDirectory, "home"), PLUGIN_DATA: pluginData },
+      env: { HOME: home, PLUGIN_DATA: pluginData },
     }, client => client.callTool({
       name: "list_pdfs",
       arguments: { directory: tempDirectory },
     }));
 
     expect(structuredErrorCode(result)).toBe("path_policy_denied");
-    // A fresh install must not merely refuse; it must say where to fix it.
-    // Editing this file is a human action the agent cannot perform, which is
-    // what keeps widening off the agent's own authority.
+    // A fresh install must not merely refuse; it must say where to configure it.
     expect(textFromToolResult(result)).toContain(configPath);
 
     const written = JSON.parse(await fs.readFile(configPath, "utf8"));
     expect(written.allowedDirectories).toEqual([]);
+    await expect(fs.stat(pluginConfigPath)).rejects.toMatchObject({ code: "ENOENT" });
   }, 30_000);
 
   it("does not overwrite a config that already exists", async () => {


### PR DESCRIPTION
Closes #121.

Plugin installs had no usable way to configure allowed folders. The only location was `${PLUGIN_DATA}/config.json`, whose path carries a 64-character hash, and the Agent Plugins standard defines no settings surface for a host to render. A new user met a refusal plus a path they could not type, which is a reasonable place to conclude the extension is broken.

This adds `~/.pdf-tools/config.json` as the lowest configuration layer.

## What does not change

Precedence above it is untouched: `--allowed-directories` argv, then `ALLOWED_DIRECTORIES`, then plugin data, then this, then empty. An MCPB or Claude Desktop install that receives argv or environment configuration behaves exactly as before. Fail-closed is preserved everywhere: absent, unreadable, malformed, or empty means no directories, never a built-in default.

It adds no authority. Anything able to write this file could already write the plugin-data one. It replaces an unmemorable hash with a path a person can be told over the phone. `get_allowed_directories` reports `home_config_file` so the active layer is always visible.

## Two subtleties, both found by testing rather than reasoning

**An empty plugin template no longer shadows the home file.** Versions up to 0.10.0 wrote exactly that empty template on first run, so treating a valid-but-empty file as authoritative would mean everyone upgrading edits the friendlier file and silently sees nothing happen. That is worse than the original problem, because it looks like the fix does not work. Verified against a simulated upgrade before and after.

**A malformed plugin file still blocks.** A file nobody can parse is a problem the user has to see, not one a lower layer papers over. This required separating "present but unusable" from "present and deliberately empty", which the reader previously collapsed into the same empty list.

## Verification

- 111 tests pass across the boundary and contract suites: home config, allowed directories, plugin data config, sandbox boundary findings, host substitution, mcpb archive, packed contract smoke, MCP contract.
- Both `server/` files mirrored byte-identically into `pdf-toolkit-mcp-share/server/`.
- Behaviour checked directly against a running server for four cases: upgraded install with an empty plugin template, malformed plugin config, non-empty plugin config, and argv.

## Provenance

Implemented by Codex against a written brief; it verified eleven mutations went red before restoring each guard. Reviewed here, where the empty-template upgrade trap was found and fixed, and where its test asserting the old behaviour was corrected with a case covering the upgrade path.

This is the alternative to the design in #120, which was blocked three times because a server cannot turn a caller-supplied string into consent. Here the human action is the user's own edit, which is the property that survived review.
