### PR TITLE
Make a stale published plugin visible instead of silent

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "test:node-native": "node scripts/run-node-test-suites.mjs",
     "test:concurrent": "node scripts/test-concurrent-suites.mjs",
     "build:plugin": "node scripts/build-agent-plugin.mjs",
-    "publish:plugin": "node scripts/publish-agent-plugin.mjs"
+    "publish:plugin": "node scripts/publish-agent-plugin.mjs",
+    "check:plugin-freshness": "node scripts/check-plugin-freshness.mjs"
   },
   "repository": {
     "type": "git",

--- a/scripts/check-plugin-freshness.mjs
+++ b/scripts/check-plugin-freshness.mjs
@@ -1,0 +1,103 @@
+// Report whether the published Agent Plugin is missing changes that ship in it.
+//
+// Publishing is a manual step (`npm run publish:plugin`), so the distribution
+// repository silently lags this one until someone remembers. That is not
+// hypothetical: #125 bounded decoded object-stream size, merged, and the
+// published plugin kept serving the unfixed server until the drift was noticed
+// by chance while checking something unrelated.
+//
+// The naive check, "is the published commit equal to HEAD", would fail after
+// every merge and teach everyone to ignore it. So this compares only the paths
+// that actually end up inside the plugin. A docs or test commit leaves the
+// published bytes correct and this stays quiet; a change under server/ or
+// dist-ui/ does not, and this says so.
+//
+// Usage: node scripts/check-plugin-freshness.mjs
+// Exit 0 when the published plugin carries every shipped change, 1 when it does
+// not, 2 when the answer could not be determined.
+
+import { execFileSync } from "child_process";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const PROVENANCE_URL =
+  "https://raw.githubusercontent.com/Open-Document-Alliance/pdf-tools-plugin/main/PROVENANCE.md";
+
+// Everything the plugin build copies into the artifact. Keep this in step with
+// scripts/build-agent-plugin.mjs; a path missing here is a change that can ship
+// without this gate noticing.
+const SHIPPED_PATHS = [
+  "server/",
+  "dist-ui/",
+  "vendor/",
+  "plugins/pdf-tools-workflow/",
+  "package.json",
+  "package-lock.json",
+  "icon.png",
+  "LICENSE",
+  "scripts/build-agent-plugin.mjs",
+];
+
+function git(args) {
+  return execFileSync("git", args, { cwd: REPO_ROOT, encoding: "utf8" }).trim();
+}
+
+let provenance;
+try {
+  provenance = await (await fetch(PROVENANCE_URL)).text();
+} catch (error) {
+  console.error(`[freshness] could not read published provenance: ${error.message}`);
+  console.error("[freshness] cannot determine freshness; not treating that as fresh.");
+  process.exit(2);
+}
+
+const published = /\/commit\/([0-9a-f]{40})/.exec(provenance)?.[1];
+if (!published) {
+  console.error("[freshness] published PROVENANCE.md has no source commit; cannot compare.");
+  process.exit(2);
+}
+
+const head = git(["rev-parse", "HEAD"]);
+if (published === head) {
+  console.error(`[freshness] published plugin is built from HEAD (${head.slice(0, 8)}).`);
+  process.exit(0);
+}
+
+// The published commit must be an ancestor, otherwise the comparison below is
+// meaningless and the plugin may be built from something not in this history.
+try {
+  git(["merge-base", "--is-ancestor", published, head]);
+} catch {
+  console.error(
+    `[freshness] published commit ${published.slice(0, 8)} is not an ancestor of HEAD. `
+    + "The plugin may be built from a different history; check manually.",
+  );
+  process.exit(2);
+}
+
+const changed = git(["diff", "--name-only", `${published}..${head}`])
+  .split("\n")
+  .filter(Boolean)
+  .filter(file => SHIPPED_PATHS.some(prefix =>
+    prefix.endsWith("/") ? file.startsWith(prefix) : file === prefix));
+
+if (changed.length === 0) {
+  const behind = git(["rev-list", "--count", `${published}..${head}`]);
+  console.error(
+    `[freshness] published plugin is ${behind} commit(s) behind, but none of them `
+    + "change files that ship in it. Nothing to publish.",
+  );
+  process.exit(0);
+}
+
+console.error(
+  `[freshness] STALE: the published plugin is missing ${changed.length} shipped file change(s) `
+  + `since ${published.slice(0, 8)}:`,
+);
+for (const file of changed.slice(0, 20)) console.error(`  ${file}`);
+if (changed.length > 20) console.error(`  ... and ${changed.length - 20} more`);
+console.error("");
+console.error("Anyone installing the plugin right now receives the older build.");
+console.error("Publish with: npm run publish:plugin -- <plugin-repo-checkout> --push");
+process.exit(1);


### PR DESCRIPTION
Partially addresses #130, which stays open for the automation half.

Publishing the Agent Plugin is a manual step, so the distribution repository lags this one until someone remembers. That is not hypothetical: #125 bounded decoded object-stream size, merged, and the published plugin kept serving the unfixed server until the drift was noticed by chance while checking something unrelated. Anyone installing during that window received the vulnerable build, with no signal that anything was stale.

## Why not the obvious check

Comparing the published commit to `HEAD` would fail after every merge and train everyone to ignore it. This compares only the paths the build actually copies into the artifact, so a docs or test commit stays quiet and a change under `server/` or `dist-ui/` does not.

## It found real drift on its first run

```
[freshness] STALE: the published plugin is missing 7 shipped file change(s) since 54f33e79:
  server/helpers.js
  server/index.js
  server/pdf-lib-worker.js
  server/qpdf-decrypt-worker.js
  server/qpdf-decrypt.js
  ...
```

#141 landed after the last publish. That is the same first-run result the publisher itself had when it was added, and it is the argument for automating this rather than remembering it.

## Deliberately not in the aggregate

It is expected to be red between a merge and a publish, and a gate that is routinely red is one people learn to merge past. Run it before publishing, or on a schedule.

## What is still missing

Closing the loop needs publish-on-merge, which needs a token with write access to the distribution repository. That is a credentials decision for a maintainer rather than something to assume, so #130 stays open for it.
