### PR TITLE
Serve the viewer under a real host CSP in the lifecycle smoke

### DIFF
--- a/scripts/dev-ui-app-lifecycle-smoke.mjs
+++ b/scripts/dev-ui-app-lifecycle-smoke.mjs
@@ -750,6 +750,43 @@ const server = http.createServer((request, response) => {
       "content-type": "text/html; charset=utf-8",
       "content-length": viewerHtml.length,
       "cache-control": "no-store",
+      // Serve the component under the policy a real sandboxed MCP Apps host
+      // applies. Until 2026-08-10 this harness sent no policy at all, so it
+      // permitted exactly what a real sandbox refuses: the viewer shipped a
+      // ~2.7 MB `data:` worker module, rendered blank in ChatGPT desktop, and
+      // every gate here stayed green. A permissive harness cannot detect a
+      // permission failure.
+      //
+      // Transcribed from the ChatGPT Mac desktop app, version 26.803.41515
+      // build 6321, observed 2026-08-10 for a component declaring no
+      // `_meta.ui.csp`. It is observed implementation, not a published
+      // contract, so re-check it before relying on the exact directives.
+      //
+      // The load-bearing directive is `worker-src`, which that host constructs
+      // as `'self' blob:` and never widens with resourceDomains. A `data:`
+      // worker is therefore refused twice: once by `worker-src` when pdf.js
+      // calls `new Worker()`, and again by `script-src`, which omits `data:`,
+      // when its fake-worker fallback dynamically imports the same URL. That
+      // is exactly the failure this smoke now reproduces.
+      //
+      // `D`, the host's built-in resource allowlist (jsdelivr, unpkg, esm.sh
+      // and similar), is deliberately omitted: the viewer must not depend on
+      // any external origin, so leaving it out keeps this honest.
+      "content-security-policy": [
+        "default-src 'self'",
+        "script-src 'self' 'wasm-unsafe-eval' 'unsafe-inline' 'unsafe-eval' blob:",
+        "worker-src 'self' blob:",
+        "style-src 'self' 'unsafe-inline'",
+        "style-src-elem 'self' 'unsafe-inline'",
+        "style-src-attr 'unsafe-inline'",
+        "img-src 'self' data:",
+        "font-src 'self'",
+        "connect-src 'self'",
+        "media-src 'self'",
+        "object-src 'none'",
+        "frame-src 'none'",
+        "base-uri 'self'",
+      ].join("; "),
     });
     response.end(viewerHtml);
     return;


### PR DESCRIPTION
The lifecycle smoke served the component with **no Content-Security-Policy at all**, so it permitted exactly what a sandboxed MCP Apps host refuses. That is why #131 shipped: the viewer carried a ~2.7 MB `data:` worker module, rendered blank in ChatGPT desktop, and every automated gate stayed green.

A permissive harness cannot detect a permission failure.

## The policy

Transcribed from the ChatGPT Mac desktop app, version `26.803.41515` build `6321`, observed 2026-08-10 for a component that declares no `_meta.ui.csp`. The comment records that this is observed implementation rather than a published contract, and says to re-check it.

The load-bearing directive is `worker-src`. That host constructs it as `'self' blob:` and **never widens it with `resourceDomains`**, which is not in OpenAI's documentation. So a `data:` worker is refused twice:

- by `worker-src`, when pdf.js calls `new Worker()`
- by `script-src`, which omits `data:`, when the fake-worker fallback dynamically imports the same URL

That is exactly the double refusal a user hit.

The host's built-in resource allowlist (jsdelivr, unpkg, esm.sh and similar) is deliberately **omitted**. The viewer must not depend on any external origin, so leaving it out keeps the test honest rather than merely faithful.

## Verified in both directions, on macOS

| build | result |
|---|---|
| in-realm worker (current) | **exit 0**, viewer renders |
| `?url` import restored | **exit 1**, "The first built-viewer lifecycle did not become ready" |

The second is the failure that previously reached a user with every gate green.

## Provenance

The CSP was observed by Codex from inside the host. That is the one measurement that cannot be taken from this repository, and it is why the policy here is transcribed rather than invented: an arbitrary strict policy would catch this bug too, but would also fail on things the real host permits, and would drift from reality without anyone noticing.

## Scope

This closes the harness half of the gap recorded in #131. It does not emulate the host, and a component that passes here can still fail on a host with a different policy. The rule in `docs/agent-plugins-packaging.md` stands: treat rendering on any specific host as unverified until observed there.
