### PR TITLE
Bound decoded object-stream size before the parser materializes it

### DIFF
--- a/pdf-toolkit-mcp-share/server/pdf-lib-worker.js
+++ b/pdf-toolkit-mcp-share/server/pdf-lib-worker.js
@@ -2,12 +2,14 @@ import { createHash } from "node:crypto";
 import { closeSync, writeSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { Readable } from "node:stream";
 import { fileURLToPath } from "node:url";
 import {
   isMainThread,
   parentPort as threadParentPort,
   workerData as threadWorkerData,
 } from "node:worker_threads";
+import { createInflate } from "node:zlib";
 import {
   PDFArray,
   PDFDict,
@@ -81,6 +83,15 @@ const MAX_PARSED_CONTAINER_VISITS = 1_000_000;
 const MAX_PDF_GRAPH_EDGES = 2_000_000;
 const MAX_PDF_GRAPH_PENDING = 1_000_000;
 const MAX_SPEC_NULL_REFERENCE_SAMPLE = 32;
+// Object streams contain serialized non-stream objects, and pdf-lib's writer
+// groups only 50 objects into each one. A decoded object stream above 16 MiB is
+// therefore far outside ordinary writer output. More importantly, the pinned
+// parser eagerly materializes it before our post-parse 128 MiB stream probe can
+// run: a measured 256 MiB object stream drove RSS above 4.3 GiB. Keeping this
+// ceiling at 16 MiB leaves useful headroom inside the worker's 384 MiB V8 old-
+// space budget while preserving large PDFs whose bulk lives in image/content
+// streams rather than in one serialized-object container.
+const MAX_DECODED_OBJECT_STREAM_BYTES = 16 * 1024 * 1024;
 const MIN_DECODED_STREAM_BUDGET_BYTES = 16 * 1024 * 1024;
 const MAX_DECODED_STREAM_BUDGET_BYTES = 128 * 1024 * 1024;
 const MAX_DECODE_EXPANSION_RATIO = 512;
@@ -395,7 +406,7 @@ const PDF_ENDSTREAM_KEYWORD = Buffer.from("endstream", "ascii");
 // endstream keyword, and otherwise fall back to searching for that keyword.
 // A payload that misleads this also misleads pdf-lib, so the two views of a
 // document cannot be made to disagree about where structure resumes.
-function skipPdfStreamPayload(bytes, offset, declaredLength) {
+function resolvePdfStreamPayload(bytes, offset, declaredLength) {
   let start = offset;
   if (bytes[start] === 0x0d) start += 1;
   if (bytes[start] === 0x0a) start += 1;
@@ -404,11 +415,12 @@ function skipPdfStreamPayload(bytes, offset, declaredLength) {
     while (probe < bytes.length && isPdfWhitespace(bytes[probe])) probe += 1;
     if (bytes.subarray(probe, probe + PDF_ENDSTREAM_KEYWORD.length)
       .equals(PDF_ENDSTREAM_KEYWORD)) {
-      return probe;
+      return { payloadStart: start, payloadEnd: start + declaredLength, resumeAt: probe };
     }
   }
   const found = bytes.indexOf(PDF_ENDSTREAM_KEYWORD, start);
-  return found < 0 ? bytes.length : found;
+  const end = found < 0 ? bytes.length : found;
+  return { payloadStart: start, payloadEnd: end, resumeAt: end };
 }
 
 // This lexer retains only a bounded token and a handful of parser states. It
@@ -500,9 +512,12 @@ function* pdfStructureTokens(bytes, { skipStreamPayloads = false } = {}) {
       overlong: length > MAX_STRUCTURE_TOKEN_BYTES,
       digitLength: allDigits ? digitLength : 0,
     };
-    yield token;
-    if (!skipStreamPayloads) continue;
+    if (!skipStreamPayloads) {
+      yield token;
+      continue;
+    }
     if (expectLengthValue) {
+      yield token;
       expectLengthValue = false;
       const value = token.type === "integer" && token.digitLength <= 15
         ? Number(token.value)
@@ -511,8 +526,187 @@ function* pdfStructureTokens(bytes, { skipStreamPayloads = false } = {}) {
       continue;
     }
     if (token.type === "word" && !token.overlong && token.value === "stream") {
-      offset = skipPdfStreamPayload(bytes, offset, declaredLength);
+      const { payloadStart, payloadEnd, resumeAt } = resolvePdfStreamPayload(
+        bytes,
+        offset,
+        declaredLength,
+      );
+      yield { ...token, payloadStart, payloadEnd };
+      offset = resumeAt;
       declaredLength = null;
+      continue;
+    }
+    yield token;
+  }
+}
+
+function collectPreparseStreamDecodes(bytes) {
+  const streams = [];
+  const dictionaries = [];
+  let lastClosedDictionary = null;
+  const markMalformedValue = frame => {
+    if (frame?.pendingKey === "Type") frame.typeAmbiguous = true;
+    if (frame?.pendingKey === "Filter") frame.filterAmbiguous = true;
+    if (frame) frame.pendingKey = null;
+  };
+  for (const token of pdfStructureTokens(bytes, { skipStreamPayloads: true })) {
+    const frame = dictionaries.at(-1);
+    if (token.type === "delimiter" && token.value === "<<") {
+      markMalformedValue(frame);
+      dictionaries.push({
+        type: null,
+        typeAmbiguous: false,
+        filters: null,
+        filterAmbiguous: false,
+        filterArray: false,
+        pendingKey: null,
+      });
+      lastClosedDictionary = null;
+      continue;
+    }
+    if (token.type === "delimiter" && token.value === ">>") {
+      const closing = dictionaries.pop() ?? null;
+      markMalformedValue(closing);
+      lastClosedDictionary = closing;
+      continue;
+    }
+    if (frame?.filterArray) {
+      if (token.type === "delimiter" && token.value === "]") {
+        frame.filterArray = false;
+        frame.pendingKey = null;
+      } else if (token.type === "name" && !token.overlong) {
+        frame.filters.push(token.value);
+      } else {
+        frame.filterAmbiguous = true;
+      }
+      lastClosedDictionary = null;
+      continue;
+    }
+    if (frame?.pendingKey === "Type") {
+      if (token.type === "name" && !token.overlong) frame.type = token.value;
+      else frame.typeAmbiguous = true;
+      frame.pendingKey = null;
+      lastClosedDictionary = null;
+      continue;
+    }
+    if (frame?.pendingKey === "Filter") {
+      if (token.type === "name" && !token.overlong) {
+        frame.filters = [token.value];
+        frame.pendingKey = null;
+      } else if (token.type === "delimiter" && token.value === "[") {
+        frame.filters = [];
+        frame.filterArray = true;
+      } else {
+        frame.filterAmbiguous = true;
+        frame.pendingKey = null;
+      }
+      lastClosedDictionary = null;
+      continue;
+    }
+    if (frame && token.type === "name" && !token.overlong
+        && (token.value === "Type" || token.value === "Filter")) {
+      frame.pendingKey = token.value;
+      lastClosedDictionary = null;
+      continue;
+    }
+    if (token.type === "word" && token.value === "stream"
+        && Number.isSafeInteger(token.payloadStart)
+        && Number.isSafeInteger(token.payloadEnd)) {
+      if (lastClosedDictionary) {
+        streams.push({
+          ...lastClosedDictionary,
+          payloadStart: token.payloadStart,
+          payloadEnd: token.payloadEnd,
+        });
+      }
+      lastClosedDictionary = null;
+      continue;
+    }
+    lastClosedDictionary = null;
+  }
+  return streams;
+}
+
+async function countFlateBytesWithinLimit(payload, maximumDecodedBytes) {
+  const source = Readable.from((function* compressedChunks() {
+    for (let offset = 0; offset < payload.length; offset += DECODE_INSPECTION_CHUNK_BYTES) {
+      yield payload.subarray(offset, offset + DECODE_INSPECTION_CHUNK_BYTES);
+    }
+  })());
+  const decoder = createInflate({ chunkSize: DECODE_INSPECTION_CHUNK_BYTES });
+  source.pipe(decoder);
+  let decodedBytes = 0;
+  try {
+    for await (const chunk of decoder) {
+      decodedBytes += chunk.length;
+      if (decodedBytes > maximumDecodedBytes) {
+        throw resourceError(
+          "unsafe_object_stream_expansion",
+          `PDF object stream exceeds the ${maximumDecodedBytes}-byte decoded ceiling; `
+          + "mutation was stopped before parsing.",
+        );
+      }
+    }
+    return decodedBytes;
+  } finally {
+    source.destroy();
+    decoder.destroy();
+  }
+}
+
+export async function assertBoundedPdfStreamDecodes(bytes, {
+  maximumDecodedObjectStreamBytes = MAX_DECODED_OBJECT_STREAM_BYTES,
+} = {}) {
+  if (!(bytes instanceof Uint8Array)
+      || !Number.isSafeInteger(maximumDecodedObjectStreamBytes)
+      || maximumDecodedObjectStreamBytes < 1
+      || maximumDecodedObjectStreamBytes > MAX_DECODED_OBJECT_STREAM_BYTES) {
+    throw new TypeError("Decoded object-stream inspection options are invalid.");
+  }
+  const rejectUnsupportedObjectStream = detail => {
+    throw resourceError(
+      "unsafe_object_stream_decode",
+      `PDF object stream cannot be decoded within a deterministic byte budget (${detail}); `
+      + "mutation was stopped before parsing.",
+    );
+  };
+  for (const stream of collectPreparseStreamDecodes(bytes)) {
+    if (stream.typeAmbiguous) {
+      rejectUnsupportedObjectStream("indirect or malformed Type");
+    }
+    const objectStream = stream.type === "ObjStm";
+    // Content and image streams are not decoded eagerly by PDFDocument.load;
+    // they remain covered by the existing parsed-stream probe. Re-decoding
+    // them here would add full-document work without closing the object-stream
+    // allocation gap this preflight exists to cover.
+    if (!objectStream) continue;
+    if (stream.filterAmbiguous) {
+      rejectUnsupportedObjectStream("indirect or malformed Filter");
+    }
+    const filters = stream.filters?.map(value => FILTER_NAME_ALIASES.get(value) ?? value) ?? [];
+    if (filters.length === 0) {
+      if (stream.payloadEnd - stream.payloadStart > maximumDecodedObjectStreamBytes) {
+        throw resourceError(
+          "unsafe_object_stream_expansion",
+          `PDF object stream exceeds the ${maximumDecodedObjectStreamBytes}-byte decoded ceiling; `
+          + "mutation was stopped before parsing.",
+        );
+      }
+      continue;
+    }
+    if (filters.length !== 1 || filters[0] !== "FlateDecode") {
+      rejectUnsupportedObjectStream("unsupported Filter chain");
+    }
+    try {
+      await countFlateBytesWithinLimit(
+        bytes.subarray(stream.payloadStart, stream.payloadEnd),
+        maximumDecodedObjectStreamBytes,
+      );
+    } catch (error) {
+      if (error?.code === RESOURCE_CODE) throw error;
+      // A malformed stream that fails before reaching the ceiling remains the
+      // parser's responsibility. The preflight exists only to prevent an
+      // otherwise valid expanding decode from allocating past its budget.
     }
   }
 }
@@ -1618,6 +1812,7 @@ export async function savePdfDocumentSafely(document, options = {}) {
   let verified;
   let graphAfterSave;
   try {
+    await assertBoundedPdfStreamDecodes(bytes);
     verified = await PDFDocument.load(bytes, { updateMetadata: false });
     graphAfterSave = enforceSafeParsedPdfGraph(
       verified,
@@ -1661,6 +1856,7 @@ export async function savePdfDocumentSafely(document, options = {}) {
 
 export async function loadPdfForMutation(bytes, password) {
   assertBoundedPdfStructure(bytes);
+  await assertBoundedPdfStreamDecodes(bytes);
   let document;
   try {
     document = await PDFDocument.load(bytes, password ? { password } : {});
@@ -1714,6 +1910,8 @@ async function reopenSource(binding) {
 }
 
 async function inspectAccessibilitySource(bytes, binding) {
+  assertBoundedPdfStructure(bytes);
+  await assertBoundedPdfStreamDecodes(bytes);
   let document;
   try {
     document = await PDFDocument.load(bytes, { updateMetadata: false });
@@ -1724,7 +1922,6 @@ async function inspectAccessibilitySource(bytes, binding) {
       source_file_name: path.basename(binding.canonical_path),
     });
   }
-  assertBoundedPdfStructure(bytes);
   assertSafeParsedPdfDecodeChains(document);
   assertSafeParsedPdfComplexity(document);
   enforceSafeParsedPdfGraph(document);

--- a/server/pdf-lib-worker.js
+++ b/server/pdf-lib-worker.js
@@ -2,12 +2,14 @@ import { createHash } from "node:crypto";
 import { closeSync, writeSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { Readable } from "node:stream";
 import { fileURLToPath } from "node:url";
 import {
   isMainThread,
   parentPort as threadParentPort,
   workerData as threadWorkerData,
 } from "node:worker_threads";
+import { createInflate } from "node:zlib";
 import {
   PDFArray,
   PDFDict,
@@ -81,6 +83,15 @@ const MAX_PARSED_CONTAINER_VISITS = 1_000_000;
 const MAX_PDF_GRAPH_EDGES = 2_000_000;
 const MAX_PDF_GRAPH_PENDING = 1_000_000;
 const MAX_SPEC_NULL_REFERENCE_SAMPLE = 32;
+// Object streams contain serialized non-stream objects, and pdf-lib's writer
+// groups only 50 objects into each one. A decoded object stream above 16 MiB is
+// therefore far outside ordinary writer output. More importantly, the pinned
+// parser eagerly materializes it before our post-parse 128 MiB stream probe can
+// run: a measured 256 MiB object stream drove RSS above 4.3 GiB. Keeping this
+// ceiling at 16 MiB leaves useful headroom inside the worker's 384 MiB V8 old-
+// space budget while preserving large PDFs whose bulk lives in image/content
+// streams rather than in one serialized-object container.
+const MAX_DECODED_OBJECT_STREAM_BYTES = 16 * 1024 * 1024;
 const MIN_DECODED_STREAM_BUDGET_BYTES = 16 * 1024 * 1024;
 const MAX_DECODED_STREAM_BUDGET_BYTES = 128 * 1024 * 1024;
 const MAX_DECODE_EXPANSION_RATIO = 512;
@@ -395,7 +406,7 @@ const PDF_ENDSTREAM_KEYWORD = Buffer.from("endstream", "ascii");
 // endstream keyword, and otherwise fall back to searching for that keyword.
 // A payload that misleads this also misleads pdf-lib, so the two views of a
 // document cannot be made to disagree about where structure resumes.
-function skipPdfStreamPayload(bytes, offset, declaredLength) {
+function resolvePdfStreamPayload(bytes, offset, declaredLength) {
   let start = offset;
   if (bytes[start] === 0x0d) start += 1;
   if (bytes[start] === 0x0a) start += 1;
@@ -404,11 +415,12 @@ function skipPdfStreamPayload(bytes, offset, declaredLength) {
     while (probe < bytes.length && isPdfWhitespace(bytes[probe])) probe += 1;
     if (bytes.subarray(probe, probe + PDF_ENDSTREAM_KEYWORD.length)
       .equals(PDF_ENDSTREAM_KEYWORD)) {
-      return probe;
+      return { payloadStart: start, payloadEnd: start + declaredLength, resumeAt: probe };
     }
   }
   const found = bytes.indexOf(PDF_ENDSTREAM_KEYWORD, start);
-  return found < 0 ? bytes.length : found;
+  const end = found < 0 ? bytes.length : found;
+  return { payloadStart: start, payloadEnd: end, resumeAt: end };
 }
 
 // This lexer retains only a bounded token and a handful of parser states. It
@@ -500,9 +512,12 @@ function* pdfStructureTokens(bytes, { skipStreamPayloads = false } = {}) {
       overlong: length > MAX_STRUCTURE_TOKEN_BYTES,
       digitLength: allDigits ? digitLength : 0,
     };
-    yield token;
-    if (!skipStreamPayloads) continue;
+    if (!skipStreamPayloads) {
+      yield token;
+      continue;
+    }
     if (expectLengthValue) {
+      yield token;
       expectLengthValue = false;
       const value = token.type === "integer" && token.digitLength <= 15
         ? Number(token.value)
@@ -511,8 +526,187 @@ function* pdfStructureTokens(bytes, { skipStreamPayloads = false } = {}) {
       continue;
     }
     if (token.type === "word" && !token.overlong && token.value === "stream") {
-      offset = skipPdfStreamPayload(bytes, offset, declaredLength);
+      const { payloadStart, payloadEnd, resumeAt } = resolvePdfStreamPayload(
+        bytes,
+        offset,
+        declaredLength,
+      );
+      yield { ...token, payloadStart, payloadEnd };
+      offset = resumeAt;
       declaredLength = null;
+      continue;
+    }
+    yield token;
+  }
+}
+
+function collectPreparseStreamDecodes(bytes) {
+  const streams = [];
+  const dictionaries = [];
+  let lastClosedDictionary = null;
+  const markMalformedValue = frame => {
+    if (frame?.pendingKey === "Type") frame.typeAmbiguous = true;
+    if (frame?.pendingKey === "Filter") frame.filterAmbiguous = true;
+    if (frame) frame.pendingKey = null;
+  };
+  for (const token of pdfStructureTokens(bytes, { skipStreamPayloads: true })) {
+    const frame = dictionaries.at(-1);
+    if (token.type === "delimiter" && token.value === "<<") {
+      markMalformedValue(frame);
+      dictionaries.push({
+        type: null,
+        typeAmbiguous: false,
+        filters: null,
+        filterAmbiguous: false,
+        filterArray: false,
+        pendingKey: null,
+      });
+      lastClosedDictionary = null;
+      continue;
+    }
+    if (token.type === "delimiter" && token.value === ">>") {
+      const closing = dictionaries.pop() ?? null;
+      markMalformedValue(closing);
+      lastClosedDictionary = closing;
+      continue;
+    }
+    if (frame?.filterArray) {
+      if (token.type === "delimiter" && token.value === "]") {
+        frame.filterArray = false;
+        frame.pendingKey = null;
+      } else if (token.type === "name" && !token.overlong) {
+        frame.filters.push(token.value);
+      } else {
+        frame.filterAmbiguous = true;
+      }
+      lastClosedDictionary = null;
+      continue;
+    }
+    if (frame?.pendingKey === "Type") {
+      if (token.type === "name" && !token.overlong) frame.type = token.value;
+      else frame.typeAmbiguous = true;
+      frame.pendingKey = null;
+      lastClosedDictionary = null;
+      continue;
+    }
+    if (frame?.pendingKey === "Filter") {
+      if (token.type === "name" && !token.overlong) {
+        frame.filters = [token.value];
+        frame.pendingKey = null;
+      } else if (token.type === "delimiter" && token.value === "[") {
+        frame.filters = [];
+        frame.filterArray = true;
+      } else {
+        frame.filterAmbiguous = true;
+        frame.pendingKey = null;
+      }
+      lastClosedDictionary = null;
+      continue;
+    }
+    if (frame && token.type === "name" && !token.overlong
+        && (token.value === "Type" || token.value === "Filter")) {
+      frame.pendingKey = token.value;
+      lastClosedDictionary = null;
+      continue;
+    }
+    if (token.type === "word" && token.value === "stream"
+        && Number.isSafeInteger(token.payloadStart)
+        && Number.isSafeInteger(token.payloadEnd)) {
+      if (lastClosedDictionary) {
+        streams.push({
+          ...lastClosedDictionary,
+          payloadStart: token.payloadStart,
+          payloadEnd: token.payloadEnd,
+        });
+      }
+      lastClosedDictionary = null;
+      continue;
+    }
+    lastClosedDictionary = null;
+  }
+  return streams;
+}
+
+async function countFlateBytesWithinLimit(payload, maximumDecodedBytes) {
+  const source = Readable.from((function* compressedChunks() {
+    for (let offset = 0; offset < payload.length; offset += DECODE_INSPECTION_CHUNK_BYTES) {
+      yield payload.subarray(offset, offset + DECODE_INSPECTION_CHUNK_BYTES);
+    }
+  })());
+  const decoder = createInflate({ chunkSize: DECODE_INSPECTION_CHUNK_BYTES });
+  source.pipe(decoder);
+  let decodedBytes = 0;
+  try {
+    for await (const chunk of decoder) {
+      decodedBytes += chunk.length;
+      if (decodedBytes > maximumDecodedBytes) {
+        throw resourceError(
+          "unsafe_object_stream_expansion",
+          `PDF object stream exceeds the ${maximumDecodedBytes}-byte decoded ceiling; `
+          + "mutation was stopped before parsing.",
+        );
+      }
+    }
+    return decodedBytes;
+  } finally {
+    source.destroy();
+    decoder.destroy();
+  }
+}
+
+export async function assertBoundedPdfStreamDecodes(bytes, {
+  maximumDecodedObjectStreamBytes = MAX_DECODED_OBJECT_STREAM_BYTES,
+} = {}) {
+  if (!(bytes instanceof Uint8Array)
+      || !Number.isSafeInteger(maximumDecodedObjectStreamBytes)
+      || maximumDecodedObjectStreamBytes < 1
+      || maximumDecodedObjectStreamBytes > MAX_DECODED_OBJECT_STREAM_BYTES) {
+    throw new TypeError("Decoded object-stream inspection options are invalid.");
+  }
+  const rejectUnsupportedObjectStream = detail => {
+    throw resourceError(
+      "unsafe_object_stream_decode",
+      `PDF object stream cannot be decoded within a deterministic byte budget (${detail}); `
+      + "mutation was stopped before parsing.",
+    );
+  };
+  for (const stream of collectPreparseStreamDecodes(bytes)) {
+    if (stream.typeAmbiguous) {
+      rejectUnsupportedObjectStream("indirect or malformed Type");
+    }
+    const objectStream = stream.type === "ObjStm";
+    // Content and image streams are not decoded eagerly by PDFDocument.load;
+    // they remain covered by the existing parsed-stream probe. Re-decoding
+    // them here would add full-document work without closing the object-stream
+    // allocation gap this preflight exists to cover.
+    if (!objectStream) continue;
+    if (stream.filterAmbiguous) {
+      rejectUnsupportedObjectStream("indirect or malformed Filter");
+    }
+    const filters = stream.filters?.map(value => FILTER_NAME_ALIASES.get(value) ?? value) ?? [];
+    if (filters.length === 0) {
+      if (stream.payloadEnd - stream.payloadStart > maximumDecodedObjectStreamBytes) {
+        throw resourceError(
+          "unsafe_object_stream_expansion",
+          `PDF object stream exceeds the ${maximumDecodedObjectStreamBytes}-byte decoded ceiling; `
+          + "mutation was stopped before parsing.",
+        );
+      }
+      continue;
+    }
+    if (filters.length !== 1 || filters[0] !== "FlateDecode") {
+      rejectUnsupportedObjectStream("unsupported Filter chain");
+    }
+    try {
+      await countFlateBytesWithinLimit(
+        bytes.subarray(stream.payloadStart, stream.payloadEnd),
+        maximumDecodedObjectStreamBytes,
+      );
+    } catch (error) {
+      if (error?.code === RESOURCE_CODE) throw error;
+      // A malformed stream that fails before reaching the ceiling remains the
+      // parser's responsibility. The preflight exists only to prevent an
+      // otherwise valid expanding decode from allocating past its budget.
     }
   }
 }
@@ -1618,6 +1812,7 @@ export async function savePdfDocumentSafely(document, options = {}) {
   let verified;
   let graphAfterSave;
   try {
+    await assertBoundedPdfStreamDecodes(bytes);
     verified = await PDFDocument.load(bytes, { updateMetadata: false });
     graphAfterSave = enforceSafeParsedPdfGraph(
       verified,
@@ -1661,6 +1856,7 @@ export async function savePdfDocumentSafely(document, options = {}) {
 
 export async function loadPdfForMutation(bytes, password) {
   assertBoundedPdfStructure(bytes);
+  await assertBoundedPdfStreamDecodes(bytes);
   let document;
   try {
     document = await PDFDocument.load(bytes, password ? { password } : {});
@@ -1714,6 +1910,8 @@ async function reopenSource(binding) {
 }
 
 async function inspectAccessibilitySource(bytes, binding) {
+  assertBoundedPdfStructure(bytes);
+  await assertBoundedPdfStreamDecodes(bytes);
   let document;
   try {
     document = await PDFDocument.load(bytes, { updateMetadata: false });
@@ -1724,7 +1922,6 @@ async function inspectAccessibilitySource(bytes, binding) {
       source_file_name: path.basename(binding.canonical_path),
     });
   }
-  assertBoundedPdfStructure(bytes);
   assertSafeParsedPdfDecodeChains(document);
   assertSafeParsedPdfComplexity(document);
   enforceSafeParsedPdfGraph(document);

--- a/test/pdf-lib-worker-contract.test.js
+++ b/test/pdf-lib-worker-contract.test.js
@@ -13,10 +13,12 @@ import {
   PDFName,
   PDFRawStream,
   PDFRef,
+  PDFString,
 } from "pdf-lib";
 import {
   __testOnlyCopyPdfPagesForRebuiltOutput,
   assertBoundedPdfStructure,
+  assertBoundedPdfStreamDecodes,
   assertSafeParsedPdfComplexity,
   assertSafeParsedPdfDecodeChains,
   enforceSafeParsedPdfGraph,
@@ -57,6 +59,20 @@ async function xrefStreamPdfWithByteWidths(widths) {
   }
   if (widths === null) return written;
   return Buffer.from(text.replace(/\/W\s*\[[^\]]*\]/, widths), "latin1");
+}
+
+// Keep the expansion fixture reproducible and tied to the exact parser/writer
+// combination under test. A referenced PDFString is eligible for pdf-lib's
+// own object-stream writer, which emits the same eager /ObjStm decode path the
+// production loader uses.
+async function pdfLibObjectStreamExpansionPdf(decodedStringBytes) {
+  const document = await PDFDocument.create();
+  document.addPage([100, 100]);
+  const ref = document.context.register(PDFString.of("A".repeat(decodedStringBytes)));
+  document.catalog.set(PDFName.of("ExpansionFixture"), ref);
+  const bytes = Buffer.from(await document.save({ useObjectStreams: true }));
+  expect(bytes.toString("latin1")).toMatch(/\/Type\s*\/ObjStm/);
+  return bytes;
 }
 
 function sparseDeclarationAcrossBoundary(prefix, suffix) {
@@ -136,6 +152,84 @@ afterEach(async () => {
 });
 
 describe("pdf-lib mutation worker contract", () => {
+  describe("pre-parse object-stream expansion budget", () => {
+    it("refuses a pdf-lib-written object stream above the production ceiling", {
+      timeout: 30_000,
+    }, async () => {
+      const bytes = await pdfLibObjectStreamExpansionPdf(17 * 1024 * 1024);
+      await expect(assertBoundedPdfStreamDecodes(bytes)).rejects.toMatchObject({
+        name: "PdfResourceLimitError",
+        code: "PDF_RESOURCE_LIMIT_EXCEEDED",
+        reason: "unsafe_object_stream_expansion",
+      });
+    });
+
+    it("runs the decoded ceiling before the production mutation parser", {
+      timeout: 30_000,
+    }, async () => {
+      const bytes = await pdfLibObjectStreamExpansionPdf(17 * 1024 * 1024);
+      await expect(loadPdfForMutation(bytes)).rejects.toMatchObject({
+        reason: "unsafe_object_stream_expansion",
+      });
+    });
+
+    it("enforces an injected small ceiling without coupling the test to a huge allocation", async () => {
+      const bytes = await pdfLibObjectStreamExpansionPdf(2 * 1024 * 1024);
+      await expect(assertBoundedPdfStreamDecodes(bytes, {
+        maximumDecodedObjectStreamBytes: 1024 * 1024,
+      })).rejects.toMatchObject({
+        code: "PDF_RESOURCE_LIMIT_EXCEEDED",
+        reason: "unsafe_object_stream_expansion",
+      });
+    });
+
+    it("accepts a highly compressible object stream below the byte ceiling", async () => {
+      const bytes = await pdfLibObjectStreamExpansionPdf(8 * 1024 * 1024);
+      expect(bytes.length).toBeLessThan(32 * 1024);
+      await expect(assertBoundedPdfStreamDecodes(bytes)).resolves.toBeUndefined();
+      await expect(loadPdfForMutation(bytes)).resolves.toBeDefined();
+    });
+
+    it("accepts an ordinary pdf-lib object-stream PDF", async () => {
+      const document = await PDFDocument.create();
+      for (let index = 0; index < 100; index += 1) document.addPage([200, 200]);
+      const bytes = Buffer.from(await document.save({ useObjectStreams: true }));
+      await expect(assertBoundedPdfStreamDecodes(bytes)).resolves.toBeUndefined();
+      await expect(loadPdfForMutation(bytes)).resolves.toBeDefined();
+    });
+
+    it("accepts an ordinary well-formed compressed content stream", async () => {
+      const bytes = flateContentPdf(4 * 1024 * 1024);
+      await expect(assertBoundedPdfStreamDecodes(bytes)).resolves.toBeUndefined();
+      await expect(loadPdfForMutation(bytes)).resolves.toBeDefined();
+    });
+
+    it("leaves a non-object stream with an image-only filter to existing controls", async () => {
+      const bytes = parsedStreamPdf("/DCTDecode", { payload: "not-decoded-by-this-preflight" });
+      await expect(assertBoundedPdfStreamDecodes(bytes)).resolves.toBeUndefined();
+    });
+
+    it.each([
+      ["an indirect Type", "/Type 5 0 R /Filter /FlateDecode"],
+      ["an indirect Filter", "/Type /ObjStm /Filter 5 0 R"],
+      ["an unsupported object-stream filter", "/Type /ObjStm /Filter /LZWDecode"],
+    ])("fails closed before parsing %s", async (_label, declaration) => {
+      const payload = zlib.deflateSync(Buffer.from("5 0 (safe)", "ascii"));
+      const bytes = buildPdf([
+        [1, "<< /Type /Catalog /Pages 2 0 R >>"],
+        [2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>"],
+        [3, "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Resources <<>> >>"],
+        [4, `<< ${declaration} /N 1 /First 4 /Length ${payload.length} >>`
+          + `\nstream\n${payload.toString("latin1")}\nendstream`],
+        [5, "/FlateDecode"],
+      ], 1);
+      await expect(assertBoundedPdfStreamDecodes(bytes)).rejects.toMatchObject({
+        code: "PDF_RESOURCE_LIMIT_EXCEEDED",
+        reason: "unsafe_object_stream_decode",
+      });
+    });
+  });
+
   it.each([
     "sparse-high-object-numbers",
     "sparse-xref-range-overflow",


### PR DESCRIPTION
Closes #123.

A compressed object stream with a very high expansion ratio could push the worker far past its memory ceiling in a single allocation. Measured on a reproducible fixture:

| | before | after |
|---|---|---|
| wall time | 35.03 s | **45 ms** |
| peak RSS | 4.4 GiB | **81 MiB** |

## Why the existing ceilings did not cover it

- `MAX_EXPANDING_FILTER_STAGES` bounds how many filters may be **chained**, not the output size of one decode.
- `assertBoundedPdfStructure` bounds structural density of the **raw** bytes; the hostile input is small and structurally ordinary, and its cost only exists after decoding.
- The RSS check **samples on an interval**, so a single allocation that jumps orders of magnitude between samples is never observed in an intermediate state. This is the key point: it is not that the monitor was mistuned, it is that a sampler cannot see a step function.
- The subprocess timeout was the only remaining backstop, and it is coarse: the work still runs to the ceiling.

## The bound

16 MiB of decoded object stream, enforced by streaming rather than sampling, refused with a typed resource error.

The rationale is in a comment at the constant: pdf-lib's own writer groups only fifty objects into each object stream, so a decoded stream above 16 MiB is far outside ordinary output, and the ceiling leaves headroom inside the worker's 384 MiB V8 old-space budget. Large legitimate PDFs are unaffected, because their bulk lives in image and content streams rather than in one serialized-object container.

## Verification

- Full unfiltered `test:all` on the macOS qualification host: **2,262 passed**, 91 skipped, up from 2,253 at `bb748a6`.
- The single failure in that run is `accessibility-formal-v2 > kills and reports a stubborn descendant after its leader exits`, which is unrelated to PDF decoding and **passes 3 out of 3 in isolation**. It is the race #113 addressed; #113 reduced it but has not eliminated it under aggregate load. Noted below rather than folded into this change.
- Raising the ceiling to `Number.MAX_SAFE_INTEGER` turns **two tests red**, so they bind to the guard rather than restate it.
- Acceptance controls that pass either way: a normal 100-page object-stream PDF, a normal compressed content stream, and a high-ratio-but-small stream. These are not vacuously coupled to the limit.
- `server/pdf-lib-worker.js` mirrored byte-identically into `pdf-toolkit-mcp-share/server/`.

## Provenance

Implemented by Codex against a written brief, then reviewed here. Worth recording that the first dispatch was refused by Codex's cybersecurity classifier because the brief was phrased around constructing a hostile file; rephrasing it around adding a resource limit, which is the more accurate description of the work, went through unchanged in substance.

## Follow-up, not fixed here

The descendant-cleanup race above still fires under full aggregate load. Worth its own look, since #113 was intended to close it.
