### PR TITLE
Move decryption off the server thread and give it a real deadline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,15 +43,20 @@ PDF Toolkit is a Claude Desktop extension (MCPB) and MCP server that enables aut
 - `example-fw9.pdf` - Sample form for smoke tests. Keep anonymized assets only.
 - `docs/MAINTAINERS.md` - Maintainer onboarding and operations
 - `docs/RELEASE.md` - Release checklist
-- `server/qpdf-decrypt.js` - The only module that loads the qpdf runtime, and
-  the only path by which PDF Tools decrypts. Owns the password rules, the `/P`
-  permission enforcement, and the encrypted-input size cap. See
-  `## Password Support`.
+- `server/qpdf-decrypt.js` - The only path by which PDF Tools decrypts. Owns the
+  password rules, the `/P` permission enforcement, the encrypted-input size cap,
+  the one-at-a-time queue, and the 30-second deadline. It does not run qpdf
+  itself. See `## Password Support`.
+- `server/qpdf-decrypt-worker.js` - The worker thread that does. The only module
+  that loads the qpdf runtime, and never on the server's own thread. Decides
+  nothing: it runs the two qpdf passes the wrapper asks for and reports opaque
+  reason codes.
 - `vendor/qpdf-wasm/` - Reproducible QPDF WebAssembly build recipe. The
   promoted artifact under `vendor/qpdf-wasm/runtime/` is shipped in both the
   MCPB and the share ZIP at that same path, and is loaded by **exactly one
-  module**, `server/qpdf-decrypt.js` — a second importer would bypass its
-  safety rules and fails the artifact test. Do not
+  module**, `server/qpdf-decrypt-worker.js`, which is started from exactly one
+  place, `server/qpdf-decrypt.js` — a second importer, or a second starter,
+  would bypass the safety rules and fails the artifact test. Do not
   hand-edit `runtime/` or `runtime.provenance.json`; regenerate them with
   `node scripts/vendor-qpdf-wasm-runtime.mjs <extracted-build-directory>`.
   `npm run qpdf-wasm:verify` is a ~45-minute Docker release gate and must stay
@@ -76,10 +81,42 @@ on an encrypted PDF regardless of the password supplied. `pdfjs-dist` 5.4.624
 does accept `{ password }` and opens the same document correctly.
 
 `read_pdf_fields`, `validate_pdf`, and `extract_to_csv` decrypt through the
-vendored qpdf WebAssembly runtime in `server/qpdf-decrypt.js` before handing
-plaintext to pdf-lib. They qualify because they only ever read: none of them
-writes a PDF back, so none can re-encrypt a document or alter its protection.
-Decrypted bytes stay in memory and are never written to disk.
+vendored qpdf WebAssembly runtime before handing plaintext to pdf-lib. They
+qualify because they only ever read: none of them writes a PDF back, so none can
+re-encrypt a document or alter its protection. Decrypted bytes stay in memory
+and are never written to disk.
+
+**Decryption runs on a worker thread, never on the server's.** qpdf-wasm's
+`callMain` is synchronous and cannot be interrupted by the thread that called
+it, so an in-process `setTimeout` deadline could not fire until the work it was
+meant to bound had already finished. Since the size cap bounds *bytes* while
+qpdf's cost tracks *objects*, a lawful 14.3 MiB encrypted document built from
+800,000 tiny objects spends over five seconds inside one `callMain` — and
+nothing bounds object count. `server/qpdf-decrypt.js` therefore starts
+`server/qpdf-decrypt-worker.js` per request and destroys it with
+`worker.terminate()`, which is the only thing that actually stops WebAssembly
+mid-flight. Measured: deadlines of 100 ms, 250 ms, 1 s, 2.5 s and 4 s against
+that document each land within ~60 ms of themselves, and the process then burns
+under 1 ms of further CPU over the next 2 seconds — against the 4 seconds of CPU
+the same decrypt costs when it is allowed to finish.
+
+**Deadline: 30 seconds**, matching `DEFAULT_TIMEOUT_MS` in
+`server/pdf-lib-subprocess.js`. It bounds how long a hostile document may hold
+the decryption queue and a core, not how long the server is unresponsive — the
+server's thread is free throughout. Plaintext crosses no new boundary: the
+worker is a thread in the same process and hands the decrypted bytes over
+through `postMessage`'s transfer list, which moves ownership of the same pages
+rather than serializing them. Routing decryption into the existing pdf-lib
+*child process* would have reused proven containment but forced plaintext
+through a pipe or a staged file, which is exactly what the design avoids.
+
+Isolation costs a roughly constant **45-65 ms per decryption** — worker start,
+a fresh runtime instantiation, and the message round trip. Measured on
+macOS/arm64: an 84 KB document goes from 32 ms to 81 ms, a 1 MB one from 68 ms
+to 110 ms, and a 14.6 MiB one from 671 ms to 734 ms. Back-to-back decryptions
+pay an extra ~55 ms because the queue is held until the previous worker is gone,
+which is deliberate: one qpdf heap at a time is what the size cap assumes.
+Isolation does **not** improve the memory picture; see the size-cap note below.
 
 **The scope rule.** Decryption is not a "remove the password" facility:
 
@@ -108,6 +145,20 @@ below the 250 MiB `PDF_MUTATION_MAX_FILE_BYTES`. Decryption costs roughly
 `16 x input + 45 MB` of peak RSS, so 16 MiB keeps a full read inside the
 1024 MiB the project already treats as too much. Oversized input gets a clear
 size message rather than an out-of-memory kill.
+
+**Do not raise the cap on the strength of worker isolation.** The hypothesis
+that a terminated worker would reclaim the WebAssembly heap where in-process GC
+could not does not survive measurement on macOS/arm64. After one 14.6 MiB
+decrypt and a forced-GC settle, the in-process arrangement retains ~190 MB over
+baseline and the worker arrangement retains ~260 MB: terminating the thread
+returns *less* to the OS than collecting the module did, because the freed pages
+stay mapped. Neither arrangement accumulates — eight consecutive near-cap
+decrypts plateau at ~370 MB in-process and ~350 MB in workers rather than
+summing — so a per-file cap is still sufficient and `extract_to_csv` still needs
+no aggregate bound. What the cap is derived from is the *peak* of a single
+decrypt, which isolation leaves essentially unchanged (~315 MB in a worker
+versus ~333 MB in-process), so there is no measurement here that licenses a
+larger number.
 
 Measured against an AES-256 PDF produced with
 `qpdf --encrypt --user-password=secret --owner-password=secret --bits=256`:

