### PR TITLE
Wait for the descendant to become stubborn instead of assuming it has

### DIFF
--- a/test/eval/accessibility-formal-v2.test.js
+++ b/test/eval/accessibility-formal-v2.test.js
@@ -460,15 +460,30 @@ describe.sequential("bounded process groups", () => {
   });
 
   it("kills and reports a stubborn descendant after its leader exits", async () => {
-    // The leader must not exit until the descendant actually exists. spawn() is
-    // asynchronous, so a fixed timer raced the fork: under a loaded parallel
-    // run the leader could exit first, leaving nothing for the cleanup path to
-    // observe and failing on descendant_observed_after_leader_close. Waiting
-    // for the spawn event removes the assumption rather than lengthening it.
+    // Two separate races had to be removed here, both of the same shape: the
+    // test assumed something had happened by a certain time rather than waiting
+    // for it to happen.
+    //
+    // The first was the fork itself. spawn() is asynchronous, so a fixed timer
+    // let a loaded run exit the leader before the descendant existed, failing
+    // on descendant_observed_after_leader_close. Waiting for the spawn event
+    // fixed that.
+    //
+    // The second is subtler and is what this change removes. `spawn` fires when
+    // the process exists, not when its script has run. The descendant is only
+    // stubborn once it has installed its SIGTERM handler, and a starved host
+    // can take longer than the 50 ms that followed to get there. SIGTERM then
+    // arrives at a process still running default disposition, the descendant
+    // dies politely, and kill_signal_sent is false: the cleanup path behaved
+    // correctly, but the test was no longer testing a stubborn descendant.
+    //
+    // So the descendant now announces that its handler is installed, and the
+    // leader exits on that byte rather than on a timer. There is nothing left
+    // to tune, because there is no longer a duration being guessed.
     const script = [
       "const {spawn}=require('node:child_process');",
-      "const child=spawn(process.execPath,['-e',\"process.on('SIGTERM',()=>{});setInterval(()=>{},1000)\"],{stdio:'ignore'});",
-      "child.on('spawn',()=>{setTimeout(()=>process.exit(0),50);});",
+      "const child=spawn(process.execPath,['-e',\"process.on('SIGTERM',()=>{});setInterval(()=>{},1000);process.stdout.write('ready')\"],{stdio:['ignore','pipe','ignore']});",
+      "child.stdout.once('data',()=>{process.exit(0);});",
       "child.on('error',()=>{process.exit(1);});",
     ].join("");
     const result = await runBoundedProcess(process.execPath, ["-e", script], {


### PR DESCRIPTION
Closes #126.

The bounded-process-group test failed in **six consecutive full aggregate runs** while passing in isolation every time. The exact mismatch was precise:

| field | expected | observed |
|---|---|---|
| `descendant_observed_after_leader_close` | true | correct |
| `term_signal_sent` | true | correct |
| **`kill_signal_sent`** | **true** | **false** |
| `process_group_empty_after_cleanup` | true | correct |

That combination says the cleanup path worked and the fixture did not.

The descendant is only stubborn once it has installed its SIGTERM handler. `spawn` fires when the process exists, not when its script has run, and the 50 ms that followed was a guess about how long node needs to get there. On a host starved by the aggregate's own workers, SIGTERM arrived while the descendant was still running default disposition, it died politely, and no SIGKILL was required.

The descendant now writes a byte once its handler is installed, and the leader exits on that byte. **Nothing is left to tune, because no duration is being guessed.** This is the same correction #138 applied to the two supervisor tests, whose comment names it exactly: remove the assumption rather than lengthen it.

## Verification

Full aggregate on macOS: **2,344 passed, 0 failed**, with `accessibility-formal-v2` green. That is the first fully clean aggregate in this stretch. Together with #138 it closes the whole flake class, which at its widest was three suites failing under load while passing alone.

## Honest limit

This could not be reproduced on the Linux VM even at load average 116, so the trigger is the aggregate's particular contention rather than CPU starvation alone. The macOS aggregate, where it failed six for six, is the only reproduction available and is what this was judged against.
