### PR TITLE
Let the read-only tools open password-protected documents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,9 +43,15 @@ PDF Toolkit is a Claude Desktop extension (MCPB) and MCP server that enables aut
 - `example-fw9.pdf` - Sample form for smoke tests. Keep anonymized assets only.
 - `docs/MAINTAINERS.md` - Maintainer onboarding and operations
 - `docs/RELEASE.md` - Release checklist
+- `server/qpdf-decrypt.js` - The only module that loads the qpdf runtime, and
+  the only path by which PDF Tools decrypts. Owns the password rules, the `/P`
+  permission enforcement, and the encrypted-input size cap. See
+  `## Password Support`.
 - `vendor/qpdf-wasm/` - Reproducible QPDF WebAssembly build recipe. The
   promoted artifact under `vendor/qpdf-wasm/runtime/` is shipped in both the
-  MCPB and the share ZIP at that same path, but **no tool loads it**. Do not
+  MCPB and the share ZIP at that same path, and is loaded by **exactly one
+  module**, `server/qpdf-decrypt.js` — a second importer would bypass its
+  safety rules and fails the artifact test. Do not
   hand-edit `runtime/` or `runtime.provenance.json`; regenerate them with
   `node scripts/vendor-qpdf-wasm-runtime.mjs <extracted-build-directory>`.
   `npm run qpdf-wasm:verify` is a ~45-minute Docker release gate and must stay
@@ -61,13 +67,47 @@ The project uses ES modules (`"type": "module"` in package.json):
 
 ## Password Support
 
-**Only PDF.js decrypts. pdf-lib does not.** `pdf-lib` 1.17.1 ships no decryption
-of any kind: `PDFDocument.load` has no `password` option, it throws
-`EncryptedPDFError` on an encrypted document, and `{ ignoreEncryption: true }`
-returns an unusable document that fails on the first page access. Every tool
-that reaches pdf-lib therefore fails on an encrypted PDF regardless of the
-password supplied. `pdfjs-dist` 5.4.624 does accept `{ password }` and opens the
-same document correctly.
+**pdf-lib does not decrypt. PDF.js does, and three read-only tools now do too
+via qpdf.** `pdf-lib` 1.17.1 ships no decryption of any kind: `PDFDocument.load`
+has no `password` option, it throws `EncryptedPDFError` on an encrypted
+document, and `{ ignoreEncryption: true }` returns an unusable document that
+fails on the first page access. Every tool that reaches pdf-lib therefore fails
+on an encrypted PDF regardless of the password supplied. `pdfjs-dist` 5.4.624
+does accept `{ password }` and opens the same document correctly.
+
+`read_pdf_fields`, `validate_pdf`, and `extract_to_csv` decrypt through the
+vendored qpdf WebAssembly runtime in `server/qpdf-decrypt.js` before handing
+plaintext to pdf-lib. They qualify because they only ever read: none of them
+writes a PDF back, so none can re-encrypt a document or alter its protection.
+Decrypted bytes stay in memory and are never written to disk.
+
+**The scope rule.** Decryption is not a "remove the password" facility:
+
+- Correct password supplied → decrypt and proceed.
+- Wrong password supplied → fail, saying the password was not accepted. The
+  empty string counts as *no password*, so it cannot be used to claim
+  credentialed access to a document whose user password is empty. A password
+  containing a line break is refused outright: it cannot be represented in the
+  single-line password file that keeps passwords off the command line.
+- **No password supplied, document opens with an empty user password** (the
+  owner-locked shape: opens freely, `/P` denies modification) → proceed only if
+  `/P` grants `extract`; otherwise refuse, naming the denied permission. qpdf
+  can decrypt, edit, and re-lock such a document with identical `/P` and `/R`
+  and no password at all, and PDF Tools must not become a tool for that.
+- Not encrypted → unchanged. pdf-lib is tried first, so no qpdf module is
+  instantiated and there is no measurable cost.
+
+All three require `/P` bit 5 (`extract`, content copying), because all three
+copy document content out. The `accessibility` bit is not accepted as a
+substitute — it is granted almost universally and nothing can verify the caller
+is assistive technology — and neither is `modifyforms`, which authorizes filling
+a form, not reading what is already in it.
+
+**Size cap.** Encrypted inputs are capped at **16 MiB**, separate from and far
+below the 250 MiB `PDF_MUTATION_MAX_FILE_BYTES`. Decryption costs roughly
+`16 x input + 45 MB` of peak RSS, so 16 MiB keeps a full read inside the
+1024 MiB the project already treats as too much. Oversized input gets a clear
+size message rather than an out-of-memory kill.
 
 Measured against an AES-256 PDF produced with
 `qpdf --encrypt --user-password=secret --owner-password=secret --bits=256`:
@@ -77,25 +117,27 @@ Measured against an AES-256 PDF produced with
 | `read_pdf_layout` | PDF.js | Real. Succeeds; reports a `RAW_PAGE_GEOMETRY_UNAVAILABLE` gap because raw geometry comes from pdf-lib. |
 | `convert_pdf_to_markdown` | PDF.js | Real. Same partial-coverage gap. |
 | `get_pdf_info` | PDF.js | Real. Same partial-coverage gap. |
-| `read_pdf_fields` | pdf-lib | None. Accepts `password`, cannot use it. |
+| `read_pdf_fields` | qpdf + pdf-lib | **Real.** Decrypts with the password; without one, reads only if `/P` allows `extract`. 16 MiB cap. |
 | `fill_pdf` | pdf-lib | None. Accepts `password`, cannot use it. |
 | `bulk_fill_from_csv` | pdf-lib | None. Accepts `password`, cannot use it. |
 | `fill_with_profile` | pdf-lib | None. Accepts `password`, cannot use it. |
-| `validate_pdf` | pdf-lib | None. Accepts `password`, cannot use it. |
+| `validate_pdf` | qpdf + pdf-lib | **Real.** Same rule and cap as `read_pdf_fields`. |
 | `merge_pdfs`, `split_pdf`, `rotate_pdf_pages`, `reorder_pdf_pages`, `apply_page_plan` | pdf-lib worker | None. Accept `password`, cannot use it. |
 | `add_signature_field`, `apply_signature`, `prepare_signing_packet`, `apply_text` | pdf-lib worker | None. Accept `password`, cannot use it. |
 | `render_pdf_page`, `render_pdf_region`, `get_page_analysis` | PDF.js plus pdf-lib geometry | None in practice. PDF.js uses the password, but the pdf-lib geometry load still fails. |
 | `detect_signature_zones` | PDF.js plus pdf-lib geometry | None in practice. It degrades through `ignoreEncryption` and succeeds only on the committed header-malformed R4 oracle; a well-formed AES-128 or AES-256 file fails. |
 | `compare_pdfs` | PDF.js plus pdf-lib geometry | None. With `include_visual` it reports the pdf-lib limit; without it, the run still ends in `internal_validation_error` (pre-existing, unrelated to the password). |
-| `extract_to_csv` | pdf-lib | None. No `password` parameter exists. |
+| `extract_to_csv` | qpdf + pdf-lib | **Partial.** No `password` parameter (one password cannot serve a list of documents), so it reads an encrypted document only when that document opens without a password and its `/P` allows `extract`. |
 | `read_pdf_content`, `read_pdf_pages`, `search_pdf_text` | PDF.js | None reachable. No `password` parameter exists, so an encrypted PDF cannot be opened. |
 | `inspect_pdf_accessibility` | pdf-lib | None, and it says so: it rejects a `password` argument outright. |
 
-Pass the optional `password` parameter only to `read_pdf_layout`,
-`convert_pdf_to_markdown`, and `get_pdf_info`. For anything else, decrypt the
-document first (for example with `qpdf --decrypt`) and operate on the plaintext
-copy. Adding decryption to the write paths means replacing or supplementing
-pdf-lib, which is an open dependency decision, not a bug fix.
+Pass the optional `password` parameter to `read_pdf_layout`,
+`convert_pdf_to_markdown`, `get_pdf_info`, `read_pdf_fields`, and
+`validate_pdf`. For anything else, decrypt the document first (for example with
+`qpdf --decrypt`) and operate on the plaintext copy. Adding decryption to the
+**write** paths is a separate, harder problem: a write path must re-encrypt to
+preserve the source's protection, which is exactly the capability the scope
+rule above withholds. It remains an open decision, not a bug fix.
 
 ## Development Commands
 

--- a/package-for-friend.js
+++ b/package-for-friend.js
@@ -52,6 +52,7 @@ export const SHARE_FILES = [
   "server/pdf-lib-worker.js",
   "server/pdfjs-subprocess.js",
   "server/pdfjs-worker.js",
+  "server/qpdf-decrypt.js",
   "server/resource-uri.js",
   "server/stderr-suppression.js",
   "server/type3-cm-pk-reference.js",

--- a/pdf-toolkit-mcp-share/server/index.js
+++ b/pdf-toolkit-mcp-share/server/index.js
@@ -54,6 +54,11 @@ import {
   publicPdfComparisonError,
 } from "./pdf-comparison.js";
 import {
+  PDF_DECRYPTABLE_PASSWORD_DESCRIPTION,
+  PdfDecryptionError,
+  decryptPdfForRead,
+} from "./qpdf-decrypt.js";
+import {
   PDF_MUTATION_MAX_FILE_BYTES,
   assertDanglingPdfInputAlias,
   assertCanonicalRecoveryDirectory,
@@ -594,34 +599,77 @@ function validateLoadedPdfStructure(pdfDoc, pdfBytes) {
   return pdfDoc;
 }
 
-async function loadPdfBytes(pdfBytes, password = null) {
+/**
+ * Loads bytes through pdf-lib, optionally decrypting first.
+ *
+ * pdf-lib is always tried first, so an unencrypted document pays nothing for
+ * this path: no QPDF module is instantiated and no extra parse happens. Only
+ * once pdf-lib has refused the document as encrypted, and only for an
+ * operation named in `ENCRYPTED_READ_OPERATIONS`, is the decrypting path
+ * entered at all.
+ *
+ * `decryptFor` is the opt-in. Passing it means "this operation only reads, and
+ * is allowed to decrypt subject to the rules in server/qpdf-decrypt.js".
+ * Without it the behaviour is exactly what it was: the honest pdf-lib message.
+ *
+ * When decryption happens the caller is handed a `releaseDecryptedBytes` and
+ * must call it once it has finished reading `pdfDoc`. pdf-lib copies the input
+ * during parsing, so releasing afterwards does not disturb the loaded
+ * document.
+ */
+async function loadPdfBytes(pdfBytes, password = null, { decryptFor = null } = {}) {
   const invalidPdfMessage = "Failed to load PDF: the file is malformed, incomplete, or unsupported.";
   let pdfDoc;
   try {
     pdfDoc = await PDFDocument.load(pdfBytes, password ? { password } : {});
   } catch (error) {
     if (error.message?.includes("password") || error.message?.includes("encrypt")) {
-      throw new Error(PDF_LIB_ENCRYPTED_MESSAGE);
+      if (!decryptFor) throw new Error(PDF_LIB_ENCRYPTED_MESSAGE);
+      return loadEncryptedPdfBytes(pdfBytes, password, decryptFor, invalidPdfMessage);
     }
     throw new Error(invalidPdfMessage, { cause: error });
   }
-  return validateLoadedPdfStructure(pdfDoc, pdfBytes);
+  return { pdfDoc: validateLoadedPdfStructure(pdfDoc, pdfBytes), releaseDecryptedBytes: () => {} };
 }
 
-async function loadPdf(inputPath, password = null) {
+/**
+ * The encrypted branch of `loadPdfBytes`. Decrypts in memory, parses the
+ * plaintext, and releases the plaintext immediately if parsing fails so a
+ * malformed decrypted document does not leave it sitting in the heap.
+ */
+async function loadEncryptedPdfBytes(pdfBytes, password, decryptFor, invalidPdfMessage) {
+  const decrypted = await decryptPdfForRead(pdfBytes, password, decryptFor);
+  let pdfDoc;
+  try {
+    pdfDoc = await PDFDocument.load(decrypted.plaintext);
+    // Validated against the plaintext, because that is the byte sequence this
+    // document was actually parsed from.
+    validateLoadedPdfStructure(pdfDoc, decrypted.plaintext);
+  } catch (error) {
+    decrypted.release();
+    if (error?.message === invalidPdfMessage) throw error;
+    throw new Error(invalidPdfMessage, { cause: error });
+  }
+  return { pdfDoc, releaseDecryptedBytes: () => decrypted.release() };
+}
+
+async function loadPdf(inputPath, password = null, { decryptFor = null } = {}) {
   const {
     resolvedPath,
     pdfBytes,
     fileIdentity,
     inputRecoveryBinding,
   } = await readPdfInputWithRecovery(inputPath);
-  const pdfDoc = await loadPdfBytes(pdfBytes, password);
+  const { pdfDoc, releaseDecryptedBytes } = await loadPdfBytes(pdfBytes, password, { decryptFor });
   return {
     pdfDoc,
     resolvedPath,
+    // Always the bytes as they are on disk. A decrypted copy is never returned
+    // here and never reaches a caller that might persist it.
     pdfBytes,
     fileIdentity,
     inputRecoveryBinding,
+    releaseDecryptedBytes,
   };
 }
 
@@ -2716,7 +2764,10 @@ async function fillPdfDocumentFields(pdfDoc, fieldData) {
 }
 
 async function fillPdfBytes(pdfBytes, fieldData, password = null) {
-  return await fillPdfDocumentFields(await loadPdfBytes(pdfBytes, password), fieldData);
+  // No `decryptFor`: filling writes the document back, so it stays on the
+  // honest pdf-lib limit rather than the decrypting path.
+  const { pdfDoc } = await loadPdfBytes(pdfBytes, password);
+  return await fillPdfDocumentFields(pdfDoc, fieldData);
 }
 
 // read_pdf_content, read_pdf_pages, and search_pdf_text decrypt through PDF.js
@@ -2777,7 +2828,7 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
             },
             password: {
               type: "string",
-              description: PDF_LIB_UNUSABLE_PASSWORD_DESCRIPTION,
+              description: PDF_DECRYPTABLE_PASSWORD_DESCRIPTION,
             }
           },
           required: ["pdf_path"]
@@ -3012,7 +3063,7 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
             },
             password: {
               type: "string",
-              description: PDF_LIB_UNUSABLE_PASSWORD_DESCRIPTION,
+              description: PDF_DECRYPTABLE_PASSWORD_DESCRIPTION,
             }
           },
           required: ["pdf_path"]