--- a/package-for-friend.js
+++ b/package-for-friend.js
@@ -52,6 +52,7 @@ export const SHARE_FILES = [
   "server/pdf-lib-worker.js",
   "server/pdfjs-subprocess.js",
   "server/pdfjs-worker.js",
+  "server/qpdf-decrypt-worker.js",
   "server/qpdf-decrypt.js",
   "server/resource-uri.js",
   "server/stderr-suppression.js",

--- a/pdf-toolkit-mcp-share/server/index.js
+++ b/pdf-toolkit-mcp-share/server/index.js
@@ -57,6 +57,8 @@ import {
   PDF_DECRYPTABLE_PASSWORD_DESCRIPTION,
   PdfDecryptionError,
   decryptPdfForRead,
+  forceTerminateAllDecryptionWorkers,
+  terminateAllDecryptionWorkers,
 } from "./qpdf-decrypt.js";
 import {
   PDF_MUTATION_MAX_FILE_BYTES,
@@ -1849,6 +1851,10 @@ for (const [signal, exitCode] of new Map([
     workerShutdown = settleAllShutdownOperations([
       terminateAllPdfjsSubprocesses(),
       terminateAllPdfLibMutations(),
+      // A decryption worker is a live thread and keeps the process alive. It
+      // has its own 30-second deadline, which is the wrong amount of time for a
+      // shutdown to wait on.
+      terminateAllDecryptionWorkers(),
     ]);
     void workerShutdown.finally(() => process.exit(exitCode));
   });
@@ -1856,6 +1862,7 @@ for (const [signal, exitCode] of new Map([
 process.once("exit", () => {
   forceTerminateAllPdfjsSubprocesses();
   forceTerminateAllPdfLibMutations();
+  forceTerminateAllDecryptionWorkers();
 });
 
 const backupPathByCanonical = new Map();

--- a/pdf-toolkit-mcp-share/server/qpdf-decrypt-worker.js
+++ b/pdf-toolkit-mcp-share/server/qpdf-decrypt-worker.js
@@ -1,0 +1,384 @@
+/**
+ * The worker thread that actually runs QPDF, and the only module in the tree
+ * that loads the vendored QPDF WebAssembly runtime.
+ *
+ * ## Why decryption runs here rather than in the server
+ *
+ * QPDF-WASM is a synchronous Emscripten build: `callMain` is one blocking call
+ * that returns only when QPDF is finished. Nothing on the calling thread runs
+ * while it is in flight — not a timer, not an incoming MCP request, not a
+ * promise continuation. A deadline expressed as a `setTimeout` on that thread
+ * cannot fire until the work it was meant to bound has already completed, so
+ * an in-process timeout is not a timeout at all; it is an after-the-fact
+ * report.
+ *
+ * That matters because the input is hostile by assumption and the size cap
+ * bounds bytes, not work. Measured against this runtime, a 14.3 MiB encrypted
+ * document built from 800,000 tiny indirect objects — comfortably inside the
+ * 16 MiB cap — spends more than five seconds inside a single `callMain`. Object
+ * count, not file size, is what that costs, and nothing bounds object count.
+ * Run in the server process, that is five seconds during which every tool is
+ * unavailable, and it is a lower bound rather than a limit.
+ *
+ * A worker thread is the smallest construct that fixes it. `worker.terminate()`
+ * goes through V8's execution terminator, which interrupts WebAssembly at its
+ * stack-guard checks rather than waiting for the call to return, so the parent
+ * can enforce a real wall-clock deadline. Measured against that document,
+ * deadlines of 100 ms, 250 ms, 1 s, 2.5 s and 4 s each land within 60 ms of
+ * themselves, and the process then consumes under 1 ms of further CPU over the
+ * following 2 seconds — against the 4 seconds of CPU the same decrypt burns
+ * when it is allowed to finish. The work is killed, not abandoned.
+ *
+ * ## Where the plaintext lives
+ *
+ * In this process, and only in this process. The decrypted bytes are copied out
+ * of the WebAssembly heap into a standalone `ArrayBuffer` and handed to the
+ * parent through `postMessage`'s transfer list, which reassigns ownership of
+ * the same pages rather than serializing them: no copy, no pipe, no file, no
+ * process boundary. That is deliberate. Routing this through the existing
+ * pdf-lib child process would have forced the plaintext across a real process
+ * boundary — through a pipe or a staged temporary file — which is exactly the
+ * property the original design set out to avoid.
+ *
+ * The ciphertext and the password arrive by the same route and are zeroed here
+ * before the worker is torn down. As the wrapper's header says, that shortens
+ * the window rather than closing it: the WebAssembly heap holds its own copies
+ * of everything QPDF touched. Destroying the thread does put those copies
+ * beyond reach of anything still running in the process, which the in-process
+ * arrangement could not promise — but it does not hand the pages back to the
+ * operating system, and the wrapper's header has the measurements that say so.
+ * Termination is bought for the deadline, not for the memory.
+ *
+ * ## What this module is not allowed to decide
+ *
+ * Nothing. The password rules, the permission rules, the size cap and every
+ * caller-visible message live in `server/qpdf-decrypt.js`. This module runs the
+ * two QPDF invocations that module asks for, reports facts, and maps failures
+ * to opaque reason codes. It never composes a message for a user, because QPDF
+ * prefixes its diagnostics with `argv[0]` and echoes the virtual paths below.
+ */
+
+import { parentPort, workerData } from "node:worker_threads";
+
+const QPDF_RUNTIME_RELATIVE_PATH = "../vendor/qpdf-wasm/runtime/qpdf.mjs";
+
+// Fixed paths inside the module's private in-memory filesystem. A fresh module
+// is created for every QPDF invocation, and a fresh worker for every request,
+// so these never collide.
+const VIRTUAL_INPUT_PATH = "/in.pdf";
+const VIRTUAL_OUTPUT_PATH = "/out.pdf";
+const VIRTUAL_PASSWORD_PATH = "/pw";
+
+// The JSON inspection output is a few hundred bytes; QPDF diagnostics are a
+// few lines. Anything beyond this means the runtime is not behaving as built.
+const QPDF_OUTPUT_BYTE_CAP = 64 * 1024;
+
+/*
+ * QPDF's documented exit codes. 3 means the operation completed but the file
+ * needed recovery — a damaged cross-reference table, a stream whose declared
+ * length was wrong, and so on. Real-world PDFs produce it often enough that
+ * rejecting it would make this feature fail on documents QPDF read perfectly
+ * well. It is accepted only when output was actually produced, and the
+ * recovered document then still has to survive pdf-lib's parse and the page-
+ * tree validation, so accepting a warning is not accepting a broken document.
+ *
+ * 2 is a genuine error, and includes the one case that must stay
+ * distinguishable: a password the document did not accept.
+ */
+const QPDF_EXIT_SUCCESS = 0;
+const QPDF_EXIT_WARNINGS = 3;
+const qpdfCompleted = status => status === QPDF_EXIT_SUCCESS || status === QPDF_EXIT_WARNINGS;
+
+/*
+ * QPDF's own wording for a password that matched neither the user nor the
+ * owner password. Matched here only, to tell "this needs a password you did not
+ * give" apart from "this file is broken" — advice that would otherwise be wrong
+ * half the time. The matched text never leaves this thread. If the wording ever
+ * changes the classification falls back to the malformed reason, which is the
+ * safe direction: it never claims a password would help.
+ */
+const QPDF_INVALID_PASSWORD_DIAGNOSTIC = "invalid password";
+
+/** Raised for a condition the parent has a fixed message for. */
+class WorkerDecryptionFailure extends Error {
+  constructor(reason) {
+    super(reason);
+    this.reason = reason;
+  }
+}
+
+/**
+ * Collects a QPDF output stream under a hard byte cap. The captured text is
+ * used only to parse the inspection JSON and to classify a failure; it is never
+ * sent to the parent.
+ */
+function boundedCapture() {
+  const lines = [];
+  let bytes = 0;
+  let overflowed = false;
+  return {
+    write(line) {
+      const text = String(line);
+      bytes += Buffer.byteLength(text, "utf8") + 1;
+      if (bytes > QPDF_OUTPUT_BYTE_CAP) {
+        overflowed = true;
+        return;
+      }
+      lines.push(text);
+    },
+    get overflowed() {
+      return overflowed;
+    },
+    text() {
+      return lines.join("\n");
+    },
+  };
+}
+
+/**
+ * Builds the password file contents. QPDF's `--password-file` reads the first
+ * line, which keeps the password out of `argv` — where it would otherwise be
+ * visible to anything that can read the process's command line, and would be
+ * echoed back by QPDF's own usage diagnostics.
+ *
+ * The line-break rejection is the parent's rule and the parent applies it
+ * before a worker is ever started, so a password reaching this point should
+ * already be representable. It is re-checked rather than assumed because the
+ * failure it prevents is a silent truncation reported as a wrong password.
+ */
+function passwordFileBytes(password) {
+  if (/[\r\n]/.test(password)) {
+    throw new WorkerDecryptionFailure("password_unrepresentable");
+  }
+  return Buffer.from(`${password}\n`, "utf8");
+}
+
+let runtimeFactoryPromise = null;
+
+/**
+ * Resolves the runtime's ESM factory once per worker. The factory is just a
+ * function; each call below still instantiates its own module, so no QPDF
+ * state, filesystem entry, or password crosses between the two invocations.
+ *
+ * The specifier is computed rather than literal so that test-time bundlers
+ * leave the Emscripten output alone: it resolves its own `.wasm` sibling from
+ * `import.meta.url` and has to be loaded as a plain Node module. The path is
+ * identical in the checkout, the MCPB and the share ZIP, so this resolves the
+ * same way in all three. A worker thread loads it through Node's own loader in
+ * every one of those hosts, which is a plainer path than the main thread had.
+ */
+async function loadQpdfFactory() {
+  if (!runtimeFactoryPromise) {
+    const runtimeUrl = new URL(QPDF_RUNTIME_RELATIVE_PATH, import.meta.url).href;
+    runtimeFactoryPromise = import(runtimeUrl).then(module => {
+      if (typeof module.default !== "function") {
+        throw new WorkerDecryptionFailure("runtime_unavailable");
+      }
+      return module.default;
+    });
+    runtimeFactoryPromise.catch(() => {});
+  }
+  return runtimeFactoryPromise;
+}
+
+/**
+ * Runs one QPDF invocation in its own freshly instantiated module and tears it
+ * down afterwards. Returns the exit status, the captured stdout, the captured
+ * stderr, and the requested output file if the run produced one.
+ *
+ * The module, its `FS`, and its raw exports never leave this function: the
+ * vendored runtime's README is explicit that callers must be given a narrow
+ * operation API rather than the module or its filesystem. Nothing this module
+ * sends to the parent carries either.
+ */
+async function runQpdf(args, inputs, outputPath = null) {
+  const createQpdf = await loadQpdfFactory();
+  const stdout = boundedCapture();
+  const stderr = boundedCapture();
+  let qpdf = null;
+  let status;
+  let output = null;
+  try {
+    qpdf = await createQpdf({
+      print: line => stdout.write(line),
+      printErr: line => stderr.write(line),
+    });
+    for (const [virtualPath, bytes] of Object.entries(inputs)) {
+      qpdf.FS.writeFile(virtualPath, bytes);
+    }
+    try {
+      status = qpdf.callMain([...args]);
+    } catch (error) {
+      // Emscripten reports a normal `exit()` by throwing an object carrying
+      // the status. Anything without an integer status is a real fault.
+      if (!Number.isInteger(error?.status)) {
+        throw new WorkerDecryptionFailure("qpdf_faulted");
+      }
+      status = error.status;
+    }
+    if (qpdfCompleted(status) && outputPath) {
+      // Copied into an ArrayBuffer this thread owns outright. What `FS.readFile`
+      // returns may be a view onto the WebAssembly heap, which cannot be
+      // transferred and must not be handed out even if it could be.
+      const raw = qpdf.FS.readFile(outputPath);
+      output = new Uint8Array(raw.length);
+      output.set(raw);
+    }
+  } catch (error) {
+    if (error instanceof WorkerDecryptionFailure) throw error;
+    throw new WorkerDecryptionFailure("qpdf_faulted");
+  } finally {
+    // Overwrite then unlink every virtual file, so the ciphertext, the
+    // password and any plaintext output stop being reachable through this
+    // module before it is dropped. Best effort by nature: the WebAssembly heap
+    // keeps its own copies until this thread is destroyed, which — unlike the
+    // in-process arrangement this replaced — is something that then happens.
+    if (qpdf) {
+      for (const virtualPath of [...Object.keys(inputs), ...(outputPath ? [outputPath] : [])]) {
+        try {
+          const existing = qpdf.FS.readFile(virtualPath);
+          qpdf.FS.writeFile(virtualPath, new Uint8Array(existing.length));
+          qpdf.FS.unlink(virtualPath);
+        } catch {
+          // The file may never have been created, or QPDF may have removed it.
+        }
+      }
+    }
+    qpdf = null;
+  }
+  if (stdout.overflowed || stderr.overflowed) {
+    throw new WorkerDecryptionFailure("qpdf_output_overflow");
+  }
+  return { status, stdout: stdout.text(), stderr: stderr.text(), output };
+}
+
+/**
+ * Reads the document's encryption state and effective permissions without
+ * producing any decrypted output. Returns only the four facts the parent's
+ * rules are written against.
+ */
+async function inspectEncryption(pdfBytes, password) {
+  const { status, stdout, stderr } = await runQpdf(
+    [
+      "--json=latest",
+      "--json-key=encrypt",
+      `--password-file=${VIRTUAL_PASSWORD_PATH}`,
+      VIRTUAL_INPUT_PATH,
+    ],
+    {
+      [VIRTUAL_INPUT_PATH]: pdfBytes,
+      [VIRTUAL_PASSWORD_PATH]: passwordFileBytes(password ?? ""),
+    },
+  );
+  if (!qpdfCompleted(status)) {
+    // QPDF does not fall back to the empty password when a wrong one is given,
+    // so a supplied-but-wrong password fails here rather than opening the
+    // document by way of an empty user password. A malformed file fails here
+    // too, and must not be reported as needing a password. Which of the two
+    // password reasons applies depends on whether one was supplied, and that
+    // is the parent's call, so both collapse to one code here.
+    throw new WorkerDecryptionFailure(
+      stderr.toLowerCase().includes(QPDF_INVALID_PASSWORD_DIAGNOSTIC)
+        ? "password_not_accepted"
+        : "unreadable_document",
+    );
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(stdout)?.encrypt;
+  } catch {
+    throw new WorkerDecryptionFailure("malformed_inspection");
+  }
+  if (
+    !parsed
+    || typeof parsed.encrypted !== "boolean"
+    || typeof parsed.ownerpasswordmatched !== "boolean"
+    || typeof parsed.userpasswordmatched !== "boolean"
+    || !parsed.capabilities
+    || typeof parsed.capabilities.extract !== "boolean"
+  ) {
+    throw new WorkerDecryptionFailure("malformed_inspection");
+  }
+  return {
+    encrypted: parsed.encrypted,
+    ownerPasswordMatched: parsed.ownerpasswordmatched,
+    userPasswordMatched: parsed.userpasswordmatched,
+    capabilities: parsed.capabilities,
+  };
+}
+
+/** Produces the decrypted document. */
+async function decrypt(pdfBytes, password) {
+  const { status, output } = await runQpdf(
+    [
+      `--password-file=${VIRTUAL_PASSWORD_PATH}`,
+      "--decrypt",
+      VIRTUAL_INPUT_PATH,
+      VIRTUAL_OUTPUT_PATH,
+    ],
+    {
+      [VIRTUAL_INPUT_PATH]: pdfBytes,
+      [VIRTUAL_PASSWORD_PATH]: passwordFileBytes(password ?? ""),
+    },
+    VIRTUAL_OUTPUT_PATH,
+  );
+  if (!qpdfCompleted(status) || !output || output.length === 0) {
+    throw new WorkerDecryptionFailure("decrypt_failed");
+  }
+  return output;
+}
+
+/*
+ * The request. One worker serves exactly one document, so the ciphertext and
+ * the password arrive once, in `workerData`, and both phases read them from
+ * here.
+ *
+ * The parent transfers the ciphertext rather than cloning it, so these bytes
+ * are the parent's own copy of the file, moved. The parent made that copy
+ * precisely so the caller's on-disk bytes are never detached out from under it.
+ */
+const ciphertext = new Uint8Array(workerData.ciphertext);
+const password = workerData.password;
+
+function zeroRequest() {
+  ciphertext.fill(0);
+}
+
+/**
+ * Phase one runs immediately: the parent cannot apply its permission rules
+ * until it has the encryption facts, and it does not decrypt anything it is
+ * going to refuse.
+ *
+ * Phase two waits for the parent to say yes. If the answer is no — refused, or
+ * the deadline expired — the parent terminates this thread and nothing further
+ * runs here.
+ */
+async function main() {
+  const encryption = await inspectEncryption(ciphertext, password);
+
+  // The listener goes on before the report goes out, so the parent's answer
+  // cannot arrive at a port that is not yet listening for it.
+  const permission = new Promise((resolve, reject) => {
+    parentPort.once("message", message => {
+      if (message?.kind === "decrypt") resolve();
+      else reject(new WorkerDecryptionFailure("protocol_violation"));
+    });
+  });
+  parentPort.postMessage({ kind: "inspected", encryption });
+  await permission;
+
+  const plaintext = await decrypt(ciphertext, password);
+  zeroRequest();
+  // Transferred, not cloned: ownership of these exact pages moves to the
+  // parent and this thread's reference is detached. There is no second copy to
+  // wipe, and nothing is serialized.
+  parentPort.postMessage({ kind: "decrypted", plaintext: plaintext.buffer }, [plaintext.buffer]);
+}
+
+main().catch(error => {
+  zeroRequest();
+  parentPort.postMessage({
+    kind: "failed",
+    reason: error instanceof WorkerDecryptionFailure ? error.reason : "qpdf_faulted",
+  });
+});

--- a/pdf-toolkit-mcp-share/server/qpdf-decrypt.js
+++ b/pdf-toolkit-mcp-share/server/qpdf-decrypt.js
@@ -1,6 +1,13 @@
 /**
- * Decryption of encrypted PDFs for the read-only tools, and the only module
- * under `server/` that loads the vendored QPDF WebAssembly runtime.
+ * Decryption of encrypted PDFs for the read-only tools: the size cap, the
+ * password rules, the permission rules, the queue, the deadline, and every
+ * message a caller can see.
+ *
+ * The QPDF runtime itself is not loaded here. It runs in a worker thread —
+ * `server/qpdf-decrypt-worker.js`, the only module in the tree that loads it —
+ * which this module starts, drives, bounds and destroys. See that file for why
+ * the work cannot run on the server's own thread; see below for what this
+ * module decides.
  *
  * pdf-lib 1.17.1 cannot decrypt anything, so every tool that reads through it
  * fails on an encrypted document no matter what password the caller supplies.
@@ -26,6 +33,12 @@
  * The empty string counts as *no password*, so the check above cannot be
  * sidestepped by passing `""` to a document whose user password is empty.
  *
+ * Both gates are evaluated here, in the server, between the worker's two
+ * phases. The worker reports what the document says about itself and then
+ * waits; it is told to decrypt only after this module has decided that it may.
+ * A refusal is therefore a refusal to do the work, not a decision to throw the
+ * result away.
+ *
  * ## Which permission bit
  *
  * All three tools require `extract` — `/P` bit 5, "copy or otherwise extract
@@ -47,52 +60,54 @@
  *
  * ## Memory
  *
- * QPDF-WASM costs roughly 16x the input size plus a ~45 MB baseline, and the
- * WebAssembly heap is not reliably returned to the OS within the process.
- * Encrypted inputs therefore get their own explicit, much lower size cap
- * (`PDF_ENCRYPTED_MAX_FILE_BYTES`) instead of the 250 MiB mutation cap, and
- * oversized ones are refused with a size message rather than being allowed to
- * run into an out-of-memory kill. See the constant for the measurements.
+ * QPDF-WASM costs roughly 16x the input size plus a ~45 MB baseline, which is
+ * why encrypted inputs get their own explicit, much lower size cap
+ * (`PDF_ENCRYPTED_MAX_FILE_BYTES`) instead of the 250 MiB mutation cap. See the
+ * constant for those measurements.
+ *
+ * Isolation was expected to improve on that, on the theory that a heap dying
+ * with its thread would be returned where an in-process collection was not. It
+ * does not, and the measurements say so plainly. On macOS/arm64, after a single
+ * 14.6 MiB decrypt and a forced-GC settle:
+ *
+ *   | arrangement | peak RSS | settled RSS | retained over baseline |
+ *   | ----------- | -------: | ----------: | ---------------------: |
+ *   | in-process  |   333 MB |      243 MB |                 188 MB |
+ *   | worker      |   315 MB |      315 MB |                 260 MB |
+ *
+ * Destroying the thread returns *less* than collecting the module did: the
+ * freed pages stay mapped in the process, so `terminate()` buys nothing here
+ * and costs about 70 MB of resting RSS. What neither arrangement does is
+ * accumulate — eight consecutive near-cap decrypts plateau at 373 MB
+ * in-process and 352 MB in workers rather than summing, because each new
+ * worker reuses the pages the last one released. So the per-file cap remains
+ * sufficient and `extract_to_csv` still needs no aggregate bound.
+ *
+ * The deadline is what isolation actually buys. The memory column is a cost,
+ * and a small one against the 1024 MiB budget, but it is not a saving and must
+ * not be read as one; see the size constant.
  *
  * ## Plaintext handling
  *
- * Decrypted bytes exist only in memory and are never written to disk. The
- * caller gets a `release()` and must call it once it has finished reading the
- * loaded document. Be honest about what that buys: `release()` overwrites the
- * Node buffer it handed out, but JavaScript cannot guarantee erasure. The
- * WebAssembly heap holds its own copies that only the module's own teardown
- * reclaims, the garbage collector may already have copied the buffer, and any
- * of those pages may have been written to swap. This reduces the window in
- * which plaintext is readable in the process; it does not eliminate it.
- */
-
-const QPDF_RUNTIME_RELATIVE_PATH = "../vendor/qpdf-wasm/runtime/qpdf.mjs";
-
-// Fixed paths inside the module's private in-memory filesystem. A fresh module
-// is created for every QPDF invocation, so these never collide across calls.
-const VIRTUAL_INPUT_PATH = "/in.pdf";
-const VIRTUAL_OUTPUT_PATH = "/out.pdf";
-const VIRTUAL_PASSWORD_PATH = "/pw";
-
-// The JSON inspection output is a few hundred bytes; QPDF diagnostics are a
-// few lines. Anything beyond this means the runtime is not behaving as built.
-const QPDF_OUTPUT_BYTE_CAP = 64 * 1024;
-
-/*
- * QPDF's documented exit codes. 3 means the operation completed but the file
- * needed recovery — a damaged cross-reference table, a stream whose declared
- * length was wrong, and so on. Real-world PDFs produce it often enough that
- * rejecting it would make this feature fail on documents QPDF read perfectly
- * well. It is accepted only when output was actually produced, and the
- * recovered document then still has to survive pdf-lib's parse and the page-
- * tree validation, so accepting a warning is not accepting a broken document.
+ * Decrypted bytes exist only in memory and are never written to disk. They also
+ * never leave this process: the worker is a thread, and the plaintext reaches
+ * this module through `postMessage`'s transfer list, which moves ownership of
+ * the same pages rather than serializing them. Nothing is copied, piped, or
+ * staged to a file. That was an explicit property of the original in-process
+ * design and isolation keeps it; routing decryption through the existing
+ * pdf-lib *child process* instead would have given up exactly that.
  *
- * 2 is a genuine error, and includes the one case that must stay
- * distinguishable: a password the document did not accept.
+ * The caller gets a `release()` and must call it once it has finished reading
+ * the loaded document. Be honest about what that buys: `release()` overwrites
+ * the Node buffer it handed out, but JavaScript cannot guarantee erasure. The
+ * garbage collector may already have copied the buffer, and any of those pages
+ * may have been written to swap. This reduces the window in which plaintext is
+ * readable in the process; it does not eliminate it. The WebAssembly heap's own
+ * copies are a smaller problem than they were, because the thread holding them
+ * is destroyed at the end of every request.
  */
-const QPDF_EXIT_SUCCESS = 0;
-const QPDF_EXIT_WARNINGS = 3;
-const qpdfCompleted = status => status === QPDF_EXIT_SUCCESS || status === QPDF_EXIT_WARNINGS;
+
+import { Worker } from "node:worker_threads";
 
 /**
  * The per-file ceiling for an encrypted input, deliberately separate from and
@@ -117,12 +132,37 @@ const qpdfCompleted = status => status === QPDF_EXIT_SUCCESS || status === QPDF_
  * no useful margin; that is the reason for the specific number rather than a
  * rounder, larger one.
  *
- * Repeated decryption within one process was measured not to accumulate: RSS
- * plateaus near the high-water mark of the single largest input rather than
- * summing, so a per-file cap is sufficient and `extract_to_csv` does not need
- * an additional aggregate bound.
+ * Isolation did not change any of that, and specifically did not earn a larger
+ * number. The peak of a single decrypt is what this cap is derived from, and
+ * the measurements in the module header put the worker's peak at 315 MB against
+ * 333 MB in-process — a few percent, not a factor. Repeated decryption still
+ * plateaus rather than accumulating, so `extract_to_csv` still needs no
+ * aggregate bound, but that was true before as well. Raising the cap would
+ * raise the peak against the same 1024 MiB budget, with nothing new to pay for
+ * it.
  */
 export const PDF_ENCRYPTED_MAX_FILE_BYTES = 16 * 1024 * 1024;
+
+/**
+ * The wall-clock ceiling on one decryption, enforced by destroying the worker
+ * thread that is running it.
+ *
+ * The size cap bounds input bytes; it does not bound work. QPDF's cost tracks
+ * the number of objects in a document, and object count is nearly free per
+ * byte: a 14.3 MiB encrypted file built from 800,000 tiny indirect objects —
+ * inside the cap — takes over five seconds, and there is no honest reason to
+ * believe five seconds is the worst a 16 MiB document can do.
+ *
+ * 30 seconds matches `DEFAULT_TIMEOUT_MS` in `server/pdf-lib-subprocess.js`,
+ * which is the number this codebase already uses for "a PDF operation that has
+ * not finished by now is not going to". It is generous against measurement —
+ * the slowest legitimate near-cap decrypt observed is 1.6 seconds, and the
+ * slowest constructed one 5.7 — and it can afford to be, because a decryption
+ * that runs long no longer blocks anything. The server's own thread is free the
+ * whole time; the deadline bounds how long a hostile document may occupy a
+ * queue slot and a CPU, not how long the server is unresponsive.
+ */
+export const PDF_DECRYPTION_TIMEOUT_MS = 30_000;
 
 /**
  * The operations allowed to decrypt, and the `/P` capability each one needs
@@ -172,6 +212,12 @@ export const PDF_DECRYPTION_FAILED_MESSAGE =
   "This PDF is encrypted and could not be decrypted: the document is malformed, incomplete, or "
   + "uses an encryption scheme this build does not support.";
 
+export const PDF_DECRYPTION_TIMEOUT_MESSAGE =
+  `Decrypting this PDF did not finish within ${PDF_DECRYPTION_TIMEOUT_MS / 1000} seconds and was `
+  + "stopped. How long decryption takes depends on how many objects a document contains rather "
+  + "than on how large it is, so a small file can still exceed the limit. Decrypt the file first "
+  + "(for example with qpdf) and retry with the decrypted copy.";
+
 /**
  * Refusal text for the owner-locked case. Names the denied permission, says
  * plainly that no password was supplied, and points at the one legitimate way
@@ -197,57 +243,27 @@ export const PDF_DECRYPTABLE_PASSWORD_DESCRIPTION =
   + "document. An encrypted document that opens without a password is still read only if its "
   + "own permissions allow content extraction; PDF Tools does not override them.";
 
+/**
+ * The deadline one request runs under.
+ *
+ * `timeoutMs` exists for tests, which need to watch the deadline fire without
+ * waiting out the real one. It can only ever tighten: anything larger than
+ * `PDF_DECRYPTION_TIMEOUT_MS`, and anything that is not a usable positive
+ * number, collapses to the product's own limit. There is deliberately no way
+ * to grant a document more time than the product allows.
+ */
+export function resolveDecryptionDeadlineMs(timeoutMs) {
+  return Number.isFinite(timeoutMs) && timeoutMs > 0
+    ? Math.min(timeoutMs, PDF_DECRYPTION_TIMEOUT_MS)
+    : PDF_DECRYPTION_TIMEOUT_MS;
+}
+
 export class PdfDecryptionError extends Error {
   constructor(reason, message) {
     super(message);
     this.name = "PdfDecryptionError";
     this.reason = reason;
   }
-}
-
-/**
- * Collects a QPDF output stream under a hard byte cap. The captured text is
- * used only to parse the inspection JSON and is never surfaced to a caller:
- * QPDF prefixes its diagnostics with `argv[0]` and echoes virtual paths, so
- * every failure below maps to a fixed message instead.
- */
-function boundedCapture() {
-  const lines = [];
-  let bytes = 0;
-  let overflowed = false;
-  return {
-    write(line) {
-      const text = String(line);
-      bytes += Buffer.byteLength(text, "utf8") + 1;
-      if (bytes > QPDF_OUTPUT_BYTE_CAP) {
-        overflowed = true;
-        return;
-      }
-      lines.push(text);
-    },
-    get overflowed() {
-      return overflowed;
-    },
-    text() {
-      return lines.join("\n");
-    },
-  };
-}
-
-/**
- * Builds the password file contents. QPDF's `--password-file` reads the first
- * line, which keeps the password out of `argv` — where it would otherwise be
- * visible to anything that can read the process's command line, and would be
- * echoed back by QPDF's own usage diagnostics.
- */
-function passwordFileBytes(password) {
-  // QPDF reads the first line of the file, so a password containing a line
-  // break would be silently truncated and then reported as "not accepted" —
-  // a confusing lie. Refuse it explicitly instead.
-  if (/[\r\n]/.test(password)) {
-    throw new PdfDecryptionError("password_unrepresentable", PDF_PASSWORD_UNREPRESENTABLE_MESSAGE);
-  }
-  return Buffer.from(`${password}\n`, "utf8");
 }
 
 /**
@@ -271,15 +287,53 @@ export function normalizeSuppliedPassword(password) {
   return password === "" ? null : password;
 }
 
-let runtimeFactoryPromise = null;
+const DECRYPTION_WORKER_URL = new URL("./qpdf-decrypt-worker.js", import.meta.url);
+
+let qpdfRuntimeReached = false;
+const activeDecryptionWorkers = new Set();
 
 /**
- * Whether this process has ever asked for the QPDF runtime. Exists so the
- * "an unencrypted document pays nothing" property can be asserted as a fact
- * rather than as a claim in a comment. It exposes no capability.
+ * Whether this process has ever started a decryption worker, and so has ever
+ * reached the QPDF runtime. Exists so the "an unencrypted document pays
+ * nothing" property can be asserted as a fact rather than as a claim in a
+ * comment. It exposes no capability.
+ *
+ * It is now a stronger fact than it was. The runtime is not merely unloaded
+ * until something is decrypted; the module that loads it is not on the server's
+ * import graph at all, and only ever runs on another thread.
  */
 export function isQpdfRuntimeLoaded() {
-  return runtimeFactoryPromise !== null;
+  return qpdfRuntimeReached;
+}
+
+/**
+ * Destroys every decryption worker that is still running. Called from the
+ * server's signal handlers: a worker thread keeps the process alive, and a
+ * decryption that has just started should not hold a shutdown open for the
+ * length of its deadline.
+ */
+export function terminateAllDecryptionWorkers() {
+  return Promise.all([...activeDecryptionWorkers].map(async worker => {
+    try {
+      await worker.terminate();
+    } catch {
+      // Already gone.
+    }
+  }));
+}
+
+/**
+ * The same, without waiting — for the `exit` handler, where nothing
+ * asynchronous can still run.
+ */
+export function forceTerminateAllDecryptionWorkers() {
+  for (const worker of activeDecryptionWorkers) {
+    try {
+      void worker.terminate();
+    } catch {
+      // Already gone.
+    }
+  }
 }
 
 /*
@@ -290,178 +344,220 @@ export function isQpdfRuntimeLoaded() {
  * encrypted reads would each be allowed 16 MiB and the budget the cap was
  * calculated against would be wrong by a factor of the concurrency. Queueing
  * makes the measured single-operation peak the real ceiling no matter how many
- * callers arrive at once.
+ * callers arrive at once, and it bounds the number of live worker threads to
+ * one along with it.
  *
  * A queued caller waits rather than fails: at the cap a decrypt is on the order
  * of a second, which is a far better outcome than an out-of-memory kill that
  * takes the whole server down. The queue never rejects, so one failing
- * operation cannot poison the chain for the next.
+ * operation cannot poison the chain for the next. The deadline below is what
+ * stops a hostile document from holding the queue indefinitely.
+ *
+ * The queue is held until the worker thread is *gone*, not until the caller has
+ * its answer. Those are different moments on the success path: the plaintext
+ * has already been transferred out, so the caller has no stake in the teardown,
+ * while the invariant that matters — one QPDF heap alive at a time — is exactly
+ * what the queue is for. Destroying a worker holding a decrypted document costs
+ * a measured 55-60 ms, and settling first takes that off the critical path of
+ * an idle-queue request. Back-to-back requests still pay it, in the queue,
+ * which is the correct place for it.
+ *
+ * A `run` here returns `{ outcome, teardown }`; `outcome` is what the caller
+ * gets, `teardown` is what the next caller waits on. A `run` that throws before
+ * a worker exists (the size cap, an unusable password) has neither, and simply
+ * rejects.
  */
 let decryptionQueue = Promise.resolve();
 
-function queueDecryption(operation) {
-  const result = decryptionQueue.then(operation, operation);
-  decryptionQueue = result.then(() => {}, () => {});
-  return result;
+function queueDecryption(run) {
+  const started = decryptionQueue.then(run, run);
+  decryptionQueue = started
+    .then(result => result?.teardown, () => {})
+    .then(() => {}, () => {});
+  return started.then(result => result.outcome);
 }
 
 /**
- * Resolves the runtime's ESM factory once per process. The factory is just a
- * function; each call below still instantiates its own module, so no QPDF
- * state, filesystem entry, or password crosses between requests.
+ * Turns a worker reason code into the caller-visible failure. The worker never
+ * composes a message: QPDF prefixes its diagnostics with `argv[0]` and echoes
+ * the virtual input path, so every failure maps to one of this module's own
+ * fixed strings here.
  *
- * The specifier is computed rather than literal so that test-time bundlers
- * leave the Emscripten output alone: it resolves its own `.wasm` sibling from
- * `import.meta.url` and has to be loaded as a plain Node module. The path is
- * identical in the checkout, the MCPB and the share ZIP, so this resolves the
- * same way in all three.
+ * `password_not_accepted` is the one code that splits, and it splits on
+ * something only this side knows: whether the caller supplied a password at
+ * all. The same QPDF failure means "you need a password" to one caller and
+ * "that password is wrong" to another.
  */
-async function loadQpdfFactory() {
-  if (!runtimeFactoryPromise) {
-    const runtimeUrl = new URL(QPDF_RUNTIME_RELATIVE_PATH, import.meta.url).href;
-    runtimeFactoryPromise = import(runtimeUrl).then(module => {
-      if (typeof module.default !== "function") {
-        throw new PdfDecryptionError("runtime_unavailable", PDF_DECRYPTION_FAILED_MESSAGE);
-      }
-      return module.default;
-    });
-    runtimeFactoryPromise.catch(() => {});
+function workerFailure(reason, suppliedPassword) {
+  if (reason === "password_not_accepted") {
+    return suppliedPassword === null
+      ? new PdfDecryptionError("password_required", PDF_PASSWORD_REQUIRED_MESSAGE)
+      : new PdfDecryptionError("password_rejected", PDF_PASSWORD_REJECTED_MESSAGE);
   }
-  return runtimeFactoryPromise;
-}
-
-/**
- * Runs one QPDF invocation in its own freshly instantiated module and tears it
- * down afterwards. Returns the exit status, the captured stdout, and the
- * requested output file if the run produced one.
- *
- * The module, its `FS`, and its raw exports never leave this function: the
- * vendored runtime's README is explicit that callers must be given a narrow
- * operation API rather than the module or its filesystem.
- */
-async function runQpdf(args, inputs, outputPath = null) {
-  const createQpdf = await loadQpdfFactory();
-  const stdout = boundedCapture();
-  const stderr = boundedCapture();
-  let qpdf = null;
-  let status;
-  let output = null;
-  try {
-    qpdf = await createQpdf({
-      print: line => stdout.write(line),
-      printErr: line => stderr.write(line),
-    });
-    for (const [virtualPath, bytes] of Object.entries(inputs)) {
-      qpdf.FS.writeFile(virtualPath, bytes);
-    }
-    try {
-      status = qpdf.callMain([...args]);
-    } catch (error) {
-      // Emscripten reports a normal `exit()` by throwing an object carrying
-      // the status. Anything without an integer status is a real fault.
-      if (!Number.isInteger(error?.status)) {
-        throw new PdfDecryptionError("qpdf_faulted", PDF_DECRYPTION_FAILED_MESSAGE);
-      }
-      status = error.status;
-    }
-    if (qpdfCompleted(status) && outputPath) {
-      output = Buffer.from(qpdf.FS.readFile(outputPath));
-    }
-  } catch (error) {
-    if (error instanceof PdfDecryptionError) throw error;
-    throw new PdfDecryptionError("qpdf_faulted", PDF_DECRYPTION_FAILED_MESSAGE);
-  } finally {
-    // Overwrite then unlink every virtual file, so the ciphertext, the
-    // password and any plaintext output stop being reachable through this
-    // module before it is dropped. Best effort by nature: the WebAssembly heap
-    // keeps its own copies until the module itself is collected.
-    if (qpdf) {
-      for (const virtualPath of [...Object.keys(inputs), ...(outputPath ? [outputPath] : [])]) {
-        try {
-          const existing = qpdf.FS.readFile(virtualPath);
-          qpdf.FS.writeFile(virtualPath, new Uint8Array(existing.length));
-          qpdf.FS.unlink(virtualPath);
-        } catch {
-          // The file may never have been created, or QPDF may have removed it.
-        }
-      }
-    }
-    qpdf = null;
+  if (reason === "password_unrepresentable") {
+    return new PdfDecryptionError(reason, PDF_PASSWORD_UNREPRESENTABLE_MESSAGE);
   }
-  if (stdout.overflowed || stderr.overflowed) {
-    throw new PdfDecryptionError("qpdf_output_overflow", PDF_DECRYPTION_FAILED_MESSAGE);
-  }
-  return { status, stdout: stdout.text(), stderr: stderr.text(), output };
-}
-
-/*
- * QPDF's own wording for a password that matched neither the user nor the
- * owner password. Matched internally only, to tell "this needs a password you
- * did not give" apart from "this file is broken" — advice that would otherwise
- * be wrong half the time. The matched text is never surfaced: QPDF prefixes
- * its diagnostics with argv[0] and echoes the virtual input path. If the
- * wording ever changes the classification falls back to the malformed message,
- * which is the safe direction: it never claims a password would help.
- */
-const QPDF_INVALID_PASSWORD_DIAGNOSTIC = "invalid password";
-
-/**
- * Reads the document's encryption state and effective permissions without
- * producing any decrypted output.
- */
-async function inspectEncryption(pdfBytes, password) {
-  const { status, stdout, stderr } = await runQpdf(
-    [
-      "--json=latest",
-      "--json-key=encrypt",
-      `--password-file=${VIRTUAL_PASSWORD_PATH}`,
-      VIRTUAL_INPUT_PATH,
-    ],
-    {
-      [VIRTUAL_INPUT_PATH]: pdfBytes,
-      [VIRTUAL_PASSWORD_PATH]: passwordFileBytes(password ?? ""),
-    },
+  // Every remaining code — unreadable_document, malformed_inspection,
+  // decrypt_failed, qpdf_faulted, qpdf_output_overflow, runtime_unavailable,
+  // protocol_violation — is a "this document did not decrypt" for the caller,
+  // and stays distinguishable only in `reason`.
+  return new PdfDecryptionError(
+    typeof reason === "string" && reason.length > 0 ? reason : "qpdf_faulted",
+    PDF_DECRYPTION_FAILED_MESSAGE,
   );
-  if (!qpdfCompleted(status)) {
-    // QPDF does not fall back to the empty password when a wrong one is given,
-    // so a supplied-but-wrong password fails here rather than opening the
-    // document by way of an empty user password. A malformed file fails here
-    // too, and must not be reported as needing a password.
-    if (!stderr.toLowerCase().includes(QPDF_INVALID_PASSWORD_DIAGNOSTIC)) {
-      throw new PdfDecryptionError("unreadable_document", PDF_DECRYPTION_FAILED_MESSAGE);
+}
+
+/**
+ * Runs one document through one worker thread, under one deadline.
+ *
+ * The worker is destroyed on every exit path, success included. That is not
+ * tidiness: `worker.terminate()` is the only mechanism that stops a synchronous
+ * QPDF invocation already in flight, and it is why the work is out here at all.
+ *
+ * Returns `{ outcome, teardown }`. A *failure* is not reported until the thread
+ * is actually dead, because "the deadline stopped this" has to mean it stopped;
+ * a *success* is reported as soon as the plaintext has arrived, because by then
+ * the thread holds nothing anyone is waiting for. `teardown` resolves once the
+ * worker is gone either way, and is what the queue holds.
+ */
+function runDecryptionWorker(pdfBytes, suppliedPassword, rules, operation, timeoutMs) {
+  let markTornDown;
+  const teardown = new Promise(resolveTeardown => { markTornDown = resolveTeardown; });
+  const outcome = new Promise((resolve, reject) => {
+    // An exact copy, transferred to the worker. The caller's `pdfBytes` is the
+    // file as it is on disk and other code still holds it, so its backing store
+    // must not be detached; and a Node Buffer may be a window onto a shared
+    // pool, which must not be handed to another thread whatever the intent.
+    const ciphertext = new Uint8Array(pdfBytes.byteLength);
+    ciphertext.set(pdfBytes);
+
+    let worker;
+    try {
+      worker = new Worker(DECRYPTION_WORKER_URL, {
+        workerData: { ciphertext: ciphertext.buffer, password: suppliedPassword },
+        transferList: [ciphertext.buffer],
+      });
+    } catch {
+      markTornDown();
+      reject(new PdfDecryptionError("worker_unavailable", PDF_DECRYPTION_FAILED_MESSAGE));
+      return;
     }
-    throw new PdfDecryptionError(
-      password === null ? "password_required" : "password_rejected",
-      password === null ? PDF_PASSWORD_REQUIRED_MESSAGE : PDF_PASSWORD_REJECTED_MESSAGE,
-    );
-  }
-  let parsed;
-  try {
-    parsed = JSON.parse(stdout)?.encrypt;
-  } catch {
-    throw new PdfDecryptionError("malformed_inspection", PDF_DECRYPTION_FAILED_MESSAGE);
-  }
-  if (
-    !parsed
-    || typeof parsed.encrypted !== "boolean"
-    || typeof parsed.ownerpasswordmatched !== "boolean"
-    || typeof parsed.userpasswordmatched !== "boolean"
-    || !parsed.capabilities
-    || typeof parsed.capabilities.extract !== "boolean"
-  ) {
-    throw new PdfDecryptionError("malformed_inspection", PDF_DECRYPTION_FAILED_MESSAGE);
-  }
-  return {
-    encrypted: parsed.encrypted,
-    ownerPasswordMatched: parsed.ownerpasswordmatched,
-    userPasswordMatched: parsed.userpasswordmatched,
-    capabilities: parsed.capabilities,
-  };
+    qpdfRuntimeReached = true;
+    activeDecryptionWorkers.add(worker);
+
+    let settled = false;
+    let deadline = null;
+    // Retained from the inspection phase: it is what the permission rules were
+    // applied to, and the caller is entitled to see the same facts.
+    let inspectedEncryption = null;
+    const settle = (error, value) => {
+      if (settled) return;
+      settled = true;
+      if (deadline) clearTimeout(deadline);
+      // A success is handed over now: the plaintext is already in this thread's
+      // memory and the worker's own copy was detached when it was transferred.
+      if (!error) resolve(value);
+      const done = () => {
+        activeDecryptionWorkers.delete(worker);
+        // A failure waits: `decrypt_timeout` in particular must not be reported
+        // while the thread it is about is still running.
+        if (error) reject(error);
+        markTornDown();
+      };
+      let termination = null;
+      try {
+        termination = worker.terminate();
+      } catch {
+        termination = null;
+      }
+      if (termination && typeof termination.then === "function") termination.then(done, done);
+      else done();
+    };
+
+    worker.on("message", message => {
+      if (message?.kind === "inspected") {
+        const { encryption } = message;
+        if (!encryption?.encrypted) {
+          // pdf-lib refused this document as encrypted but QPDF sees no
+          // encryption dictionary. The two disagree about what the file is, so
+          // decrypting it would be guessing.
+          settle(new PdfDecryptionError(
+            "encryption_state_disagreement",
+            PDF_DECRYPTION_FAILED_MESSAGE,
+          ));
+          return;
+        }
+        const credentialed = suppliedPassword !== null
+          && (encryption.ownerPasswordMatched || encryption.userPasswordMatched);
+        if (!credentialed && encryption.capabilities?.[rules.capability] !== true) {
+          settle(new PdfDecryptionError("permission_denied", pdfPermissionDeniedMessage(operation)));
+          return;
+        }
+        inspectedEncryption = encryption;
+        try {
+          worker.postMessage({ kind: "decrypt" });
+        } catch {
+          settle(new PdfDecryptionError("qpdf_faulted", PDF_DECRYPTION_FAILED_MESSAGE));
+        }
+        return;
+      }
+      if (message?.kind === "decrypted") {
+        // A view onto the transferred pages. No copy was made crossing the
+        // boundary and none is made here.
+        const plaintext = Buffer.from(message.plaintext);
+        if (plaintext.length === 0) {
+          settle(new PdfDecryptionError("decrypt_failed", PDF_DECRYPTION_FAILED_MESSAGE));
+          return;
+        }
+        let released = false;
+        settle(null, {
+          plaintext,
+          encryption: inspectedEncryption,
+          release() {
+            if (released) return;
+            released = true;
+            // See the module header: this shortens the window in which
+            // plaintext is readable in this process. It cannot guarantee
+            // erasure.
+            plaintext.fill(0);
+          },
+        });
+        return;
+      }
+      if (message?.kind === "failed") {
+        settle(workerFailure(message.reason, suppliedPassword));
+        return;
+      }
+      settle(new PdfDecryptionError("protocol_violation", PDF_DECRYPTION_FAILED_MESSAGE));
+    });
+
+    worker.once("messageerror", () => {
+      settle(new PdfDecryptionError("protocol_violation", PDF_DECRYPTION_FAILED_MESSAGE));
+    });
+    worker.once("error", () => {
+      settle(new PdfDecryptionError("worker_faulted", PDF_DECRYPTION_FAILED_MESSAGE));
+    });
+    worker.once("exit", () => {
+      // Only reachable when the thread died without reporting: an
+      // out-of-memory abort, or a fault the worker's own handler could not
+      // survive. A settled request has already terminated it.
+      settle(new PdfDecryptionError("worker_exited", PDF_DECRYPTION_FAILED_MESSAGE));
+    });
+
+    deadline = setTimeout(() => {
+      settle(new PdfDecryptionError("decrypt_timeout", PDF_DECRYPTION_TIMEOUT_MESSAGE));
+    }, timeoutMs);
+    // The deadline must not be a reason for the process to stay alive; the
+    // worker it is guarding already is one.
+    deadline.unref();
+  });
+  return { outcome, teardown };
 }
 
 /**
  * Decrypts an encrypted PDF for one of the read-only operations, subject to
- * the size cap, the password rules and the permission rules documented above.
+ * the size cap, the password rules, the permission rules and the deadline
+ * documented above.
  *
  * Returns `{ plaintext, encryption, release }`. The caller owns `release()`
  * and must call it once it has finished reading the document that was loaded
@@ -470,13 +566,14 @@ async function inspectEncryption(pdfBytes, password) {
  * @param {Buffer} pdfBytes  The encrypted file exactly as it is on disk.
  * @param {string|null} password  The caller-supplied password, if any.
  * @param {string} operation  A key of `ENCRYPTED_READ_OPERATIONS`.
+ * @param {{timeoutMs?: number}} [options]  See `resolveDecryptionDeadlineMs`.
  */
-export async function decryptPdfForRead(pdfBytes, password, operation) {
-  return queueDecryption(() => decryptPdfForReadExclusively(pdfBytes, password, operation));
+export async function decryptPdfForRead(pdfBytes, password, operation, options = {}) {
+  return queueDecryption(() => decryptPdfForReadExclusively(pdfBytes, password, operation, options));
 }
 
 /** The body of `decryptPdfForRead`, run with the decryption queue held. */
-async function decryptPdfForReadExclusively(pdfBytes, password, operation) {
+async function decryptPdfForReadExclusively(pdfBytes, password, operation, { timeoutMs } = {}) {
   const rules = ENCRYPTED_READ_OPERATIONS[operation];
   if (!rules) {
     throw new TypeError(`Operation '${operation}' is not permitted to decrypt PDFs.`);
@@ -492,50 +589,20 @@ async function decryptPdfForReadExclusively(pdfBytes, password, operation) {
     throw new PdfDecryptionError("encrypted_input_too_large", PDF_ENCRYPTED_FILE_LIMIT_MESSAGE);
   }
 
-  const encryption = await inspectEncryption(pdfBytes, suppliedPassword);
-  if (!encryption.encrypted) {
-    // pdf-lib refused this document as encrypted but QPDF sees no encryption
-    // dictionary. The two disagree about what the file is, so decrypting it
-    // would be guessing.
-    throw new PdfDecryptionError("encryption_state_disagreement", PDF_DECRYPTION_FAILED_MESSAGE);
+  // The worker hands QPDF the password through a single-line password file
+  // rather than through argv, and QPDF reads the first line of it, so a
+  // password containing a line break would be silently truncated and then
+  // reported as "not accepted" — a confusing lie. Refuse it here, before a
+  // thread is started for it.
+  if (suppliedPassword !== null && /[\r\n]/.test(suppliedPassword)) {
+    throw new PdfDecryptionError("password_unrepresentable", PDF_PASSWORD_UNREPRESENTABLE_MESSAGE);
   }
 
-  const credentialed = suppliedPassword !== null
-    && (encryption.ownerPasswordMatched || encryption.userPasswordMatched);
-  if (!credentialed && encryption.capabilities[rules.capability] !== true) {
-    throw new PdfDecryptionError(
-      "permission_denied",
-      pdfPermissionDeniedMessage(operation),
-    );
-  }
-
-  const { status, output } = await runQpdf(
-    [
-      `--password-file=${VIRTUAL_PASSWORD_PATH}`,
-      "--decrypt",
-      VIRTUAL_INPUT_PATH,
-      VIRTUAL_OUTPUT_PATH,
-    ],
-    {
-      [VIRTUAL_INPUT_PATH]: pdfBytes,
-      [VIRTUAL_PASSWORD_PATH]: passwordFileBytes(suppliedPassword ?? ""),
-    },
-    VIRTUAL_OUTPUT_PATH,
+  return runDecryptionWorker(
+    pdfBytes,
+    suppliedPassword,
+    rules,
+    operation,
+    resolveDecryptionDeadlineMs(timeoutMs),
   );
-  if (!qpdfCompleted(status) || !output || output.length === 0) {
-    throw new PdfDecryptionError("decrypt_failed", PDF_DECRYPTION_FAILED_MESSAGE);
-  }
-
-  let released = false;
-  return {
-    plaintext: output,
-    encryption,
-    release() {
-      if (released) return;
-      released = true;
-      // See the module header: this shortens the window in which plaintext is
-      // readable in this process. It cannot guarantee erasure.
-      output.fill(0);
-    },
-  };
 }

--- a/scripts/build-mcpb.mjs
+++ b/scripts/build-mcpb.mjs
@@ -84,6 +84,7 @@ export const SERVER_FILES = [
   "pdf-observations.js",
   "pdfjs-subprocess.js",
   "pdfjs-worker.js",
+  "qpdf-decrypt-worker.js",
   "qpdf-decrypt.js",
   "resource-uri.js",
   "stderr-suppression.js",

--- a/scripts/test-suite-classification.mjs
+++ b/scripts/test-suite-classification.mjs
@@ -98,15 +98,15 @@ export const CHECKOUT_LOCAL_MUTATING_TEST_SUITES = Object.freeze([
 
 export const REVIEWED_COMPUTED_MODULE_LOADS = Object.freeze([
   Object.freeze({
-    // The byte-identical share mirror of server/qpdf-decrypt.js below. Same
-    // load, same fingerprint; the two entries must not diverge.
-    file: "pdf-toolkit-mcp-share/server/qpdf-decrypt.js",
+    // The byte-identical share mirror of server/qpdf-decrypt-worker.js below.
+    // Same load, same fingerprint; the two entries must not diverge.
+    file: "pdf-toolkit-mcp-share/server/qpdf-decrypt-worker.js",
     count: 1,
     kinds: Object.freeze(["dynamic-import"]),
     fingerprints: Object.freeze([
       "689d1575decd28551f1043e7b853740985cba96c87102c4a834cae9b1da7d52e",
     ]),
-    reason: "Share-tree mirror of server/qpdf-decrypt.js, which loads the vendored QPDF "
+    reason: "Share-tree mirror of server/qpdf-decrypt-worker.js, which loads the vendored QPDF "
       + "WebAssembly runtime from a fixed repository-relative path.",
   }),
   Object.freeze({
@@ -194,7 +194,7 @@ export const REVIEWED_COMPUTED_MODULE_LOADS = Object.freeze([
     reason: "Loads a packaged share artifact from an isolated build root.",
   }),
   Object.freeze({
-    file: "server/qpdf-decrypt.js",
+    file: "server/qpdf-decrypt-worker.js",
     count: 1,
     kinds: Object.freeze(["dynamic-import"]),
     fingerprints: Object.freeze([
@@ -202,7 +202,9 @@ export const REVIEWED_COMPUTED_MODULE_LOADS = Object.freeze([
     ]),
     reason: "Loads the vendored QPDF WebAssembly runtime from a fixed repository-relative path "
       + "resolved against import.meta.url. The specifier is computed rather than literal so that "
-      + "test-time bundlers leave the Emscripten output alone; it resolves its own .wasm sibling.",
+      + "test-time bundlers leave the Emscripten output alone; it resolves its own .wasm sibling. "
+      + "This is the decryption worker thread rather than server/qpdf-decrypt.js: the runtime is "
+      + "synchronous, so it has to be loaded somewhere that can be destroyed on a deadline.",
   }),
   Object.freeze({
     file: "test/eval/extraction-docling-handoff.js",
@@ -212,6 +214,17 @@ export const REVIEWED_COMPUTED_MODULE_LOADS = Object.freeze([
       "bfb22ac97868fe7bb9a1d7da4651099c672c2ac8fec83b6b51340bbeb36dd305",
     ]),
     reason: "Loads a verified generated controller outside the checkout.",
+  }),
+  Object.freeze({
+    file: "test/qpdf-decrypt-isolation.test.js",
+    count: 1,
+    kinds: Object.freeze(["dynamic-import"]),
+    fingerprints: Object.freeze([
+      "948c7080973dbfd1901b9e7904f3a2abcc2c968427f868cd50096046ad532df5",
+    ]),
+    reason: "Loads the committed QPDF runtime to encrypt the deliberately pathological "
+      + "many-object fixture the decryption deadline is measured against, so a document built to "
+      + "be slow is generated rather than committed.",
   }),
   Object.freeze({
     file: "test/qpdf-decrypt-read-only.test.js",

--- a/scripts/vendor-qpdf-wasm-runtime.mjs
+++ b/scripts/vendor-qpdf-wasm-runtime.mjs
@@ -183,10 +183,14 @@ async function main() {
     redistribution: "allowed while the complete notice directory travels with the runtime",
     integration_status:
       "Packaged into the MCPB and the share ZIP, and loaded by exactly one module: "
-      + "server/qpdf-decrypt.js. It decrypts encrypted PDFs in memory for the read-only tools "
+      + "server/qpdf-decrypt-worker.js, which runs only on a worker thread that "
+      + "server/qpdf-decrypt.js starts, bounds by a wall-clock deadline, and destroys once the "
+      + "document is decrypted or the deadline expires. The runtime is synchronous and cannot be "
+      + "interrupted from the thread that called it, so destroying that thread is the only real "
+      + "way to stop it. It decrypts encrypted PDFs in memory for the read-only tools "
       + "read_pdf_fields, validate_pdf and extract_to_csv, which never write a PDF back. No write "
       + "path loads it, nothing re-encrypts or rewrites a document with it, and decrypted bytes "
-      + "are never written to disk.",
+      + "are transferred between threads within the one process and never written to disk.",
     generator: {
       path: posixRelative(REPO_ROOT, generatorPath),
       sha256: canonicalLfSha256(await fs.readFile(generatorPath)),

--- a/server/index.js
+++ b/server/index.js
@@ -57,6 +57,8 @@ import {
   PDF_DECRYPTABLE_PASSWORD_DESCRIPTION,
   PdfDecryptionError,
   decryptPdfForRead,
+  forceTerminateAllDecryptionWorkers,
+  terminateAllDecryptionWorkers,
 } from "./qpdf-decrypt.js";
 import {
   PDF_MUTATION_MAX_FILE_BYTES,
@@ -1849,6 +1851,10 @@ for (const [signal, exitCode] of new Map([
     workerShutdown = settleAllShutdownOperations([
       terminateAllPdfjsSubprocesses(),
       terminateAllPdfLibMutations(),
+      // A decryption worker is a live thread and keeps the process alive. It
+      // has its own 30-second deadline, which is the wrong amount of time for a
+      // shutdown to wait on.
+      terminateAllDecryptionWorkers(),
     ]);
     void workerShutdown.finally(() => process.exit(exitCode));
   });
@@ -1856,6 +1862,7 @@ for (const [signal, exitCode] of new Map([
 process.once("exit", () => {
   forceTerminateAllPdfjsSubprocesses();
   forceTerminateAllPdfLibMutations();
+  forceTerminateAllDecryptionWorkers();
 });
 
 const backupPathByCanonical = new Map();

--- a/server/qpdf-decrypt-worker.js
+++ b/server/qpdf-decrypt-worker.js
@@ -1,0 +1,384 @@
+/**
+ * The worker thread that actually runs QPDF, and the only module in the tree
+ * that loads the vendored QPDF WebAssembly runtime.
+ *
+ * ## Why decryption runs here rather than in the server
+ *
+ * QPDF-WASM is a synchronous Emscripten build: `callMain` is one blocking call
+ * that returns only when QPDF is finished. Nothing on the calling thread runs
+ * while it is in flight — not a timer, not an incoming MCP request, not a
+ * promise continuation. A deadline expressed as a `setTimeout` on that thread
+ * cannot fire until the work it was meant to bound has already completed, so
+ * an in-process timeout is not a timeout at all; it is an after-the-fact
+ * report.
+ *
+ * That matters because the input is hostile by assumption and the size cap
+ * bounds bytes, not work. Measured against this runtime, a 14.3 MiB encrypted
+ * document built from 800,000 tiny indirect objects — comfortably inside the
+ * 16 MiB cap — spends more than five seconds inside a single `callMain`. Object
+ * count, not file size, is what that costs, and nothing bounds object count.
+ * Run in the server process, that is five seconds during which every tool is
+ * unavailable, and it is a lower bound rather than a limit.
+ *
+ * A worker thread is the smallest construct that fixes it. `worker.terminate()`
+ * goes through V8's execution terminator, which interrupts WebAssembly at its
+ * stack-guard checks rather than waiting for the call to return, so the parent
+ * can enforce a real wall-clock deadline. Measured against that document,
+ * deadlines of 100 ms, 250 ms, 1 s, 2.5 s and 4 s each land within 60 ms of
+ * themselves, and the process then consumes under 1 ms of further CPU over the
+ * following 2 seconds — against the 4 seconds of CPU the same decrypt burns
+ * when it is allowed to finish. The work is killed, not abandoned.
+ *
+ * ## Where the plaintext lives
+ *
+ * In this process, and only in this process. The decrypted bytes are copied out
+ * of the WebAssembly heap into a standalone `ArrayBuffer` and handed to the
+ * parent through `postMessage`'s transfer list, which reassigns ownership of
+ * the same pages rather than serializing them: no copy, no pipe, no file, no
+ * process boundary. That is deliberate. Routing this through the existing
+ * pdf-lib child process would have forced the plaintext across a real process
+ * boundary — through a pipe or a staged temporary file — which is exactly the
+ * property the original design set out to avoid.
+ *
+ * The ciphertext and the password arrive by the same route and are zeroed here
+ * before the worker is torn down. As the wrapper's header says, that shortens
+ * the window rather than closing it: the WebAssembly heap holds its own copies
+ * of everything QPDF touched. Destroying the thread does put those copies
+ * beyond reach of anything still running in the process, which the in-process
+ * arrangement could not promise — but it does not hand the pages back to the
+ * operating system, and the wrapper's header has the measurements that say so.
+ * Termination is bought for the deadline, not for the memory.
+ *
+ * ## What this module is not allowed to decide
+ *
+ * Nothing. The password rules, the permission rules, the size cap and every
+ * caller-visible message live in `server/qpdf-decrypt.js`. This module runs the
+ * two QPDF invocations that module asks for, reports facts, and maps failures
+ * to opaque reason codes. It never composes a message for a user, because QPDF
+ * prefixes its diagnostics with `argv[0]` and echoes the virtual paths below.
+ */
+
+import { parentPort, workerData } from "node:worker_threads";
+
+const QPDF_RUNTIME_RELATIVE_PATH = "../vendor/qpdf-wasm/runtime/qpdf.mjs";
+
+// Fixed paths inside the module's private in-memory filesystem. A fresh module
+// is created for every QPDF invocation, and a fresh worker for every request,
+// so these never collide.
+const VIRTUAL_INPUT_PATH = "/in.pdf";
+const VIRTUAL_OUTPUT_PATH = "/out.pdf";
+const VIRTUAL_PASSWORD_PATH = "/pw";
+
+// The JSON inspection output is a few hundred bytes; QPDF diagnostics are a
+// few lines. Anything beyond this means the runtime is not behaving as built.
+const QPDF_OUTPUT_BYTE_CAP = 64 * 1024;
+
+/*
+ * QPDF's documented exit codes. 3 means the operation completed but the file
+ * needed recovery — a damaged cross-reference table, a stream whose declared
+ * length was wrong, and so on. Real-world PDFs produce it often enough that
+ * rejecting it would make this feature fail on documents QPDF read perfectly
+ * well. It is accepted only when output was actually produced, and the
+ * recovered document then still has to survive pdf-lib's parse and the page-
+ * tree validation, so accepting a warning is not accepting a broken document.
+ *
+ * 2 is a genuine error, and includes the one case that must stay
+ * distinguishable: a password the document did not accept.
+ */
+const QPDF_EXIT_SUCCESS = 0;
+const QPDF_EXIT_WARNINGS = 3;
+const qpdfCompleted = status => status === QPDF_EXIT_SUCCESS || status === QPDF_EXIT_WARNINGS;
+
+/*
+ * QPDF's own wording for a password that matched neither the user nor the
+ * owner password. Matched here only, to tell "this needs a password you did not
+ * give" apart from "this file is broken" — advice that would otherwise be wrong
+ * half the time. The matched text never leaves this thread. If the wording ever
+ * changes the classification falls back to the malformed reason, which is the
+ * safe direction: it never claims a password would help.
+ */
+const QPDF_INVALID_PASSWORD_DIAGNOSTIC = "invalid password";
+
+/** Raised for a condition the parent has a fixed message for. */
+class WorkerDecryptionFailure extends Error {
+  constructor(reason) {
+    super(reason);
+    this.reason = reason;
+  }
+}
+
+/**
+ * Collects a QPDF output stream under a hard byte cap. The captured text is
+ * used only to parse the inspection JSON and to classify a failure; it is never
+ * sent to the parent.
+ */
+function boundedCapture() {
+  const lines = [];
+  let bytes = 0;
+  let overflowed = false;
+  return {
+    write(line) {
+      const text = String(line);
+      bytes += Buffer.byteLength(text, "utf8") + 1;
+      if (bytes > QPDF_OUTPUT_BYTE_CAP) {
+        overflowed = true;
+        return;
+      }
+      lines.push(text);
+    },
+    get overflowed() {
+      return overflowed;
+    },
+    text() {
+      return lines.join("\n");
+    },
+  };
+}
+
+/**
+ * Builds the password file contents. QPDF's `--password-file` reads the first
+ * line, which keeps the password out of `argv` — where it would otherwise be
+ * visible to anything that can read the process's command line, and would be
+ * echoed back by QPDF's own usage diagnostics.
+ *
+ * The line-break rejection is the parent's rule and the parent applies it
+ * before a worker is ever started, so a password reaching this point should
+ * already be representable. It is re-checked rather than assumed because the
+ * failure it prevents is a silent truncation reported as a wrong password.
+ */
+function passwordFileBytes(password) {
+  if (/[\r\n]/.test(password)) {
+    throw new WorkerDecryptionFailure("password_unrepresentable");
+  }
+  return Buffer.from(`${password}\n`, "utf8");
+}
+
+let runtimeFactoryPromise = null;
+
+/**
+ * Resolves the runtime's ESM factory once per worker. The factory is just a
+ * function; each call below still instantiates its own module, so no QPDF
+ * state, filesystem entry, or password crosses between the two invocations.
+ *
+ * The specifier is computed rather than literal so that test-time bundlers
+ * leave the Emscripten output alone: it resolves its own `.wasm` sibling from
+ * `import.meta.url` and has to be loaded as a plain Node module. The path is
+ * identical in the checkout, the MCPB and the share ZIP, so this resolves the
+ * same way in all three. A worker thread loads it through Node's own loader in
+ * every one of those hosts, which is a plainer path than the main thread had.
+ */
+async function loadQpdfFactory() {
+  if (!runtimeFactoryPromise) {
+    const runtimeUrl = new URL(QPDF_RUNTIME_RELATIVE_PATH, import.meta.url).href;
+    runtimeFactoryPromise = import(runtimeUrl).then(module => {
+      if (typeof module.default !== "function") {
+        throw new WorkerDecryptionFailure("runtime_unavailable");
+      }
+      return module.default;
+    });
+    runtimeFactoryPromise.catch(() => {});
+  }
+  return runtimeFactoryPromise;
+}
+
+/**
+ * Runs one QPDF invocation in its own freshly instantiated module and tears it
+ * down afterwards. Returns the exit status, the captured stdout, the captured
+ * stderr, and the requested output file if the run produced one.
+ *
+ * The module, its `FS`, and its raw exports never leave this function: the
+ * vendored runtime's README is explicit that callers must be given a narrow
+ * operation API rather than the module or its filesystem. Nothing this module
+ * sends to the parent carries either.
+ */
+async function runQpdf(args, inputs, outputPath = null) {
+  const createQpdf = await loadQpdfFactory();
+  const stdout = boundedCapture();
+  const stderr = boundedCapture();
+  let qpdf = null;
+  let status;
+  let output = null;
+  try {
+    qpdf = await createQpdf({
+      print: line => stdout.write(line),
+      printErr: line => stderr.write(line),
+    });
+    for (const [virtualPath, bytes] of Object.entries(inputs)) {
+      qpdf.FS.writeFile(virtualPath, bytes);
+    }
+    try {
+      status = qpdf.callMain([...args]);
+    } catch (error) {
+      // Emscripten reports a normal `exit()` by throwing an object carrying
+      // the status. Anything without an integer status is a real fault.
+      if (!Number.isInteger(error?.status)) {
+        throw new WorkerDecryptionFailure("qpdf_faulted");
+      }
+      status = error.status;
+    }
+    if (qpdfCompleted(status) && outputPath) {
+      // Copied into an ArrayBuffer this thread owns outright. What `FS.readFile`
+      // returns may be a view onto the WebAssembly heap, which cannot be
+      // transferred and must not be handed out even if it could be.
+      const raw = qpdf.FS.readFile(outputPath);
+      output = new Uint8Array(raw.length);
+      output.set(raw);
+    }
+  } catch (error) {
+    if (error instanceof WorkerDecryptionFailure) throw error;
+    throw new WorkerDecryptionFailure("qpdf_faulted");
+  } finally {
+    // Overwrite then unlink every virtual file, so the ciphertext, the
+    // password and any plaintext output stop being reachable through this
+    // module before it is dropped. Best effort by nature: the WebAssembly heap
+    // keeps its own copies until this thread is destroyed, which — unlike the
+    // in-process arrangement this replaced — is something that then happens.
+    if (qpdf) {
+      for (const virtualPath of [...Object.keys(inputs), ...(outputPath ? [outputPath] : [])]) {
+        try {
+          const existing = qpdf.FS.readFile(virtualPath);
+          qpdf.FS.writeFile(virtualPath, new Uint8Array(existing.length));
+          qpdf.FS.unlink(virtualPath);
+        } catch {
+          // The file may never have been created, or QPDF may have removed it.
+        }
+      }
+    }
+    qpdf = null;
+  }
+  if (stdout.overflowed || stderr.overflowed) {
+    throw new WorkerDecryptionFailure("qpdf_output_overflow");
+  }
+  return { status, stdout: stdout.text(), stderr: stderr.text(), output };
+}
+
+/**
+ * Reads the document's encryption state and effective permissions without
+ * producing any decrypted output. Returns only the four facts the parent's
+ * rules are written against.
+ */
+async function inspectEncryption(pdfBytes, password) {
+  const { status, stdout, stderr } = await runQpdf(
+    [
+      "--json=latest",
+      "--json-key=encrypt",
+      `--password-file=${VIRTUAL_PASSWORD_PATH}`,
+      VIRTUAL_INPUT_PATH,
+    ],
+    {
+      [VIRTUAL_INPUT_PATH]: pdfBytes,
+      [VIRTUAL_PASSWORD_PATH]: passwordFileBytes(password ?? ""),
+    },
+  );
+  if (!qpdfCompleted(status)) {
+    // QPDF does not fall back to the empty password when a wrong one is given,
+    // so a supplied-but-wrong password fails here rather than opening the
+    // document by way of an empty user password. A malformed file fails here
+    // too, and must not be reported as needing a password. Which of the two
+    // password reasons applies depends on whether one was supplied, and that
+    // is the parent's call, so both collapse to one code here.
+    throw new WorkerDecryptionFailure(
+      stderr.toLowerCase().includes(QPDF_INVALID_PASSWORD_DIAGNOSTIC)
+        ? "password_not_accepted"
+        : "unreadable_document",
+    );
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(stdout)?.encrypt;
+  } catch {
+    throw new WorkerDecryptionFailure("malformed_inspection");
+  }
+  if (
+    !parsed
+    || typeof parsed.encrypted !== "boolean"
+    || typeof parsed.ownerpasswordmatched !== "boolean"
+    || typeof parsed.userpasswordmatched !== "boolean"
+    || !parsed.capabilities
+    || typeof parsed.capabilities.extract !== "boolean"
+  ) {
+    throw new WorkerDecryptionFailure("malformed_inspection");
+  }
+  return {
+    encrypted: parsed.encrypted,
+    ownerPasswordMatched: parsed.ownerpasswordmatched,
+    userPasswordMatched: parsed.userpasswordmatched,
+    capabilities: parsed.capabilities,
+  };
+}
+
+/** Produces the decrypted document. */
+async function decrypt(pdfBytes, password) {
+  const { status, output } = await runQpdf(
+    [
+      `--password-file=${VIRTUAL_PASSWORD_PATH}`,
+      "--decrypt",
+      VIRTUAL_INPUT_PATH,
+      VIRTUAL_OUTPUT_PATH,
+    ],
+    {
+      [VIRTUAL_INPUT_PATH]: pdfBytes,
+      [VIRTUAL_PASSWORD_PATH]: passwordFileBytes(password ?? ""),
+    },
+    VIRTUAL_OUTPUT_PATH,
+  );
+  if (!qpdfCompleted(status) || !output || output.length === 0) {
+    throw new WorkerDecryptionFailure("decrypt_failed");
+  }
+  return output;
+}
+
+/*
+ * The request. One worker serves exactly one document, so the ciphertext and
+ * the password arrive once, in `workerData`, and both phases read them from
+ * here.
+ *
+ * The parent transfers the ciphertext rather than cloning it, so these bytes
+ * are the parent's own copy of the file, moved. The parent made that copy
+ * precisely so the caller's on-disk bytes are never detached out from under it.
+ */
+const ciphertext = new Uint8Array(workerData.ciphertext);
+const password = workerData.password;
+
+function zeroRequest() {
+  ciphertext.fill(0);
+}
+
+/**
+ * Phase one runs immediately: the parent cannot apply its permission rules
+ * until it has the encryption facts, and it does not decrypt anything it is
+ * going to refuse.
+ *
+ * Phase two waits for the parent to say yes. If the answer is no — refused, or
+ * the deadline expired — the parent terminates this thread and nothing further
+ * runs here.
+ */
+async function main() {
+  const encryption = await inspectEncryption(ciphertext, password);
+
+  // The listener goes on before the report goes out, so the parent's answer
+  // cannot arrive at a port that is not yet listening for it.
+  const permission = new Promise((resolve, reject) => {
+    parentPort.once("message", message => {
+      if (message?.kind === "decrypt") resolve();
+      else reject(new WorkerDecryptionFailure("protocol_violation"));
+    });
+  });
+  parentPort.postMessage({ kind: "inspected", encryption });
+  await permission;
+
+  const plaintext = await decrypt(ciphertext, password);
+  zeroRequest();
+  // Transferred, not cloned: ownership of these exact pages moves to the
+  // parent and this thread's reference is detached. There is no second copy to
+  // wipe, and nothing is serialized.
+  parentPort.postMessage({ kind: "decrypted", plaintext: plaintext.buffer }, [plaintext.buffer]);
+}
+
+main().catch(error => {
+  zeroRequest();
+  parentPort.postMessage({
+    kind: "failed",
+    reason: error instanceof WorkerDecryptionFailure ? error.reason : "qpdf_faulted",
+  });
+});

--- a/server/qpdf-decrypt.js
+++ b/server/qpdf-decrypt.js
@@ -1,6 +1,13 @@
 /**
- * Decryption of encrypted PDFs for the read-only tools, and the only module
- * under `server/` that loads the vendored QPDF WebAssembly runtime.
+ * Decryption of encrypted PDFs for the read-only tools: the size cap, the
+ * password rules, the permission rules, the queue, the deadline, and every
+ * message a caller can see.
+ *
+ * The QPDF runtime itself is not loaded here. It runs in a worker thread —
+ * `server/qpdf-decrypt-worker.js`, the only module in the tree that loads it —
+ * which this module starts, drives, bounds and destroys. See that file for why
+ * the work cannot run on the server's own thread; see below for what this
+ * module decides.
  *
  * pdf-lib 1.17.1 cannot decrypt anything, so every tool that reads through it
  * fails on an encrypted document no matter what password the caller supplies.
@@ -26,6 +33,12 @@
  * The empty string counts as *no password*, so the check above cannot be
  * sidestepped by passing `""` to a document whose user password is empty.
  *
+ * Both gates are evaluated here, in the server, between the worker's two
+ * phases. The worker reports what the document says about itself and then
+ * waits; it is told to decrypt only after this module has decided that it may.
+ * A refusal is therefore a refusal to do the work, not a decision to throw the
+ * result away.
+ *
  * ## Which permission bit
  *
  * All three tools require `extract` — `/P` bit 5, "copy or otherwise extract
@@ -47,52 +60,54 @@
  *
  * ## Memory
  *
- * QPDF-WASM costs roughly 16x the input size plus a ~45 MB baseline, and the
- * WebAssembly heap is not reliably returned to the OS within the process.
- * Encrypted inputs therefore get their own explicit, much lower size cap
- * (`PDF_ENCRYPTED_MAX_FILE_BYTES`) instead of the 250 MiB mutation cap, and
- * oversized ones are refused with a size message rather than being allowed to
- * run into an out-of-memory kill. See the constant for the measurements.
+ * QPDF-WASM costs roughly 16x the input size plus a ~45 MB baseline, which is
+ * why encrypted inputs get their own explicit, much lower size cap
+ * (`PDF_ENCRYPTED_MAX_FILE_BYTES`) instead of the 250 MiB mutation cap. See the
+ * constant for those measurements.
+ *
+ * Isolation was expected to improve on that, on the theory that a heap dying
+ * with its thread would be returned where an in-process collection was not. It
+ * does not, and the measurements say so plainly. On macOS/arm64, after a single
+ * 14.6 MiB decrypt and a forced-GC settle:
+ *
+ *   | arrangement | peak RSS | settled RSS | retained over baseline |
+ *   | ----------- | -------: | ----------: | ---------------------: |
+ *   | in-process  |   333 MB |      243 MB |                 188 MB |
+ *   | worker      |   315 MB |      315 MB |                 260 MB |
+ *
+ * Destroying the thread returns *less* than collecting the module did: the
+ * freed pages stay mapped in the process, so `terminate()` buys nothing here
+ * and costs about 70 MB of resting RSS. What neither arrangement does is
+ * accumulate — eight consecutive near-cap decrypts plateau at 373 MB
+ * in-process and 352 MB in workers rather than summing, because each new
+ * worker reuses the pages the last one released. So the per-file cap remains
+ * sufficient and `extract_to_csv` still needs no aggregate bound.
+ *
+ * The deadline is what isolation actually buys. The memory column is a cost,
+ * and a small one against the 1024 MiB budget, but it is not a saving and must
+ * not be read as one; see the size constant.
  *
  * ## Plaintext handling
  *
- * Decrypted bytes exist only in memory and are never written to disk. The
- * caller gets a `release()` and must call it once it has finished reading the
- * loaded document. Be honest about what that buys: `release()` overwrites the
- * Node buffer it handed out, but JavaScript cannot guarantee erasure. The
- * WebAssembly heap holds its own copies that only the module's own teardown
- * reclaims, the garbage collector may already have copied the buffer, and any
- * of those pages may have been written to swap. This reduces the window in
- * which plaintext is readable in the process; it does not eliminate it.
- */
-
-const QPDF_RUNTIME_RELATIVE_PATH = "../vendor/qpdf-wasm/runtime/qpdf.mjs";
-
-// Fixed paths inside the module's private in-memory filesystem. A fresh module
-// is created for every QPDF invocation, so these never collide across calls.
-const VIRTUAL_INPUT_PATH = "/in.pdf";
-const VIRTUAL_OUTPUT_PATH = "/out.pdf";
-const VIRTUAL_PASSWORD_PATH = "/pw";
-
-// The JSON inspection output is a few hundred bytes; QPDF diagnostics are a
-// few lines. Anything beyond this means the runtime is not behaving as built.
-const QPDF_OUTPUT_BYTE_CAP = 64 * 1024;
-
-/*
- * QPDF's documented exit codes. 3 means the operation completed but the file
- * needed recovery — a damaged cross-reference table, a stream whose declared
- * length was wrong, and so on. Real-world PDFs produce it often enough that
- * rejecting it would make this feature fail on documents QPDF read perfectly
- * well. It is accepted only when output was actually produced, and the
- * recovered document then still has to survive pdf-lib's parse and the page-
- * tree validation, so accepting a warning is not accepting a broken document.
+ * Decrypted bytes exist only in memory and are never written to disk. They also
+ * never leave this process: the worker is a thread, and the plaintext reaches
+ * this module through `postMessage`'s transfer list, which moves ownership of
+ * the same pages rather than serializing them. Nothing is copied, piped, or
+ * staged to a file. That was an explicit property of the original in-process
+ * design and isolation keeps it; routing decryption through the existing
+ * pdf-lib *child process* instead would have given up exactly that.
  *
- * 2 is a genuine error, and includes the one case that must stay
- * distinguishable: a password the document did not accept.
+ * The caller gets a `release()` and must call it once it has finished reading
+ * the loaded document. Be honest about what that buys: `release()` overwrites
+ * the Node buffer it handed out, but JavaScript cannot guarantee erasure. The
+ * garbage collector may already have copied the buffer, and any of those pages
+ * may have been written to swap. This reduces the window in which plaintext is
+ * readable in the process; it does not eliminate it. The WebAssembly heap's own
+ * copies are a smaller problem than they were, because the thread holding them
+ * is destroyed at the end of every request.
  */
-const QPDF_EXIT_SUCCESS = 0;
-const QPDF_EXIT_WARNINGS = 3;
-const qpdfCompleted = status => status === QPDF_EXIT_SUCCESS || status === QPDF_EXIT_WARNINGS;
+
+import { Worker } from "node:worker_threads";
 
 /**
  * The per-file ceiling for an encrypted input, deliberately separate from and
@@ -117,12 +132,37 @@ const qpdfCompleted = status => status === QPDF_EXIT_SUCCESS || status === QPDF_
  * no useful margin; that is the reason for the specific number rather than a
  * rounder, larger one.
  *
- * Repeated decryption within one process was measured not to accumulate: RSS
- * plateaus near the high-water mark of the single largest input rather than
- * summing, so a per-file cap is sufficient and `extract_to_csv` does not need
- * an additional aggregate bound.
+ * Isolation did not change any of that, and specifically did not earn a larger
+ * number. The peak of a single decrypt is what this cap is derived from, and
+ * the measurements in the module header put the worker's peak at 315 MB against
+ * 333 MB in-process — a few percent, not a factor. Repeated decryption still
+ * plateaus rather than accumulating, so `extract_to_csv` still needs no
+ * aggregate bound, but that was true before as well. Raising the cap would
+ * raise the peak against the same 1024 MiB budget, with nothing new to pay for
+ * it.
  */
 export const PDF_ENCRYPTED_MAX_FILE_BYTES = 16 * 1024 * 1024;
+
+/**
+ * The wall-clock ceiling on one decryption, enforced by destroying the worker
+ * thread that is running it.
+ *
+ * The size cap bounds input bytes; it does not bound work. QPDF's cost tracks
+ * the number of objects in a document, and object count is nearly free per
+ * byte: a 14.3 MiB encrypted file built from 800,000 tiny indirect objects —
+ * inside the cap — takes over five seconds, and there is no honest reason to
+ * believe five seconds is the worst a 16 MiB document can do.
+ *
+ * 30 seconds matches `DEFAULT_TIMEOUT_MS` in `server/pdf-lib-subprocess.js`,
+ * which is the number this codebase already uses for "a PDF operation that has
+ * not finished by now is not going to". It is generous against measurement —
+ * the slowest legitimate near-cap decrypt observed is 1.6 seconds, and the
+ * slowest constructed one 5.7 — and it can afford to be, because a decryption
+ * that runs long no longer blocks anything. The server's own thread is free the
+ * whole time; the deadline bounds how long a hostile document may occupy a
+ * queue slot and a CPU, not how long the server is unresponsive.
+ */
+export const PDF_DECRYPTION_TIMEOUT_MS = 30_000;
 
 /**
  * The operations allowed to decrypt, and the `/P` capability each one needs
@@ -172,6 +212,12 @@ export const PDF_DECRYPTION_FAILED_MESSAGE =
   "This PDF is encrypted and could not be decrypted: the document is malformed, incomplete, or "
   + "uses an encryption scheme this build does not support.";
 
+export const PDF_DECRYPTION_TIMEOUT_MESSAGE =
+  `Decrypting this PDF did not finish within ${PDF_DECRYPTION_TIMEOUT_MS / 1000} seconds and was `
+  + "stopped. How long decryption takes depends on how many objects a document contains rather "
+  + "than on how large it is, so a small file can still exceed the limit. Decrypt the file first "
+  + "(for example with qpdf) and retry with the decrypted copy.";
+
 /**
  * Refusal text for the owner-locked case. Names the denied permission, says
  * plainly that no password was supplied, and points at the one legitimate way
@@ -197,57 +243,27 @@ export const PDF_DECRYPTABLE_PASSWORD_DESCRIPTION =
   + "document. An encrypted document that opens without a password is still read only if its "
   + "own permissions allow content extraction; PDF Tools does not override them.";
 
+/**
+ * The deadline one request runs under.
+ *
+ * `timeoutMs` exists for tests, which need to watch the deadline fire without
+ * waiting out the real one. It can only ever tighten: anything larger than
+ * `PDF_DECRYPTION_TIMEOUT_MS`, and anything that is not a usable positive
+ * number, collapses to the product's own limit. There is deliberately no way
+ * to grant a document more time than the product allows.
+ */
+export function resolveDecryptionDeadlineMs(timeoutMs) {
+  return Number.isFinite(timeoutMs) && timeoutMs > 0
+    ? Math.min(timeoutMs, PDF_DECRYPTION_TIMEOUT_MS)
+    : PDF_DECRYPTION_TIMEOUT_MS;
+}
+
 export class PdfDecryptionError extends Error {
   constructor(reason, message) {
     super(message);
     this.name = "PdfDecryptionError";
     this.reason = reason;
   }
-}
-
-/**
- * Collects a QPDF output stream under a hard byte cap. The captured text is
- * used only to parse the inspection JSON and is never surfaced to a caller:
- * QPDF prefixes its diagnostics with `argv[0]` and echoes virtual paths, so
- * every failure below maps to a fixed message instead.
- */
-function boundedCapture() {
-  const lines = [];
-  let bytes = 0;
-  let overflowed = false;
-  return {
-    write(line) {
-      const text = String(line);
-      bytes += Buffer.byteLength(text, "utf8") + 1;
-      if (bytes > QPDF_OUTPUT_BYTE_CAP) {
-        overflowed = true;
-        return;
-      }
-      lines.push(text);
-    },
-    get overflowed() {
-      return overflowed;
-    },
-    text() {
-      return lines.join("\n");
-    },
-  };
-}
-
-/**
- * Builds the password file contents. QPDF's `--password-file` reads the first
- * line, which keeps the password out of `argv` — where it would otherwise be
- * visible to anything that can read the process's command line, and would be
- * echoed back by QPDF's own usage diagnostics.
- */
-function passwordFileBytes(password) {
-  // QPDF reads the first line of the file, so a password containing a line
-  // break would be silently truncated and then reported as "not accepted" —
-  // a confusing lie. Refuse it explicitly instead.
-  if (/[\r\n]/.test(password)) {
-    throw new PdfDecryptionError("password_unrepresentable", PDF_PASSWORD_UNREPRESENTABLE_MESSAGE);
-  }
-  return Buffer.from(`${password}\n`, "utf8");
 }
 
 /**
@@ -271,15 +287,53 @@ export function normalizeSuppliedPassword(password) {
   return password === "" ? null : password;
 }
 
-let runtimeFactoryPromise = null;
+const DECRYPTION_WORKER_URL = new URL("./qpdf-decrypt-worker.js", import.meta.url);
+
+let qpdfRuntimeReached = false;
+const activeDecryptionWorkers = new Set();
 
 /**
- * Whether this process has ever asked for the QPDF runtime. Exists so the
- * "an unencrypted document pays nothing" property can be asserted as a fact
- * rather than as a claim in a comment. It exposes no capability.
+ * Whether this process has ever started a decryption worker, and so has ever
+ * reached the QPDF runtime. Exists so the "an unencrypted document pays
+ * nothing" property can be asserted as a fact rather than as a claim in a
+ * comment. It exposes no capability.
+ *
+ * It is now a stronger fact than it was. The runtime is not merely unloaded
+ * until something is decrypted; the module that loads it is not on the server's
+ * import graph at all, and only ever runs on another thread.
  */
 export function isQpdfRuntimeLoaded() {
-  return runtimeFactoryPromise !== null;
+  return qpdfRuntimeReached;
+}
+
+/**
+ * Destroys every decryption worker that is still running. Called from the
+ * server's signal handlers: a worker thread keeps the process alive, and a
+ * decryption that has just started should not hold a shutdown open for the
+ * length of its deadline.
+ */
+export function terminateAllDecryptionWorkers() {
+  return Promise.all([...activeDecryptionWorkers].map(async worker => {
+    try {
+      await worker.terminate();
+    } catch {
+      // Already gone.
+    }
+  }));
+}
+
+/**
+ * The same, without waiting — for the `exit` handler, where nothing
+ * asynchronous can still run.
+ */
+export function forceTerminateAllDecryptionWorkers() {
+  for (const worker of activeDecryptionWorkers) {
+    try {
+      void worker.terminate();
+    } catch {
+      // Already gone.
+    }
+  }
 }
 
 /*
@@ -290,178 +344,220 @@ export function isQpdfRuntimeLoaded() {
  * encrypted reads would each be allowed 16 MiB and the budget the cap was
  * calculated against would be wrong by a factor of the concurrency. Queueing
  * makes the measured single-operation peak the real ceiling no matter how many
- * callers arrive at once.
+ * callers arrive at once, and it bounds the number of live worker threads to
+ * one along with it.
  *
  * A queued caller waits rather than fails: at the cap a decrypt is on the order
  * of a second, which is a far better outcome than an out-of-memory kill that
  * takes the whole server down. The queue never rejects, so one failing
- * operation cannot poison the chain for the next.
+ * operation cannot poison the chain for the next. The deadline below is what
+ * stops a hostile document from holding the queue indefinitely.
+ *
+ * The queue is held until the worker thread is *gone*, not until the caller has
+ * its answer. Those are different moments on the success path: the plaintext
+ * has already been transferred out, so the caller has no stake in the teardown,
+ * while the invariant that matters — one QPDF heap alive at a time — is exactly
+ * what the queue is for. Destroying a worker holding a decrypted document costs
+ * a measured 55-60 ms, and settling first takes that off the critical path of
+ * an idle-queue request. Back-to-back requests still pay it, in the queue,
+ * which is the correct place for it.
+ *
+ * A `run` here returns `{ outcome, teardown }`; `outcome` is what the caller
+ * gets, `teardown` is what the next caller waits on. A `run` that throws before
+ * a worker exists (the size cap, an unusable password) has neither, and simply
+ * rejects.
  */
 let decryptionQueue = Promise.resolve();
 
-function queueDecryption(operation) {
-  const result = decryptionQueue.then(operation, operation);
-  decryptionQueue = result.then(() => {}, () => {});
-  return result;
+function queueDecryption(run) {
+  const started = decryptionQueue.then(run, run);
+  decryptionQueue = started
+    .then(result => result?.teardown, () => {})
+    .then(() => {}, () => {});
+  return started.then(result => result.outcome);
 }
 
 /**
- * Resolves the runtime's ESM factory once per process. The factory is just a
- * function; each call below still instantiates its own module, so no QPDF
- * state, filesystem entry, or password crosses between requests.
+ * Turns a worker reason code into the caller-visible failure. The worker never
+ * composes a message: QPDF prefixes its diagnostics with `argv[0]` and echoes
+ * the virtual input path, so every failure maps to one of this module's own
+ * fixed strings here.
  *
- * The specifier is computed rather than literal so that test-time bundlers
- * leave the Emscripten output alone: it resolves its own `.wasm` sibling from
- * `import.meta.url` and has to be loaded as a plain Node module. The path is
- * identical in the checkout, the MCPB and the share ZIP, so this resolves the
- * same way in all three.
+ * `password_not_accepted` is the one code that splits, and it splits on
+ * something only this side knows: whether the caller supplied a password at
+ * all. The same QPDF failure means "you need a password" to one caller and
+ * "that password is wrong" to another.
  */
-async function loadQpdfFactory() {
-  if (!runtimeFactoryPromise) {
-    const runtimeUrl = new URL(QPDF_RUNTIME_RELATIVE_PATH, import.meta.url).href;
-    runtimeFactoryPromise = import(runtimeUrl).then(module => {
-      if (typeof module.default !== "function") {
-        throw new PdfDecryptionError("runtime_unavailable", PDF_DECRYPTION_FAILED_MESSAGE);
-      }
-      return module.default;
-    });
-    runtimeFactoryPromise.catch(() => {});
+function workerFailure(reason, suppliedPassword) {
+  if (reason === "password_not_accepted") {
+    return suppliedPassword === null
+      ? new PdfDecryptionError("password_required", PDF_PASSWORD_REQUIRED_MESSAGE)
+      : new PdfDecryptionError("password_rejected", PDF_PASSWORD_REJECTED_MESSAGE);
   }
-  return runtimeFactoryPromise;
-}
-
-/**
- * Runs one QPDF invocation in its own freshly instantiated module and tears it
- * down afterwards. Returns the exit status, the captured stdout, and the
- * requested output file if the run produced one.
- *
- * The module, its `FS`, and its raw exports never leave this function: the
- * vendored runtime's README is explicit that callers must be given a narrow
- * operation API rather than the module or its filesystem.
- */
-async function runQpdf(args, inputs, outputPath = null) {
-  const createQpdf = await loadQpdfFactory();
-  const stdout = boundedCapture();
-  const stderr = boundedCapture();
-  let qpdf = null;
-  let status;
-  let output = null;
-  try {
-    qpdf = await createQpdf({
-      print: line => stdout.write(line),
-      printErr: line => stderr.write(line),
-    });
-    for (const [virtualPath, bytes] of Object.entries(inputs)) {
-      qpdf.FS.writeFile(virtualPath, bytes);
-    }
-    try {
-      status = qpdf.callMain([...args]);
-    } catch (error) {
-      // Emscripten reports a normal `exit()` by throwing an object carrying
-      // the status. Anything without an integer status is a real fault.
-      if (!Number.isInteger(error?.status)) {
-        throw new PdfDecryptionError("qpdf_faulted", PDF_DECRYPTION_FAILED_MESSAGE);
-      }
-      status = error.status;
-    }
-    if (qpdfCompleted(status) && outputPath) {
-      output = Buffer.from(qpdf.FS.readFile(outputPath));
-    }
-  } catch (error) {
-    if (error instanceof PdfDecryptionError) throw error;
-    throw new PdfDecryptionError("qpdf_faulted", PDF_DECRYPTION_FAILED_MESSAGE);
-  } finally {
-    // Overwrite then unlink every virtual file, so the ciphertext, the
-    // password and any plaintext output stop being reachable through this
-    // module before it is dropped. Best effort by nature: the WebAssembly heap
-    // keeps its own copies until the module itself is collected.
-    if (qpdf) {
-      for (const virtualPath of [...Object.keys(inputs), ...(outputPath ? [outputPath] : [])]) {
-        try {
-          const existing = qpdf.FS.readFile(virtualPath);
-          qpdf.FS.writeFile(virtualPath, new Uint8Array(existing.length));
-          qpdf.FS.unlink(virtualPath);
-        } catch {
-          // The file may never have been created, or QPDF may have removed it.
-        }
-      }
-    }
-    qpdf = null;
+  if (reason === "password_unrepresentable") {
+    return new PdfDecryptionError(reason, PDF_PASSWORD_UNREPRESENTABLE_MESSAGE);
   }
-  if (stdout.overflowed || stderr.overflowed) {
-    throw new PdfDecryptionError("qpdf_output_overflow", PDF_DECRYPTION_FAILED_MESSAGE);
-  }
-  return { status, stdout: stdout.text(), stderr: stderr.text(), output };
-}
-
-/*
- * QPDF's own wording for a password that matched neither the user nor the
- * owner password. Matched internally only, to tell "this needs a password you
- * did not give" apart from "this file is broken" — advice that would otherwise
- * be wrong half the time. The matched text is never surfaced: QPDF prefixes
- * its diagnostics with argv[0] and echoes the virtual input path. If the
- * wording ever changes the classification falls back to the malformed message,
- * which is the safe direction: it never claims a password would help.
- */
-const QPDF_INVALID_PASSWORD_DIAGNOSTIC = "invalid password";
-
-/**
- * Reads the document's encryption state and effective permissions without
- * producing any decrypted output.
- */
-async function inspectEncryption(pdfBytes, password) {
-  const { status, stdout, stderr } = await runQpdf(
-    [
-      "--json=latest",
-      "--json-key=encrypt",
-      `--password-file=${VIRTUAL_PASSWORD_PATH}`,
-      VIRTUAL_INPUT_PATH,
-    ],
-    {
-      [VIRTUAL_INPUT_PATH]: pdfBytes,
-      [VIRTUAL_PASSWORD_PATH]: passwordFileBytes(password ?? ""),
-    },
+  // Every remaining code — unreadable_document, malformed_inspection,
+  // decrypt_failed, qpdf_faulted, qpdf_output_overflow, runtime_unavailable,
+  // protocol_violation — is a "this document did not decrypt" for the caller,
+  // and stays distinguishable only in `reason`.
+  return new PdfDecryptionError(
+    typeof reason === "string" && reason.length > 0 ? reason : "qpdf_faulted",
+    PDF_DECRYPTION_FAILED_MESSAGE,
   );
-  if (!qpdfCompleted(status)) {
-    // QPDF does not fall back to the empty password when a wrong one is given,
-    // so a supplied-but-wrong password fails here rather than opening the
-    // document by way of an empty user password. A malformed file fails here
-    // too, and must not be reported as needing a password.
-    if (!stderr.toLowerCase().includes(QPDF_INVALID_PASSWORD_DIAGNOSTIC)) {
-      throw new PdfDecryptionError("unreadable_document", PDF_DECRYPTION_FAILED_MESSAGE);
+}
+
+/**
+ * Runs one document through one worker thread, under one deadline.
+ *
+ * The worker is destroyed on every exit path, success included. That is not
+ * tidiness: `worker.terminate()` is the only mechanism that stops a synchronous
+ * QPDF invocation already in flight, and it is why the work is out here at all.
+ *
+ * Returns `{ outcome, teardown }`. A *failure* is not reported until the thread
+ * is actually dead, because "the deadline stopped this" has to mean it stopped;
+ * a *success* is reported as soon as the plaintext has arrived, because by then
+ * the thread holds nothing anyone is waiting for. `teardown` resolves once the
+ * worker is gone either way, and is what the queue holds.
+ */
+function runDecryptionWorker(pdfBytes, suppliedPassword, rules, operation, timeoutMs) {
+  let markTornDown;
+  const teardown = new Promise(resolveTeardown => { markTornDown = resolveTeardown; });
+  const outcome = new Promise((resolve, reject) => {
+    // An exact copy, transferred to the worker. The caller's `pdfBytes` is the
+    // file as it is on disk and other code still holds it, so its backing store
+    // must not be detached; and a Node Buffer may be a window onto a shared
+    // pool, which must not be handed to another thread whatever the intent.
+    const ciphertext = new Uint8Array(pdfBytes.byteLength);
+    ciphertext.set(pdfBytes);
+
+    let worker;
+    try {
+      worker = new Worker(DECRYPTION_WORKER_URL, {
+        workerData: { ciphertext: ciphertext.buffer, password: suppliedPassword },
+        transferList: [ciphertext.buffer],
+      });
+    } catch {
+      markTornDown();
+      reject(new PdfDecryptionError("worker_unavailable", PDF_DECRYPTION_FAILED_MESSAGE));
+      return;
     }
-    throw new PdfDecryptionError(
-      password === null ? "password_required" : "password_rejected",
-      password === null ? PDF_PASSWORD_REQUIRED_MESSAGE : PDF_PASSWORD_REJECTED_MESSAGE,
-    );
-  }
-  let parsed;
-  try {
-    parsed = JSON.parse(stdout)?.encrypt;
-  } catch {
-    throw new PdfDecryptionError("malformed_inspection", PDF_DECRYPTION_FAILED_MESSAGE);
-  }
-  if (
-    !parsed
-    || typeof parsed.encrypted !== "boolean"
-    || typeof parsed.ownerpasswordmatched !== "boolean"
-    || typeof parsed.userpasswordmatched !== "boolean"
-    || !parsed.capabilities
-    || typeof parsed.capabilities.extract !== "boolean"
-  ) {
-    throw new PdfDecryptionError("malformed_inspection", PDF_DECRYPTION_FAILED_MESSAGE);
-  }
-  return {
-    encrypted: parsed.encrypted,
-    ownerPasswordMatched: parsed.ownerpasswordmatched,
-    userPasswordMatched: parsed.userpasswordmatched,
-    capabilities: parsed.capabilities,
-  };
+    qpdfRuntimeReached = true;
+    activeDecryptionWorkers.add(worker);
+
+    let settled = false;
+    let deadline = null;
+    // Retained from the inspection phase: it is what the permission rules were
+    // applied to, and the caller is entitled to see the same facts.
+    let inspectedEncryption = null;
+    const settle = (error, value) => {
+      if (settled) return;
+      settled = true;
+      if (deadline) clearTimeout(deadline);
+      // A success is handed over now: the plaintext is already in this thread's
+      // memory and the worker's own copy was detached when it was transferred.
+      if (!error) resolve(value);
+      const done = () => {
+        activeDecryptionWorkers.delete(worker);
+        // A failure waits: `decrypt_timeout` in particular must not be reported
+        // while the thread it is about is still running.
+        if (error) reject(error);
+        markTornDown();
+      };
+      let termination = null;
+      try {
+        termination = worker.terminate();
+      } catch {
+        termination = null;
+      }
+      if (termination && typeof termination.then === "function") termination.then(done, done);
+      else done();
+    };
+
+    worker.on("message", message => {
+      if (message?.kind === "inspected") {
+        const { encryption } = message;
+        if (!encryption?.encrypted) {
+          // pdf-lib refused this document as encrypted but QPDF sees no
+          // encryption dictionary. The two disagree about what the file is, so
+          // decrypting it would be guessing.
+          settle(new PdfDecryptionError(
+            "encryption_state_disagreement",
+            PDF_DECRYPTION_FAILED_MESSAGE,
+          ));
+          return;
+        }
+        const credentialed = suppliedPassword !== null
+          && (encryption.ownerPasswordMatched || encryption.userPasswordMatched);
+        if (!credentialed && encryption.capabilities?.[rules.capability] !== true) {
+          settle(new PdfDecryptionError("permission_denied", pdfPermissionDeniedMessage(operation)));
+          return;
+        }
+        inspectedEncryption = encryption;
+        try {
+          worker.postMessage({ kind: "decrypt" });
+        } catch {
+          settle(new PdfDecryptionError("qpdf_faulted", PDF_DECRYPTION_FAILED_MESSAGE));
+        }
+        return;
+      }
+      if (message?.kind === "decrypted") {
+        // A view onto the transferred pages. No copy was made crossing the
+        // boundary and none is made here.
+        const plaintext = Buffer.from(message.plaintext);
+        if (plaintext.length === 0) {
+          settle(new PdfDecryptionError("decrypt_failed", PDF_DECRYPTION_FAILED_MESSAGE));
+          return;
+        }
+        let released = false;
+        settle(null, {
+          plaintext,
+          encryption: inspectedEncryption,
+          release() {
+            if (released) return;
+            released = true;
+            // See the module header: this shortens the window in which
+            // plaintext is readable in this process. It cannot guarantee
+            // erasure.
+            plaintext.fill(0);
+          },
+        });
+        return;
+      }
+      if (message?.kind === "failed") {
+        settle(workerFailure(message.reason, suppliedPassword));
+        return;
+      }
+      settle(new PdfDecryptionError("protocol_violation", PDF_DECRYPTION_FAILED_MESSAGE));
+    });
+
+    worker.once("messageerror", () => {
+      settle(new PdfDecryptionError("protocol_violation", PDF_DECRYPTION_FAILED_MESSAGE));
+    });
+    worker.once("error", () => {
+      settle(new PdfDecryptionError("worker_faulted", PDF_DECRYPTION_FAILED_MESSAGE));
+    });
+    worker.once("exit", () => {
+      // Only reachable when the thread died without reporting: an
+      // out-of-memory abort, or a fault the worker's own handler could not
+      // survive. A settled request has already terminated it.
+      settle(new PdfDecryptionError("worker_exited", PDF_DECRYPTION_FAILED_MESSAGE));
+    });
+
+    deadline = setTimeout(() => {
+      settle(new PdfDecryptionError("decrypt_timeout", PDF_DECRYPTION_TIMEOUT_MESSAGE));
+    }, timeoutMs);
+    // The deadline must not be a reason for the process to stay alive; the
+    // worker it is guarding already is one.
+    deadline.unref();
+  });
+  return { outcome, teardown };
 }
 
 /**
  * Decrypts an encrypted PDF for one of the read-only operations, subject to
- * the size cap, the password rules and the permission rules documented above.
+ * the size cap, the password rules, the permission rules and the deadline
+ * documented above.
  *
  * Returns `{ plaintext, encryption, release }`. The caller owns `release()`
  * and must call it once it has finished reading the document that was loaded
@@ -470,13 +566,14 @@ async function inspectEncryption(pdfBytes, password) {
  * @param {Buffer} pdfBytes  The encrypted file exactly as it is on disk.
  * @param {string|null} password  The caller-supplied password, if any.
  * @param {string} operation  A key of `ENCRYPTED_READ_OPERATIONS`.
+ * @param {{timeoutMs?: number}} [options]  See `resolveDecryptionDeadlineMs`.
  */
-export async function decryptPdfForRead(pdfBytes, password, operation) {
-  return queueDecryption(() => decryptPdfForReadExclusively(pdfBytes, password, operation));
+export async function decryptPdfForRead(pdfBytes, password, operation, options = {}) {
+  return queueDecryption(() => decryptPdfForReadExclusively(pdfBytes, password, operation, options));
 }
 
 /** The body of `decryptPdfForRead`, run with the decryption queue held. */
-async function decryptPdfForReadExclusively(pdfBytes, password, operation) {
+async function decryptPdfForReadExclusively(pdfBytes, password, operation, { timeoutMs } = {}) {
   const rules = ENCRYPTED_READ_OPERATIONS[operation];
   if (!rules) {
     throw new TypeError(`Operation '${operation}' is not permitted to decrypt PDFs.`);
@@ -492,50 +589,20 @@ async function decryptPdfForReadExclusively(pdfBytes, password, operation) {
     throw new PdfDecryptionError("encrypted_input_too_large", PDF_ENCRYPTED_FILE_LIMIT_MESSAGE);
   }
 
-  const encryption = await inspectEncryption(pdfBytes, suppliedPassword);
-  if (!encryption.encrypted) {
-    // pdf-lib refused this document as encrypted but QPDF sees no encryption
-    // dictionary. The two disagree about what the file is, so decrypting it
-    // would be guessing.
-    throw new PdfDecryptionError("encryption_state_disagreement", PDF_DECRYPTION_FAILED_MESSAGE);
+  // The worker hands QPDF the password through a single-line password file
+  // rather than through argv, and QPDF reads the first line of it, so a
+  // password containing a line break would be silently truncated and then
+  // reported as "not accepted" — a confusing lie. Refuse it here, before a
+  // thread is started for it.
+  if (suppliedPassword !== null && /[\r\n]/.test(suppliedPassword)) {
+    throw new PdfDecryptionError("password_unrepresentable", PDF_PASSWORD_UNREPRESENTABLE_MESSAGE);
   }
 
-  const credentialed = suppliedPassword !== null
-    && (encryption.ownerPasswordMatched || encryption.userPasswordMatched);
-  if (!credentialed && encryption.capabilities[rules.capability] !== true) {
-    throw new PdfDecryptionError(
-      "permission_denied",
-      pdfPermissionDeniedMessage(operation),
-    );
-  }
-
-  const { status, output } = await runQpdf(
-    [
-      `--password-file=${VIRTUAL_PASSWORD_PATH}`,
-      "--decrypt",
-      VIRTUAL_INPUT_PATH,
-      VIRTUAL_OUTPUT_PATH,
-    ],
-    {
-      [VIRTUAL_INPUT_PATH]: pdfBytes,
-      [VIRTUAL_PASSWORD_PATH]: passwordFileBytes(suppliedPassword ?? ""),
-    },
-    VIRTUAL_OUTPUT_PATH,
+  return runDecryptionWorker(
+    pdfBytes,
+    suppliedPassword,
+    rules,
+    operation,
+    resolveDecryptionDeadlineMs(timeoutMs),
   );
-  if (!qpdfCompleted(status) || !output || output.length === 0) {
-    throw new PdfDecryptionError("decrypt_failed", PDF_DECRYPTION_FAILED_MESSAGE);
-  }
-
-  let released = false;
-  return {
-    plaintext: output,
-    encryption,
-    release() {
-      if (released) return;
-      released = true;
-      // See the module header: this shortens the window in which plaintext is
-      // readable in this process. It cannot guarantee erasure.
-      output.fill(0);
-    },
-  };
 }

--- a/test/mcp-contract.test.js
+++ b/test/mcp-contract.test.js
@@ -351,6 +351,7 @@ describe("MCPB static declarations", () => {
       "pdf-lib-rss-monitor.js",
       "pdf-observations.js",
       "qpdf-decrypt.js",
+      "qpdf-decrypt-worker.js",
       "resource-uri.js",
       "stderr-suppression.js",
     ]) {
@@ -360,7 +361,7 @@ describe("MCPB static declarations", () => {
     }
     // A new server file must be added to the list above, not silently shipped
     // in the mirror unchecked. Two already had been.
-    expect(mirrored).toHaveLength(20);
+    expect(mirrored).toHaveLength(21);
     const sourceUi = await fs.readFile(path.join(REPO_ROOT, "dist-ui", "index.html"));
     const shareUi = await fs.readFile(
       path.join(REPO_ROOT, "pdf-toolkit-mcp-share", "dist-ui", "index.html"),

--- a/test/qpdf-decrypt-isolation.test.js
+++ b/test/qpdf-decrypt-isolation.test.js
@@ -1,0 +1,408 @@
+/**
+ * The containment around decryption: a wall-clock deadline that genuinely
+ * stops the work, and a server that stays answerable while a hostile document
+ * is being chewed on.
+ *
+ * The exposure this suite exists for is specific. QPDF-WASM's `callMain` is
+ * synchronous, so on the thread that calls it nothing else runs — no timer, no
+ * incoming request — until it returns. The 16 MiB cap on encrypted inputs
+ * bounds *bytes*, and QPDF's cost tracks *objects*, which are nearly free per
+ * byte. The fixture below is the demonstration: a valid, well under-cap
+ * encrypted PDF whose object count alone buys seconds of uninterruptible
+ * compute. Run in the server process, that is seconds during which every tool
+ * is dead, and there is no reason to think the fixture is the worst case.
+ *
+ * So the assertions here are about termination rather than about detection. A
+ * deadline that only rejects a promise while the work keeps running would pass
+ * a naive timing test and fix nothing, which is why the CPU-flatline assertion
+ * exists and why the responsiveness test talks to the real MCP server rather
+ * than to the module.
+ *
+ * The fixture is generated here, from the runtime the product uses, rather than
+ * committed: it exists to be pathological, and a pathological PDF is not
+ * something to add to the tree.
+ */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import zlib from "node:zlib";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  PDF_DECRYPTION_TIMEOUT_MESSAGE,
+  PDF_DECRYPTION_TIMEOUT_MS,
+  PDF_ENCRYPTED_MAX_FILE_BYTES,
+  PdfDecryptionError,
+  decryptPdfForRead,
+  resolveDecryptionDeadlineMs,
+} from "../server/qpdf-decrypt.js";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const PLAIN_PDF = path.join(REPO_ROOT, "example-fw9.pdf");
+const RUNTIME_ENTRY = path.join(REPO_ROOT, "vendor", "qpdf-wasm", "runtime", "qpdf.mjs");
+
+const PASSWORD = "user-secret";
+
+/*
+ * How many tiny indirect objects the hostile fixture carries.
+ *
+ * Chosen so the fixture stays a few MB — well inside the 16 MiB cap, so the cap
+ * is not what is being tested — while costing over a second of QPDF time on
+ * ordinary hardware. Measured on macOS/arm64 with this runtime: 200,000 objects
+ * is a 3.5 MiB encrypted file and a 1.2-second decrypt; 800,000 is 14.3 MiB and
+ * 5.7 seconds. The smaller point on that line is enough to demonstrate the
+ * property and keeps the suite quick.
+ */
+const HOSTILE_OBJECT_COUNT = 200_000;
+
+/**
+ * Builds a structurally valid PDF whose only unusual feature is how many
+ * objects it contains. Everything is reachable from the catalog, so QPDF cannot
+ * prune it, and the leaves are packed into compressed object streams, so the
+ * file is small: object count, not size, is the whole point.
+ */
+function manyObjectPdf(objectCount) {
+  const CATALOG = 1;
+  const PAGES = 2;
+  const PAGE = 3;
+  const HOLDER = 4;
+  const FIRST_LEAF = 5;
+  const OBJECTS_PER_STREAM = 20_000;
+
+  const leaves = Array.from({ length: objectCount }, (unused, index) => FIRST_LEAF + index);
+  const streams = [];
+  for (let start = 0; start < objectCount; start += OBJECTS_PER_STREAM) {
+    const members = leaves.slice(start, start + OBJECTS_PER_STREAM);
+    let header = "";
+    let body = "";
+    for (const number of members) {
+      header += `${number} ${body.length} `;
+      body += `<</T ${number}/K(x)>>\n`;
+    }
+    streams.push({ members, header, body });
+  }
+  const firstStreamNumber = FIRST_LEAF + objectCount;
+  const xrefNumber = firstStreamNumber + streams.length;
+
+  const chunks = [];
+  let offset = 0;
+  const offsets = new Map();
+  const push = buffer => {
+    chunks.push(buffer);
+    offset += buffer.length;
+  };
+  const pushObject = (number, text) => {
+    offsets.set(number, offset);
+    push(Buffer.from(`${number} 0 obj\n${text}\nendobj\n`, "latin1"));
+  };
+
+  push(Buffer.from("%PDF-1.7\n%\xe2\xe3\xcf\xd3\n", "latin1"));
+  pushObject(CATALOG, `<</Type/Catalog/Pages ${PAGES} 0 R/PDFToolsLeaves ${HOLDER} 0 R>>`);
+  pushObject(PAGES, `<</Type/Pages/Kids[${PAGE} 0 R]/Count 1>>`);
+  pushObject(PAGE, `<</Type/Page/Parent ${PAGES} 0 R/MediaBox[0 0 612 792]>>`);
+  pushObject(HOLDER, `<</Refs[${leaves.map(number => `${number} 0 R`).join(" ")}]>>`);
+
+  const compressedIn = new Map();
+  streams.forEach((stream, index) => {
+    const streamNumber = firstStreamNumber + index;
+    stream.members.forEach((number, position) => compressedIn.set(number, [streamNumber, position]));
+    const raw = Buffer.from(stream.header + stream.body, "latin1");
+    const first = Buffer.byteLength(stream.header, "latin1");
+    const deflated = zlib.deflateSync(raw, { level: 9 });
+    offsets.set(streamNumber, offset);
+    push(Buffer.from(
+      `${streamNumber} 0 obj\n<</Type/ObjStm/N ${stream.members.length}/First ${first}`
+      + `/Length ${deflated.length}/Filter/FlateDecode>>\nstream\n`,
+      "latin1",
+    ));
+    push(deflated);
+    push(Buffer.from("\nendstream\nendobj\n", "latin1"));
+  });
+
+  const xrefOffset = offset;
+  const entryCount = xrefNumber + 1;
+  const table = Buffer.alloc(entryCount * 7);
+  const setEntry = (number, type, second, third) => {
+    const base = number * 7;
+    table[base] = type;
+    table.writeUInt32BE(second, base + 1);
+    table.writeUInt16BE(third, base + 5);
+  };
+  setEntry(0, 0, 0, 0xffff);
+  for (const [number, at] of offsets) setEntry(number, 1, at, 0);
+  for (const [number, [streamNumber, position]] of compressedIn) {
+    setEntry(number, 2, streamNumber, position);
+  }
+  setEntry(xrefNumber, 1, xrefOffset, 0);
+  const deflatedTable = zlib.deflateSync(table, { level: 9 });
+  push(Buffer.from(
+    `${xrefNumber} 0 obj\n<</Type/XRef/Size ${entryCount}/W[1 4 2]/Root ${CATALOG} 0 R`
+    + `/Length ${deflatedTable.length}/Filter/FlateDecode>>\nstream\n`,
+    "latin1",
+  ));
+  push(deflatedTable);
+  push(Buffer.from(`\nendstream\nendobj\nstartxref\n${xrefOffset}\n%%EOF\n`, "latin1"));
+  return Buffer.concat(chunks);
+}
+
+/** Encrypts a fixture with the vendored runtime, as the #133 suite does. */
+async function encryptFixture(sourceBytes) {
+  const createQpdf = (await import(RUNTIME_ENTRY)).default;
+  const stderr = [];
+  const qpdf = await createQpdf({ print: () => {}, printErr: line => stderr.push(String(line)) });
+  qpdf.FS.writeFile("/in.pdf", new Uint8Array(sourceBytes));
+  let status;
+  try {
+    status = qpdf.callMain([
+      "--encrypt", `--user-password=${PASSWORD}`, `--owner-password=${PASSWORD}-owner`,
+      "--bits=256", "--", "/in.pdf", "/out.pdf",
+    ]);
+  } catch (error) {
+    status = Number.isInteger(error?.status) ? error.status : -1;
+  }
+  if (status !== 0) throw new Error(`fixture encryption failed (${status}): ${stderr.join(" ")}`);
+  return Buffer.from(qpdf.FS.readFile("/out.pdf"));
+}
+
+const cpuMilliseconds = () => {
+  const { user, system } = process.cpuUsage();
+  return (user + system) / 1000;
+};
+
+let temporaryRoot;
+let hostilePath;
+let hostileBytes;
+let plainPath;
+/** What the hostile fixture actually costs, measured rather than assumed. */
+let uninterruptedDecryptMs = 0;
+
+beforeAll(async () => {
+  temporaryRoot = await fs.mkdtemp(path.join(os.tmpdir(), "pdf-tools-decrypt-isolation-"));
+  hostileBytes = await encryptFixture(manyObjectPdf(HOSTILE_OBJECT_COUNT));
+  hostilePath = path.join(temporaryRoot, "hostile.pdf");
+  await fs.writeFile(hostilePath, hostileBytes);
+  plainPath = path.join(temporaryRoot, "plain.pdf");
+  await fs.copyFile(PLAIN_PDF, plainPath);
+}, 300_000);
+
+afterAll(async () => {
+  if (temporaryRoot) await fs.rm(temporaryRoot, { recursive: true, force: true });
+});
+
+describe("the hostile fixture", () => {
+  it("is a lawful under-cap document that still costs seconds of QPDF time", async () => {
+    // The premise every assertion below rests on, established rather than
+    // asserted in a comment: the cap did not stop this file, and the work it
+    // demands is long enough that killing it early is observable.
+    expect(hostileBytes.length).toBeLessThan(PDF_ENCRYPTED_MAX_FILE_BYTES);
+
+    const startedAt = performance.now();
+    const result = await decryptPdfForRead(hostileBytes, PASSWORD, "read_pdf_fields");
+    uninterruptedDecryptMs = performance.now() - startedAt;
+    try {
+      // Derived from the decrypted bytes: an encrypted PDF's body is
+      // ciphertext, so a readable header and trailer prove real decryption.
+      expect(result.plaintext.subarray(0, 5).toString("latin1")).toBe("%PDF-");
+      expect(result.plaintext.toString("latin1")).toContain("%%EOF");
+    } finally {
+      result.release();
+    }
+    expect(uninterruptedDecryptMs).toBeGreaterThan(500);
+  }, 120_000);
+});
+
+describe("the decryption deadline", () => {
+  it("can only ever tighten, never widen", () => {
+    expect(resolveDecryptionDeadlineMs(undefined)).toBe(PDF_DECRYPTION_TIMEOUT_MS);
+    expect(resolveDecryptionDeadlineMs(250)).toBe(250);
+    // The seam tests use is not a way to buy a hostile document more time.
+    expect(resolveDecryptionDeadlineMs(PDF_DECRYPTION_TIMEOUT_MS * 1000))
+      .toBe(PDF_DECRYPTION_TIMEOUT_MS);
+    for (const bogus of [0, -1, Number.NaN, Number.POSITIVE_INFINITY, "500", null]) {
+      expect(resolveDecryptionDeadlineMs(bogus), String(bogus)).toBe(PDF_DECRYPTION_TIMEOUT_MS);
+    }
+  });
+
+  it("matches the deadline the rest of the PDF pipeline already uses", async () => {
+    const source = await fs.readFile(
+      path.join(REPO_ROOT, "server", "pdf-lib-subprocess.js"),
+      "utf8",
+    );
+    const declared = /const DEFAULT_TIMEOUT_MS = ([\d_]+);/.exec(source);
+    expect(Number(declared[1].replaceAll("_", ""))).toBe(PDF_DECRYPTION_TIMEOUT_MS);
+  });
+
+  it("stops a decryption that is already inside QPDF, rather than waiting it out", async () => {
+    const startedAt = performance.now();
+    const rejection = await decryptPdfForRead(hostileBytes, PASSWORD, "read_pdf_fields", {
+      timeoutMs: 200,
+    }).catch(error => error);
+    const elapsedMs = performance.now() - startedAt;
+
+    expect(rejection).toBeInstanceOf(PdfDecryptionError);
+    expect(rejection.reason).toBe("decrypt_timeout");
+    expect(rejection.message).toBe(PDF_DECRYPTION_TIMEOUT_MESSAGE);
+    // Compared against what this very document costs when it is allowed to
+    // finish, so the assertion survives a loaded machine: a deadline that only
+    // reported after the work completed would land at the full cost.
+    expect(uninterruptedDecryptMs).toBeGreaterThan(500);
+    expect(elapsedMs).toBeLessThan(uninterruptedDecryptMs / 2);
+  }, 120_000);
+
+  it("kills the work rather than abandoning the promise", async () => {
+    // The distinction the whole change turns on. A deadline that rejects while
+    // QPDF keeps running would satisfy the timing assertion above and leave the
+    // machine burning a core on a hostile document until it happened to finish.
+    // Process CPU is the witness: this suite runs in its own forked process, so
+    // anything still executing has to show up here.
+    const beforeCpuMs = cpuMilliseconds();
+    const startedAt = performance.now();
+    await decryptPdfForRead(hostileBytes, PASSWORD, "read_pdf_fields", { timeoutMs: 300 })
+      .catch(() => {});
+    const killedAfterMs = performance.now() - startedAt;
+    const spentWhileRunningMs = cpuMilliseconds() - beforeCpuMs;
+    const killedAtCpuMs = cpuMilliseconds();
+
+    // Long enough for the remainder of the interrupted decrypt to have run
+    // several times over, had it survived.
+    const idleWindowMs = 2_000;
+    await new Promise(resolve => setTimeout(resolve, idleWindowMs));
+    const afterIdleCpuMs = cpuMilliseconds() - killedAtCpuMs;
+
+    // It really was working when it was killed, so "no CPU afterwards" is not
+    // vacuous.
+    expect(spentWhileRunningMs).toBeGreaterThan(100);
+    expect(killedAfterMs).toBeLessThan(uninterruptedDecryptMs);
+    // And afterwards the process is quiet. The bound is generous — a tenth of
+    // what the killed work was consuming per unit time, over a window six times
+    // longer — because the point is the difference between "stopped" and
+    // "still going", not a precise idle figure.
+    expect(afterIdleCpuMs).toBeLessThan(spentWhileRunningMs / 2);
+    expect(afterIdleCpuMs).toBeLessThan(idleWindowMs / 10);
+  }, 120_000);
+
+  it("leaves the queue usable by the next caller", async () => {
+    // A killed worker must not take the serialization chain with it.
+    await decryptPdfForRead(hostileBytes, PASSWORD, "validate_pdf", { timeoutMs: 150 })
+      .catch(() => {});
+    const encryptedPlain = await encryptFixture(await fs.readFile(PLAIN_PDF));
+    const result = await decryptPdfForRead(encryptedPlain, PASSWORD, "validate_pdf");
+    try {
+      expect(result.plaintext.subarray(0, 5).toString("latin1")).toBe("%PDF-");
+    } finally {
+      result.release();
+    }
+  }, 120_000);
+});
+
+describe("memory across repeated decryptions", () => {
+  it("plateaus rather than accumulating one QPDF heap per request", async () => {
+    // The per-file cap is derived from the peak of a *single* decrypt, and is
+    // only sufficient if repeated decryption does not stack. Isolation did not
+    // change that property and must not be allowed to quietly break it.
+    const baselineBytes = process.memoryUsage.rss();
+    const first = await decryptPdfForRead(hostileBytes, PASSWORD, "read_pdf_fields");
+    first.release();
+    const afterFirstBytes = process.memoryUsage.rss();
+    const oneDecryptDelta = afterFirstBytes - baselineBytes;
+
+    for (let index = 0; index < 4; index += 1) {
+      const result = await decryptPdfForRead(hostileBytes, PASSWORD, "read_pdf_fields");
+      result.release();
+    }
+    const afterFiveBytes = process.memoryUsage.rss();
+
+    // Five decrypts must not cost five heaps. Measured, the fifth lands within
+    // a few percent of the first; the bound is twice that so a loaded machine's
+    // allocator behaviour cannot make it fail.
+    expect(oneDecryptDelta).toBeGreaterThan(0);
+    expect(afterFiveBytes - baselineBytes).toBeLessThan(oneDecryptDelta * 2);
+  }, 180_000);
+});
+
+describe("plaintext boundaries", () => {
+  it("keeps decryption on a thread, so no decrypted byte crosses a process", async () => {
+    const wrapper = await fs.readFile(path.join(REPO_ROOT, "server", "qpdf-decrypt.js"), "utf8");
+    const worker = await fs.readFile(
+      path.join(REPO_ROOT, "server", "qpdf-decrypt-worker.js"),
+      "utf8",
+    );
+    // A thread, not a child. Routing this through the existing pdf-lib child
+    // process would have put the plaintext through a pipe or a staged file,
+    // which is the property the design was built to avoid.
+    expect(wrapper).toContain('from "node:worker_threads"');
+    for (const source of [wrapper, worker]) {
+      expect(source).not.toMatch(/node:child_process|node:fs|spawn\(|execFile\(/);
+    }
+    // And the transfer is a transfer: the plaintext moves by reassigning
+    // ownership of the same pages, so there is no serialized second copy.
+    expect(worker).toMatch(/postMessage\(\s*\{ kind: "decrypted"[\s\S]{0,120}\[plaintext\.buffer\]/);
+  });
+});
+
+describe("the server while a hostile document is decrypting", () => {
+  let client;
+  let transport;
+
+  beforeAll(async () => {
+    transport = new StdioClientTransport({
+      command: process.execPath,
+      args: [path.join(REPO_ROOT, "server/index.js")],
+      cwd: REPO_ROOT,
+      env: { ALLOWED_DIRECTORIES: [REPO_ROOT, temporaryRoot].join(path.delimiter) },
+      stderr: "ignore",
+    });
+    client = new Client({ name: "pdf-tools-decrypt-isolation-test", version: "1.0.0" });
+    await client.connect(transport);
+  }, 60_000);
+
+  afterAll(async () => {
+    await client?.close();
+    await transport?.close();
+  });
+
+  it("answers an unrelated tool call before the decryption it is racing finishes", async () => {
+    // The exposure, stated as a test. With QPDF on the server's own thread this
+    // is impossible by construction: nothing on that thread runs until
+    // `callMain` returns, so the second call could only ever be answered after
+    // the first. Completion order is the assertion because it is what the
+    // blocking arrangement cannot produce, whatever the machine is doing.
+    const completed = [];
+
+    const decrypting = client.callTool({
+      name: "read_pdf_fields",
+      arguments: { pdf_path: hostilePath, password: PASSWORD },
+    }).then(result => {
+      completed.push("decrypt");
+      return result;
+    });
+
+    const unrelated = client.callTool({
+      name: "get_pdf_info",
+      arguments: { pdf_path: plainPath },
+    }).then(result => {
+      completed.push("info");
+      return result;
+    });
+
+    const [decryptResult, infoResult] = await Promise.all([decrypting, unrelated]);
+    expect(infoResult.isError).not.toBe(true);
+    expect(decryptResult.isError).not.toBe(true);
+    expect(completed).toEqual(["info", "decrypt"]);
+  }, 120_000);
+
+  it("is still answering after a decryption was killed by the deadline", async () => {
+    // The deadline is 30 seconds and cannot be shortened from outside, so this
+    // does not wait one out. What it checks is the other half: a decryption
+    // that has been terminated leaves a healthy server rather than a wedged
+    // one, which is the same code path a timeout takes.
+    const validated = await client.callTool({
+      name: "validate_pdf",
+      arguments: { pdf_path: plainPath },
+    });
+    expect(validated.isError).not.toBe(true);
+    expect(validated.structuredContent.total_field_count).toBeGreaterThan(0);
+  }, 60_000);
+});

--- a/test/qpdf-wasm-runtime-artifact.test.js
+++ b/test/qpdf-wasm-runtime-artifact.test.js
@@ -196,21 +196,31 @@ describe("qpdf-wasm runtime provenance", () => {
   /*
    * This assertion used to require that *no* `server/` module referenced the
    * runtime, which was the correct statement while the artifact shipped
-   * unintegrated. Read-only decryption made it false on purpose, so it is
-   * narrowed rather than dropped: the runtime is now reachable, from exactly
-   * one module.
+   * unintegrated. Read-only decryption made it false on purpose, so it was
+   * narrowed rather than dropped: the runtime is reachable, from exactly one
+   * module.
    *
-   * That single-module property is the thing worth guarding. The wrapper is
-   * where the password rules, the permission rules and the size cap live, and
-   * where the vendored README's requirement that callers never receive the raw
-   * module or its `FS` is enforced. A second `server/` module loading the
-   * runtime directly would bypass all of it, which is why that has to fail
-   * here rather than in review.
+   * Which module changed when decryption was moved off the server's thread.
+   * QPDF-WASM's `callMain` is synchronous and cannot be interrupted by the
+   * thread that called it, so the only way to enforce a deadline on it is to
+   * destroy the thread — which means the runtime has to be loaded somewhere
+   * destroyable. It is now loaded by `server/qpdf-decrypt-worker.js` and by
+   * nothing else, and that module is a worker entry point: it is not on the
+   * server's import graph and never executes on the server's thread.
+   *
+   * The single-module property is still the thing worth guarding, and it is now
+   * two facts rather than one. The runtime is reachable from exactly one
+   * module; and that module is started from exactly one place, the wrapper
+   * where the password rules, the permission rules, the size cap and the
+   * deadline live. A second `server/` module loading the runtime, or a second
+   * one starting the worker, would bypass all of it — which is why both have to
+   * fail here rather than in review.
    */
-  it("is reachable from exactly one server module, which owns the safety rules", async () => {
+  it("is reachable from exactly one server module, started from exactly one other", async () => {
     expect(QPDF_WASM_RUNTIME_PROVENANCE.integration_status)
-      .toMatch(/server\/qpdf-decrypt\.js/);
+      .toMatch(/server\/qpdf-decrypt-worker\.js/);
     const referencing = [];
+    const starting = [];
     for (const filename of await fs.readdir(path.join(REPO_ROOT, "server"))) {
       const source = await fs.readFile(path.join(REPO_ROOT, "server", filename), "utf8");
       for (const marker of ["qpdf-wasm", "qpdf.mjs", "qpdf.wasm", QPDF_WASM_RUNTIME_DIRECTORY]) {
@@ -219,18 +229,33 @@ describe("qpdf-wasm runtime provenance", () => {
           break;
         }
       }
+      if (filename !== "qpdf-decrypt-worker.js" && source.includes("qpdf-decrypt-worker.js")) {
+        starting.push(`server/${filename}`);
+      }
     }
-    expect(referencing).toEqual(["server/qpdf-decrypt.js"]);
+    expect(referencing).toEqual(["server/qpdf-decrypt-worker.js"]);
+    expect(starting).toEqual(["server/qpdf-decrypt.js"]);
 
-    const wrapper = await fs.readFile(path.join(REPO_ROOT, "server", "qpdf-decrypt.js"), "utf8");
-    // The module and its filesystem stay inside the wrapper: nothing it
-    // exports hands a caller the raw Emscripten object or `FS`.
-    expect(wrapper).not.toMatch(/export[^\n]*\b(createQpdf|FS)\b/);
+    const worker = await fs.readFile(
+      path.join(REPO_ROOT, "server", "qpdf-decrypt-worker.js"),
+      "utf8",
+    );
+    // The module and its filesystem stay inside the worker: nothing it exports,
+    // and nothing it posts back across the thread boundary, hands a caller the
+    // raw Emscripten object or `FS`.
+    expect(worker).not.toMatch(/export[^\n]*\b(createQpdf|FS)\b/);
+    expect(worker).not.toMatch(/postMessage\([^)]*\b(qpdf|FS)\b/);
     // Passwords reach QPDF through a file in the module's private in-memory
     // filesystem, never through argv, where they would be readable from the
     // process command line and echoed by QPDF's own usage diagnostics.
-    expect(wrapper).toContain("--password-file=");
-    expect(wrapper).not.toMatch(/"--password=|`--password=/);
+    expect(worker).toContain("--password-file=");
+    expect(worker).not.toMatch(/"--password=|`--password=/);
+
+    // The wrapper builds no QPDF command line at all now, so the argv property
+    // above cannot be quietly re-broken from the other side of the boundary.
+    const wrapper = await fs.readFile(path.join(REPO_ROOT, "server", "qpdf-decrypt.js"), "utf8");
+    expect(wrapper).not.toMatch(/["'`]--password/);
+    expect(wrapper).not.toMatch(/callMain/);
   });
 });
 

--- a/vendor/qpdf-wasm/runtime.provenance.json
+++ b/vendor/qpdf-wasm/runtime.provenance.json
@@ -5,10 +5,10 @@
   "license": "Apache-2.0 (qpdf) plus the additional bundled notices in runtime/licenses/manifest.json",
   "privacy": "Compiled third-party source only; no personal data and no PDF content",
   "redistribution": "allowed while the complete notice directory travels with the runtime",
-  "integration_status": "Packaged into the MCPB and the share ZIP, and loaded by exactly one module: server/qpdf-decrypt.js. It decrypts encrypted PDFs in memory for the read-only tools read_pdf_fields, validate_pdf and extract_to_csv, which never write a PDF back. No write path loads it, nothing re-encrypts or rewrites a document with it, and decrypted bytes are never written to disk.",
+  "integration_status": "Packaged into the MCPB and the share ZIP, and loaded by exactly one module: server/qpdf-decrypt-worker.js, which runs only on a worker thread that server/qpdf-decrypt.js starts, bounds by a wall-clock deadline, and destroys once the document is decrypted or the deadline expires. The runtime is synchronous and cannot be interrupted from the thread that called it, so destroying that thread is the only real way to stop it. It decrypts encrypted PDFs in memory for the read-only tools read_pdf_fields, validate_pdf and extract_to_csv, which never write a PDF back. No write path loads it, nothing re-encrypts or rewrites a document with it, and decrypted bytes are transferred between threads within the one process and never written to disk.",
   "generator": {
     "path": "scripts/vendor-qpdf-wasm-runtime.mjs",
-    "sha256": "08c5cb17a1f113d5d652f49de16641d6cc5efd666fac529b9e35bf7379e09b8e",
+    "sha256": "26381d2f159b8122672f9373228d9ed268bcee39f3ed2bb3b9597257eff320c3",
     "hash_contract": "SHA-256 of UTF-8 generator source after CRLF or CR line endings are normalized to LF",
     "runtime": "Node.js standard library only",
     "command": "node scripts/vendor-qpdf-wasm-runtime.mjs <extracted-build-directory>"


### PR DESCRIPTION
## The exposure I shipped

#133 let three read tools decrypt, but the runtime was imported straight into
`server/index.js` and QPDF's `callMain` is **synchronous**. The work ran on the
server's own thread with nothing able to interrupt it. `DEFAULT_TIMEOUT_MS` in the
pdf-lib child never applied, because decryption never entered that child.

**The 16 MiB cap bounds input bytes, not parse time.** I checked the cap and did
not check the process boundary.

## It is real, and there is now a fixture proving it

A lawful AES-256 document, **14.3 MiB — comfortably under the cap** — carrying
800,000 tiny indirect objects in compressed object streams. Uninterrupted it
spends **5.1 s wall / 4.0 s CPU inside one synchronous call**. Cost tracks object
count, which no byte limit bounds. On the old arrangement that froze *every* tool.

## Fixed, and proven killed rather than abandoned

| deadline | wall | reason | CPU in next 2 s |
|---|---|---|---|
| 100 ms | 110 ms | `decrypt_timeout` | 0.1 ms |
| 1000 ms | 1016 ms | `decrypt_timeout` | 0.1 ms |
| 4000 ms | 4022 ms | `decrypt_timeout` | 0.1 ms |

Through the real MCP server, `read_pdf_fields` on the hostile document raced
against `get_pdf_info` on a plain one: **the unrelated call always completes
first**, which the blocking arrangement cannot produce by construction. Also
verified from the unpacked MCPB.

## A thread, not the existing child process

The child has proven deadline/RSS/SIGKILL machinery, but it would force plaintext
across a real process boundary via pipe or staged file — the property #133 bought
deliberately. Decrypted bytes now reach the parent by **transfer**: ownership of
the same pages moves, nothing is copied, piped or staged. Passwords cross in
`workerData` and still never reach argv.

Policy stays in the parent. The worker inspects and *waits*; only after the
permission and password rules pass is it told to decrypt. A refusal is a refusal
to do the work, not a decision to discard a result.

## My memory hypothesis was wrong

I expected a terminated worker to reclaim the wasm heap where in-process GC could
not, and suggested the cap might then rise. Measured, after one 14.6 MiB decrypt
plus forced-GC settle:

| | peak | settled | retained over baseline |
|---|---|---|---|
| in-process | 333 MB | 243 MB | **188 MB** |
| worker | 315 MB | 315 MB | **260 MB** |

Terminating returns *less* — freed pages stay mapped. Isolation costs ~70 MB at
rest. **The cap does not move**, because it derives from the single-decrypt peak,
which is essentially unchanged. Recorded rather than claimed as a win.

## Cost

+45–65 ms constant (worker boot ~14 ms, `terminate()` ~55–60 ms). Significant for
a small document's ~32 ms decrypt, negligible at the cap. Teardown is off the
caller's critical path — the queue absorbs it.

## Preserved and tightened

`test/qpdf-decrypt-read-only.test.js` is **unmodified**; 26/26 pass. The artifact
test's single-module assertion was **tightened, not loosened**: the runtime is
reachable from exactly one module, that module is started from exactly one other,
and the wrapper builds no qpdf command line at all.

## Deliberately not done

**No RSS guard on the worker.** Node's `resourceLimits` bounds the V8 heap, not
WebAssembly memory — it would look like the protection it is not. Containment is
the cap, the queue, and a wasm overrun now killing only the worker.

`npm test` — 2326 passed, 0 failed. `build:mcpb` reproducible, `smoke:mcpb` and
`test:contract:share` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)