### PR TITLE
Stop two supervisor tests assuming the host is idle

### DIFF
--- a/test/eval/docling-macos-supervisor.test.js
+++ b/test/eval/docling-macos-supervisor.test.js
@@ -107,6 +107,88 @@ describe.runIf(RUNS_ON_DARWIN)("native macOS structured-extraction supervisor", 
     }, fault);
   }
 
+  // EPERM and ESRCH are the only two errnos the bounded sampling-revalidation
+  // budget can surface for a live workload: a process the supervisor saw was
+  // either not inspectable (EPERM) or already gone (ESRCH) for longer than
+  // SAMPLE_REVALIDATION_BUDGET_NS. Every other errno means something other
+  // than CPU starvation went wrong and must still fail the suite.
+  const SAMPLING_RACE_ERRNOS = [os.constants.errno.EPERM, os.constants.errno.ESRCH];
+
+  /**
+   * Assert every property of a supervised run that does not depend on host
+   * load, then assert the branch the supervisor actually took.
+   *
+   * Certifying a run requires observing the whole process group inside a
+   * sealed sampling window. On a CPU-starved host the supervisor cannot always
+   * finish that observation, so it fails closed with `enumeration` instead of
+   * certifying what it could not see. That is the correct product behaviour,
+   * which makes the *outcome* a genuine disjunction rather than a constant.
+   *
+   * The disjunction is deliberately narrow. Everything load-independent -- the
+   * drained process group, the schema-valid envelope, the honest claim
+   * boundary, the acceptance biconditional, and the no-stdout-without-
+   * certification rule -- is asserted unconditionally, above the branch. The
+   * failure branch is pinned to one exact failure code and a closed errno set,
+   * so a supervisor that started failing closed for some *other* reason still
+   * fails the suite. Callers add the workload-specific observation assertions
+   * that hold in both branches.
+   *
+   * @returns {boolean} whether the supervisor certified the run
+   */
+  function expectContainedRun(result) {
+    const evidence = result.evidence;
+    const observations = evidence.observations;
+
+    // Holds either way: the envelope is schema-valid and honestly labelled.
+    expect(recordValidator(evidence)).toMatchObject({ valid: true });
+    expect(evidence.claim_boundary).toContain("Sampled resource observations");
+
+    // Holds either way: nothing survived the run and nothing escaped. A
+    // supervisor that declines to certify must still leave no live process
+    // group behind.
+    expect(observations.original_process_group_empty).toBe(true);
+    expect(observations.escaped_session_detected).toBe(false);
+
+    // Holds either way: the supervisor really observed the group rather than
+    // giving up before looking at it.
+    expect(observations.sample_count).toBeGreaterThan(0);
+    expect(observations.max_group_members).toBeGreaterThan(0);
+    expect(observations.observed_process_identity_count)
+      .toBeGreaterThanOrEqual(observations.max_group_members);
+
+    // Holds either way: acceptance is exactly the conjunction of the clean
+    // observations, so neither branch can be reached by mislabelling the
+    // other. Duplicated from validateSupervisorEvidence on purpose -- the test
+    // keeps the invariant if the harness ever stops enforcing it.
+    expect(evidence.controller_accepted).toBe(
+      evidence.controller_failure === "none"
+      && evidence.controller_errno === 0
+      && evidence.child_setup_stage === 0
+      && evidence.leader.exit_code === 0
+      && evidence.leader.signal === null
+      && !evidence.capture.stdout_limit_exceeded
+      && !evidence.capture.stderr_limit_exceeded
+      && !observations.escaped_session_detected
+      && observations.original_process_group_empty,
+    );
+
+    if (evidence.controller_accepted) {
+      expect(evidence.controller_failure).toBe("none");
+      expect(evidence.controller_errno).toBe(0);
+      expect(evidence.leader).toMatchObject({ exit_code: 0, signal: null });
+      expect(parseCanonicalCandidateJson(result.stdout, 1024))
+        .toMatchObject({ ok: true });
+      return true;
+    }
+
+    // Declined: only ever the CPU-starvation enumeration boundary, with an
+    // errno that names a sampling race, and never any candidate stdout.
+    expect(evidence.controller_failure).toBe("enumeration");
+    expect(SAMPLING_RACE_ERRNOS).toContain(evidence.controller_errno);
+    expect(result.stdout).toHaveLength(0);
+    return false;
+  }
+
   async function waitForFile(filename, timeoutMs = 2000) {
     const deadline = Date.now() + timeoutMs;
     while (Date.now() < deadline) {
@@ -239,16 +321,19 @@ describe.runIf(RUNS_ON_DARWIN)("native macOS structured-extraction supervisor", 
   });
 
   it("drains multiple children and labels short-lived CPU evidence as sampled", async () => {
+    // Certification here is host-load dependent (see expectContainedRun), but
+    // the drain count and the sampled-CPU labelling this test is named for are
+    // not: they are recorded from the snapshots the supervisor did complete,
+    // whether or not it went on to certify. So they are asserted first, for
+    // both branches, and only the outcome is left to the disjunction.
     const multiple = await run("multiple-children", [4, 100], { deadlineMs: 3000 });
-    expect(multiple.evidence).toMatchObject({
-      controller_accepted: true,
-      observations: { max_group_members: 5, original_process_group_empty: true },
-    });
+    expect(multiple.evidence.observations.max_group_members).toBe(5);
+    expectContainedRun(multiple);
+
     const shortLived = await run("short-lived-cpu-children", [12, 20], { deadlineMs: 5000 });
-    expect(shortLived.evidence.controller_accepted).toBe(true);
     expect(shortLived.evidence.observations.max_group_members).toBeGreaterThan(1);
     expect(shortLived.evidence.observations.max_sampled_group_cpu_ns).toBeGreaterThan(0);
-    expect(shortLived.evidence.claim_boundary).toContain("Sampled resource observations");
+    expectContainedRun(shortLived);
   });
 
   it("revalidates a transient sampling EPERM only after the child becomes inspectable", async () => {
@@ -399,17 +484,17 @@ describe.runIf(RUNS_ON_DARWIN)("native macOS structured-extraction supervisor", 
   });
 
   it("survives repeated real /bin/ps exec windows on the release host", async () => {
+    // 256 back-to-back /bin/ps execs churn the process group faster than the
+    // 1ms sampler can settle, so on a busy host the supervisor legitimately
+    // runs out of revalidation budget and declines. What must hold on every
+    // host is that it saw the churn and contained it.
     const result = await run("repeated-ps", [256], {
       deadlineMs: 15000,
       sampleIntervalMs: 1,
     });
-    expect(result.evidence).toMatchObject({
-      controller_accepted: true,
-      controller_failure: "none",
-      observations: { original_process_group_empty: true },
-    });
     expect(result.evidence.observations.max_group_members).toBeGreaterThan(1);
     expect(result.evidence.observations.sample_race_count).toBeGreaterThan(0);
+    expectContainedRun(result);
   }, 30000);
 
   it("rejects a successful leader that leaves a live descendant", async () => {


### PR DESCRIPTION
## Not a flake — a load assumption

`test/eval/docling-macos-supervisor.test.js` fails **deterministically under CPU
contention**. Measured on one machine, 12 busy processes, full suite ×8:

| | suites green | `repeated /bin/ps` | `drains multiple children` |
|---|---|---|---|
| `origin/master` | **1 / 8** | failed 7/8 | failed 2/8 |
| this branch | **6 / 8** | **8/8** | **8/8** |

Idle: 7/7. At 48 busy processes: 6/7 suites, both named tests 7/7.

It has already caused two wrong diagnoses — an agent dismissed it as a flake, and
I concluded from a single sample on each side that my own feature branch caused
it. A test that misleads about causation costs more than one that simply fails.

## The product is correct; the test was not

Under starvation a churning child outlives `SAMPLE_REVALIDATION_BUDGET_NS`
(20 ms, `docling-macos-supervisor.c:34`) — the sealed budget for re-proving that
a PID which returned EPERM or ESRCH either became inspectable or provably
vanished. The supervisor then declines to certify a process group it could not
observe. **Failing closed is the entire point of a supervisor.** The tests
asserted success as though deterministic, encoding an idle host as an unstated
precondition.

*(Correcting my own earlier diagnosis, which is in the branch history: the
supervisor does **not** exec `/bin/ps`. It uses `proc_listpgrppids` /
`proc_listchildpids` — syscalls, no fork. The `/bin/ps` execs belong to the
candidate workload being supervised. That is why the errno set is exactly
`{EPERM, ESRCH}` rather than anything timeout-shaped.)*

## The assertions

Either the run was certified with clean evidence, **or** it declined with exactly
`enumeration`, errno in `{EPERM, ESRCH}`, and no stdout.

The anti-vacuity work is where the care went:

- **Invariants that must hold either way sit above the branch** — process group
  empty, no escaped session, `sample_count > 0`, and the full acceptance
  biconditional, deliberately duplicating `validateSupervisorEvidence` so the test
  still holds the line if the harness stops enforcing it.
- **Each test's own named property stays outside the disjunction.** The supervisor
  records observations from snapshots it completed whether or not it later
  certifies, so `max_group_members === 5`, `max_sampled_group_cpu_ns > 0` and
  `sample_race_count > 0` are asserted unconditionally. A disjunction cannot
  swallow the thing the test is named for.

## Mutation evidence — 9 against the C supervisor

Caught **in both conditions**: reporting the group as undrained; emitting zero
sampled CPU; never growing the member count.

Caught **under load**, provably inert idle: certifying unconditionally on
`FAILURE_ENUMERATION`; mislabelling the failure as `internal`; reporting a wrong
errno; leaking 12 bytes of stdout on a declined run.

Two further mutations turned out **inert rather than missed** and were replaced
with sharper ones — reported rather than counted as passes.

## Rejected alternatives

Raising the deadline (the binding constant is the 20 ms sealed budget, not the
outer deadline — it would not even move); detect-and-skip (a silent skip is
indistinguishable from a pass, and is how a vacuous test survived here recently);
longer-lived children (`short-lived-cpu-children` is the subject, not the fixture).

## Scope left deliberately

Three sibling tests share the defect and are **not** touched. One
(`accepts sampling EPERM only after…ESRCH probes`) has an accept-branch assertion
that is the whole point of the test — making it disjunctive would collapse it into
its sibling and leave one genuinely vacuous. Independent sampling found two more
(`shares one monotonic retry budget…`, `accepts only after sampling proves the
reserved leader became terminal`).

That is a suite-wide question — whether these should assert *containment
properties*, which hold under any load, rather than *acceptance outcomes*, which
do not — and it deserves its own analysis rather than expanding this change.

Test-only; the C supervisor is untouched. `npm test` — 2316 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)