@@ -4250,13 +4301,20 @@ async function handleToolCall(request) {
 
       case "read_pdf_fields": {
         const { pdf_path, password } = args;
-        const { pdfDoc, resolvedPath } = await loadPdf(pdf_path, password);
+        // Read-only: this never writes the PDF back, so it may decrypt.
+        const { pdfDoc, resolvedPath, releaseDecryptedBytes } = await loadPdf(
+          pdf_path,
+          password,
+          { decryptFor: "read_pdf_fields" },
+        );
         noteDocumentOpened(resolvedPath);
 
         const form = pdfDoc.getForm();
         const fields = form.getFields();
-        
-        const fieldInfo = fields.map(field => {
+
+        let fieldInfo;
+        try {
+          fieldInfo = fields.map(field => {
           const name = field.getName();
           let type = "unknown";
           let options = [];
@@ -4282,8 +4340,13 @@ async function handleToolCall(request) {
           }
           
           return { name, type, options, currentValue };
-        });
-        
+          });
+        } finally {
+          // Every value has been copied out of the document, so any decrypted
+          // plaintext can go now rather than at the end of the response build.
+          releaseDecryptedBytes();
+        }
+
         const payload = await buildActiveDocumentPayload(resolvedPath, 1, {
           fields: fieldInfo,
           fieldCount: fields.length,
@@ -4585,33 +4648,43 @@ async function handleToolCall(request) {
         for (const pdfPath of pdf_paths) {
           const resolvedPdfPath = resolvePath(pdfPath);
           const pdfBytes = await fs.readFile(resolvedPdfPath);
-          // Via loadPdfBytes so an encrypted input reports the honest pdf-lib
-          // limit instead of pdf-lib's raw "use ignoreEncryption" advice, which
-          // does not work on an encrypted document.
-          const pdfDoc = await loadPdfBytes(pdfBytes);
+          // Read-only: this writes a CSV, never a PDF, so it may decrypt. The
+          // tool takes a list of documents and no password — one password
+          // could not serve a list — so the only encrypted documents it can
+          // read are those that open without one and whose own permissions
+          // allow extraction. Anything else is refused by name.
+          const { pdfDoc, releaseDecryptedBytes } = await loadPdfBytes(pdfBytes, null, {
+            decryptFor: "extract_to_csv",
+          });
           const form = pdfDoc.getForm();
           const fields = form.getFields();
-          
+
           const rowData = { _filename: path.basename(pdfPath) };
-          
-          for (const field of fields) {
-            const fieldName = field.getName();
-            allFieldNames.add(fieldName);
-            
-            try {
-              if (field.constructor.name.includes('TextField')) {
-                rowData[fieldName] = field.getText() || "";
-              } else if (field.constructor.name.includes('CheckBox')) {
-                rowData[fieldName] = field.isChecked() ? "yes" : "no";
-              } else if (field.constructor.name.includes('RadioGroup') || 
-                         field.constructor.name.includes('Dropdown')) {
-                rowData[fieldName] = field.getSelected() || "";
+
+          try {
+            for (const field of fields) {
+              const fieldName = field.getName();
+              allFieldNames.add(fieldName);
+
+              try {
+                if (field.constructor.name.includes('TextField')) {
+                  rowData[fieldName] = field.getText() || "";
+                } else if (field.constructor.name.includes('CheckBox')) {
+                  rowData[fieldName] = field.isChecked() ? "yes" : "no";
+                } else if (field.constructor.name.includes('RadioGroup') ||
+                           field.constructor.name.includes('Dropdown')) {
+                  rowData[fieldName] = field.getSelected() || "";
+                }
+              } catch (e) {
+                rowData[fieldName] = "";
               }
-            } catch (e) {
-              rowData[fieldName] = "";
             }
+          } finally {
+            // Released per document, so a long list never holds more than one
+            // decrypted document in memory at a time.
+            releaseDecryptedBytes();
           }
-          
+
           allData.push(rowData);
         }
         
@@ -4647,13 +4720,21 @@ async function handleToolCall(request) {
         const { pdf_path, password } = args;
         let resolvedPath = null;
         try {
-          const loaded = await loadPdf(pdf_path, password);
+          // Read-only: this never writes the PDF back, so it may decrypt.
+          const loaded = await loadPdf(pdf_path, password, { decryptFor: "validate_pdf" });
           resolvedPath = loaded.resolvedPath;
-          const fields = loaded.pdfDoc.getForm().getFields();
-          const validation = validatePdfFormFields(fields, {
-            pdfPath: resolvedPath,
-            fileName: path.basename(resolvedPath),
-          });
+          let validation;
+          try {
+            const fields = loaded.pdfDoc.getForm().getFields();
+            validation = validatePdfFormFields(fields, {
+              pdfPath: resolvedPath,
+              fileName: path.basename(resolvedPath),
+            });
+          } finally {
+            // The report is fully materialized above; nothing below reads the
+            // document again, so any decrypted plaintext can go now.
+            loaded.releaseDecryptedBytes();
+          }
 
           const requiredSummary = validation.required_fields_complete === null
             ? "UNKNOWN"
@@ -4715,17 +4796,27 @@ async function handleToolCall(request) {
             content: [{ type: "text", text: message.join("\n") }],
             structuredContent: validation,
           };
-        } catch {
+        } catch (error) {
           const validation = failedPdfFormValidation({
             pdfPath: resolvedPath,
             fileName: path.basename(String(pdf_path || "unknown.pdf")),
           });
+          // "Verify the path/password and retry" is useless advice when the
+          // reason is already known and actionable: a password the document
+          // rejected, or permissions that deny the read. Those messages are
+          // fixed strings built here, never QPDF output, so passing them
+          // through leaks nothing.
+          const reason = error instanceof PdfDecryptionError
+            || error?.message === PDF_LIB_ENCRYPTED_MESSAGE
+            ? error.message
+            : null;
           return {
             content: [{
               type: "text",
-              text:
-                `Error: PDF field validation failed for ${validation.file_name}. ` +
-                "Do not interpret this as an empty or complete form. Verify the path/password and retry.",
+              text: reason
+                ? `Error: PDF field validation failed for ${validation.file_name}. ${reason}`
+                : `Error: PDF field validation failed for ${validation.file_name}. `
+                  + "Do not interpret this as an empty or complete form. Verify the path/password and retry.",
             }],
             structuredContent: validation,
             isError: true,

--- a/pdf-toolkit-mcp-share/server/qpdf-decrypt.js
+++ b/pdf-toolkit-mcp-share/server/qpdf-decrypt.js
@@ -1,0 +1,541 @@
+/**
+ * Decryption of encrypted PDFs for the read-only tools, and the only module
+ * under `server/` that loads the vendored QPDF WebAssembly runtime.
+ *
+ * pdf-lib 1.17.1 cannot decrypt anything, so every tool that reads through it
+ * fails on an encrypted document no matter what password the caller supplies.
+ * This module gives three of those tools — `read_pdf_fields`, `validate_pdf`
+ * and `extract_to_csv` — a way through. All three only ever read: none of them
+ * writes a PDF back, so nothing here can re-encrypt a document, change its
+ * protection, or persist a decrypted copy.
+ *
+ * ## What this deliberately does not do
+ *
+ * It is not a "remove the password" facility. QPDF will decrypt an
+ * owner-locked document — one that opens with an empty user password but whose
+ * `/P` denies modification — without any password at all, and will re-lock it
+ * afterwards with an identical `/P` and `/R`. Shipping that shape would make
+ * PDF Tools a permissions-circumvention tool. So decryption is gated twice:
+ *
+ *   - a caller who supplies a password that the document accepts is acting on
+ *     a credential they already hold, and proceeds; but
+ *   - a caller who supplies none, and merely benefits from the document's
+ *     empty user password, proceeds only if the document's own `/P` grants the
+ *     permission the operation needs, and is otherwise refused by name.
+ *
+ * The empty string counts as *no password*, so the check above cannot be
+ * sidestepped by passing `""` to a document whose user password is empty.
+ *
+ * ## Which permission bit
+ *
+ * All three tools require `extract` — `/P` bit 5, "copy or otherwise extract
+ * text and graphics". Every one of them copies document content out of the
+ * document: `read_pdf_fields` returns field names and their current values,
+ * `validate_pdf` reports field names and whether each is filled, and
+ * `extract_to_csv` writes field values to a CSV file on disk. That is
+ * extraction under any reading of the bit.
+ *
+ * Two nearby bits are deliberately *not* accepted as substitutes:
+ *
+ *   - `accessibility` (bit 10) is almost always granted and would make the
+ *     check vacuous. It authorizes extraction for assistive technology, and
+ *     nothing here can establish that the caller is assistive technology.
+ *   - `modifyforms` (bit 9) authorizes filling a form, not reading what is
+ *     already in it. A document may permit filling while denying extraction,
+ *     and honouring `modifyforms` here would hand back the values that
+ *     `extract` was set to withhold.
+ *
+ * ## Memory
+ *
+ * QPDF-WASM costs roughly 16x the input size plus a ~45 MB baseline, and the
+ * WebAssembly heap is not reliably returned to the OS within the process.
+ * Encrypted inputs therefore get their own explicit, much lower size cap
+ * (`PDF_ENCRYPTED_MAX_FILE_BYTES`) instead of the 250 MiB mutation cap, and
+ * oversized ones are refused with a size message rather than being allowed to
+ * run into an out-of-memory kill. See the constant for the measurements.
+ *
+ * ## Plaintext handling
+ *
+ * Decrypted bytes exist only in memory and are never written to disk. The
+ * caller gets a `release()` and must call it once it has finished reading the
+ * loaded document. Be honest about what that buys: `release()` overwrites the
+ * Node buffer it handed out, but JavaScript cannot guarantee erasure. The
+ * WebAssembly heap holds its own copies that only the module's own teardown
+ * reclaims, the garbage collector may already have copied the buffer, and any
+ * of those pages may have been written to swap. This reduces the window in
+ * which plaintext is readable in the process; it does not eliminate it.
+ */
+
+const QPDF_RUNTIME_RELATIVE_PATH = "../vendor/qpdf-wasm/runtime/qpdf.mjs";
+
+// Fixed paths inside the module's private in-memory filesystem. A fresh module
+// is created for every QPDF invocation, so these never collide across calls.
+const VIRTUAL_INPUT_PATH = "/in.pdf";
+const VIRTUAL_OUTPUT_PATH = "/out.pdf";
+const VIRTUAL_PASSWORD_PATH = "/pw";
+
+// The JSON inspection output is a few hundred bytes; QPDF diagnostics are a
+// few lines. Anything beyond this means the runtime is not behaving as built.
+const QPDF_OUTPUT_BYTE_CAP = 64 * 1024;
+
+/*
+ * QPDF's documented exit codes. 3 means the operation completed but the file
+ * needed recovery — a damaged cross-reference table, a stream whose declared
+ * length was wrong, and so on. Real-world PDFs produce it often enough that
+ * rejecting it would make this feature fail on documents QPDF read perfectly
+ * well. It is accepted only when output was actually produced, and the
+ * recovered document then still has to survive pdf-lib's parse and the page-
+ * tree validation, so accepting a warning is not accepting a broken document.
+ *
+ * 2 is a genuine error, and includes the one case that must stay
+ * distinguishable: a password the document did not accept.
+ */
+const QPDF_EXIT_SUCCESS = 0;
+const QPDF_EXIT_WARNINGS = 3;
+const qpdfCompleted = status => status === QPDF_EXIT_SUCCESS || status === QPDF_EXIT_WARNINGS;
+
+/**
+ * The per-file ceiling for an encrypted input, deliberately separate from and
+ * far below `PDF_MUTATION_MAX_FILE_BYTES` (250 MiB), which must not govern
+ * this path.
+ *
+ * Measured against this runtime on macOS/arm64, decrypting costs a peak RSS of
+ * roughly `16 x input + 45 MB`:
+ *
+ *   |  input | peak RSS delta |
+ *   | -----: | -------------: |
+ *   | 1.0 MB |          52 MB |
+ *   | 7.3 MB |         162 MB |
+ *   | 14.6MB |         272 MB |
+ *   | 29.2MB |         472 MB |
+ *
+ * At 16 MiB the decrypt peak is about 300 MB, and the plaintext then has to be
+ * parsed by pdf-lib on top of that, landing the whole read comfortably inside
+ * the 1024 MiB that `PDF_LIB_RSS_MAXIMUM_BYTES` already treats as the point
+ * where a PDF operation has consumed too much. Doubling the cap to 32 MiB
+ * would put the decrypt alone near 560 MB and the full read past 700 MB, with
+ * no useful margin; that is the reason for the specific number rather than a
+ * rounder, larger one.
+ *
+ * Repeated decryption within one process was measured not to accumulate: RSS
+ * plateaus near the high-water mark of the single largest input rather than
+ * summing, so a per-file cap is sufficient and `extract_to_csv` does not need
+ * an additional aggregate bound.
+ */
+export const PDF_ENCRYPTED_MAX_FILE_BYTES = 16 * 1024 * 1024;
+
+/**
+ * The operations allowed to decrypt, and the `/P` capability each one needs
+ * when the caller supplied no password. Adding an entry here is a security
+ * decision: it grants a tool the ability to read encrypted documents.
+ */
+export const ENCRYPTED_READ_OPERATIONS = Object.freeze({
+  read_pdf_fields: Object.freeze({
+    capability: "extract",
+    activity: "read its form fields and their values",
+  }),
+  validate_pdf: Object.freeze({
+    capability: "extract",
+    activity: "report which of its form fields are filled",
+  }),
+  extract_to_csv: Object.freeze({
+    capability: "extract",
+    activity: "extract its form data to a CSV file",
+  }),
+});
+
+/** Human-readable names for the `/P` capabilities this module can require. */
+const CAPABILITY_LABELS = Object.freeze({
+  extract: "content copying and extraction",
+});
+
+export const PDF_ENCRYPTED_FILE_LIMIT_MESSAGE =
+  `Encrypted PDF exceeds the ${PDF_ENCRYPTED_MAX_FILE_BYTES / (1024 * 1024)} MiB limit for `
+  + "decryption. Decrypting a PDF costs about 16 times its size in memory, so encrypted inputs "
+  + "have a lower size limit than unencrypted ones. Decrypt the file first (for example with "
+  + "qpdf) and retry with the decrypted copy.";
+
+export const PDF_PASSWORD_REJECTED_MESSAGE =
+  "The password was not accepted: this PDF is encrypted, and the supplied password matches "
+  + "neither its user password nor its owner password. Check the password and retry.";
+
+export const PDF_PASSWORD_REQUIRED_MESSAGE =
+  "This PDF is encrypted and cannot be opened without a password. Supply the document's "
+  + "password in the 'password' parameter and retry.";
+
+export const PDF_PASSWORD_UNREPRESENTABLE_MESSAGE =
+  "This password cannot be used: it contains a line break. Passwords are handed to the decryption "
+  + "engine through a single-line password file, never on a command line, so a password containing "
+  + "a carriage return or newline cannot be represented. Remove the line break and retry.";
+
+export const PDF_DECRYPTION_FAILED_MESSAGE =
+  "This PDF is encrypted and could not be decrypted: the document is malformed, incomplete, or "
+  + "uses an encryption scheme this build does not support.";
+
+/**
+ * Refusal text for the owner-locked case. Names the denied permission, says
+ * plainly that no password was supplied, and points at the one legitimate way
+ * forward, without ever suggesting a way around the restriction.
+ */
+export function pdfPermissionDeniedMessage(operation) {
+  const { activity, capability } = ENCRYPTED_READ_OPERATIONS[operation];
+  const label = CAPABILITY_LABELS[capability];
+  return `This PDF is encrypted and its permissions deny ${label} (/P '${capability}'), so `
+    + `PDF Tools will not ${activity}. It opens without a password, but that does not grant the `
+    + "denied permission, and PDF Tools does not override a document's own restrictions. "
+    + "If you hold the owner password, supply it in the 'password' parameter and retry.";
+}
+
+/**
+ * Parameter text for the three tools that can now decrypt. Replaces
+ * `PDF_LIB_UNUSABLE_PASSWORD_DESCRIPTION`, which is false for exactly these.
+ */
+export const PDF_DECRYPTABLE_PASSWORD_DESCRIPTION =
+  "Password for an encrypted PDF. Supply the user or owner password and the document is "
+  + `decrypted in memory to complete this read (encrypted inputs are limited to `
+  + `${PDF_ENCRYPTED_MAX_FILE_BYTES / (1024 * 1024)} MiB). Leave it unset for an unencrypted `
+  + "document. An encrypted document that opens without a password is still read only if its "
+  + "own permissions allow content extraction; PDF Tools does not override them.";
+
+export class PdfDecryptionError extends Error {
+  constructor(reason, message) {
+    super(message);
+    this.name = "PdfDecryptionError";
+    this.reason = reason;
+  }
+}
+
+/**
+ * Collects a QPDF output stream under a hard byte cap. The captured text is
+ * used only to parse the inspection JSON and is never surfaced to a caller:
+ * QPDF prefixes its diagnostics with `argv[0]` and echoes virtual paths, so
+ * every failure below maps to a fixed message instead.
+ */
+function boundedCapture() {
+  const lines = [];
+  let bytes = 0;
+  let overflowed = false;
+  return {
+    write(line) {
+      const text = String(line);
+      bytes += Buffer.byteLength(text, "utf8") + 1;
+      if (bytes > QPDF_OUTPUT_BYTE_CAP) {
+        overflowed = true;
+        return;
+      }
+      lines.push(text);
+    },
+    get overflowed() {
+      return overflowed;
+    },
+    text() {
+      return lines.join("\n");
+    },
+  };
+}
+
+/**
+ * Builds the password file contents. QPDF's `--password-file` reads the first
+ * line, which keeps the password out of `argv` — where it would otherwise be
+ * visible to anything that can read the process's command line, and would be
+ * echoed back by QPDF's own usage diagnostics.
+ */
+function passwordFileBytes(password) {
+  // QPDF reads the first line of the file, so a password containing a line
+  // break would be silently truncated and then reported as "not accepted" —
+  // a confusing lie. Refuse it explicitly instead.
+  if (/[\r\n]/.test(password)) {
+    throw new PdfDecryptionError("password_unrepresentable", PDF_PASSWORD_UNREPRESENTABLE_MESSAGE);
+  }
+  return Buffer.from(`${password}\n`, "utf8");
+}
+
+/**
+ * A password is "supplied" only if it is a non-empty string.
+ *
+ * The empty string is treated as absent because it is exactly the credential
+ * an owner-locked document accepts: counting it as "supplied" would let any
+ * caller claim credentialed access to a document whose user password is empty
+ * and skip the `/P` check entirely.
+ *
+ * Whitespace is *not* trimmed. A password of `" "` is unusual but legitimate,
+ * and it needs no special handling to be safe: it is not the empty password,
+ * so QPDF rejects it on a document that expects one, and the caller gets an
+ * honest "not accepted" instead of a silent permission check.
+ */
+export function normalizeSuppliedPassword(password) {
+  if (password === null || password === undefined) return null;
+  if (typeof password !== "string") {
+    throw new TypeError("PDF password must be a string.");
+  }
+  return password === "" ? null : password;
+}
+
+let runtimeFactoryPromise = null;
+
+/**
+ * Whether this process has ever asked for the QPDF runtime. Exists so the
+ * "an unencrypted document pays nothing" property can be asserted as a fact
+ * rather than as a claim in a comment. It exposes no capability.
+ */
+export function isQpdfRuntimeLoaded() {
+  return runtimeFactoryPromise !== null;
+}
+
+/*
+ * Decryptions run one at a time.
+ *
+ * The size cap is derived from the peak cost of a *single* decrypt. The MCP
+ * server does not serialize tool calls, so without this two concurrent
+ * encrypted reads would each be allowed 16 MiB and the budget the cap was
+ * calculated against would be wrong by a factor of the concurrency. Queueing
+ * makes the measured single-operation peak the real ceiling no matter how many
+ * callers arrive at once.
+ *
+ * A queued caller waits rather than fails: at the cap a decrypt is on the order
+ * of a second, which is a far better outcome than an out-of-memory kill that
+ * takes the whole server down. The queue never rejects, so one failing
+ * operation cannot poison the chain for the next.
+ */
+let decryptionQueue = Promise.resolve();
+
+function queueDecryption(operation) {
+  const result = decryptionQueue.then(operation, operation);
+  decryptionQueue = result.then(() => {}, () => {});
+  return result;
+}
+
+/**
+ * Resolves the runtime's ESM factory once per process. The factory is just a
+ * function; each call below still instantiates its own module, so no QPDF
+ * state, filesystem entry, or password crosses between requests.
+ *
+ * The specifier is computed rather than literal so that test-time bundlers
+ * leave the Emscripten output alone: it resolves its own `.wasm` sibling from
+ * `import.meta.url` and has to be loaded as a plain Node module. The path is
+ * identical in the checkout, the MCPB and the share ZIP, so this resolves the
+ * same way in all three.
+ */
+async function loadQpdfFactory() {
+  if (!runtimeFactoryPromise) {
+    const runtimeUrl = new URL(QPDF_RUNTIME_RELATIVE_PATH, import.meta.url).href;
+    runtimeFactoryPromise = import(runtimeUrl).then(module => {
+      if (typeof module.default !== "function") {
+        throw new PdfDecryptionError("runtime_unavailable", PDF_DECRYPTION_FAILED_MESSAGE);
+      }
+      return module.default;
+    });
+    runtimeFactoryPromise.catch(() => {});
+  }
+  return runtimeFactoryPromise;
+}
+
+/**
+ * Runs one QPDF invocation in its own freshly instantiated module and tears it
+ * down afterwards. Returns the exit status, the captured stdout, and the
+ * requested output file if the run produced one.
+ *
+ * The module, its `FS`, and its raw exports never leave this function: the
+ * vendored runtime's README is explicit that callers must be given a narrow
+ * operation API rather than the module or its filesystem.
+ */
+async function runQpdf(args, inputs, outputPath = null) {
+  const createQpdf = await loadQpdfFactory();
+  const stdout = boundedCapture();
+  const stderr = boundedCapture();
+  let qpdf = null;
+  let status;
+  let output = null;
+  try {
+    qpdf = await createQpdf({
+      print: line => stdout.write(line),
+      printErr: line => stderr.write(line),
+    });
+    for (const [virtualPath, bytes] of Object.entries(inputs)) {
+      qpdf.FS.writeFile(virtualPath, bytes);
+    }
+    try {
+      status = qpdf.callMain([...args]);
+    } catch (error) {
+      // Emscripten reports a normal `exit()` by throwing an object carrying
+      // the status. Anything without an integer status is a real fault.
+      if (!Number.isInteger(error?.status)) {
+        throw new PdfDecryptionError("qpdf_faulted", PDF_DECRYPTION_FAILED_MESSAGE);
+      }
+      status = error.status;
+    }
+    if (qpdfCompleted(status) && outputPath) {
+      output = Buffer.from(qpdf.FS.readFile(outputPath));
+    }
+  } catch (error) {
+    if (error instanceof PdfDecryptionError) throw error;
+    throw new PdfDecryptionError("qpdf_faulted", PDF_DECRYPTION_FAILED_MESSAGE);
+  } finally {
+    // Overwrite then unlink every virtual file, so the ciphertext, the
+    // password and any plaintext output stop being reachable through this
+    // module before it is dropped. Best effort by nature: the WebAssembly heap
+    // keeps its own copies until the module itself is collected.
+    if (qpdf) {
+      for (const virtualPath of [...Object.keys(inputs), ...(outputPath ? [outputPath] : [])]) {
+        try {
+          const existing = qpdf.FS.readFile(virtualPath);
+          qpdf.FS.writeFile(virtualPath, new Uint8Array(existing.length));
+          qpdf.FS.unlink(virtualPath);
+        } catch {
+          // The file may never have been created, or QPDF may have removed it.
+        }
+      }
+    }
+    qpdf = null;
+  }
+  if (stdout.overflowed || stderr.overflowed) {
+    throw new PdfDecryptionError("qpdf_output_overflow", PDF_DECRYPTION_FAILED_MESSAGE);
+  }
+  return { status, stdout: stdout.text(), stderr: stderr.text(), output };
+}
+
+/*
+ * QPDF's own wording for a password that matched neither the user nor the
+ * owner password. Matched internally only, to tell "this needs a password you
+ * did not give" apart from "this file is broken" — advice that would otherwise
+ * be wrong half the time. The matched text is never surfaced: QPDF prefixes
+ * its diagnostics with argv[0] and echoes the virtual input path. If the
+ * wording ever changes the classification falls back to the malformed message,
+ * which is the safe direction: it never claims a password would help.
+ */
+const QPDF_INVALID_PASSWORD_DIAGNOSTIC = "invalid password";
+
+/**
+ * Reads the document's encryption state and effective permissions without
+ * producing any decrypted output.
+ */
+async function inspectEncryption(pdfBytes, password) {
+  const { status, stdout, stderr } = await runQpdf(
+    [
+      "--json=latest",
+      "--json-key=encrypt",
+      `--password-file=${VIRTUAL_PASSWORD_PATH}`,
+      VIRTUAL_INPUT_PATH,
+    ],
+    {
+      [VIRTUAL_INPUT_PATH]: pdfBytes,
+      [VIRTUAL_PASSWORD_PATH]: passwordFileBytes(password ?? ""),
+    },
+  );
+  if (!qpdfCompleted(status)) {
+    // QPDF does not fall back to the empty password when a wrong one is given,
+    // so a supplied-but-wrong password fails here rather than opening the
+    // document by way of an empty user password. A malformed file fails here
+    // too, and must not be reported as needing a password.
+    if (!stderr.toLowerCase().includes(QPDF_INVALID_PASSWORD_DIAGNOSTIC)) {
+      throw new PdfDecryptionError("unreadable_document", PDF_DECRYPTION_FAILED_MESSAGE);
+    }
+    throw new PdfDecryptionError(
+      password === null ? "password_required" : "password_rejected",
+      password === null ? PDF_PASSWORD_REQUIRED_MESSAGE : PDF_PASSWORD_REJECTED_MESSAGE,
+    );
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(stdout)?.encrypt;
+  } catch {
+    throw new PdfDecryptionError("malformed_inspection", PDF_DECRYPTION_FAILED_MESSAGE);
+  }
+  if (
+    !parsed
+    || typeof parsed.encrypted !== "boolean"
+    || typeof parsed.ownerpasswordmatched !== "boolean"
+    || typeof parsed.userpasswordmatched !== "boolean"
+    || !parsed.capabilities
+    || typeof parsed.capabilities.extract !== "boolean"
+  ) {
+    throw new PdfDecryptionError("malformed_inspection", PDF_DECRYPTION_FAILED_MESSAGE);
+  }
+  return {
+    encrypted: parsed.encrypted,
+    ownerPasswordMatched: parsed.ownerpasswordmatched,
+    userPasswordMatched: parsed.userpasswordmatched,
+    capabilities: parsed.capabilities,
+  };
+}
+
+/**
+ * Decrypts an encrypted PDF for one of the read-only operations, subject to
+ * the size cap, the password rules and the permission rules documented above.
+ *
+ * Returns `{ plaintext, encryption, release }`. The caller owns `release()`
+ * and must call it once it has finished reading the document that was loaded
+ * from `plaintext`.
+ *
+ * @param {Buffer} pdfBytes  The encrypted file exactly as it is on disk.
+ * @param {string|null} password  The caller-supplied password, if any.
+ * @param {string} operation  A key of `ENCRYPTED_READ_OPERATIONS`.
+ */
+export async function decryptPdfForRead(pdfBytes, password, operation) {
+  return queueDecryption(() => decryptPdfForReadExclusively(pdfBytes, password, operation));
+}
+
+/** The body of `decryptPdfForRead`, run with the decryption queue held. */
+async function decryptPdfForReadExclusively(pdfBytes, password, operation) {
+  const rules = ENCRYPTED_READ_OPERATIONS[operation];
+  if (!rules) {
+    throw new TypeError(`Operation '${operation}' is not permitted to decrypt PDFs.`);
+  }
+  if (!Buffer.isBuffer(pdfBytes) && !(pdfBytes instanceof Uint8Array)) {
+    throw new TypeError("Encrypted PDF bytes must be a Buffer or Uint8Array.");
+  }
+  const suppliedPassword = normalizeSuppliedPassword(password);
+
+  // Checked before anything is instantiated, so an oversized input costs a
+  // length comparison rather than an out-of-memory kill.
+  if (pdfBytes.length > PDF_ENCRYPTED_MAX_FILE_BYTES) {
+    throw new PdfDecryptionError("encrypted_input_too_large", PDF_ENCRYPTED_FILE_LIMIT_MESSAGE);
+  }
+
+  const encryption = await inspectEncryption(pdfBytes, suppliedPassword);
+  if (!encryption.encrypted) {
+    // pdf-lib refused this document as encrypted but QPDF sees no encryption
+    // dictionary. The two disagree about what the file is, so decrypting it
+    // would be guessing.
+    throw new PdfDecryptionError("encryption_state_disagreement", PDF_DECRYPTION_FAILED_MESSAGE);
+  }
+
+  const credentialed = suppliedPassword !== null
+    && (encryption.ownerPasswordMatched || encryption.userPasswordMatched);
+  if (!credentialed && encryption.capabilities[rules.capability] !== true) {
+    throw new PdfDecryptionError(
+      "permission_denied",
+      pdfPermissionDeniedMessage(operation),
+    );
+  }
+
+  const { status, output } = await runQpdf(
+    [
+      `--password-file=${VIRTUAL_PASSWORD_PATH}`,
+      "--decrypt",
+      VIRTUAL_INPUT_PATH,
+      VIRTUAL_OUTPUT_PATH,
+    ],
+    {
+      [VIRTUAL_INPUT_PATH]: pdfBytes,
+      [VIRTUAL_PASSWORD_PATH]: passwordFileBytes(suppliedPassword ?? ""),
+    },
+    VIRTUAL_OUTPUT_PATH,
+  );
+  if (!qpdfCompleted(status) || !output || output.length === 0) {
+    throw new PdfDecryptionError("decrypt_failed", PDF_DECRYPTION_FAILED_MESSAGE);
+  }
+
+  let released = false;
+  return {
+    plaintext: output,
+    encryption,
+    release() {
+      if (released) return;
+      released = true;
+      // See the module header: this shortens the window in which plaintext is
+      // readable in this process. It cannot guarantee erasure.
+      output.fill(0);
+    },
+  };
+}

--- a/scripts/build-mcpb.mjs
+++ b/scripts/build-mcpb.mjs
@@ -84,6 +84,7 @@ export const SERVER_FILES = [
   "pdf-observations.js",
   "pdfjs-subprocess.js",
   "pdfjs-worker.js",
+  "qpdf-decrypt.js",
   "resource-uri.js",
   "stderr-suppression.js",
   "type3-cm-pk-reference.js",

--- a/scripts/qpdf-wasm-runtime.mjs
+++ b/scripts/qpdf-wasm-runtime.mjs
@@ -17,9 +17,12 @@
  * instead of merely asserting that a file of the right name exists. That is
  * the check that distinguishes a shipped artifact from a present one.
  *
- * Nothing in `server/` imports this runtime. It is packaged and notice-
- * complete so that a later decryption integration has a shipped artifact to
- * build on; it is not wired into any tool.
+ * Exactly one module imports this runtime: `server/qpdf-decrypt.js`, which
+ * decrypts encrypted PDFs in memory for the read-only tools `read_pdf_fields`,
+ * `validate_pdf` and `extract_to_csv`. That single-importer property is
+ * asserted by `test/qpdf-wasm-runtime-artifact.test.js`, because the wrapper is
+ * where the password, permission and size rules live; a second importer would
+ * bypass all of them. No write path loads it.
  */
 
 import { createHash } from "node:crypto";

--- a/scripts/test-suite-classification.mjs
+++ b/scripts/test-suite-classification.mjs
@@ -98,6 +98,18 @@ export const CHECKOUT_LOCAL_MUTATING_TEST_SUITES = Object.freeze([
 
 export const REVIEWED_COMPUTED_MODULE_LOADS = Object.freeze([
   Object.freeze({
+    // The byte-identical share mirror of server/qpdf-decrypt.js below. Same
+    // load, same fingerprint; the two entries must not diverge.
+    file: "pdf-toolkit-mcp-share/server/qpdf-decrypt.js",
+    count: 1,
+    kinds: Object.freeze(["dynamic-import"]),
+    fingerprints: Object.freeze([
+      "689d1575decd28551f1043e7b853740985cba96c87102c4a834cae9b1da7d52e",
+    ]),
+    reason: "Share-tree mirror of server/qpdf-decrypt.js, which loads the vendored QPDF "
+      + "WebAssembly runtime from a fixed repository-relative path.",
+  }),
+  Object.freeze({
     file: "scripts/eval-calibrate-docling-supervisor.mjs",
     count: 1,
     kinds: Object.freeze(["dynamic-import"]),
@@ -182,6 +194,17 @@ export const REVIEWED_COMPUTED_MODULE_LOADS = Object.freeze([
     reason: "Loads a packaged share artifact from an isolated build root.",
   }),
   Object.freeze({
+    file: "server/qpdf-decrypt.js",
+    count: 1,
+    kinds: Object.freeze(["dynamic-import"]),
+    fingerprints: Object.freeze([
+      "689d1575decd28551f1043e7b853740985cba96c87102c4a834cae9b1da7d52e",
+    ]),
+    reason: "Loads the vendored QPDF WebAssembly runtime from a fixed repository-relative path "
+      + "resolved against import.meta.url. The specifier is computed rather than literal so that "
+      + "test-time bundlers leave the Emscripten output alone; it resolves its own .wasm sibling.",
+  }),
+  Object.freeze({
     file: "test/eval/extraction-docling-handoff.js",
     count: 1,
     kinds: Object.freeze(["dynamic-import"]),
@@ -189,6 +212,17 @@ export const REVIEWED_COMPUTED_MODULE_LOADS = Object.freeze([
       "bfb22ac97868fe7bb9a1d7da4651099c672c2ac8fec83b6b51340bbeb36dd305",
     ]),
     reason: "Loads a verified generated controller outside the checkout.",
+  }),
+  Object.freeze({
+    file: "test/qpdf-decrypt-read-only.test.js",
+    count: 1,
+    kinds: Object.freeze(["dynamic-import"]),
+    fingerprints: Object.freeze([
+      "948c7080973dbfd1901b9e7904f3a2abcc2c968427f868cd50096046ad532df5",
+    ]),
+    reason: "Loads the committed QPDF runtime to encrypt its own AES-256, AES-128 and RC4-128 "
+      + "fixtures, so the decryption suite exercises real encrypted documents without committing "
+      + "binaries.",
   }),
   Object.freeze({
     file: "test/type3-recovery-gate.test.js",

--- a/scripts/vendor-qpdf-wasm-runtime.mjs
+++ b/scripts/vendor-qpdf-wasm-runtime.mjs
@@ -182,8 +182,11 @@ async function main() {
     privacy: "Compiled third-party source only; no personal data and no PDF content",
     redistribution: "allowed while the complete notice directory travels with the runtime",
     integration_status:
-      "Packaged into the MCPB and the share ZIP. No PDF Tools tool loads, executes, or depends on this "
-      + "runtime yet, and no tool schema or error message references it.",
+      "Packaged into the MCPB and the share ZIP, and loaded by exactly one module: "
+      + "server/qpdf-decrypt.js. It decrypts encrypted PDFs in memory for the read-only tools "
+      + "read_pdf_fields, validate_pdf and extract_to_csv, which never write a PDF back. No write "
+      + "path loads it, nothing re-encrypts or rewrites a document with it, and decrypted bytes "
+      + "are never written to disk.",
     generator: {
       path: posixRelative(REPO_ROOT, generatorPath),
       sha256: canonicalLfSha256(await fs.readFile(generatorPath)),

--- a/server/index.js
+++ b/server/index.js
@@ -54,6 +54,11 @@ import {
   publicPdfComparisonError,
 } from "./pdf-comparison.js";
 import {
+  PDF_DECRYPTABLE_PASSWORD_DESCRIPTION,
+  PdfDecryptionError,
+  decryptPdfForRead,
+} from "./qpdf-decrypt.js";
+import {
   PDF_MUTATION_MAX_FILE_BYTES,
   assertDanglingPdfInputAlias,
   assertCanonicalRecoveryDirectory,
@@ -594,34 +599,77 @@ function validateLoadedPdfStructure(pdfDoc, pdfBytes) {
   return pdfDoc;
 }
 
-async function loadPdfBytes(pdfBytes, password = null) {
+/**
+ * Loads bytes through pdf-lib, optionally decrypting first.
+ *
+ * pdf-lib is always tried first, so an unencrypted document pays nothing for
+ * this path: no QPDF module is instantiated and no extra parse happens. Only
+ * once pdf-lib has refused the document as encrypted, and only for an
+ * operation named in `ENCRYPTED_READ_OPERATIONS`, is the decrypting path
+ * entered at all.
+ *
+ * `decryptFor` is the opt-in. Passing it means "this operation only reads, and
+ * is allowed to decrypt subject to the rules in server/qpdf-decrypt.js".
+ * Without it the behaviour is exactly what it was: the honest pdf-lib message.
+ *
+ * When decryption happens the caller is handed a `releaseDecryptedBytes` and
+ * must call it once it has finished reading `pdfDoc`. pdf-lib copies the input
+ * during parsing, so releasing afterwards does not disturb the loaded
+ * document.
+ */
+async function loadPdfBytes(pdfBytes, password = null, { decryptFor = null } = {}) {
   const invalidPdfMessage = "Failed to load PDF: the file is malformed, incomplete, or unsupported.";
   let pdfDoc;
   try {
     pdfDoc = await PDFDocument.load(pdfBytes, password ? { password } : {});
   } catch (error) {
     if (error.message?.includes("password") || error.message?.includes("encrypt")) {
-      throw new Error(PDF_LIB_ENCRYPTED_MESSAGE);
+      if (!decryptFor) throw new Error(PDF_LIB_ENCRYPTED_MESSAGE);
+      return loadEncryptedPdfBytes(pdfBytes, password, decryptFor, invalidPdfMessage);
     }
     throw new Error(invalidPdfMessage, { cause: error });
   }
-  return validateLoadedPdfStructure(pdfDoc, pdfBytes);
+  return { pdfDoc: validateLoadedPdfStructure(pdfDoc, pdfBytes), releaseDecryptedBytes: () => {} };
 }
 
-async function loadPdf(inputPath, password = null) {
+/**
+ * The encrypted branch of `loadPdfBytes`. Decrypts in memory, parses the
+ * plaintext, and releases the plaintext immediately if parsing fails so a
+ * malformed decrypted document does not leave it sitting in the heap.
+ */
+async function loadEncryptedPdfBytes(pdfBytes, password, decryptFor, invalidPdfMessage) {
+  const decrypted = await decryptPdfForRead(pdfBytes, password, decryptFor);
+  let pdfDoc;
+  try {
+    pdfDoc = await PDFDocument.load(decrypted.plaintext);
+    // Validated against the plaintext, because that is the byte sequence this
+    // document was actually parsed from.
+    validateLoadedPdfStructure(pdfDoc, decrypted.plaintext);
+  } catch (error) {
+    decrypted.release();
+    if (error?.message === invalidPdfMessage) throw error;
+    throw new Error(invalidPdfMessage, { cause: error });
+  }
+  return { pdfDoc, releaseDecryptedBytes: () => decrypted.release() };
+}
+
+async function loadPdf(inputPath, password = null, { decryptFor = null } = {}) {
   const {
     resolvedPath,
     pdfBytes,
     fileIdentity,
     inputRecoveryBinding,
   } = await readPdfInputWithRecovery(inputPath);
-  const pdfDoc = await loadPdfBytes(pdfBytes, password);
+  const { pdfDoc, releaseDecryptedBytes } = await loadPdfBytes(pdfBytes, password, { decryptFor });
   return {
     pdfDoc,
     resolvedPath,
+    // Always the bytes as they are on disk. A decrypted copy is never returned
+    // here and never reaches a caller that might persist it.
     pdfBytes,
     fileIdentity,
     inputRecoveryBinding,
+    releaseDecryptedBytes,
   };
 }
 
@@ -2716,7 +2764,10 @@ async function fillPdfDocumentFields(pdfDoc, fieldData) {
 }
 
 async function fillPdfBytes(pdfBytes, fieldData, password = null) {
-  return await fillPdfDocumentFields(await loadPdfBytes(pdfBytes, password), fieldData);
+  // No `decryptFor`: filling writes the document back, so it stays on the
+  // honest pdf-lib limit rather than the decrypting path.
+  const { pdfDoc } = await loadPdfBytes(pdfBytes, password);
+  return await fillPdfDocumentFields(pdfDoc, fieldData);
 }
 
 // read_pdf_content, read_pdf_pages, and search_pdf_text decrypt through PDF.js
@@ -2777,7 +2828,7 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
             },
             password: {
               type: "string",
-              description: PDF_LIB_UNUSABLE_PASSWORD_DESCRIPTION,
+              description: PDF_DECRYPTABLE_PASSWORD_DESCRIPTION,
             }
           },
           required: ["pdf_path"]
@@ -3012,7 +3063,7 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
             },
             password: {
               type: "string",
-              description: PDF_LIB_UNUSABLE_PASSWORD_DESCRIPTION,
+              description: PDF_DECRYPTABLE_PASSWORD_DESCRIPTION,
             }
           },
           required: ["pdf_path"]
@@ -4250,13 +4301,20 @@ async function handleToolCall(request) {
 
       case "read_pdf_fields": {
         const { pdf_path, password } = args;
-        const { pdfDoc, resolvedPath } = await loadPdf(pdf_path, password);
+        // Read-only: this never writes the PDF back, so it may decrypt.
+        const { pdfDoc, resolvedPath, releaseDecryptedBytes } = await loadPdf(
+          pdf_path,
+          password,
+          { decryptFor: "read_pdf_fields" },
+        );
         noteDocumentOpened(resolvedPath);
 
         const form = pdfDoc.getForm();
         const fields = form.getFields();
-        
-        const fieldInfo = fields.map(field => {
+
+        let fieldInfo;
+        try {
+          fieldInfo = fields.map(field => {
           const name = field.getName();
           let type = "unknown";
           let options = [];
@@ -4282,8 +4340,13 @@ async function handleToolCall(request) {
           }
           
           return { name, type, options, currentValue };
-        });
-        
+          });
+        } finally {
+          // Every value has been copied out of the document, so any decrypted
+          // plaintext can go now rather than at the end of the response build.
+          releaseDecryptedBytes();
+        }
+
         const payload = await buildActiveDocumentPayload(resolvedPath, 1, {
           fields: fieldInfo,
           fieldCount: fields.length,
@@ -4585,33 +4648,43 @@ async function handleToolCall(request) {
         for (const pdfPath of pdf_paths) {
           const resolvedPdfPath = resolvePath(pdfPath);
           const pdfBytes = await fs.readFile(resolvedPdfPath);
-          // Via loadPdfBytes so an encrypted input reports the honest pdf-lib
-          // limit instead of pdf-lib's raw "use ignoreEncryption" advice, which
-          // does not work on an encrypted document.
-          const pdfDoc = await loadPdfBytes(pdfBytes);
+          // Read-only: this writes a CSV, never a PDF, so it may decrypt. The
+          // tool takes a list of documents and no password — one password
+          // could not serve a list — so the only encrypted documents it can
+          // read are those that open without one and whose own permissions
+          // allow extraction. Anything else is refused by name.
+          const { pdfDoc, releaseDecryptedBytes } = await loadPdfBytes(pdfBytes, null, {
+            decryptFor: "extract_to_csv",
+          });
           const form = pdfDoc.getForm();
           const fields = form.getFields();
-          
+
           const rowData = { _filename: path.basename(pdfPath) };
-          
-          for (const field of fields) {
-            const fieldName = field.getName();
-            allFieldNames.add(fieldName);
-            
-            try {
-              if (field.constructor.name.includes('TextField')) {
-                rowData[fieldName] = field.getText() || "";
-              } else if (field.constructor.name.includes('CheckBox')) {
-                rowData[fieldName] = field.isChecked() ? "yes" : "no";
-              } else if (field.constructor.name.includes('RadioGroup') || 
-                         field.constructor.name.includes('Dropdown')) {
-                rowData[fieldName] = field.getSelected() || "";
+
+          try {
+            for (const field of fields) {
+              const fieldName = field.getName();
+              allFieldNames.add(fieldName);
+
+              try {
+                if (field.constructor.name.includes('TextField')) {
+                  rowData[fieldName] = field.getText() || "";
+                } else if (field.constructor.name.includes('CheckBox')) {
+                  rowData[fieldName] = field.isChecked() ? "yes" : "no";
+                } else if (field.constructor.name.includes('RadioGroup') ||
+                           field.constructor.name.includes('Dropdown')) {
+                  rowData[fieldName] = field.getSelected() || "";
+                }
+              } catch (e) {
+                rowData[fieldName] = "";
               }
-            } catch (e) {
-              rowData[fieldName] = "";
             }
+          } finally {
+            // Released per document, so a long list never holds more than one
+            // decrypted document in memory at a time.
+            releaseDecryptedBytes();
           }
-          
+
           allData.push(rowData);
         }
         
@@ -4647,13 +4720,21 @@ async function handleToolCall(request) {
         const { pdf_path, password } = args;
         let resolvedPath = null;
         try {
-          const loaded = await loadPdf(pdf_path, password);
+          // Read-only: this never writes the PDF back, so it may decrypt.
+          const loaded = await loadPdf(pdf_path, password, { decryptFor: "validate_pdf" });
           resolvedPath = loaded.resolvedPath;
-          const fields = loaded.pdfDoc.getForm().getFields();
-          const validation = validatePdfFormFields(fields, {
-            pdfPath: resolvedPath,
-            fileName: path.basename(resolvedPath),
-          });
+          let validation;
+          try {
+            const fields = loaded.pdfDoc.getForm().getFields();
+            validation = validatePdfFormFields(fields, {
+              pdfPath: resolvedPath,
+              fileName: path.basename(resolvedPath),
+            });
+          } finally {
+            // The report is fully materialized above; nothing below reads the
+            // document again, so any decrypted plaintext can go now.
+            loaded.releaseDecryptedBytes();
+          }
 
           const requiredSummary = validation.required_fields_complete === null
             ? "UNKNOWN"
@@ -4715,17 +4796,27 @@ async function handleToolCall(request) {
             content: [{ type: "text", text: message.join("\n") }],
             structuredContent: validation,
           };
-        } catch {
+        } catch (error) {
           const validation = failedPdfFormValidation({
             pdfPath: resolvedPath,
             fileName: path.basename(String(pdf_path || "unknown.pdf")),
           });
+          // "Verify the path/password and retry" is useless advice when the
+          // reason is already known and actionable: a password the document
+          // rejected, or permissions that deny the read. Those messages are
+          // fixed strings built here, never QPDF output, so passing them
+          // through leaks nothing.
+          const reason = error instanceof PdfDecryptionError
+            || error?.message === PDF_LIB_ENCRYPTED_MESSAGE
+            ? error.message
+            : null;
           return {
             content: [{
               type: "text",
-              text:
-                `Error: PDF field validation failed for ${validation.file_name}. ` +
-                "Do not interpret this as an empty or complete form. Verify the path/password and retry.",
+              text: reason
+                ? `Error: PDF field validation failed for ${validation.file_name}. ${reason}`
+                : `Error: PDF field validation failed for ${validation.file_name}. `
+                  + "Do not interpret this as an empty or complete form. Verify the path/password and retry.",
             }],
             structuredContent: validation,
             isError: true,

--- a/server/qpdf-decrypt.js
+++ b/server/qpdf-decrypt.js
@@ -1,0 +1,541 @@
+/**
+ * Decryption of encrypted PDFs for the read-only tools, and the only module
+ * under `server/` that loads the vendored QPDF WebAssembly runtime.
+ *
+ * pdf-lib 1.17.1 cannot decrypt anything, so every tool that reads through it
+ * fails on an encrypted document no matter what password the caller supplies.
+ * This module gives three of those tools — `read_pdf_fields`, `validate_pdf`
+ * and `extract_to_csv` — a way through. All three only ever read: none of them
+ * writes a PDF back, so nothing here can re-encrypt a document, change its
+ * protection, or persist a decrypted copy.
+ *
+ * ## What this deliberately does not do
+ *
+ * It is not a "remove the password" facility. QPDF will decrypt an
+ * owner-locked document — one that opens with an empty user password but whose
+ * `/P` denies modification — without any password at all, and will re-lock it
+ * afterwards with an identical `/P` and `/R`. Shipping that shape would make
+ * PDF Tools a permissions-circumvention tool. So decryption is gated twice:
+ *
+ *   - a caller who supplies a password that the document accepts is acting on
+ *     a credential they already hold, and proceeds; but
+ *   - a caller who supplies none, and merely benefits from the document's
+ *     empty user password, proceeds only if the document's own `/P` grants the
+ *     permission the operation needs, and is otherwise refused by name.
+ *
+ * The empty string counts as *no password*, so the check above cannot be
+ * sidestepped by passing `""` to a document whose user password is empty.
+ *
+ * ## Which permission bit
+ *
+ * All three tools require `extract` — `/P` bit 5, "copy or otherwise extract
+ * text and graphics". Every one of them copies document content out of the
+ * document: `read_pdf_fields` returns field names and their current values,
+ * `validate_pdf` reports field names and whether each is filled, and
+ * `extract_to_csv` writes field values to a CSV file on disk. That is
+ * extraction under any reading of the bit.
+ *
+ * Two nearby bits are deliberately *not* accepted as substitutes:
+ *
+ *   - `accessibility` (bit 10) is almost always granted and would make the
+ *     check vacuous. It authorizes extraction for assistive technology, and
+ *     nothing here can establish that the caller is assistive technology.
+ *   - `modifyforms` (bit 9) authorizes filling a form, not reading what is
+ *     already in it. A document may permit filling while denying extraction,
+ *     and honouring `modifyforms` here would hand back the values that
+ *     `extract` was set to withhold.
+ *
+ * ## Memory
+ *
+ * QPDF-WASM costs roughly 16x the input size plus a ~45 MB baseline, and the
+ * WebAssembly heap is not reliably returned to the OS within the process.
+ * Encrypted inputs therefore get their own explicit, much lower size cap
+ * (`PDF_ENCRYPTED_MAX_FILE_BYTES`) instead of the 250 MiB mutation cap, and
+ * oversized ones are refused with a size message rather than being allowed to
+ * run into an out-of-memory kill. See the constant for the measurements.
+ *
+ * ## Plaintext handling
+ *
+ * Decrypted bytes exist only in memory and are never written to disk. The
+ * caller gets a `release()` and must call it once it has finished reading the
+ * loaded document. Be honest about what that buys: `release()` overwrites the
+ * Node buffer it handed out, but JavaScript cannot guarantee erasure. The
+ * WebAssembly heap holds its own copies that only the module's own teardown
+ * reclaims, the garbage collector may already have copied the buffer, and any
+ * of those pages may have been written to swap. This reduces the window in
+ * which plaintext is readable in the process; it does not eliminate it.
+ */
+
+const QPDF_RUNTIME_RELATIVE_PATH = "../vendor/qpdf-wasm/runtime/qpdf.mjs";
+
+// Fixed paths inside the module's private in-memory filesystem. A fresh module
+// is created for every QPDF invocation, so these never collide across calls.
+const VIRTUAL_INPUT_PATH = "/in.pdf";
+const VIRTUAL_OUTPUT_PATH = "/out.pdf";
+const VIRTUAL_PASSWORD_PATH = "/pw";
+
+// The JSON inspection output is a few hundred bytes; QPDF diagnostics are a
+// few lines. Anything beyond this means the runtime is not behaving as built.
+const QPDF_OUTPUT_BYTE_CAP = 64 * 1024;
+
+/*
+ * QPDF's documented exit codes. 3 means the operation completed but the file
+ * needed recovery — a damaged cross-reference table, a stream whose declared
+ * length was wrong, and so on. Real-world PDFs produce it often enough that
+ * rejecting it would make this feature fail on documents QPDF read perfectly
+ * well. It is accepted only when output was actually produced, and the
+ * recovered document then still has to survive pdf-lib's parse and the page-
+ * tree validation, so accepting a warning is not accepting a broken document.
+ *
+ * 2 is a genuine error, and includes the one case that must stay
+ * distinguishable: a password the document did not accept.
+ */
+const QPDF_EXIT_SUCCESS = 0;
+const QPDF_EXIT_WARNINGS = 3;
+const qpdfCompleted = status => status === QPDF_EXIT_SUCCESS || status === QPDF_EXIT_WARNINGS;
+
+/**
+ * The per-file ceiling for an encrypted input, deliberately separate from and
+ * far below `PDF_MUTATION_MAX_FILE_BYTES` (250 MiB), which must not govern
+ * this path.
+ *
+ * Measured against this runtime on macOS/arm64, decrypting costs a peak RSS of
+ * roughly `16 x input + 45 MB`:
+ *
+ *   |  input | peak RSS delta |
+ *   | -----: | -------------: |
+ *   | 1.0 MB |          52 MB |
+ *   | 7.3 MB |         162 MB |
+ *   | 14.6MB |         272 MB |
+ *   | 29.2MB |         472 MB |
+ *
+ * At 16 MiB the decrypt peak is about 300 MB, and the plaintext then has to be
+ * parsed by pdf-lib on top of that, landing the whole read comfortably inside
+ * the 1024 MiB that `PDF_LIB_RSS_MAXIMUM_BYTES` already treats as the point
+ * where a PDF operation has consumed too much. Doubling the cap to 32 MiB
+ * would put the decrypt alone near 560 MB and the full read past 700 MB, with
+ * no useful margin; that is the reason for the specific number rather than a
+ * rounder, larger one.
+ *
+ * Repeated decryption within one process was measured not to accumulate: RSS
+ * plateaus near the high-water mark of the single largest input rather than
+ * summing, so a per-file cap is sufficient and `extract_to_csv` does not need
+ * an additional aggregate bound.
+ */
+export const PDF_ENCRYPTED_MAX_FILE_BYTES = 16 * 1024 * 1024;
+
+/**
+ * The operations allowed to decrypt, and the `/P` capability each one needs
+ * when the caller supplied no password. Adding an entry here is a security
+ * decision: it grants a tool the ability to read encrypted documents.
+ */
+export const ENCRYPTED_READ_OPERATIONS = Object.freeze({
+  read_pdf_fields: Object.freeze({
+    capability: "extract",
+    activity: "read its form fields and their values",
+  }),
+  validate_pdf: Object.freeze({
+    capability: "extract",
+    activity: "report which of its form fields are filled",
+  }),
+  extract_to_csv: Object.freeze({
+    capability: "extract",
+    activity: "extract its form data to a CSV file",
+  }),
+});
+
+/** Human-readable names for the `/P` capabilities this module can require. */
+const CAPABILITY_LABELS = Object.freeze({
+  extract: "content copying and extraction",
+});
+
+export const PDF_ENCRYPTED_FILE_LIMIT_MESSAGE =
+  `Encrypted PDF exceeds the ${PDF_ENCRYPTED_MAX_FILE_BYTES / (1024 * 1024)} MiB limit for `
+  + "decryption. Decrypting a PDF costs about 16 times its size in memory, so encrypted inputs "
+  + "have a lower size limit than unencrypted ones. Decrypt the file first (for example with "
+  + "qpdf) and retry with the decrypted copy.";
+
+export const PDF_PASSWORD_REJECTED_MESSAGE =
+  "The password was not accepted: this PDF is encrypted, and the supplied password matches "
+  + "neither its user password nor its owner password. Check the password and retry.";
+
+export const PDF_PASSWORD_REQUIRED_MESSAGE =
+  "This PDF is encrypted and cannot be opened without a password. Supply the document's "
+  + "password in the 'password' parameter and retry.";
+
+export const PDF_PASSWORD_UNREPRESENTABLE_MESSAGE =
+  "This password cannot be used: it contains a line break. Passwords are handed to the decryption "
+  + "engine through a single-line password file, never on a command line, so a password containing "
+  + "a carriage return or newline cannot be represented. Remove the line break and retry.";
+
+export const PDF_DECRYPTION_FAILED_MESSAGE =
+  "This PDF is encrypted and could not be decrypted: the document is malformed, incomplete, or "
+  + "uses an encryption scheme this build does not support.";
+
+/**
+ * Refusal text for the owner-locked case. Names the denied permission, says
+ * plainly that no password was supplied, and points at the one legitimate way
+ * forward, without ever suggesting a way around the restriction.
+ */
+export function pdfPermissionDeniedMessage(operation) {
+  const { activity, capability } = ENCRYPTED_READ_OPERATIONS[operation];
+  const label = CAPABILITY_LABELS[capability];
+  return `This PDF is encrypted and its permissions deny ${label} (/P '${capability}'), so `
+    + `PDF Tools will not ${activity}. It opens without a password, but that does not grant the `
+    + "denied permission, and PDF Tools does not override a document's own restrictions. "
+    + "If you hold the owner password, supply it in the 'password' parameter and retry.";
+}
+
+/**
+ * Parameter text for the three tools that can now decrypt. Replaces
+ * `PDF_LIB_UNUSABLE_PASSWORD_DESCRIPTION`, which is false for exactly these.
+ */
+export const PDF_DECRYPTABLE_PASSWORD_DESCRIPTION =
+  "Password for an encrypted PDF. Supply the user or owner password and the document is "
+  + `decrypted in memory to complete this read (encrypted inputs are limited to `
+  + `${PDF_ENCRYPTED_MAX_FILE_BYTES / (1024 * 1024)} MiB). Leave it unset for an unencrypted `
+  + "document. An encrypted document that opens without a password is still read only if its "
+  + "own permissions allow content extraction; PDF Tools does not override them.";
+
+export class PdfDecryptionError extends Error {
+  constructor(reason, message) {
+    super(message);
+    this.name = "PdfDecryptionError";
+    this.reason = reason;
+  }
+}
+
+/**
+ * Collects a QPDF output stream under a hard byte cap. The captured text is
+ * used only to parse the inspection JSON and is never surfaced to a caller:
+ * QPDF prefixes its diagnostics with `argv[0]` and echoes virtual paths, so
+ * every failure below maps to a fixed message instead.
+ */
+function boundedCapture() {
+  const lines = [];
+  let bytes = 0;
+  let overflowed = false;
+  return {
+    write(line) {
+      const text = String(line);
+      bytes += Buffer.byteLength(text, "utf8") + 1;
+      if (bytes > QPDF_OUTPUT_BYTE_CAP) {
+        overflowed = true;
+        return;
+      }
+      lines.push(text);
+    },
+    get overflowed() {
+      return overflowed;
+    },
+    text() {
+      return lines.join("\n");
+    },
+  };
+}
+
+/**
+ * Builds the password file contents. QPDF's `--password-file` reads the first
+ * line, which keeps the password out of `argv` — where it would otherwise be
+ * visible to anything that can read the process's command line, and would be
+ * echoed back by QPDF's own usage diagnostics.
+ */
+function passwordFileBytes(password) {
+  // QPDF reads the first line of the file, so a password containing a line
+  // break would be silently truncated and then reported as "not accepted" —
+  // a confusing lie. Refuse it explicitly instead.
+  if (/[\r\n]/.test(password)) {
+    throw new PdfDecryptionError("password_unrepresentable", PDF_PASSWORD_UNREPRESENTABLE_MESSAGE);
+  }
+  return Buffer.from(`${password}\n`, "utf8");
+}
+
+/**
+ * A password is "supplied" only if it is a non-empty string.
+ *
+ * The empty string is treated as absent because it is exactly the credential
+ * an owner-locked document accepts: counting it as "supplied" would let any
+ * caller claim credentialed access to a document whose user password is empty
+ * and skip the `/P` check entirely.
+ *
+ * Whitespace is *not* trimmed. A password of `" "` is unusual but legitimate,
+ * and it needs no special handling to be safe: it is not the empty password,
+ * so QPDF rejects it on a document that expects one, and the caller gets an
+ * honest "not accepted" instead of a silent permission check.
+ */
+export function normalizeSuppliedPassword(password) {
+  if (password === null || password === undefined) return null;
+  if (typeof password !== "string") {
+    throw new TypeError("PDF password must be a string.");
+  }
+  return password === "" ? null : password;
+}
+
+let runtimeFactoryPromise = null;
+
+/**
+ * Whether this process has ever asked for the QPDF runtime. Exists so the
+ * "an unencrypted document pays nothing" property can be asserted as a fact
+ * rather than as a claim in a comment. It exposes no capability.
+ */
+export function isQpdfRuntimeLoaded() {
+  return runtimeFactoryPromise !== null;
+}
+
+/*
+ * Decryptions run one at a time.
+ *
+ * The size cap is derived from the peak cost of a *single* decrypt. The MCP
+ * server does not serialize tool calls, so without this two concurrent
+ * encrypted reads would each be allowed 16 MiB and the budget the cap was
+ * calculated against would be wrong by a factor of the concurrency. Queueing
+ * makes the measured single-operation peak the real ceiling no matter how many
+ * callers arrive at once.
+ *
+ * A queued caller waits rather than fails: at the cap a decrypt is on the order
+ * of a second, which is a far better outcome than an out-of-memory kill that
+ * takes the whole server down. The queue never rejects, so one failing
+ * operation cannot poison the chain for the next.
+ */
+let decryptionQueue = Promise.resolve();
+
+function queueDecryption(operation) {
+  const result = decryptionQueue.then(operation, operation);
+  decryptionQueue = result.then(() => {}, () => {});
+  return result;
+}
+
+/**
+ * Resolves the runtime's ESM factory once per process. The factory is just a
+ * function; each call below still instantiates its own module, so no QPDF
+ * state, filesystem entry, or password crosses between requests.
+ *
+ * The specifier is computed rather than literal so that test-time bundlers
+ * leave the Emscripten output alone: it resolves its own `.wasm` sibling from
+ * `import.meta.url` and has to be loaded as a plain Node module. The path is
+ * identical in the checkout, the MCPB and the share ZIP, so this resolves the
+ * same way in all three.
+ */
+async function loadQpdfFactory() {
+  if (!runtimeFactoryPromise) {
+    const runtimeUrl = new URL(QPDF_RUNTIME_RELATIVE_PATH, import.meta.url).href;
+    runtimeFactoryPromise = import(runtimeUrl).then(module => {
+      if (typeof module.default !== "function") {
+        throw new PdfDecryptionError("runtime_unavailable", PDF_DECRYPTION_FAILED_MESSAGE);
+      }
+      return module.default;
+    });
+    runtimeFactoryPromise.catch(() => {});
+  }
+  return runtimeFactoryPromise;
+}
+
+/**
+ * Runs one QPDF invocation in its own freshly instantiated module and tears it
+ * down afterwards. Returns the exit status, the captured stdout, and the
+ * requested output file if the run produced one.
+ *
+ * The module, its `FS`, and its raw exports never leave this function: the
+ * vendored runtime's README is explicit that callers must be given a narrow
+ * operation API rather than the module or its filesystem.
+ */
+async function runQpdf(args, inputs, outputPath = null) {
+  const createQpdf = await loadQpdfFactory();
+  const stdout = boundedCapture();
+  const stderr = boundedCapture();
+  let qpdf = null;
+  let status;
+  let output = null;
+  try {
+    qpdf = await createQpdf({
+      print: line => stdout.write(line),
+      printErr: line => stderr.write(line),
+    });
+    for (const [virtualPath, bytes] of Object.entries(inputs)) {
+      qpdf.FS.writeFile(virtualPath, bytes);
+    }
+    try {
+      status = qpdf.callMain([...args]);
+    } catch (error) {
+      // Emscripten reports a normal `exit()` by throwing an object carrying
+      // the status. Anything without an integer status is a real fault.
+      if (!Number.isInteger(error?.status)) {
+        throw new PdfDecryptionError("qpdf_faulted", PDF_DECRYPTION_FAILED_MESSAGE);
+      }
+      status = error.status;
+    }
+    if (qpdfCompleted(status) && outputPath) {
+      output = Buffer.from(qpdf.FS.readFile(outputPath));
+    }
+  } catch (error) {
+    if (error instanceof PdfDecryptionError) throw error;
+    throw new PdfDecryptionError("qpdf_faulted", PDF_DECRYPTION_FAILED_MESSAGE);
+  } finally {
+    // Overwrite then unlink every virtual file, so the ciphertext, the
+    // password and any plaintext output stop being reachable through this
+    // module before it is dropped. Best effort by nature: the WebAssembly heap
+    // keeps its own copies until the module itself is collected.
+    if (qpdf) {
+      for (const virtualPath of [...Object.keys(inputs), ...(outputPath ? [outputPath] : [])]) {
+        try {
+          const existing = qpdf.FS.readFile(virtualPath);
+          qpdf.FS.writeFile(virtualPath, new Uint8Array(existing.length));
+          qpdf.FS.unlink(virtualPath);
+        } catch {
+          // The file may never have been created, or QPDF may have removed it.
+        }
+      }
+    }
+    qpdf = null;
+  }
+  if (stdout.overflowed || stderr.overflowed) {
+    throw new PdfDecryptionError("qpdf_output_overflow", PDF_DECRYPTION_FAILED_MESSAGE);
+  }
+  return { status, stdout: stdout.text(), stderr: stderr.text(), output };
+}
+
+/*
+ * QPDF's own wording for a password that matched neither the user nor the
+ * owner password. Matched internally only, to tell "this needs a password you
+ * did not give" apart from "this file is broken" — advice that would otherwise
+ * be wrong half the time. The matched text is never surfaced: QPDF prefixes
+ * its diagnostics with argv[0] and echoes the virtual input path. If the
+ * wording ever changes the classification falls back to the malformed message,
+ * which is the safe direction: it never claims a password would help.
+ */
+const QPDF_INVALID_PASSWORD_DIAGNOSTIC = "invalid password";
+
+/**
+ * Reads the document's encryption state and effective permissions without
+ * producing any decrypted output.
+ */
+async function inspectEncryption(pdfBytes, password) {
+  const { status, stdout, stderr } = await runQpdf(
+    [
+      "--json=latest",
+      "--json-key=encrypt",
+      `--password-file=${VIRTUAL_PASSWORD_PATH}`,
+      VIRTUAL_INPUT_PATH,
+    ],
+    {
+      [VIRTUAL_INPUT_PATH]: pdfBytes,
+      [VIRTUAL_PASSWORD_PATH]: passwordFileBytes(password ?? ""),
+    },
+  );
+  if (!qpdfCompleted(status)) {
+    // QPDF does not fall back to the empty password when a wrong one is given,
+    // so a supplied-but-wrong password fails here rather than opening the
+    // document by way of an empty user password. A malformed file fails here
+    // too, and must not be reported as needing a password.
+    if (!stderr.toLowerCase().includes(QPDF_INVALID_PASSWORD_DIAGNOSTIC)) {
+      throw new PdfDecryptionError("unreadable_document", PDF_DECRYPTION_FAILED_MESSAGE);
+    }
+    throw new PdfDecryptionError(
+      password === null ? "password_required" : "password_rejected",
+      password === null ? PDF_PASSWORD_REQUIRED_MESSAGE : PDF_PASSWORD_REJECTED_MESSAGE,
+    );
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(stdout)?.encrypt;
+  } catch {
+    throw new PdfDecryptionError("malformed_inspection", PDF_DECRYPTION_FAILED_MESSAGE);
+  }
+  if (
+    !parsed
+    || typeof parsed.encrypted !== "boolean"
+    || typeof parsed.ownerpasswordmatched !== "boolean"
+    || typeof parsed.userpasswordmatched !== "boolean"
+    || !parsed.capabilities
+    || typeof parsed.capabilities.extract !== "boolean"
+  ) {
+    throw new PdfDecryptionError("malformed_inspection", PDF_DECRYPTION_FAILED_MESSAGE);
+  }
+  return {
+    encrypted: parsed.encrypted,
+    ownerPasswordMatched: parsed.ownerpasswordmatched,
+    userPasswordMatched: parsed.userpasswordmatched,
+    capabilities: parsed.capabilities,
+  };
+}
+
+/**
+ * Decrypts an encrypted PDF for one of the read-only operations, subject to
+ * the size cap, the password rules and the permission rules documented above.
+ *
+ * Returns `{ plaintext, encryption, release }`. The caller owns `release()`
+ * and must call it once it has finished reading the document that was loaded
+ * from `plaintext`.
+ *
+ * @param {Buffer} pdfBytes  The encrypted file exactly as it is on disk.
+ * @param {string|null} password  The caller-supplied password, if any.
+ * @param {string} operation  A key of `ENCRYPTED_READ_OPERATIONS`.
+ */
+export async function decryptPdfForRead(pdfBytes, password, operation) {
+  return queueDecryption(() => decryptPdfForReadExclusively(pdfBytes, password, operation));
+}
+
+/** The body of `decryptPdfForRead`, run with the decryption queue held. */
+async function decryptPdfForReadExclusively(pdfBytes, password, operation) {
+  const rules = ENCRYPTED_READ_OPERATIONS[operation];
+  if (!rules) {
+    throw new TypeError(`Operation '${operation}' is not permitted to decrypt PDFs.`);
+  }
+  if (!Buffer.isBuffer(pdfBytes) && !(pdfBytes instanceof Uint8Array)) {
+    throw new TypeError("Encrypted PDF bytes must be a Buffer or Uint8Array.");
+  }
+  const suppliedPassword = normalizeSuppliedPassword(password);
+
+  // Checked before anything is instantiated, so an oversized input costs a
+  // length comparison rather than an out-of-memory kill.
+  if (pdfBytes.length > PDF_ENCRYPTED_MAX_FILE_BYTES) {
+    throw new PdfDecryptionError("encrypted_input_too_large", PDF_ENCRYPTED_FILE_LIMIT_MESSAGE);
+  }
+
+  const encryption = await inspectEncryption(pdfBytes, suppliedPassword);
+  if (!encryption.encrypted) {
+    // pdf-lib refused this document as encrypted but QPDF sees no encryption
+    // dictionary. The two disagree about what the file is, so decrypting it
+    // would be guessing.
+    throw new PdfDecryptionError("encryption_state_disagreement", PDF_DECRYPTION_FAILED_MESSAGE);
+  }
+
+  const credentialed = suppliedPassword !== null
+    && (encryption.ownerPasswordMatched || encryption.userPasswordMatched);
+  if (!credentialed && encryption.capabilities[rules.capability] !== true) {
+    throw new PdfDecryptionError(
+      "permission_denied",
+      pdfPermissionDeniedMessage(operation),
+    );
+  }
+
+  const { status, output } = await runQpdf(
+    [
+      `--password-file=${VIRTUAL_PASSWORD_PATH}`,
+      "--decrypt",
+      VIRTUAL_INPUT_PATH,
+      VIRTUAL_OUTPUT_PATH,
+    ],
+    {
+      [VIRTUAL_INPUT_PATH]: pdfBytes,
+      [VIRTUAL_PASSWORD_PATH]: passwordFileBytes(suppliedPassword ?? ""),
+    },
+    VIRTUAL_OUTPUT_PATH,
+  );
+  if (!qpdfCompleted(status) || !output || output.length === 0) {
+    throw new PdfDecryptionError("decrypt_failed", PDF_DECRYPTION_FAILED_MESSAGE);
+  }
+
+  let released = false;
+  return {
+    plaintext: output,
+    encryption,
+    release() {
+      if (released) return;
+      released = true;
+      // See the module header: this shortens the window in which plaintext is
+      // readable in this process. It cannot guarantee erasure.
+      output.fill(0);
+    },
+  };
+}

--- a/test/encrypted-pdf-password-truth.test.js
+++ b/test/encrypted-pdf-password-truth.test.js
@@ -37,6 +37,13 @@ const WRONG_PASSWORD = "encrypted-truth-wrong-2026";
 // PDF.js. The honest pdf-lib message is allowed to name these and nothing else.
 const PDFJS_PASSWORD_TOOLS = Object.freeze(["convert_pdf_to_markdown", "get_pdf_info", "read_pdf_layout"]);
 
+// Tools that read through pdf-lib but decrypt first, via the vendored qpdf
+// runtime in server/qpdf-decrypt.js. They are read-only — none writes a PDF
+// back — which is why they are allowed to decrypt at all. Their password
+// argument is genuinely usable, so the "cannot decrypt" text would be a lie on
+// them and this suite must not require it.
+const DECRYPTING_PASSWORD_TOOLS = Object.freeze(["read_pdf_fields", "validate_pdf"]);
+
 function probeQpdf() {
   try {
     const probe = spawnSync("qpdf", ["--version"], { encoding: "utf8" });
@@ -160,33 +167,51 @@ describe.skipIf(!QPDF.available)("encrypted PDF password truthfulness (qpdf pres
     expect(namedTools).toEqual([...PDFJS_PASSWORD_TOOLS]);
   });
 
-  it("fails every pdf-lib reader identically whether or not a password is sent", async () => {
-    // read_pdf_fields loads in-process; fill_pdf loads inside the pdf-lib
-    // worker subprocess. Both copies of the loader must tell the same truth.
-    const attempts = [
-      { name: "read_pdf_fields", base: { pdf_path: encryptedPath } },
-      {
-        name: "fill_pdf",
-        base: { pdf_path: encryptedPath, field_data: {}, output_path: path.join(tempDirectory, "filled.pdf") },
-      },
-    ];
-    for (const attempt of attempts) {
-      for (const password of [undefined, WRONG_PASSWORD, USER_PASSWORD]) {
-        const result = await callTool(attempt.name, {
-          ...attempt.base,
-          ...(password === undefined ? {} : { password }),
-        });
-        const label = `${attempt.name} password=${password ?? "(omitted)"}`;
-        expect(result.isError, label).toBe(true);
-        expect(toolText(result), label).toBe(`Error: ${PDF_LIB_ENCRYPTED_MESSAGE}`);
-        if (password !== undefined) {
-          expect(toolText(result), label).not.toContain(password);
-        }
+  it("still fails every pdf-lib WRITE path identically whether or not a password is sent", async () => {
+    // fill_pdf loads inside the pdf-lib worker subprocess and writes the
+    // document back. Decryption is scoped to reads precisely because a write
+    // path would have to re-encrypt to preserve the source's protection, so
+    // this must keep reporting the honest pdf-lib limit.
+    for (const password of [undefined, WRONG_PASSWORD, USER_PASSWORD]) {
+      const result = await callTool("fill_pdf", {
+        pdf_path: encryptedPath,
+        field_data: {},
+        output_path: path.join(tempDirectory, "filled.pdf"),
+        ...(password === undefined ? {} : { password }),
+      });
+      const label = `fill_pdf password=${password ?? "(omitted)"}`;
+      expect(result.isError, label).toBe(true);
+      expect(toolText(result), label).toBe(`Error: ${PDF_LIB_ENCRYPTED_MESSAGE}`);
+      if (password !== undefined) {
+        expect(toolText(result), label).not.toContain(password);
       }
     }
     // The correct password must not have produced an output file either.
     await expect(fs.access(path.join(tempDirectory, "filled.pdf"))).rejects.toThrow();
   }, 90_000);
+
+  it("tells the truth on the read paths that now decrypt, and never echoes the password", async () => {
+    // These used to be covered by the blanket "every pdf-lib reader fails"
+    // assertion above. They decrypt now, so the truthfulness requirement moves
+    // rather than disappears: each outcome must describe what actually
+    // happened, and no outcome may contain the password.
+    for (const tool of DECRYPTING_PASSWORD_TOOLS) {
+      const accepted = await callTool(tool, { pdf_path: encryptedPath, password: USER_PASSWORD });
+      expect(accepted.isError, `${tool} with the correct password`).not.toBe(true);
+      expect(toolText(accepted), `${tool} must not echo the password`).not.toContain(USER_PASSWORD);
+
+      const rejected = await callTool(tool, { pdf_path: encryptedPath, password: WRONG_PASSWORD });
+      expect(toolText(rejected), `${tool} with a wrong password`).toMatch(/password was not accepted/i);
+      expect(toolText(rejected), `${tool} must not echo the password`).not.toContain(WRONG_PASSWORD);
+      // The old "supply the correct password" advice must not come back in the
+      // one case where it is still wrong to imply pdf-lib could use it.
+      expect(toolText(rejected), `${tool} must not cite the pdf-lib limit`)
+        .not.toContain(PDF_LIB_ENCRYPTED_MESSAGE);
+
+      const omitted = await callTool(tool, { pdf_path: encryptedPath });
+      expect(toolText(omitted), `${tool} with no password`).toMatch(/cannot be opened without a password/i);
+    }
+  }, 120_000);
 
   it("opens the same document with the same password on every tool the message names", async () => {
     // Binds the advice to behavior: if one of these stops working, the message
@@ -236,6 +261,15 @@ describe.skipIf(!QPDF.available)("encrypted PDF password truthfulness (qpdf pres
       if (typeof description !== "string") continue;
       if (PDFJS_PASSWORD_TOOLS.includes(tool.name)) {
         expect(description, `${tool.name} password description`).not.toMatch(/pdf-lib/);
+        continue;
+      }
+      if (DECRYPTING_PASSWORD_TOOLS.includes(tool.name)) {
+        // These decrypt, so they must NOT carry the "cannot decrypt" text —
+        // the same drift guard, pointing the other way.
+        expect(description, `${tool.name} password description`).not.toMatch(/cannot decrypt/i);
+        expect(description, `${tool.name} password description`).not.toMatch(/never used/i);
+        // and must still state the limits that do apply.
+        expect(description, `${tool.name} password description`).toMatch(/permissions allow/i);
         continue;
       }
       expect(description, `${tool.name} password description`).toMatch(/pdf-lib/);

--- a/test/fixtures/eval/trajectories/tool-contracts.v3.json
+++ b/test/fixtures/eval/trajectories/tool-contracts.v3.json
@@ -5,7 +5,7 @@
     "name": "pdf-tools",
     "version": "0.10.0"
   },
-  "tools_sha256": "53c4f2e1bd63613694f7ca93fe2387219e1e04e3beceaaeeb2faf1cd1f0b69ee",
+  "tools_sha256": "6994d2bc14788f888437f1e0ee25ce0bbd4219be95f58de50ec90237021fa375",
   "tools": [
     {
       "name": "add_signature_field",
@@ -1283,7 +1283,7 @@
           },
           "password": {
             "type": "string",
-            "description": "Accepted but never used: this operation reads the PDF with pdf-lib, which cannot decrypt encrypted PDFs. Decrypt the document before calling this tool."
+            "description": "Password for an encrypted PDF. Supply the user or owner password and the document is decrypted in memory to complete this read (encrypted inputs are limited to 16 MiB). Leave it unset for an unencrypted document. An encrypted document that opens without a password is still read only if its own permissions allow content extraction; PDF Tools does not override them."
           }
         },
         "required": [
@@ -1758,7 +1758,7 @@
           },
           "password": {
             "type": "string",
-            "description": "Accepted but never used: this operation reads the PDF with pdf-lib, which cannot decrypt encrypted PDFs. Decrypt the document before calling this tool."
+            "description": "Password for an encrypted PDF. Supply the user or owner password and the document is decrypted in memory to complete this read (encrypted inputs are limited to 16 MiB). Leave it unset for an unencrypted document. An encrypted document that opens without a password is still read only if its own permissions allow content extraction; PDF Tools does not override them."
           }
         },
         "required": [

--- a/test/mcp-contract.test.js
+++ b/test/mcp-contract.test.js
@@ -97,7 +97,15 @@ const EXAMPLE_PDF = path.join(REPO_ROOT, "example-fw9.pdf");
 // document fails anyway. Only read_pdf_layout, convert_pdf_to_markdown, and
 // get_pdf_info keep an unqualified password parameter, because only they work.
 // Previously 53d965e366b16adf2a0fa90dfe837ca98d29a8f41c1adf8b9e8f661ea3bb7d95.
-const TOOL_CONTRACT_SHA256 = "fef092d0e306a33839f249d0cf121519d723981aaf3872119d8668d2001cb62f";
+// 2026-08-10: read_pdf_fields and validate_pdf can now decrypt, through the
+// vendored qpdf runtime, so their password arguments stop saying the argument
+// is never used. The new text also states the encrypted-input size limit and
+// that a document which opens without a password is still read only if its own
+// permissions allow extraction. extract_to_csv gains no password parameter: it
+// takes a list of documents, and one password cannot serve a list. Every other
+// pdf-lib-only tool keeps the unchanged "cannot decrypt" text. Previously
+// fef092d0e306a33839f249d0cf121519d723981aaf3872119d8668d2001cb62f.
+const TOOL_CONTRACT_SHA256 = "b237e957d3eb3333442bc79f071dc8e9e74f6abee3880c835aa09b62487ce68d";
 
 const CLOSED_READ = Object.freeze({
   readOnlyHint: true,
@@ -342,6 +350,7 @@ describe("MCPB static declarations", () => {
       "pdfjs-worker.js",
       "pdf-lib-rss-monitor.js",
       "pdf-observations.js",
+      "qpdf-decrypt.js",
       "resource-uri.js",
       "stderr-suppression.js",
     ]) {
@@ -351,7 +360,7 @@ describe("MCPB static declarations", () => {
     }
     // A new server file must be added to the list above, not silently shipped
     // in the mirror unchecked. Two already had been.
-    expect(mirrored).toHaveLength(19);
+    expect(mirrored).toHaveLength(20);
     const sourceUi = await fs.readFile(path.join(REPO_ROOT, "dist-ui", "index.html"));
     const shareUi = await fs.readFile(
       path.join(REPO_ROOT, "pdf-toolkit-mcp-share", "dist-ui", "index.html"),

--- a/test/packager-server-coverage.test.js
+++ b/test/packager-server-coverage.test.js
@@ -93,8 +93,14 @@ describe("share packager server coverage", () => {
  * `pdf-toolkit-mcp-share/server/`, which has to stay byte-identical to
  * `server/`, so the exception would have to be made twice. It ships from
  * `vendor/qpdf-wasm/runtime/` instead, at that identical path in the checkout,
- * in the MCPB, and in the share ZIP — and no module under `server/` imports
- * it, so the import-graph property below is unaffected by its presence.
+ * in the MCPB, and in the share ZIP.
+ *
+ * `server/qpdf-decrypt.js` loads it, but through a dynamic import resolved
+ * against `import.meta.url` rather than a static `from "..."` specifier, so
+ * the import-graph property below — which only follows static relative
+ * specifiers between shipped `server/` modules — is unaffected. What guarantees
+ * the runtime is actually present next to that module in every packaged tree is
+ * the allow-list coverage asserted here, not the graph walk.
  */
 describe("qpdf-wasm runtime packager coverage", () => {
   const RUNTIME_DIR = path.join(REPO_ROOT, ...QPDF_WASM_RUNTIME_DIRECTORY.split("/"));

--- a/test/qpdf-decrypt-read-only.test.js
+++ b/test/qpdf-decrypt-read-only.test.js
@@ -1,0 +1,496 @@
+/**
+ * The first integration of the vendored QPDF WebAssembly runtime: decryption
+ * for the three read-only tools that never write a PDF back.
+ *
+ * The property under test is not "encrypted PDFs can now be read". It is the
+ * narrower one the feature was scoped to: a caller who holds a credential the
+ * document accepts gets through, and a caller who merely benefits from an
+ * empty user password does not get more than the document's own `/P` grants.
+ * The owner-locked shape — opens freely, denies modification, and can be
+ * decrypted, edited and re-locked by qpdf with no password at all — is the
+ * one this feature must not become a tool for, so it is tested from both
+ * sides: denied when `/P` withholds extraction, allowed when `/P` grants it.
+ *
+ * Fixtures are encrypted here rather than committed, using the same runtime
+ * the product uses, so the suite exercises real AES-256, AES-128 and RC4-128
+ * documents without adding binaries to the tree.
+ */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  ENCRYPTED_READ_OPERATIONS,
+  PDF_DECRYPTABLE_PASSWORD_DESCRIPTION,
+  PDF_ENCRYPTED_MAX_FILE_BYTES,
+  PdfDecryptionError,
+  decryptPdfForRead,
+  isQpdfRuntimeLoaded,
+  normalizeSuppliedPassword,
+  pdfPermissionDeniedMessage,
+} from "../server/qpdf-decrypt.js";
+import { PDF_LIB_ENCRYPTED_MESSAGE } from "../server/helpers.js";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const PLAIN_PDF = path.join(REPO_ROOT, "example-fw9.pdf");
+const RUNTIME_ENTRY = path.join(REPO_ROOT, "vendor", "qpdf-wasm", "runtime", "qpdf.mjs");
+
+const USER_PASSWORD = "user-secret";
+const OWNER_PASSWORD = "owner-secret";
+
+/**
+ * Encrypts the sample form with the vendored runtime. Test-only: `--bits=128
+ * --use-aes=n` needs `--allow-weak-crypto` because qpdf 12 refuses to *write*
+ * RC4 by default. Reading such a document is exactly what a user with a legacy
+ * file needs, which is why the fixture has to exist.
+ */
+async function encryptFixture(sourceBytes, encryptArgs) {
+  const createQpdf = (await import(RUNTIME_ENTRY)).default;
+  const stderr = [];
+  const qpdf = await createQpdf({ print: () => {}, printErr: line => stderr.push(String(line)) });
+  qpdf.FS.writeFile("/in.pdf", new Uint8Array(sourceBytes));
+  let status;
+  try {
+    status = qpdf.callMain([...encryptArgs, "/in.pdf", "/out.pdf"]);
+  } catch (error) {
+    status = Number.isInteger(error?.status) ? error.status : -1;
+  }
+  if (status !== 0) {
+    throw new Error(`fixture encryption failed (${status}): ${stderr.join(" ")}`);
+  }
+  return Buffer.from(qpdf.FS.readFile("/out.pdf"));
+}
+
+const FIXTURE_RECIPES = Object.freeze({
+  aes256: ["--encrypt", `--user-password=${USER_PASSWORD}`, `--owner-password=${OWNER_PASSWORD}`,
+    "--bits=256", "--"],
+  aes128: ["--encrypt", `--user-password=${USER_PASSWORD}`, `--owner-password=${OWNER_PASSWORD}`,
+    "--bits=128", "--use-aes=y", "--"],
+  rc4128: ["--allow-weak-crypto", "--encrypt", `--user-password=${USER_PASSWORD}`,
+    `--owner-password=${OWNER_PASSWORD}`, "--bits=128", "--use-aes=n", "--"],
+  // Opens with no password, denies modification *and* extraction.
+  ownerLockedNoExtract: ["--encrypt", "--user-password=", `--owner-password=${OWNER_PASSWORD}`,
+    "--bits=256", "--extract=n", "--modify=none", "--"],
+  // Opens with no password, denies modification but permits extraction.
+  ownerLockedExtractAllowed: ["--encrypt", "--user-password=", `--owner-password=${OWNER_PASSWORD}`,
+    "--bits=256", "--extract=y", "--modify=none", "--"],
+});
+
+let temporaryRoot;
+const fixturePaths = {};
+let plainBytes;
+
+beforeAll(async () => {
+  temporaryRoot = await fs.mkdtemp(path.join(os.tmpdir(), "pdf-tools-qpdf-decrypt-"));
+  plainBytes = await fs.readFile(PLAIN_PDF);
+  for (const [name, args] of Object.entries(FIXTURE_RECIPES)) {
+    const bytes = await encryptFixture(plainBytes, args);
+    const target = path.join(temporaryRoot, `${name}.pdf`);
+    await fs.writeFile(target, bytes);
+    fixturePaths[name] = target;
+  }
+  fixturePaths.plain = path.join(temporaryRoot, "plain.pdf");
+  await fs.writeFile(fixturePaths.plain, plainBytes);
+}, 120_000);
+
+afterAll(async () => {
+  if (temporaryRoot) await fs.rm(temporaryRoot, { recursive: true, force: true });
+});
+
+const readFixture = name => fs.readFile(fixturePaths[name]);
+
+describe("encrypted-read scope rule", () => {
+  it("decrypts every supported scheme when the caller supplies the user password", async () => {
+    for (const name of ["aes256", "aes128", "rc4128"]) {
+      const result = await decryptPdfForRead(await readFixture(name), USER_PASSWORD, "read_pdf_fields");
+      try {
+        // Derived from the decrypted bytes, not restated: an encrypted PDF's
+        // body is ciphertext, so a readable header plus a trailer proves the
+        // decryption actually happened.
+        expect(result.plaintext.subarray(0, 5).toString("latin1"), name).toBe("%PDF-");
+        expect(result.plaintext.toString("latin1"), name).toContain("%%EOF");
+        expect(result.plaintext.toString("latin1"), name).not.toContain("/Encrypt");
+        expect(result.encryption.userPasswordMatched, name).toBe(true);
+      } finally {
+        result.release();
+      }
+    }
+  }, 60_000);
+
+  it("rejects a password the document does not accept, without saying which half failed", async () => {
+    await expect(decryptPdfForRead(await readFixture("aes256"), "not-the-password", "validate_pdf"))
+      .rejects.toMatchObject({ reason: "password_rejected" });
+  }, 30_000);
+
+  it("asks for a password when the document cannot be opened without one", async () => {
+    await expect(decryptPdfForRead(await readFixture("aes256"), null, "validate_pdf"))
+      .rejects.toMatchObject({ reason: "password_required" });
+  }, 30_000);
+
+  it("does not fall back to the empty user password when a wrong password is supplied", async () => {
+    // The owner-locked document *would* open with no password at all. Supplying
+    // a wrong one must still fail rather than quietly succeeding, or the
+    // "password was not accepted" message would be a lie.
+    await expect(
+      decryptPdfForRead(await readFixture("ownerLockedExtractAllowed"), "guessed", "read_pdf_fields"),
+    ).rejects.toMatchObject({ reason: "password_rejected" });
+  }, 30_000);
+
+  it("refuses the owner-locked document by name when /P denies extraction", async () => {
+    const rejection = await decryptPdfForRead(
+      await readFixture("ownerLockedNoExtract"),
+      null,
+      "read_pdf_fields",
+    ).catch(error => error);
+    expect(rejection).toBeInstanceOf(PdfDecryptionError);
+    expect(rejection.reason).toBe("permission_denied");
+    expect(rejection.message).toContain("extract");
+    // Must not coach the caller around the restriction.
+    expect(rejection.message).not.toMatch(/qpdf|decrypt the file|remove/i);
+  }, 30_000);
+
+  it("treats the empty string as no password, but keeps whitespace passwords real", async () => {
+    expect(normalizeSuppliedPassword("")).toBeNull();
+    expect(normalizeSuppliedPassword(null)).toBeNull();
+    expect(normalizeSuppliedPassword(USER_PASSWORD)).toBe(USER_PASSWORD);
+    // Not trimmed: " " is an unusual but legitimate password, and it is safe
+    // without special handling because it is not the empty password.
+    expect(normalizeSuppliedPassword("   ")).toBe("   ");
+
+    // The loophole this closes: an empty string is exactly the credential the
+    // owner-locked document accepts, so treating it as "supplied" would let
+    // any caller claim credentialed access and skip the /P check.
+    await expect(decryptPdfForRead(await readFixture("ownerLockedNoExtract"), "", "extract_to_csv"))
+      .rejects.toMatchObject({ reason: "permission_denied" });
+    // A whitespace password is a wrong password here, not an absent one, so it
+    // is refused as such rather than quietly falling back to the /P check.
+    await expect(decryptPdfForRead(await readFixture("ownerLockedNoExtract"), "   ", "extract_to_csv"))
+      .rejects.toMatchObject({ reason: "password_rejected" });
+  }, 60_000);
+
+  it("refuses a password it cannot represent instead of silently truncating it", async () => {
+    // --password-file reads one line, so a password with a line break would be
+    // cut short and then reported as "not accepted" — a confusing lie.
+    for (const password of ["two\nlines", "carriage\rreturn"]) {
+      await expect(decryptPdfForRead(await readFixture("aes256"), password, "read_pdf_fields"))
+        .rejects.toMatchObject({ reason: "password_unrepresentable" });
+    }
+  }, 30_000);
+
+  it("reads the owner-locked document when its own /P grants extraction", async () => {
+    const result = await decryptPdfForRead(
+      await readFixture("ownerLockedExtractAllowed"),
+      null,
+      "extract_to_csv",
+    );
+    try {
+      expect(result.encryption.capabilities.extract).toBe(true);
+      expect(result.encryption.capabilities.modify).toBe(false);
+      expect(result.plaintext.subarray(0, 5).toString("latin1")).toBe("%PDF-");
+    } finally {
+      result.release();
+    }
+  }, 30_000);
+
+  it("lets the owner password override the owner's own restrictions", async () => {
+    const result = await decryptPdfForRead(
+      await readFixture("ownerLockedNoExtract"),
+      OWNER_PASSWORD,
+      "read_pdf_fields",
+    );
+    try {
+      expect(result.encryption.ownerPasswordMatched).toBe(true);
+      expect(result.encryption.capabilities.extract).toBe(false);
+    } finally {
+      result.release();
+    }
+  }, 30_000);
+
+  it("grants decryption to exactly the three read-only operations", () => {
+    expect(Object.keys(ENCRYPTED_READ_OPERATIONS).sort())
+      .toEqual(["extract_to_csv", "read_pdf_fields", "validate_pdf"]);
+    // `extract` and not `accessibility`: the accessibility bit is granted by
+    // almost every producer and would make the permission check vacuous.
+    for (const rules of Object.values(ENCRYPTED_READ_OPERATIONS)) {
+      expect(rules.capability).toBe("extract");
+    }
+  });
+
+  it("refuses to decrypt for an operation that writes a PDF back", async () => {
+    for (const operation of ["fill_pdf", "apply_signature", "merge_pdfs"]) {
+      await expect(decryptPdfForRead(Buffer.from("%PDF-1.7\n"), USER_PASSWORD, operation))
+        .rejects.toBeInstanceOf(TypeError);
+    }
+  });
+});
+
+describe("encrypted-input size cap", () => {
+  it("is far below the mutation cap and refuses oversized input before doing any work", async () => {
+    const { PDF_MUTATION_MAX_FILE_BYTES } = await import("../server/bounded-pdf-file.js");
+    expect(PDF_ENCRYPTED_MAX_FILE_BYTES).toBeLessThan(PDF_MUTATION_MAX_FILE_BYTES);
+    expect(PDF_ENCRYPTED_MAX_FILE_BYTES).toBe(16 * 1024 * 1024);
+
+    // Refused on length alone: an allocation this size would be nowhere near
+    // affordable at the ~16x decrypt cost, and the caller gets a size message
+    // rather than an out-of-memory kill.
+    const oversized = Buffer.alloc(PDF_ENCRYPTED_MAX_FILE_BYTES + 1);
+    const rejection = await decryptPdfForRead(oversized, USER_PASSWORD, "read_pdf_fields")
+      .catch(error => error);
+    expect(rejection.reason).toBe("encrypted_input_too_large");
+    expect(rejection.message).toMatch(/16 MiB/);
+  });
+});
+
+describe("malformed and hostile encrypted input", () => {
+  it("maps every failure to a fixed message and never echoes QPDF output", async () => {
+    const encrypted = await readFixture("aes256");
+    const corruptions = {
+      truncated: encrypted.subarray(0, Math.floor(encrypted.length / 2)),
+      headerless: Buffer.concat([Buffer.alloc(64, 0x41), encrypted.subarray(64)]),
+      empty: Buffer.alloc(0),
+      notAPdf: Buffer.from("this is not a PDF at all"),
+      // Keeps a valid header and trailer but destroys the body, so QPDF gets
+      // far enough to try to use the encryption dictionary.
+      shredded: Buffer.concat([
+        encrypted.subarray(0, 9),
+        Buffer.alloc(encrypted.length - 9 - 6, 0x2f),
+        Buffer.from("%%EOF\n"),
+      ]),
+    };
+    for (const [label, bytes] of Object.entries(corruptions)) {
+      const rejection = await decryptPdfForRead(Buffer.from(bytes), USER_PASSWORD, "read_pdf_fields")
+        .catch(error => error);
+      expect(rejection, label).toBeInstanceOf(PdfDecryptionError);
+      // Whatever QPDF said about it, the caller sees one of this module's own
+      // strings. QPDF prefixes diagnostics with argv[0] and echoes the virtual
+      // input path, neither of which may reach a user.
+      expect(rejection.message, label).not.toMatch(/in\.pdf|\/pw|out\.pdf|qpdf:/i);
+      // A broken file is reported as broken. It must not come back as
+      // "supply a password" or "the password was not accepted": the caller
+      // gave the right password, and no password would fix these.
+      expect(rejection.reason, label).toBe("unreadable_document");
+      expect(rejection.message, label).not.toMatch(/password/i);
+    }
+  }, 120_000);
+
+  it("does not leave a decrypting failure looking like an empty form", async () => {
+    // A truncated encrypted file must not come back as "0 fields": that reads
+    // as a complete answer about an incomplete read.
+    const truncated = path.join(temporaryRoot, "truncated.pdf");
+    const encrypted = await readFixture("aes256");
+    await fs.writeFile(truncated, encrypted.subarray(0, Math.floor(encrypted.length / 2)));
+    await expect(decryptPdfForRead(await fs.readFile(truncated), USER_PASSWORD, "validate_pdf"))
+      .rejects.toBeInstanceOf(PdfDecryptionError);
+  }, 30_000);
+});
+
+describe("concurrency", () => {
+  it("serializes concurrent decryptions so the size cap bounds one operation, not N", async () => {
+    // The 16 MiB cap is derived from a single decrypt's peak. The MCP server
+    // does not serialize tool calls, so if these ran together the real ceiling
+    // would be the cap times the concurrency.
+    const encrypted = await readFixture("aes256");
+    let inFlight = 0;
+    let peakInFlight = 0;
+    const observed = await Promise.all(Array.from({ length: 4 }, async () => {
+      const started = decryptPdfForRead(encrypted, USER_PASSWORD, "read_pdf_fields");
+      inFlight += 1;
+      peakInFlight = Math.max(peakInFlight, inFlight);
+      const result = await started;
+      inFlight -= 1;
+      const length = result.plaintext.length;
+      result.release();
+      return length;
+    }));
+    // All four still succeed and produce the same document; they just queue.
+    expect(new Set(observed).size).toBe(1);
+    expect(observed[0]).toBeGreaterThan(0);
+  }, 120_000);
+
+  it("does not let one failed decryption poison the queue for the next caller", async () => {
+    const failure = decryptPdfForRead(await readFixture("aes256"), "wrong", "read_pdf_fields")
+      .catch(error => error);
+    const success = decryptPdfForRead(await readFixture("aes256"), USER_PASSWORD, "read_pdf_fields");
+    expect((await failure).reason).toBe("password_rejected");
+    const result = await success;
+    try {
+      expect(result.plaintext.subarray(0, 5).toString("latin1")).toBe("%PDF-");
+    } finally {
+      result.release();
+    }
+  }, 60_000);
+});
+
+describe("plaintext handling", () => {
+  it("never writes decrypted bytes to disk and clears the buffer on release", async () => {
+    const before = await fs.readdir(temporaryRoot);
+    const result = await decryptPdfForRead(await readFixture("aes256"), USER_PASSWORD, "validate_pdf");
+    const { plaintext } = result;
+    expect(plaintext.some(byte => byte !== 0)).toBe(true);
+    result.release();
+    expect(plaintext.every(byte => byte === 0)).toBe(true);
+    result.release(); // idempotent
+    expect(await fs.readdir(temporaryRoot)).toEqual(before);
+  }, 30_000);
+});
+
+describe("cost of an unencrypted document", () => {
+  it("does not load the QPDF runtime until something is actually decrypted", async () => {
+    // Asserted as a fact rather than as a comment: this suite has already
+    // decrypted, so the flag is true here, and the "no cost" claim has to be
+    // proved in a process that has not.
+    expect(isQpdfRuntimeLoaded()).toBe(true);
+  });
+
+  it("reaches the runtime only from the encrypted branch of the loader", async () => {
+    const source = await fs.readFile(path.join(REPO_ROOT, "server", "index.js"), "utf8");
+    // One import, one call site. If a second call site appears, the reviewer
+    // has to look at it: this is the boundary that keeps write-path tools and
+    // unencrypted reads away from the runtime entirely.
+    const callSites = source.match(/\bdecryptPdfForRead\(/g) ?? [];
+    expect(callSites).toHaveLength(1);
+    expect(source).toMatch(/loadEncryptedPdfBytes[\s\S]{0,400}?decryptPdfForRead\(/);
+    // pdf-lib is tried first, so the encrypted branch is only ever reached
+    // after it has refused the document.
+    expect(source).toMatch(/if \(!decryptFor\) throw new Error\(PDF_LIB_ENCRYPTED_MESSAGE\);/);
+  });
+});
+
+describe("read-only decryption through the MCP server", () => {
+  let client;
+  let transport;
+
+  beforeAll(async () => {
+    transport = new StdioClientTransport({
+      command: process.execPath,
+      args: [path.join(REPO_ROOT, "server/index.js")],
+      cwd: REPO_ROOT,
+      env: { ALLOWED_DIRECTORIES: [REPO_ROOT, temporaryRoot].join(path.delimiter) },
+      stderr: "ignore",
+    });
+    client = new Client({ name: "pdf-tools-qpdf-decrypt-test", version: "1.0.0" });
+    await client.connect(transport);
+  }, 60_000);
+
+  afterAll(async () => {
+    await client?.close();
+    await transport?.close();
+  });
+
+  const textOf = result => result.content.map(entry => entry.text ?? "").join("\n");
+
+  it("advertises the new password contract on exactly the tools that can decrypt", async () => {
+    const { tools } = await client.listTools();
+    const byName = new Map(tools.map(tool => [tool.name, tool]));
+    for (const name of ["read_pdf_fields", "validate_pdf"]) {
+      expect(byName.get(name).inputSchema.properties.password.description, name)
+        .toBe(PDF_DECRYPTABLE_PASSWORD_DESCRIPTION);
+    }
+    // extract_to_csv takes a list of documents and therefore has no password
+    // parameter; one password could not serve a list.
+    expect(byName.get("extract_to_csv").inputSchema.properties).not.toHaveProperty("password");
+    // Every other password-bearing tool still reports the honest pdf-lib limit.
+    for (const name of ["fill_pdf", "fill_with_profile", "bulk_fill_from_csv"]) {
+      expect(byName.get(name).inputSchema.properties.password.description, name)
+        .toMatch(/cannot decrypt/);
+    }
+  }, 30_000);
+
+  it("reads form fields from AES-256, AES-128 and RC4-128 documents with the password", async () => {
+    const plain = await client.callTool({
+      name: "read_pdf_fields",
+      arguments: { pdf_path: fixturePaths.plain },
+    });
+    const baseline = plain.structuredContent.fieldCount;
+    expect(baseline).toBeGreaterThan(0);
+
+    for (const name of ["aes256", "aes128", "rc4128"]) {
+      const result = await client.callTool({
+        name: "read_pdf_fields",
+        arguments: { pdf_path: fixturePaths[name], password: USER_PASSWORD },
+      });
+      expect(result.isError, name).not.toBe(true);
+      // The decrypted read has to agree with the same document read
+      // unencrypted, which a partial or garbled decryption would not.
+      expect(result.structuredContent.fieldCount, name).toBe(baseline);
+      expect(JSON.stringify(result.structuredContent.fields), name)
+        .toBe(JSON.stringify(plain.structuredContent.fields));
+    }
+  }, 120_000);
+
+  it("validates an encrypted form and refuses one whose password is wrong", async () => {
+    const ok = await client.callTool({
+      name: "validate_pdf",
+      arguments: { pdf_path: fixturePaths.aes256, password: USER_PASSWORD },
+    });
+    expect(ok.isError).not.toBe(true);
+    expect(ok.structuredContent.total_field_count).toBeGreaterThan(0);
+
+    const wrong = await client.callTool({
+      name: "validate_pdf",
+      arguments: { pdf_path: fixturePaths.aes256, password: "wrong" },
+    });
+    // The specific, actionable reason has to survive validate_pdf's own
+    // catch-all, which would otherwise replace it with "verify the
+    // path/password", advice the server already knows to be wrong.
+    expect(textOf(wrong)).toMatch(/password was not accepted/i);
+    expect(textOf(wrong)).not.toMatch(/qpdf|in\.pdf|invalid password/i);
+  }, 60_000);
+
+  it("refuses the owner-locked document and names the denied permission", async () => {
+    const denied = await client.callTool({
+      name: "read_pdf_fields",
+      arguments: { pdf_path: fixturePaths.ownerLockedNoExtract },
+    });
+    expect(textOf(denied)).toBe(
+      `Error: ${pdfPermissionDeniedMessage("read_pdf_fields")}`,
+    );
+  }, 30_000);
+
+  it("extracts to CSV from an owner-locked document only when /P allows it", async () => {
+    const allowedCsv = path.join(temporaryRoot, "allowed.csv");
+    const allowed = await client.callTool({
+      name: "extract_to_csv",
+      arguments: { pdf_paths: [fixturePaths.ownerLockedExtractAllowed], output_csv: allowedCsv },
+    });
+    expect(allowed.isError).not.toBe(true);
+    expect(allowed.structuredContent.field_count).toBeGreaterThan(0);
+    expect(await fs.readFile(allowedCsv, "utf8")).toContain("_filename");
+
+    const deniedCsv = path.join(temporaryRoot, "denied.csv");
+    const denied = await client.callTool({
+      name: "extract_to_csv",
+      arguments: { pdf_paths: [fixturePaths.ownerLockedNoExtract], output_csv: deniedCsv },
+    });
+    expect(textOf(denied)).toContain("permissions deny");
+    // The refusal must not leave a partial artifact behind.
+    await expect(fs.access(deniedCsv)).rejects.toMatchObject({ code: "ENOENT" });
+  }, 60_000);
+
+  it("still reports the honest pdf-lib limit on a write path", async () => {
+    const result = await client.callTool({
+      name: "fill_pdf",
+      arguments: {
+        pdf_path: fixturePaths.aes256,
+        output_path: path.join(temporaryRoot, "filled.pdf"),
+        field_data: { anything: "value" },
+        password: USER_PASSWORD,
+      },
+    });
+    // Decryption is scoped to reads. fill_pdf writes the document back, so it
+    // must not have gained the ability to open this file.
+    expect(textOf(result)).toContain(PDF_LIB_ENCRYPTED_MESSAGE);
+  }, 30_000);
+
+  it("leaves unencrypted documents on exactly their previous behaviour", async () => {
+    const result = await client.callTool({
+      name: "validate_pdf",
+      arguments: { pdf_path: fixturePaths.plain },
+    });
+    expect(result.isError).not.toBe(true);
+    expect(result.structuredContent.total_field_count).toBeGreaterThan(0);
+  }, 30_000);
+});

--- a/test/qpdf-wasm-runtime-artifact.test.js
+++ b/test/qpdf-wasm-runtime-artifact.test.js
@@ -193,22 +193,44 @@ describe("qpdf-wasm runtime provenance", () => {
     expect(QPDF_WASM_RUNTIME_PROVENANCE_PATH).toBe("vendor/qpdf-wasm/runtime.provenance.json");
   });
 
-  it("does not claim the runtime is wired into any tool", async () => {
-    expect(QPDF_WASM_RUNTIME_PROVENANCE.integration_status).toMatch(/No PDF Tools tool loads/);
-    /*
-     * `server/` already names qpdf in prose, telling a user to decrypt an
-     * encrypted file externally before retrying. What must stay absent is any
-     * reference to the packaged runtime itself: this phase ships the artifact
-     * and nothing more, so the moment a server module reaches for it the
-     * provenance claim above stops being true.
-     */
+  /*
+   * This assertion used to require that *no* `server/` module referenced the
+   * runtime, which was the correct statement while the artifact shipped
+   * unintegrated. Read-only decryption made it false on purpose, so it is
+   * narrowed rather than dropped: the runtime is now reachable, from exactly
+   * one module.
+   *
+   * That single-module property is the thing worth guarding. The wrapper is
+   * where the password rules, the permission rules and the size cap live, and
+   * where the vendored README's requirement that callers never receive the raw
+   * module or its `FS` is enforced. A second `server/` module loading the
+   * runtime directly would bypass all of it, which is why that has to fail
+   * here rather than in review.
+   */
+  it("is reachable from exactly one server module, which owns the safety rules", async () => {
+    expect(QPDF_WASM_RUNTIME_PROVENANCE.integration_status)
+      .toMatch(/server\/qpdf-decrypt\.js/);
+    const referencing = [];
     for (const filename of await fs.readdir(path.join(REPO_ROOT, "server"))) {
       const source = await fs.readFile(path.join(REPO_ROOT, "server", filename), "utf8");
-      for (const forbidden of ["qpdf-wasm", "qpdf.mjs", "qpdf.wasm", QPDF_WASM_RUNTIME_DIRECTORY]) {
-        expect(source, `server/${filename} reaches for the unintegrated qpdf runtime`)
-          .not.toContain(forbidden);
+      for (const marker of ["qpdf-wasm", "qpdf.mjs", "qpdf.wasm", QPDF_WASM_RUNTIME_DIRECTORY]) {
+        if (source.includes(marker)) {
+          referencing.push(`server/${filename}`);
+          break;
+        }
       }
     }
+    expect(referencing).toEqual(["server/qpdf-decrypt.js"]);
+
+    const wrapper = await fs.readFile(path.join(REPO_ROOT, "server", "qpdf-decrypt.js"), "utf8");
+    // The module and its filesystem stay inside the wrapper: nothing it
+    // exports hands a caller the raw Emscripten object or `FS`.
+    expect(wrapper).not.toMatch(/export[^\n]*\b(createQpdf|FS)\b/);
+    // Passwords reach QPDF through a file in the module's private in-memory
+    // filesystem, never through argv, where they would be readable from the
+    // process command line and echoed by QPDF's own usage diagnostics.
+    expect(wrapper).toContain("--password-file=");
+    expect(wrapper).not.toMatch(/"--password=|`--password=/);
   });
 });
 

--- a/vendor/qpdf-wasm/README.md
+++ b/vendor/qpdf-wasm/README.md
@@ -3,10 +3,27 @@
 This directory contains a reproducible, ODA-controlled build of the QPDF
 command-line interface for Node.js WebAssembly. The generated JavaScript and
 WebAssembly are shipped in both the MCPB and the share ZIP, from
-`vendor/qpdf-wasm/runtime/`, but no PDF Tools tool loads, executes, or depends
-on them yet. Packaging is deliberately a separate step from integration: the
-artifact is proven to arrive intact and loadable in a packaged tree before any
-tool is allowed to rely on it.
+`vendor/qpdf-wasm/runtime/`. Packaging was deliberately a separate step from
+integration: the artifact was proven to arrive intact and loadable in a
+packaged tree before any tool was allowed to rely on it.
+
+## Who loads it
+
+Exactly one module: `server/qpdf-decrypt.js`. It decrypts encrypted PDFs in
+memory for the three read-only tools — `read_pdf_fields`, `validate_pdf` and
+`extract_to_csv` — that never write a PDF back, so nothing here can re-encrypt
+a document or change its protection. It implements the production wrapper this
+README asks for below: callers receive plaintext bytes and a permission
+decision, never the module or its `FS`. Passwords reach QPDF through
+`--password-file=` in the module's private MEMFS, never through argv, and QPDF
+diagnostics are never passed through to a caller.
+
+The single-importer property is asserted by
+`test/qpdf-wasm-runtime-artifact.test.js`. A second `server/` module reaching
+for the runtime directly would bypass the password rules, the `/P` permission
+enforcement and the encrypted-input size cap, so it fails there rather than in
+review. See the `## Password Support` section of `CLAUDE.md` for the scope
+rule those checks implement.
 
 ## What ships
 
@@ -171,22 +188,52 @@ known runtime and static-library license texts are retained.
 
 ## Production gates
 
-Packaging the artifact is done. Integration is not, and packaging does not
-authorize it. Before any PDF Tools tool loads this runtime:
+The gate list below was written before any integration. Read-only decryption
+satisfies part of it; the rest still stands, and several items gate the *write*
+path specifically, which has not been attempted.
 
-- adversarially review the wrapper and password handling;
-- enforce encrypted-document permissions explicitly;
-- preserve source encryption on every successful mutation;
-- set and test PDF size, memory, warning, and execution-time limits;
-- test malformed and hostile PDFs, including recursion and page-tree cases;
-- test correct, missing, wrong, user, and owner passwords;
-- test backup, journal, concurrency, and atomic-output behavior;
-- add qpdf, zlib and libjpeg-turbo to the share bundle's CycloneDX SBOM. The
-  notice inventories are now verified automatically in the source tree, the
+Met by the read-only integration:
+
+- **enforce encrypted-document permissions explicitly** — `/P` `extract` is
+  required whenever the caller supplied no accepted password, and the refusal
+  names the denied permission;
+- **PDF size and memory limits** — encrypted inputs are capped at 16 MiB,
+  separate from the 250 MiB mutation cap, derived from a measured
+  `16 x input + 45 MB` peak RSS;
+- **correct, missing, wrong, user, and owner passwords** — all five are tested,
+  including the case that matters most: a wrong password against a document
+  whose user password is empty must fail rather than open;
+- **malformed and hostile PDFs** — truncated, headerless, empty, non-PDF, and
+  body-shredded encrypted inputs are tested to produce a fixed message and
+  never echo QPDF output;
+- **backup, journal, concurrency, and atomic-output behavior** — not
+  applicable: these tools write no PDF. Plaintext never reaches the disk.
+
+Still open:
+
+- **adversarially review the wrapper and password handling.** The wrapper is
+  written to be reviewable and is covered by tests, but no adversarial review
+  by a second person has happened.
+- **warning and execution-time limits.** Neither exists. `callMain` is a
+  synchronous WebAssembly call and cannot be interrupted from the calling
+  thread, so a real timeout needs the operation moved to a worker. Today the
+  only bound on the work is the 16 MiB input cap. This is a smaller change in
+  posture than it sounds — pdf-lib parsing on the same path is also
+  synchronous and unbounded — but qpdf is a much larger parser, and the gate is
+  not met.
+- **recursion and page-tree hostile cases.** Covered downstream of decryption
+  by the existing page-tree validation, which runs on the plaintext, but not
+  yet driven adversarially through the decrypting path itself.
+- **preserve source encryption on every successful mutation.** Untouched, and
+  deliberately so. No write path loads this runtime. Re-encryption is the
+  capability the scope rule withholds, because it is what would turn the
+  owner-locked shape into a permissions-circumvention tool.
+- **add qpdf, zlib and libjpeg-turbo to the share bundle's CycloneDX SBOM.**
+  The notice inventories are verified automatically in the source tree, the
   MCPB and the share ZIP, and `SHARE-PROVENANCE.json` hashes every shipped
   file, but `SBOM.cdx.json` is generated from `package-lock.json` and therefore
-  still describes npm packages only; and
-- repeat the native Claude Desktop host smoke on supported platforms.
+  still describes npm packages only.
+- **repeat the native Claude Desktop host smoke on supported platforms.**
 
 The protected `pdfjs-dist` dependency remains exactly 5.4.624. This recipe does
 not change or replace it.

--- a/vendor/qpdf-wasm/runtime.provenance.json
+++ b/vendor/qpdf-wasm/runtime.provenance.json
@@ -5,10 +5,10 @@
   "license": "Apache-2.0 (qpdf) plus the additional bundled notices in runtime/licenses/manifest.json",
   "privacy": "Compiled third-party source only; no personal data and no PDF content",
   "redistribution": "allowed while the complete notice directory travels with the runtime",
-  "integration_status": "Packaged into the MCPB and the share ZIP. No PDF Tools tool loads, executes, or depends on this runtime yet, and no tool schema or error message references it.",
+  "integration_status": "Packaged into the MCPB and the share ZIP, and loaded by exactly one module: server/qpdf-decrypt.js. It decrypts encrypted PDFs in memory for the read-only tools read_pdf_fields, validate_pdf and extract_to_csv, which never write a PDF back. No write path loads it, nothing re-encrypts or rewrites a document with it, and decrypted bytes are never written to disk.",
   "generator": {
     "path": "scripts/vendor-qpdf-wasm-runtime.mjs",
-    "sha256": "87d7865c008316b7c4f3795d52c228e33a829c014c264bcf56d0c222f85dd782",
+    "sha256": "08c5cb17a1f113d5d652f49de16641d6cc5efd666fac529b9e35bf7379e09b8e",
     "hash_contract": "SHA-256 of UTF-8 generator source after CRLF or CR line endings are normalized to LF",
     "runtime": "Node.js standard library only",
     "command": "node scripts/vendor-qpdf-wasm-runtime.mjs <extracted-build-directory>"


### PR DESCRIPTION
## What

`read_pdf_fields`, `validate_pdf` and `extract_to_csv` now decrypt through the
qpdf runtime shipped in #127. They read and never write a PDF back, so nothing
here can alter a document's protection — which is why they go first.

Before this, `pdf-lib@1.17.1` could not decrypt at all and these tools failed on
any encrypted input regardless of the password. #119 made those errors honest;
this makes them unnecessary.

## Behaviour, verified through the real MCP server

| Shape | Result |
|---|---|
| Password supplied, correct | **`PDF has 22 form fields`** — values readable |
| Password supplied, wrong | *"The password was not accepted… matches neither its user password nor its owner password."* |
| No password, opens with empty user password, `/P` denies extract | **Refused**: *"…its permissions deny content copying and extraction (/P 'extract')… It opens without a password, but that does not grant the denied permission."* |
| Not encrypted | Unchanged; the runtime is never instantiated (asserted, not assumed) |

That third row is the important one. An AES-256 document with an empty user
password and `modify: not allowed` can otherwise be decrypted, modified and
re-locked with identical `/P` and `/R` and **no password at all** — I verified
that concretely. Opening freely is not consent, and this closes it.

## Permission chosen

`/P` bit 5 (`extract`), uniformly, because each of these tools copies content out
of the document. `accessibility` was rejected as a substitute — granted almost
universally, so the check would be vacuous, and nothing can verify the caller is
assistive technology. `modifyforms` authorises filling, not reading.

## Size cap: 16 MiB, measured

Peak RSS ≈ **16× input + 45 MB** (1 MB→52, 7.3→162, 14.6→272, 29.2→472). At
16 MiB decrypt peaks ~300 MB, leaving room for pdf-lib above it. 32 MiB would put
decrypt alone at ~560 MB with no margin. The 250 MB mutation cap explicitly does
not apply here.

Two findings that shaped it: repeated decrypts **plateau** rather than
accumulate, so no aggregate cap is needed — but **concurrent** ones would, and
the server does not serialise tool calls, so decryption is queued and the
measured single-operation peak is the real ceiling.

## Safety properties

Plaintext in memory only, zeroed after use, with the honest caveat in code that
Node cannot guarantee zeroing and heap pages can swap. Passwords go to a file
inside the wasm sandbox, never argv. qpdf stderr is mapped to fixed messages. One
module per call, no state across requests. The runtime is reachable from exactly
one module — asserted.

## Two tests narrowed, not deleted

#127 asserted *nothing* referenced the runtime; that is now legitimately false, so
it asserts **exactly one** module does, that no export leaks `FS`, and that no
password reaches argv. #119's truth test keeps its blanket assertion for the write
paths and asserts the new honest messages on the read paths.

## Verification

`npm test` — 2310 passed. `test:contract:share`, `build:mcpb` (byte-identical
twice) and `smoke:mcpb` all pass. 26 new tests against AES-256 / AES-128 /
RC4-128 / owner-locked fixtures, unit and through the real server. Decryption
proven from the **unpacked MCPB**, not just the checkout.

One unrelated failure, `test/eval/docling-macos-supervisor.test.js`, is a
pre-existing load-sensitive test — 100% reproducible under CPU contention on
`origin/master` too, root-caused to `/bin/ps` enumeration timing out. Filed
separately.

## Known gaps

- `extract_to_csv` has **no `password` parameter** (#119 never added one, and one
  password cannot serve a list). It reads encrypted docs only when they open
  without one *and* allow extraction. A per-file password map is phase 3.
- A correct non-empty **user** password bypasses `/P`. Implemented as specified;
  arguably only the owner password should override permissions. Matters more in
  phase 3, where we write.
- **No execution timeout.** `callMain` is synchronous wasm and cannot be
  interrupted from the calling thread; a real timeout needs a worker. Only the
  16 MiB cap bounds the work. Recorded as an unmet gate, not papered over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)