### PR TITLE
Say AcroForm when we measured AcroForm

### DIFF
--- a/pdf-toolkit-mcp-share/server/index.js
+++ b/pdf-toolkit-mcp-share/server/index.js
@@ -4356,7 +4356,14 @@ async function handleToolCall(request) {
           content: [
             {
               type: "text",
-              text: `PDF has ${fields.length} form fields:\n${JSON.stringify(fieldInfo, null, 2)}`
+              // "0 form fields" reads as "this document has no form", which is
+              // often false: a questionnaire can be visibly full of blanks that
+              // were flattened into page content, or built with a form
+              // technology this parser does not enumerate. We measured AcroForm
+              // fields, so say AcroForm, and say what that does not rule out.
+              text: fields.length === 0
+                ? "This PDF has no AcroForm fields. That is not the same as having no form: visible blanks may have been flattened into the page, or built with a form technology this parser does not enumerate. Use read_pdf_content or the viewer to inspect what is actually on the page."
+                : `PDF has ${fields.length} AcroForm fields:\n${JSON.stringify(fieldInfo, null, 2)}`
             }
           ],
           structuredContent: payload,

--- a/server/index.js
+++ b/server/index.js
@@ -4356,7 +4356,14 @@ async function handleToolCall(request) {
           content: [
             {
               type: "text",
-              text: `PDF has ${fields.length} form fields:\n${JSON.stringify(fieldInfo, null, 2)}`
+              // "0 form fields" reads as "this document has no form", which is
+              // often false: a questionnaire can be visibly full of blanks that
+              // were flattened into page content, or built with a form
+              // technology this parser does not enumerate. We measured AcroForm
+              // fields, so say AcroForm, and say what that does not rule out.
+              text: fields.length === 0
+                ? "This PDF has no AcroForm fields. That is not the same as having no form: visible blanks may have been flattened into the page, or built with a form technology this parser does not enumerate. Use read_pdf_content or the viewer to inspect what is actually on the page."
+                : `PDF has ${fields.length} AcroForm fields:\n${JSON.stringify(fieldInfo, null, 2)}`
             }
           ],
           structuredContent: payload,


### PR DESCRIPTION
`read_pdf_fields` reported **"PDF has 0 form fields"** for a tax organizer that is visibly full of blanks. The count was accurate; the sentence was not.

What the tool measures is interactive **AcroForm** fields. Their absence does not mean the document has no form: the blanks may have been flattened into page content, or built with a form technology this parser does not enumerate. A user reading "0 form fields" reasonably concludes there is nothing there.

The zero case now says what was measured and what it does not rule out, and points at `read_pdf_content` or the viewer for what is actually on the page. The non-zero case says AcroForm rather than a bare "form fields".

No behaviour change. This is what the tool already measured, stated honestly, which is the same standard the rest of the output surface holds: report what was observed, and never let an accurate number imply a conclusion it does not support.

Reported by Codex from a real document where the old wording would have misled.