### PR TITLE
Rebind the layout oracle and classify the new suite after #122

### DIFF
--- a/scripts/test-suite-classification.mjs
+++ b/scripts/test-suite-classification.mjs
@@ -78,6 +78,7 @@ export const CHECKOUT_LOCAL_MUTATING_TEST_SUITES = Object.freeze([
   "test/get-allowed-directories.test.js",
   "test/get-pdf-info.test.js",
   "test/golden-set-placement.test.js",
+  "test/home-config-location.test.js",
   "test/host-placeholder-expansion.test.js",
   "test/integration.test.js",
   "test/list-pdfs-default-directory.test.js",

--- a/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
+++ b/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
@@ -85,8 +85,8 @@
     {
       "role": "output_schemas_module",
       "path": "server/output-schemas.js",
-      "bytes": 51948,
-      "sha256": "8c3972812cd9d8790919644d37965ef3a60e3753fa6c9143a258ec24aea75054"
+      "bytes": 51968,
+      "sha256": "b6de24f6a9734d402322877a7270fca2924eafd571e67667c392c3fd3a6d9557"
     },
     {
       "role": "package_json",
@@ -125,7 +125,7 @@
       "sha256": "6e4429db62fcbe1dd73141d8c20a48b564d41f8bf8920d88775846995e1daf94"
     }
   ],
-  "validator_source_set_sha256": "279631d26e1be3d10f90973c31b91ba24a3ed901ad69224f97c62be35e22570e",
+  "validator_source_set_sha256": "cd53addac2f2f37d9a4b584e398b7670fc48b35a4549abad968d61d9113f6147",
   "pdfjs_version": "5.4.624",
   "generation_contract": {
     "source_path": "source.pdf",


### PR DESCRIPTION
The full aggregate went red at `e443d56` with eleven failures across four files. Both causes come from #122, and both are the derived-identity machinery working rather than breaking.

**Layout oracle.** Adding `home_config_file` to the `get_allowed_directories` output enum changed `server/output-schemas.js`, whose digest the Phase 1 layout oracle binds as `output_schemas_module`. Regenerated from `scripts/eval-generate-extraction-layout-oracle.mjs`; the only change is that one hash and every scored case is untouched.

**Runner contract.** `test/home-config-location.test.js` allocates scratch inside the checkout, so the aggregate runner contract requires it declared as checkout-local mutating.

Verified: the four previously failing suites pass, 38 tests plus the 18-test runner contract.

Worth recording that the targeted suites I ran before merging #122 all passed. Only the unfiltered aggregate catches a fixture bound to a file the change happened to touch, which is exactly why release qualification runs it.