### PR TITLE
Let /P govern writes only, and stop pretending it governs reads

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,14 +98,14 @@ the source's protection before it is staged. Two rules follow:
   `output_encryption` parameter, and no default to argue about. A document that
   cannot be faithfully re-protected fails the operation; nothing ever writes a
   decrypted copy of an encrypted document.
-- **A denied `/P` needs the owner password.** For a read, either password is
-  enough. For a write, if the document's permissions deny what the operation
-  does, only the owner password authorises it — the user password proves you may
-  open the document, not that you may override its owner. Each tool requires the
-  bit matching what it does: `modifyforms` to fill a form, `modifyassembly` for
-  page manipulation, `modify` for stamping (which draws into the page content
-  stream, so it is bit 4 and not the annotation bit). See
-  `ENCRYPTED_WRITE_OPERATIONS` in `server/qpdf-decrypt.js`.
+- **A denied `/P` needs the owner password.** If the document's permissions deny
+  what the operation does, only the owner password authorises it — the user
+  password proves you may open the document, not that you may override its
+  owner. Each tool requires the bit matching what it does: `modifyforms` to fill
+  a form, `modifyassembly` for page manipulation, `modify` for stamping (which
+  draws into the page content stream, so it is bit 4 and not the annotation
+  bit). See `ENCRYPTED_WRITE_OPERATIONS` in `server/qpdf-decrypt.js`. This is
+  the *write* rule; reads do not consult `/P` at all (see below).
 
 `merge_pdfs` refuses unless every source carries byte-identical protection,
 because N sources with different or absent encryption make "the source's
@@ -158,18 +158,31 @@ Isolation does **not** improve the memory picture; see the size-cap note below.
   containing a line break is refused outright: it cannot be represented in the
   single-line password file that keeps passwords off the command line.
 - **No password supplied, document opens with an empty user password** (the
-  owner-locked shape: opens freely, `/P` denies modification) → proceed only if
-  `/P` grants `extract`; otherwise refuse, naming the denied permission. qpdf
-  can decrypt, edit, and re-lock such a document with identical `/P` and `/R`
-  and no password at all, and PDF Tools must not become a tool for that.
+  owner-locked shape: opens freely, `/P` denies modification) → the *read*
+  proceeds; a *write* proceeds only if `/P` grants the bit it needs. qpdf can
+  decrypt, edit, and re-lock such a document with identical `/P` and `/R` and no
+  password at all, and PDF Tools must not become a tool for that — which is what
+  the write rule and "protection in, protection out" prevent.
 - Not encrypted → unchanged. pdf-lib is tried first, so no qpdf module is
   instantiated and there is no measurable cost.
 
-All three require `/P` bit 5 (`extract`, content copying), because all three
-copy document content out. The `accessibility` bit is not accepted as a
-substitute — it is granted almost universally and nothing can verify the caller
-is assistive technology — and neither is `modifyforms`, which authorizes filling
-a form, not reading what is already in it.
+**`/P` governs writes. It does not govern reads.** That is one rule, stated once
+in `pdfPermissionRefusal` in `server/qpdf-decrypt.js`, which is the only
+function in `server/` that reads `encryption.capabilities`. The read tools once
+required `/P` bit 5 (`extract`); the requirement was removed because it could
+not be applied to the family it belonged to. It only ever bound the three qpdf-
+backed reads, while every PDF.js-backed sibling — `read_pdf_content`,
+`read_pdf_layout`, `convert_pdf_to_markdown`, `render_pdf_page` and the rest —
+returned the same content regardless, PDF.js having no `/P` implementation at
+all. Extending it uniformly would have meant refusing `read_pdf_bytes`,
+`get_pdf_resource_uri` and `display_pdf`, which is refusing to show the user
+their own document; no reader on the market does that. And it cannot bite in any
+case: `/P` bit 10 (`accessibility`) is deprecated-and-required by ISO 32000-2,
+and qpdf cannot even produce an R4 or R6 document that denies it, so on anything
+encrypted with AES an owner who denies `extract` has granted extraction for
+accessibility in the same breath. The full argument is in the module header;
+`test/pdf-read-permission-consistency.test.js` pins the uniformity so a new read
+tool cannot join the family with different behaviour.
 
 **Size cap.** Encrypted inputs are capped at **16 MiB**, separate from and far
 below the 250 MiB `PDF_MUTATION_MAX_FILE_BYTES`. Decryption costs roughly

--- a/pdf-toolkit-mcp-share/server/index.js
+++ b/pdf-toolkit-mcp-share/server/index.js
@@ -89,6 +89,14 @@ import {
   runPdfLibMutation,
   terminateAllPdfLibMutations,
 } from "./pdf-lib-subprocess.js";
+// The pre-parse bounds the mutation path already applies, reused on the one
+// read path that hands pdf-lib bytes it did not read off disk. This module is
+// already on the server's import graph through pdf-lib-subprocess.js, so the
+// import costs nothing new; see `loadEncryptedPdfBytes`.
+import {
+  assertBoundedPdfStreamDecodes,
+  assertBoundedPdfStructure,
+} from "./pdf-lib-worker.js";
 
 export const READ_CONTENT_ROUTING_GUIDANCE =
   "Pages without extractable text or with suspect text integrity were successfully read in this call. Use render_pdf_page for visual inspection of those pages; the page routing fields are limited to successfully-read pages, and pages outside this read scope or stopped at a page-read error are not classified by this result.";
@@ -639,17 +647,41 @@ async function loadPdfBytes(pdfBytes, password = null, { decryptFor = null } = {
  * The encrypted branch of `loadPdfBytes`. Decrypts in memory, parses the
  * plaintext, and releases the plaintext immediately if parsing fails so a
  * malformed decrypted document does not leave it sitting in the heap.
+ *
+ * The plaintext gets the same pre-parse bounds the mutation path applies to a
+ * document it is about to hand pdf-lib: `assertBoundedPdfStructure` for hostile
+ * cross-reference byte widths and sparse object numbering, and
+ * `assertBoundedPdfStreamDecodes` for object streams that expand past a
+ * deterministic ceiling. Those are the two shapes that make `PDFDocument.load`
+ * allocate without bound, and this is the one place in the server process where
+ * pdf-lib parses bytes that did not come straight off disk.
+ *
+ * It is belt and braces rather than a live hole. `qpdf --decrypt` fully
+ * re-serializes the document, which launders hostile cross-reference structure
+ * on the way through — a `/W [1 2000000000 1]` does not survive the round trip.
+ * But that is a property of QPDF's writer, not a contract it offers us, and it
+ * is the sort of property that evaporates quietly. Measured at 7.2 MB the two
+ * checks cost 22 ms against the 314 ms of pdf-lib parsing that follows
+ * unconditionally, so paying for the guarantee outright is cheaper than
+ * depending on somebody else's serializer to keep providing it.
  */
 async function loadEncryptedPdfBytes(pdfBytes, password, decryptFor, invalidPdfMessage) {
   const decrypted = await decryptPdfForRead(pdfBytes, password, decryptFor);
   let pdfDoc;
   try {
+    assertBoundedPdfStructure(decrypted.plaintext);
+    await assertBoundedPdfStreamDecodes(decrypted.plaintext);
     pdfDoc = await PDFDocument.load(decrypted.plaintext);
     // Validated against the plaintext, because that is the byte sequence this
     // document was actually parsed from.
     validateLoadedPdfStructure(pdfDoc, decrypted.plaintext);
   } catch (error) {
     decrypted.release();
+    // A bound that was exceeded is a specific, actionable fact and says which
+    // one. Collapsing it into "the file is malformed" would throw that away and
+    // describe a document this code deliberately refused as one it could not
+    // understand.
+    if (error?.code === PDF_RESOURCE_LIMIT_CODE) throw error;
     if (error?.message === invalidPdfMessage) throw error;
     throw new Error(invalidPdfMessage, { cause: error });
   }

--- a/pdf-toolkit-mcp-share/server/pdf-lib-worker.js
+++ b/pdf-toolkit-mcp-share/server/pdf-lib-worker.js
@@ -649,7 +649,7 @@ async function countFlateBytesWithinLimit(payload, maximumDecodedBytes) {
         throw resourceError(
           "unsafe_object_stream_expansion",
           `PDF object stream exceeds the ${maximumDecodedBytes}-byte decoded ceiling; `
-          + "mutation was stopped before parsing.",
+          + "the document was rejected before parsing.",
         );
       }
     }
@@ -673,7 +673,7 @@ export async function assertBoundedPdfStreamDecodes(bytes, {
     throw resourceError(
       "unsafe_object_stream_decode",
       `PDF object stream cannot be decoded within a deterministic byte budget (${detail}); `
-      + "mutation was stopped before parsing.",
+      + "the document was rejected before parsing.",
     );
   };
   for (const stream of collectPreparseStreamDecodes(bytes)) {
@@ -695,7 +695,7 @@ export async function assertBoundedPdfStreamDecodes(bytes, {
         throw resourceError(
           "unsafe_object_stream_expansion",
           `PDF object stream exceeds the ${maximumDecodedObjectStreamBytes}-byte decoded ceiling; `
-          + "mutation was stopped before parsing.",
+          + "the document was rejected before parsing.",
         );
       }
       continue;
@@ -734,7 +734,7 @@ function assertBoundedXRefStreamByteWidths(bytes) {
     throw resourceError(
       "unsafe_xref_byte_width",
       `PDF declares an unsafe cross-reference stream byte width (${detail}); `
-      + "mutation was stopped before parsing.",
+      + "the document was rejected before parsing.",
     );
   };
   // The loop bound pdf-lib derives is the numeric magnitude, so magnitude is
@@ -855,7 +855,7 @@ export function assertBoundedPdfStructure(bytes) {
   const reject = (kind, value) => {
     throw resourceError(
       "sparse_pdf_structure",
-      `PDF declares an unsafe sparse ${kind} (${value}); mutation was stopped before parsing.`,
+      `PDF declares an unsafe sparse ${kind} (${value}); the document was rejected before parsing.`,
     );
   };
   const integerValue = token => {

--- a/pdf-toolkit-mcp-share/server/qpdf-decrypt.js
+++ b/pdf-toolkit-mcp-share/server/qpdf-decrypt.js
@@ -25,36 +25,109 @@
  * turns it into one. QPDF will decrypt an owner-locked document — one that
  * opens with an empty user password but whose `/P` denies modification —
  * without any password at all, and will re-lock it afterwards with an
- * identical `/P` and `/R`. Shipping that shape would make PDF Tools a
- * permissions-circumvention tool. So decryption is gated:
+ * identical `/P` and `/R`. Shipping *that* shape would make PDF Tools a
+ * permissions-circumvention tool, so no tool here removes, weakens or reveals
+ * a document's protection, and a document that arrives encrypted leaves
+ * encrypted or does not leave at all.
  *
- *   - a caller who supplies a password that the document accepts is acting on
- *     a credential they already hold, and proceeds *for a read*; but
- *   - a caller who supplies none, and merely benefits from the document's
- *     empty user password, proceeds only if the document's own `/P` grants the
- *     permission the operation needs, and is otherwise refused by name.
+ * The empty string counts as *no password*, so nothing that turns on whether a
+ * credential was supplied can be sidestepped by passing `""` to a document
+ * whose user password is empty.
  *
- * The empty string counts as *no password*, so the check above cannot be
- * sidestepped by passing `""` to a document whose user password is empty.
- *
- * The gates are evaluated here, between the worker's two phases. The worker
- * reports what the document says about itself and then waits; it is told to
- * decrypt only after this module has decided that it may. A refusal is
+ * The permission rule is evaluated here, between the worker's two phases. The
+ * worker reports what the document says about itself and then waits; it is told
+ * to decrypt only after this module has decided that it may. A refusal is
  * therefore a refusal to do the work, not a decision to throw the result away.
  *
- * ## Reads and writes are gated differently, on purpose
+ * ## THE PERMISSION RULE
  *
- * For a read, holding either password makes the caller the intended reader and
- * that is the end of it. For a write it is not. A document whose `/P` says
- * `modify: not allowed` is making an explicit statement about what may be done
- * to it, and the owner password is precisely the credential that exists to
- * authorise overriding that statement. So on the write path a *user* password
- * does not satisfy a permission the document denies: only the owner password
- * does, and authenticating as owner satisfies permissions by definition.
+ * `pdfPermissionRefusal` is the whole of it, and it is the only function in
+ * this tree that reads `encryption.capabilities`. In one sentence:
  *
- * Note that QPDF keeps reporting a document's declared capabilities as denied
- * even when the owner password matched, so the owner check has to be made
- * against `ownerPasswordMatched` rather than read out of the capabilities.
+ *   **`/P` governs writes. It does not govern reads.**
+ *
+ * A *write* may not proceed against a `/P` that denies the change it makes,
+ * unless the caller authenticated as owner. A *read* proceeds on a credential
+ * alone: whoever can open the document may read it, and a document that opens
+ * with an empty user password opens for everybody.
+ *
+ * The write half is unremarkable and is the same rule Acrobat applies. A
+ * document whose `/P` says `modify: not allowed` is making an explicit
+ * statement about what may be done to it, and the owner password is precisely
+ * the credential that exists to authorise overriding that statement, so a
+ * *user* password does not satisfy a permission the document denies. Note that
+ * QPDF keeps reporting a document's declared capabilities as denied even when
+ * the owner password matched, so the owner check is made against
+ * `ownerPasswordMatched` rather than read out of the capabilities.
+ *
+ * The read half is the part that needs the argument, because an earlier
+ * revision of this module did require `extract` (`/P` bit 5) for the three
+ * read-only tools, and that requirement has been removed. Four reasons, in
+ * descending order of how much they decide it.
+ *
+ * **1. A read gate cannot be made uniform without refusing to show the user
+ * their own document.** `/P` is only consulted where QPDF is, and QPDF is only
+ * reached from `loadEncryptedPdfBytes`. Everything else that reads a PDF here
+ * goes through PDF.js, which does not implement `/P` at all — measured, not
+ * assumed: on an owner-locked AES-256 document with `--extract=n`,
+ * `read_pdf_content` returned 33,173 characters while `read_pdf_fields`
+ * refused. Closing that would mean gating `read_pdf_content`,
+ * `read_pdf_pages`, `search_pdf_text`, `read_pdf_layout`,
+ * `convert_pdf_to_markdown`, `get_pdf_info`, `render_pdf_page` and
+ * `render_pdf_region` — and, because each of these hands over strictly more
+ * than any of them, also `read_pdf_bytes`, `get_pdf_resource_uri` and
+ * `display_pdf`. The last three are "give the host the file" and "show it to
+ * the user in the viewer". Refusing those is not a permission model, it is a
+ * refusal to be a PDF reader, and no reader on the market does it: Acrobat,
+ * Preview and Chrome all display owner-locked documents and grey out *Copy*.
+ * We have no Copy menu to grey out. Every tool here *is* the copy operation,
+ * so the reader convention has no analogue on this side except "refuse to
+ * function". A rule that cannot be applied to the whole family is not a rule,
+ * it is an inconsistency with a good conscience.
+ *
+ * **2. The accessibility bit makes the extract bit unenforceable on any
+ * modern document.** `/P` bit 10 authorises extraction for assistive
+ * technology, and ISO 32000-2 deprecated it and requires it set. That is not
+ * theory: QPDF cannot produce a counterexample. `--extract=n --accessibility=n`
+ * yields `accessibility: true, extract: false` at both R4 (AES-128) and R6
+ * (AES-256); only legacy R3 RC4 can deny it. So on every document produced this
+ * decade, an owner who denies `extract` has unavoidably granted extraction for
+ * accessibility in the same breath. Honour that carve-out and an extract gate
+ * is a no-op on AES; ignore it and we are stricter than the format's own
+ * authors, against a caller — a language model reading a document so it can
+ * answer its owner's questions about it — which is far closer to assistive
+ * technology than to copy-paste. There is no reading of bit 5 here that both
+ * bites and is defensible.
+ *
+ * **3. `/P` is a statement to a reader's user interface, not an access
+ * control.** It is defeated by the empty user password the document itself
+ * ships with, and it survives only where a reader volunteers to honour it. Two
+ * of the three PDF libraries this product is built on decline: PDF.js does not
+ * implement it, and QPDF decrypts owner-locked documents with no password at
+ * all — this repository's own test fixtures depend on that. Adopting a rule our
+ * own dependencies refuse to implement would put it in exactly one place, ours,
+ * where it is easiest to route around.
+ *
+ * **4. What was actually protected was a rounding error.** The gate could only
+ * ever apply to a document that is encrypted *and* opens without a password
+ * *and* sets `extract=n`. An unencrypted confidential document has no `/P` and
+ * got nothing. Within that slice, nine sibling tools returned the same content
+ * anyway, measured through the real server. The measured protective value was
+ * zero; the cost was a refusal a user
+ * answers with one `qpdf --decrypt`, having learned that the honest path is the
+ * slow one.
+ *
+ * The write gate keeps none of these problems, which is why it stays. It is
+ * *complete*: there is no sibling tool that writes a PDF without going through
+ * `decryptPdfForWrite`, so nothing routes around it. It is *enforceable*: we
+ * are the party producing the bytes, and refusing to produce them ends the
+ * matter. And it is *meaningful*: it is the difference between reading a
+ * document and altering someone else's, which is the line `/P` was actually
+ * written to draw.
+ *
+ * None of this loosens the credential rules. A document with a real user
+ * password still cannot be read without one, a wrong password is still a wrong
+ * password, and `""` is still not a credential.
  *
  * ## Protection in, protection out
  *
@@ -74,26 +147,15 @@
  *
  * ## Which permission bit
  *
- * The read tools require `extract` — `/P` bit 5, "copy or otherwise extract
- * text and graphics". Every one of them copies document content out of the
- * document: `read_pdf_fields` returns field names and their current values,
- * `validate_pdf` reports field names and whether each is filled, and
- * `extract_to_csv` writes field values to a CSV file on disk. That is
- * extraction under any reading of the bit.
+ * Only the write side has a mapping, because only the write side consults
+ * `/P`. Each mutation requires the bit that matches what it actually does to
+ * the file; see `ENCRYPTED_WRITE_OPERATIONS` for the mapping and why each one
+ * is what it is.
  *
- * Two nearby bits are deliberately *not* accepted as substitutes:
- *
- *   - `accessibility` (bit 10) is almost always granted and would make the
- *     check vacuous. It authorizes extraction for assistive technology, and
- *     nothing here can establish that the caller is assistive technology.
- *   - `modifyforms` (bit 9) authorizes filling a form, not reading what is
- *     already in it. A document may permit filling while denying extraction,
- *     and honouring `modifyforms` here would hand back the values that
- *     `extract` was set to withhold.
- *
- * The mutation tools each require the bit that matches what they actually do
- * to the file; see `ENCRYPTED_WRITE_OPERATIONS` for the mapping and why each
- * one is what it is.
+ * `ENCRYPTED_READ_OPERATIONS` carries no bit. It is still a security boundary,
+ * and adding an entry to it is still a security decision — it names the
+ * operations allowed to reach QPDF at all — but what it grants is decryption
+ * subject to a credential, not decryption subject to `/P`.
  *
  * ## Memory
  *
@@ -209,21 +271,23 @@ export const PDF_ENCRYPTED_MAX_FILE_BYTES = 16 * 1024 * 1024;
 export const PDF_DECRYPTION_TIMEOUT_MS = 30_000;
 
 /**
- * The operations allowed to decrypt, and the `/P` capability each one needs
- * when the caller supplied no password. Adding an entry here is a security
- * decision: it grants a tool the ability to read encrypted documents.
+ * The operations allowed to decrypt for a read. Adding an entry here is a
+ * security decision: it grants a tool the ability to read encrypted documents.
+ *
+ * There is deliberately no `capability` column. A read is authorised by a
+ * credential, never by `/P` — see THE PERMISSION RULE in the module header for
+ * why, and `pdfPermissionRefusal` for the code that says so. `activity` is the
+ * human description of what the grant buys, and exists so this table can be
+ * reviewed for what it actually permits rather than for what its keys suggest.
  */
 export const ENCRYPTED_READ_OPERATIONS = Object.freeze({
   read_pdf_fields: Object.freeze({
-    capability: "extract",
     activity: "read its form fields and their values",
   }),
   validate_pdf: Object.freeze({
-    capability: "extract",
     activity: "report which of its form fields are filled",
   }),
   extract_to_csv: Object.freeze({
-    capability: "extract",
     activity: "extract its form data to a CSV file",
   }),
 });
@@ -308,9 +372,14 @@ export const ENCRYPTED_WRITE_OPERATIONS = Object.freeze({
   }),
 });
 
-/** Human-readable names for the `/P` capabilities this module can require. */
+/**
+ * Human-readable names for the `/P` capabilities this module can require.
+ *
+ * `extract` is deliberately absent: it is not required by any operation, and
+ * listing a label for it would leave a ready-made slot for a read gate to be
+ * reintroduced without anyone re-reading THE PERMISSION RULE.
+ */
 const CAPABILITY_LABELS = Object.freeze({
-  extract: "content copying and extraction",
   modify: "modifying the document's contents",
   modifyforms: "filling in form fields",
   modifyassembly: "assembling the document's pages",
@@ -344,20 +413,6 @@ export const PDF_DECRYPTION_TIMEOUT_MESSAGE =
   + "stopped. How long decryption takes depends on how many objects a document contains rather "
   + "than on how large it is, so a small file can still exceed the limit. Decrypt the file first "
   + "(for example with qpdf) and retry with the decrypted copy.";
-
-/**
- * Refusal text for the owner-locked case. Names the denied permission, says
- * plainly that no password was supplied, and points at the one legitimate way
- * forward, without ever suggesting a way around the restriction.
- */
-export function pdfPermissionDeniedMessage(operation) {
-  const { activity, capability } = ENCRYPTED_READ_OPERATIONS[operation];
-  const label = CAPABILITY_LABELS[capability];
-  return `This PDF is encrypted and its permissions deny ${label} (/P '${capability}'), so `
-    + `PDF Tools will not ${activity}. It opens without a password, but that does not grant the `
-    + "denied permission, and PDF Tools does not override a document's own restrictions. "
-    + "If you hold the owner password, supply it in the 'password' parameter and retry.";
-}
 
 export const PDF_REPROTECT_FAILED_MESSAGE =
   "This PDF is encrypted and its protection could not be restored to the modified copy, so "
@@ -423,13 +478,19 @@ export const PDF_REPROTECTING_PASSWORD_DESCRIPTION =
 /**
  * Parameter text for the three read-only tools that can decrypt. They too
  * once advertised a password they could not use.
+ *
+ * It no longer carries the "only if its own permissions allow content
+ * extraction" caveat, because that is no longer true and was never true of the
+ * sibling read tools it sat beside. See THE PERMISSION RULE in the module
+ * header.
  */
 export const PDF_DECRYPTABLE_PASSWORD_DESCRIPTION =
   "Password for an encrypted PDF. Supply the user or owner password and the document is "
   + `decrypted in memory to complete this read (encrypted inputs are limited to `
   + `${PDF_ENCRYPTED_MAX_FILE_BYTES / (1024 * 1024)} MiB). Leave it unset for an unencrypted `
-  + "document. An encrypted document that opens without a password is still read only if its "
-  + "own permissions allow content extraction; PDF Tools does not override them.";
+  + "document, or for an encrypted one that opens without a password. A document that needs a "
+  + "password cannot be read without it, and this tool never removes or weakens a document's "
+  + "protection.";
 
 /**
  * The deadline one request runs under.
@@ -831,12 +892,11 @@ export async function decryptPdfForRead(pdfBytes, password, operation, options =
  * Decrypts an encrypted PDF so one of the mutation operations can change it.
  *
  * Identical to `decryptPdfForRead` in every respect but the permission rule.
- * For a read, holding either password makes the caller the intended reader and
- * that is enough. For a write it is not: if the document's `/P` denies the
- * permission the change needs, only the *owner* password authorises it.
- * Authenticating as owner satisfies permissions by definition, which is why
- * QPDF still reporting `modify: false` under an owner password is not consulted
- * once `ownerPasswordMatched` is true.
+ * A read proceeds for whoever can open the document. A write does not: if the
+ * document's `/P` denies the permission the change needs, only the *owner*
+ * password authorises it. Authenticating as owner satisfies permissions by
+ * definition, which is why QPDF still reporting `modify: false` under an owner
+ * password is not consulted once `ownerPasswordMatched` is true.
  *
  * The returned `encryption` is what the re-protection is later checked against.
  */
@@ -856,14 +916,58 @@ async function decryptPdfForWriteExclusively(pdfBytes, password, operation, { ti
   return runDecryptionWorker(
     pdfBytes,
     suppliedPassword,
-    encryption => writePermissionRefusal(encryption, suppliedPassword, operation, rules),
+    encryption => pdfPermissionRefusal({
+      intent: "write",
+      encryption,
+      suppliedPassword,
+      operation,
+    }),
     resolveDecryptionDeadlineMs(timeoutMs),
   );
 }
 
 /**
- * The write permission rule, separated so it can be read — and tested —
- * without a worker.
+ * THE PERMISSION RULE, in one function. Both intents are here so the asymmetry
+ * between them cannot drift apart, and so a reader looking for "where is this
+ * decided" finds one answer.
+ *
+ * `/P` governs writes. It does not govern reads. The module header carries the
+ * argument for the read half at length; the short version is that a read gate
+ * could only ever be applied to the one read path that happens to route through
+ * QPDF, while eight PDF.js-backed siblings and three that hand over the whole
+ * file returned the same content regardless, and that `/P` bit 10 makes bit 5
+ * unenforceable on anything encrypted with AES.
+ *
+ * This is also the only function in `server/` that reads
+ * `encryption.capabilities`, which `test/pdf-read-permission-consistency.test.js`
+ * asserts structurally. If a second reader of that field appears, the rule has
+ * grown a second home and this comment has become a lie.
+ *
+ * Returns the refusal, or `null` if the operation may proceed.
+ */
+export function pdfPermissionRefusal({ intent, encryption, suppliedPassword, operation }) {
+  if (intent === "read") {
+    // Deliberately empty. Whoever can open the document may read it; the
+    // credential check that decides "can open" has already happened inside
+    // QPDF, and a document that opens with an empty user password opens for
+    // everybody. `/P` is not consulted, and there is no branch here that could
+    // start consulting it without this comment having to be deleted first.
+    return null;
+  }
+  if (intent !== "write") {
+    throw new TypeError(`Permission intent must be 'read' or 'write', not '${intent}'.`);
+  }
+  const rules = ENCRYPTED_WRITE_OPERATIONS[operation];
+  if (!rules) {
+    throw new TypeError(`Operation '${operation}' is not permitted to rewrite encrypted PDFs.`);
+  }
+  return writePermissionRefusal(encryption, suppliedPassword, operation, rules);
+}
+
+/**
+ * The write half of `pdfPermissionRefusal`, separated so it can be read — and
+ * tested — without a worker. Call `pdfPermissionRefusal` from product code;
+ * this is not a second rule, it is the body of that one's write branch.
  *
  * Returns the refusal, or `null` if the mutation may proceed.
  */
@@ -1044,17 +1148,12 @@ async function decryptPdfForReadExclusively(pdfBytes, password, operation, { tim
   return runDecryptionWorker(
     pdfBytes,
     suppliedPassword,
-    // A reader holding either password is the intended reader, so any
-    // credential satisfies the permission check. The write path deliberately
-    // does not accept that; see `writePermissionRefusal`.
-    encryption => {
-      const credentialed = suppliedPassword !== null
-        && (encryption.ownerPasswordMatched || encryption.userPasswordMatched);
-      if (!credentialed && encryption.capabilities?.[rules.capability] !== true) {
-        return new PdfDecryptionError("permission_denied", pdfPermissionDeniedMessage(operation));
-      }
-      return null;
-    },
+    encryption => pdfPermissionRefusal({
+      intent: "read",
+      encryption,
+      suppliedPassword,
+      operation,
+    }),
     resolveDecryptionDeadlineMs(timeoutMs),
   );
 }

--- a/scripts/test-suite-classification.mjs
+++ b/scripts/test-suite-classification.mjs
@@ -217,6 +217,17 @@ export const REVIEWED_COMPUTED_MODULE_LOADS = Object.freeze([
     reason: "Loads a verified generated controller outside the checkout.",
   }),
   Object.freeze({
+    file: "test/pdf-read-permission-consistency.test.js",
+    count: 1,
+    kinds: Object.freeze(["dynamic-import"]),
+    fingerprints: Object.freeze([
+      "948c7080973dbfd1901b9e7904f3a2abcc2c968427f868cd50096046ad532df5",
+    ]),
+    reason: "Loads the committed QPDF runtime to build the matched pair of owner-locked AES-256 "
+      + "documents that differ only in /P bit 5, which is the only way to observe whether a tool "
+      + "consults the bit, and which cannot be committed as binaries.",
+  }),
+  Object.freeze({
     file: "test/qpdf-decrypt-isolation.test.js",
     count: 1,
     kinds: Object.freeze(["dynamic-import"]),

--- a/server/index.js
+++ b/server/index.js
@@ -89,6 +89,14 @@ import {
   runPdfLibMutation,
   terminateAllPdfLibMutations,
 } from "./pdf-lib-subprocess.js";
+// The pre-parse bounds the mutation path already applies, reused on the one
+// read path that hands pdf-lib bytes it did not read off disk. This module is
+// already on the server's import graph through pdf-lib-subprocess.js, so the
+// import costs nothing new; see `loadEncryptedPdfBytes`.
+import {
+  assertBoundedPdfStreamDecodes,
+  assertBoundedPdfStructure,
+} from "./pdf-lib-worker.js";
 
 export const READ_CONTENT_ROUTING_GUIDANCE =
   "Pages without extractable text or with suspect text integrity were successfully read in this call. Use render_pdf_page for visual inspection of those pages; the page routing fields are limited to successfully-read pages, and pages outside this read scope or stopped at a page-read error are not classified by this result.";
@@ -639,17 +647,41 @@ async function loadPdfBytes(pdfBytes, password = null, { decryptFor = null } = {
  * The encrypted branch of `loadPdfBytes`. Decrypts in memory, parses the
  * plaintext, and releases the plaintext immediately if parsing fails so a
  * malformed decrypted document does not leave it sitting in the heap.
+ *
+ * The plaintext gets the same pre-parse bounds the mutation path applies to a
+ * document it is about to hand pdf-lib: `assertBoundedPdfStructure` for hostile
+ * cross-reference byte widths and sparse object numbering, and
+ * `assertBoundedPdfStreamDecodes` for object streams that expand past a
+ * deterministic ceiling. Those are the two shapes that make `PDFDocument.load`
+ * allocate without bound, and this is the one place in the server process where
+ * pdf-lib parses bytes that did not come straight off disk.
+ *
+ * It is belt and braces rather than a live hole. `qpdf --decrypt` fully
+ * re-serializes the document, which launders hostile cross-reference structure
+ * on the way through — a `/W [1 2000000000 1]` does not survive the round trip.
+ * But that is a property of QPDF's writer, not a contract it offers us, and it
+ * is the sort of property that evaporates quietly. Measured at 7.2 MB the two
+ * checks cost 22 ms against the 314 ms of pdf-lib parsing that follows
+ * unconditionally, so paying for the guarantee outright is cheaper than
+ * depending on somebody else's serializer to keep providing it.
  */
 async function loadEncryptedPdfBytes(pdfBytes, password, decryptFor, invalidPdfMessage) {
   const decrypted = await decryptPdfForRead(pdfBytes, password, decryptFor);
   let pdfDoc;
   try {
+    assertBoundedPdfStructure(decrypted.plaintext);
+    await assertBoundedPdfStreamDecodes(decrypted.plaintext);
     pdfDoc = await PDFDocument.load(decrypted.plaintext);
     // Validated against the plaintext, because that is the byte sequence this
     // document was actually parsed from.
     validateLoadedPdfStructure(pdfDoc, decrypted.plaintext);
   } catch (error) {
     decrypted.release();
+    // A bound that was exceeded is a specific, actionable fact and says which
+    // one. Collapsing it into "the file is malformed" would throw that away and
+    // describe a document this code deliberately refused as one it could not
+    // understand.
+    if (error?.code === PDF_RESOURCE_LIMIT_CODE) throw error;
     if (error?.message === invalidPdfMessage) throw error;
     throw new Error(invalidPdfMessage, { cause: error });
   }

--- a/server/pdf-lib-worker.js
+++ b/server/pdf-lib-worker.js
@@ -649,7 +649,7 @@ async function countFlateBytesWithinLimit(payload, maximumDecodedBytes) {
         throw resourceError(
           "unsafe_object_stream_expansion",
           `PDF object stream exceeds the ${maximumDecodedBytes}-byte decoded ceiling; `
-          + "mutation was stopped before parsing.",
+          + "the document was rejected before parsing.",
         );
       }
     }
@@ -673,7 +673,7 @@ export async function assertBoundedPdfStreamDecodes(bytes, {
     throw resourceError(
       "unsafe_object_stream_decode",
       `PDF object stream cannot be decoded within a deterministic byte budget (${detail}); `
-      + "mutation was stopped before parsing.",
+      + "the document was rejected before parsing.",
     );
   };
   for (const stream of collectPreparseStreamDecodes(bytes)) {
@@ -695,7 +695,7 @@ export async function assertBoundedPdfStreamDecodes(bytes, {
         throw resourceError(
           "unsafe_object_stream_expansion",
           `PDF object stream exceeds the ${maximumDecodedObjectStreamBytes}-byte decoded ceiling; `
-          + "mutation was stopped before parsing.",
+          + "the document was rejected before parsing.",
         );
       }
       continue;
@@ -734,7 +734,7 @@ function assertBoundedXRefStreamByteWidths(bytes) {
     throw resourceError(
       "unsafe_xref_byte_width",
       `PDF declares an unsafe cross-reference stream byte width (${detail}); `
-      + "mutation was stopped before parsing.",
+      + "the document was rejected before parsing.",
     );
   };
   // The loop bound pdf-lib derives is the numeric magnitude, so magnitude is
@@ -855,7 +855,7 @@ export function assertBoundedPdfStructure(bytes) {
   const reject = (kind, value) => {
     throw resourceError(
       "sparse_pdf_structure",
-      `PDF declares an unsafe sparse ${kind} (${value}); mutation was stopped before parsing.`,
+      `PDF declares an unsafe sparse ${kind} (${value}); the document was rejected before parsing.`,
     );
   };
   const integerValue = token => {

--- a/server/qpdf-decrypt.js
+++ b/server/qpdf-decrypt.js
@@ -25,36 +25,109 @@
  * turns it into one. QPDF will decrypt an owner-locked document — one that
  * opens with an empty user password but whose `/P` denies modification —
  * without any password at all, and will re-lock it afterwards with an
- * identical `/P` and `/R`. Shipping that shape would make PDF Tools a
- * permissions-circumvention tool. So decryption is gated:
+ * identical `/P` and `/R`. Shipping *that* shape would make PDF Tools a
+ * permissions-circumvention tool, so no tool here removes, weakens or reveals
+ * a document's protection, and a document that arrives encrypted leaves
+ * encrypted or does not leave at all.
  *
- *   - a caller who supplies a password that the document accepts is acting on
- *     a credential they already hold, and proceeds *for a read*; but
- *   - a caller who supplies none, and merely benefits from the document's
- *     empty user password, proceeds only if the document's own `/P` grants the
- *     permission the operation needs, and is otherwise refused by name.
+ * The empty string counts as *no password*, so nothing that turns on whether a
+ * credential was supplied can be sidestepped by passing `""` to a document
+ * whose user password is empty.
  *
- * The empty string counts as *no password*, so the check above cannot be
- * sidestepped by passing `""` to a document whose user password is empty.
- *
- * The gates are evaluated here, between the worker's two phases. The worker
- * reports what the document says about itself and then waits; it is told to
- * decrypt only after this module has decided that it may. A refusal is
+ * The permission rule is evaluated here, between the worker's two phases. The
+ * worker reports what the document says about itself and then waits; it is told
+ * to decrypt only after this module has decided that it may. A refusal is
  * therefore a refusal to do the work, not a decision to throw the result away.
  *
- * ## Reads and writes are gated differently, on purpose
+ * ## THE PERMISSION RULE
  *
- * For a read, holding either password makes the caller the intended reader and
- * that is the end of it. For a write it is not. A document whose `/P` says
- * `modify: not allowed` is making an explicit statement about what may be done
- * to it, and the owner password is precisely the credential that exists to
- * authorise overriding that statement. So on the write path a *user* password
- * does not satisfy a permission the document denies: only the owner password
- * does, and authenticating as owner satisfies permissions by definition.
+ * `pdfPermissionRefusal` is the whole of it, and it is the only function in
+ * this tree that reads `encryption.capabilities`. In one sentence:
  *
- * Note that QPDF keeps reporting a document's declared capabilities as denied
- * even when the owner password matched, so the owner check has to be made
- * against `ownerPasswordMatched` rather than read out of the capabilities.
+ *   **`/P` governs writes. It does not govern reads.**
+ *
+ * A *write* may not proceed against a `/P` that denies the change it makes,
+ * unless the caller authenticated as owner. A *read* proceeds on a credential
+ * alone: whoever can open the document may read it, and a document that opens
+ * with an empty user password opens for everybody.
+ *
+ * The write half is unremarkable and is the same rule Acrobat applies. A
+ * document whose `/P` says `modify: not allowed` is making an explicit
+ * statement about what may be done to it, and the owner password is precisely
+ * the credential that exists to authorise overriding that statement, so a
+ * *user* password does not satisfy a permission the document denies. Note that
+ * QPDF keeps reporting a document's declared capabilities as denied even when
+ * the owner password matched, so the owner check is made against
+ * `ownerPasswordMatched` rather than read out of the capabilities.
+ *
+ * The read half is the part that needs the argument, because an earlier
+ * revision of this module did require `extract` (`/P` bit 5) for the three
+ * read-only tools, and that requirement has been removed. Four reasons, in
+ * descending order of how much they decide it.
+ *
+ * **1. A read gate cannot be made uniform without refusing to show the user
+ * their own document.** `/P` is only consulted where QPDF is, and QPDF is only
+ * reached from `loadEncryptedPdfBytes`. Everything else that reads a PDF here
+ * goes through PDF.js, which does not implement `/P` at all — measured, not
+ * assumed: on an owner-locked AES-256 document with `--extract=n`,
+ * `read_pdf_content` returned 33,173 characters while `read_pdf_fields`
+ * refused. Closing that would mean gating `read_pdf_content`,
+ * `read_pdf_pages`, `search_pdf_text`, `read_pdf_layout`,
+ * `convert_pdf_to_markdown`, `get_pdf_info`, `render_pdf_page` and
+ * `render_pdf_region` — and, because each of these hands over strictly more
+ * than any of them, also `read_pdf_bytes`, `get_pdf_resource_uri` and
+ * `display_pdf`. The last three are "give the host the file" and "show it to
+ * the user in the viewer". Refusing those is not a permission model, it is a
+ * refusal to be a PDF reader, and no reader on the market does it: Acrobat,
+ * Preview and Chrome all display owner-locked documents and grey out *Copy*.
+ * We have no Copy menu to grey out. Every tool here *is* the copy operation,
+ * so the reader convention has no analogue on this side except "refuse to
+ * function". A rule that cannot be applied to the whole family is not a rule,
+ * it is an inconsistency with a good conscience.
+ *
+ * **2. The accessibility bit makes the extract bit unenforceable on any
+ * modern document.** `/P` bit 10 authorises extraction for assistive
+ * technology, and ISO 32000-2 deprecated it and requires it set. That is not
+ * theory: QPDF cannot produce a counterexample. `--extract=n --accessibility=n`
+ * yields `accessibility: true, extract: false` at both R4 (AES-128) and R6
+ * (AES-256); only legacy R3 RC4 can deny it. So on every document produced this
+ * decade, an owner who denies `extract` has unavoidably granted extraction for
+ * accessibility in the same breath. Honour that carve-out and an extract gate
+ * is a no-op on AES; ignore it and we are stricter than the format's own
+ * authors, against a caller — a language model reading a document so it can
+ * answer its owner's questions about it — which is far closer to assistive
+ * technology than to copy-paste. There is no reading of bit 5 here that both
+ * bites and is defensible.
+ *
+ * **3. `/P` is a statement to a reader's user interface, not an access
+ * control.** It is defeated by the empty user password the document itself
+ * ships with, and it survives only where a reader volunteers to honour it. Two
+ * of the three PDF libraries this product is built on decline: PDF.js does not
+ * implement it, and QPDF decrypts owner-locked documents with no password at
+ * all — this repository's own test fixtures depend on that. Adopting a rule our
+ * own dependencies refuse to implement would put it in exactly one place, ours,
+ * where it is easiest to route around.
+ *
+ * **4. What was actually protected was a rounding error.** The gate could only
+ * ever apply to a document that is encrypted *and* opens without a password
+ * *and* sets `extract=n`. An unencrypted confidential document has no `/P` and
+ * got nothing. Within that slice, nine sibling tools returned the same content
+ * anyway, measured through the real server. The measured protective value was
+ * zero; the cost was a refusal a user
+ * answers with one `qpdf --decrypt`, having learned that the honest path is the
+ * slow one.
+ *
+ * The write gate keeps none of these problems, which is why it stays. It is
+ * *complete*: there is no sibling tool that writes a PDF without going through
+ * `decryptPdfForWrite`, so nothing routes around it. It is *enforceable*: we
+ * are the party producing the bytes, and refusing to produce them ends the
+ * matter. And it is *meaningful*: it is the difference between reading a
+ * document and altering someone else's, which is the line `/P` was actually
+ * written to draw.
+ *
+ * None of this loosens the credential rules. A document with a real user
+ * password still cannot be read without one, a wrong password is still a wrong
+ * password, and `""` is still not a credential.
  *
  * ## Protection in, protection out
  *
@@ -74,26 +147,15 @@
  *
  * ## Which permission bit
  *
- * The read tools require `extract` — `/P` bit 5, "copy or otherwise extract
- * text and graphics". Every one of them copies document content out of the
- * document: `read_pdf_fields` returns field names and their current values,
- * `validate_pdf` reports field names and whether each is filled, and
- * `extract_to_csv` writes field values to a CSV file on disk. That is
- * extraction under any reading of the bit.
+ * Only the write side has a mapping, because only the write side consults
+ * `/P`. Each mutation requires the bit that matches what it actually does to
+ * the file; see `ENCRYPTED_WRITE_OPERATIONS` for the mapping and why each one
+ * is what it is.
  *
- * Two nearby bits are deliberately *not* accepted as substitutes:
- *
- *   - `accessibility` (bit 10) is almost always granted and would make the
- *     check vacuous. It authorizes extraction for assistive technology, and
- *     nothing here can establish that the caller is assistive technology.
- *   - `modifyforms` (bit 9) authorizes filling a form, not reading what is
- *     already in it. A document may permit filling while denying extraction,
- *     and honouring `modifyforms` here would hand back the values that
- *     `extract` was set to withhold.
- *
- * The mutation tools each require the bit that matches what they actually do
- * to the file; see `ENCRYPTED_WRITE_OPERATIONS` for the mapping and why each
- * one is what it is.
+ * `ENCRYPTED_READ_OPERATIONS` carries no bit. It is still a security boundary,
+ * and adding an entry to it is still a security decision — it names the
+ * operations allowed to reach QPDF at all — but what it grants is decryption
+ * subject to a credential, not decryption subject to `/P`.
  *
  * ## Memory
  *
@@ -209,21 +271,23 @@ export const PDF_ENCRYPTED_MAX_FILE_BYTES = 16 * 1024 * 1024;
 export const PDF_DECRYPTION_TIMEOUT_MS = 30_000;
 
 /**
- * The operations allowed to decrypt, and the `/P` capability each one needs
- * when the caller supplied no password. Adding an entry here is a security
- * decision: it grants a tool the ability to read encrypted documents.
+ * The operations allowed to decrypt for a read. Adding an entry here is a
+ * security decision: it grants a tool the ability to read encrypted documents.
+ *
+ * There is deliberately no `capability` column. A read is authorised by a
+ * credential, never by `/P` — see THE PERMISSION RULE in the module header for
+ * why, and `pdfPermissionRefusal` for the code that says so. `activity` is the
+ * human description of what the grant buys, and exists so this table can be
+ * reviewed for what it actually permits rather than for what its keys suggest.
  */
 export const ENCRYPTED_READ_OPERATIONS = Object.freeze({
   read_pdf_fields: Object.freeze({
-    capability: "extract",
     activity: "read its form fields and their values",
   }),
   validate_pdf: Object.freeze({
-    capability: "extract",
     activity: "report which of its form fields are filled",
   }),
   extract_to_csv: Object.freeze({
-    capability: "extract",
     activity: "extract its form data to a CSV file",
   }),
 });
@@ -308,9 +372,14 @@ export const ENCRYPTED_WRITE_OPERATIONS = Object.freeze({
   }),
 });
 
-/** Human-readable names for the `/P` capabilities this module can require. */
+/**
+ * Human-readable names for the `/P` capabilities this module can require.
+ *
+ * `extract` is deliberately absent: it is not required by any operation, and
+ * listing a label for it would leave a ready-made slot for a read gate to be
+ * reintroduced without anyone re-reading THE PERMISSION RULE.
+ */
 const CAPABILITY_LABELS = Object.freeze({
-  extract: "content copying and extraction",
   modify: "modifying the document's contents",
   modifyforms: "filling in form fields",
   modifyassembly: "assembling the document's pages",
@@ -344,20 +413,6 @@ export const PDF_DECRYPTION_TIMEOUT_MESSAGE =
   + "stopped. How long decryption takes depends on how many objects a document contains rather "
   + "than on how large it is, so a small file can still exceed the limit. Decrypt the file first "
   + "(for example with qpdf) and retry with the decrypted copy.";
-
-/**
- * Refusal text for the owner-locked case. Names the denied permission, says
- * plainly that no password was supplied, and points at the one legitimate way
- * forward, without ever suggesting a way around the restriction.
- */
-export function pdfPermissionDeniedMessage(operation) {
-  const { activity, capability } = ENCRYPTED_READ_OPERATIONS[operation];
-  const label = CAPABILITY_LABELS[capability];
-  return `This PDF is encrypted and its permissions deny ${label} (/P '${capability}'), so `
-    + `PDF Tools will not ${activity}. It opens without a password, but that does not grant the `
-    + "denied permission, and PDF Tools does not override a document's own restrictions. "
-    + "If you hold the owner password, supply it in the 'password' parameter and retry.";
-}
 
 export const PDF_REPROTECT_FAILED_MESSAGE =
   "This PDF is encrypted and its protection could not be restored to the modified copy, so "
@@ -423,13 +478,19 @@ export const PDF_REPROTECTING_PASSWORD_DESCRIPTION =
 /**
  * Parameter text for the three read-only tools that can decrypt. They too
  * once advertised a password they could not use.
+ *
+ * It no longer carries the "only if its own permissions allow content
+ * extraction" caveat, because that is no longer true and was never true of the
+ * sibling read tools it sat beside. See THE PERMISSION RULE in the module
+ * header.
  */
 export const PDF_DECRYPTABLE_PASSWORD_DESCRIPTION =
   "Password for an encrypted PDF. Supply the user or owner password and the document is "
   + `decrypted in memory to complete this read (encrypted inputs are limited to `
   + `${PDF_ENCRYPTED_MAX_FILE_BYTES / (1024 * 1024)} MiB). Leave it unset for an unencrypted `
-  + "document. An encrypted document that opens without a password is still read only if its "
-  + "own permissions allow content extraction; PDF Tools does not override them.";
+  + "document, or for an encrypted one that opens without a password. A document that needs a "
+  + "password cannot be read without it, and this tool never removes or weakens a document's "
+  + "protection.";
 
 /**
  * The deadline one request runs under.
@@ -831,12 +892,11 @@ export async function decryptPdfForRead(pdfBytes, password, operation, options =
  * Decrypts an encrypted PDF so one of the mutation operations can change it.
  *
  * Identical to `decryptPdfForRead` in every respect but the permission rule.
- * For a read, holding either password makes the caller the intended reader and
- * that is enough. For a write it is not: if the document's `/P` denies the
- * permission the change needs, only the *owner* password authorises it.
- * Authenticating as owner satisfies permissions by definition, which is why
- * QPDF still reporting `modify: false` under an owner password is not consulted
- * once `ownerPasswordMatched` is true.
+ * A read proceeds for whoever can open the document. A write does not: if the
+ * document's `/P` denies the permission the change needs, only the *owner*
+ * password authorises it. Authenticating as owner satisfies permissions by
+ * definition, which is why QPDF still reporting `modify: false` under an owner
+ * password is not consulted once `ownerPasswordMatched` is true.
  *
  * The returned `encryption` is what the re-protection is later checked against.
  */
@@ -856,14 +916,58 @@ async function decryptPdfForWriteExclusively(pdfBytes, password, operation, { ti
   return runDecryptionWorker(
     pdfBytes,
     suppliedPassword,
-    encryption => writePermissionRefusal(encryption, suppliedPassword, operation, rules),
+    encryption => pdfPermissionRefusal({
+      intent: "write",
+      encryption,
+      suppliedPassword,
+      operation,
+    }),
     resolveDecryptionDeadlineMs(timeoutMs),
   );
 }
 
 /**
- * The write permission rule, separated so it can be read — and tested —
- * without a worker.
+ * THE PERMISSION RULE, in one function. Both intents are here so the asymmetry
+ * between them cannot drift apart, and so a reader looking for "where is this
+ * decided" finds one answer.
+ *
+ * `/P` governs writes. It does not govern reads. The module header carries the
+ * argument for the read half at length; the short version is that a read gate
+ * could only ever be applied to the one read path that happens to route through
+ * QPDF, while eight PDF.js-backed siblings and three that hand over the whole
+ * file returned the same content regardless, and that `/P` bit 10 makes bit 5
+ * unenforceable on anything encrypted with AES.
+ *
+ * This is also the only function in `server/` that reads
+ * `encryption.capabilities`, which `test/pdf-read-permission-consistency.test.js`
+ * asserts structurally. If a second reader of that field appears, the rule has
+ * grown a second home and this comment has become a lie.
+ *
+ * Returns the refusal, or `null` if the operation may proceed.
+ */
+export function pdfPermissionRefusal({ intent, encryption, suppliedPassword, operation }) {
+  if (intent === "read") {
+    // Deliberately empty. Whoever can open the document may read it; the
+    // credential check that decides "can open" has already happened inside
+    // QPDF, and a document that opens with an empty user password opens for
+    // everybody. `/P` is not consulted, and there is no branch here that could
+    // start consulting it without this comment having to be deleted first.
+    return null;
+  }
+  if (intent !== "write") {
+    throw new TypeError(`Permission intent must be 'read' or 'write', not '${intent}'.`);
+  }
+  const rules = ENCRYPTED_WRITE_OPERATIONS[operation];
+  if (!rules) {
+    throw new TypeError(`Operation '${operation}' is not permitted to rewrite encrypted PDFs.`);
+  }
+  return writePermissionRefusal(encryption, suppliedPassword, operation, rules);
+}
+
+/**
+ * The write half of `pdfPermissionRefusal`, separated so it can be read — and
+ * tested — without a worker. Call `pdfPermissionRefusal` from product code;
+ * this is not a second rule, it is the body of that one's write branch.
  *
  * Returns the refusal, or `null` if the mutation may proceed.
  */
@@ -1044,17 +1148,12 @@ async function decryptPdfForReadExclusively(pdfBytes, password, operation, { tim
   return runDecryptionWorker(
     pdfBytes,
     suppliedPassword,
-    // A reader holding either password is the intended reader, so any
-    // credential satisfies the permission check. The write path deliberately
-    // does not accept that; see `writePermissionRefusal`.
-    encryption => {
-      const credentialed = suppliedPassword !== null
-        && (encryption.ownerPasswordMatched || encryption.userPasswordMatched);
-      if (!credentialed && encryption.capabilities?.[rules.capability] !== true) {
-        return new PdfDecryptionError("permission_denied", pdfPermissionDeniedMessage(operation));
-      }
-      return null;
-    },
+    encryption => pdfPermissionRefusal({
+      intent: "read",
+      encryption,
+      suppliedPassword,
+      operation,
+    }),
     resolveDecryptionDeadlineMs(timeoutMs),
   );
 }

--- a/test/encrypted-pdf-password-truth.test.js
+++ b/test/encrypted-pdf-password-truth.test.js
@@ -308,8 +308,18 @@ describe.skipIf(!QPDF.available)("encrypted PDF password truthfulness (qpdf pres
         // the same drift guard, pointing the other way.
         expect(description, `${tool.name} password description`).not.toMatch(/cannot decrypt/i);
         expect(description, `${tool.name} password description`).not.toMatch(/never used/i);
-        // and must still state the limits that do apply.
-        expect(description, `${tool.name} password description`).toMatch(/permissions allow/i);
+        // This used to require the text "permissions allow", back when these
+        // three refused an owner-locked document whose `/P` denied extraction.
+        // They no longer do — `/P` governs writes only — so advertising that
+        // caveat would now be the drift, and the assertion is inverted to catch
+        // it coming back.
+        expect(description, `${tool.name} password description`)
+          .not.toMatch(/permissions allow|permissions deny/i);
+        // What has to stay true is the size bound and the promise that this is
+        // not a way to take a document's protection off.
+        expect(description, `${tool.name} password description`).toMatch(/16 MiB/);
+        expect(description, `${tool.name} password description`)
+          .toMatch(/never removes or weakens/i);
         continue;
       }
       expect(description, `${tool.name} password description`).toMatch(/pdf-lib/);

--- a/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
+++ b/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
@@ -91,8 +91,8 @@
     {
       "role": "package_json",
       "path": "package.json",
-      "bytes": 2827,
-      "sha256": "e7bab0462ca87a92c7833868bbe1de66150ce97094773fdb2a18bc13ccaba84f"
+      "bytes": 2900,
+      "sha256": "80d14adbf6a042025f1a6103fa2ee8fcdaf4e0f1b3fdc17bfbd195abdfadfd5a"
     },
     {
       "role": "package_lock",
@@ -125,7 +125,7 @@
       "sha256": "6e4429db62fcbe1dd73141d8c20a48b564d41f8bf8920d88775846995e1daf94"
     }
   ],
-  "validator_source_set_sha256": "cd53addac2f2f37d9a4b584e398b7670fc48b35a4549abad968d61d9113f6147",
+  "validator_source_set_sha256": "47ed405f9df0b4efc6f3d05d4e5074c543737f1cac6389689400ab49de8b5050",
   "pdfjs_version": "5.4.624",
   "generation_contract": {
     "source_path": "source.pdf",

--- a/test/fixtures/eval/trajectories/tool-contracts.v3.json
+++ b/test/fixtures/eval/trajectories/tool-contracts.v3.json
@@ -5,7 +5,7 @@
     "name": "pdf-tools",
     "version": "0.10.0"
   },
-  "tools_sha256": "a1284bea0d56408fb9c3071a03bda1b605825389143b6e1120782de85e48c205",
+  "tools_sha256": "64fd39889ada86e48043c411f8f64e19a1658387155f46769da5b502d3c6d1fd",
   "tools": [
     {
       "name": "add_signature_field",
@@ -1283,7 +1283,7 @@
           },
           "password": {
             "type": "string",
-            "description": "Password for an encrypted PDF. Supply the user or owner password and the document is decrypted in memory to complete this read (encrypted inputs are limited to 16 MiB). Leave it unset for an unencrypted document. An encrypted document that opens without a password is still read only if its own permissions allow content extraction; PDF Tools does not override them."
+            "description": "Password for an encrypted PDF. Supply the user or owner password and the document is decrypted in memory to complete this read (encrypted inputs are limited to 16 MiB). Leave it unset for an unencrypted document, or for an encrypted one that opens without a password. A document that needs a password cannot be read without it, and this tool never removes or weakens a document's protection."
           }
         },
         "required": [
@@ -1758,7 +1758,7 @@
           },
           "password": {
             "type": "string",
-            "description": "Password for an encrypted PDF. Supply the user or owner password and the document is decrypted in memory to complete this read (encrypted inputs are limited to 16 MiB). Leave it unset for an unencrypted document. An encrypted document that opens without a password is still read only if its own permissions allow content extraction; PDF Tools does not override them."
+            "description": "Password for an encrypted PDF. Supply the user or owner password and the document is decrypted in memory to complete this read (encrypted inputs are limited to 16 MiB). Leave it unset for an unencrypted document, or for an encrypted one that opens without a password. A document that needs a password cannot be read without it, and this tool never removes or weakens a document's protection."
           }
         },
         "required": [

--- a/test/mcp-contract.test.js
+++ b/test/mcp-contract.test.js
@@ -114,7 +114,18 @@ const EXAMPLE_PDF = path.join(REPO_ROOT, "example-fw9.pdf");
 // when the document's own permissions deny the change being made. No tool
 // gains or loses a parameter. Previously
 // b237e957d3eb3333442bc79f071dc8e9e74f6abee3880c835aa09b62487ce68d.
-const TOOL_CONTRACT_SHA256 = "565e4e6c9debad5b16b148acb5cac2814d93c1c3085b50fa7b62754acc8ec01a";
+//
+// 2026-08-10: read_pdf_fields and validate_pdf drop the "still read only if its
+// own permissions allow extraction" caveat from their password arguments,
+// because it is no longer true. `/P` governs writes and no longer governs
+// reads: the read gate bound the three qpdf-backed reads while every PDF.js-
+// backed sibling returned the same content regardless, and it could not be
+// extended to the rest of the family without refusing to display the user's own
+// document. The replacement text states the size limit and promises that the
+// tool never removes or weakens a document's protection. No tool gains or loses
+// a parameter, and no write description changes. Previously
+// 565e4e6c9debad5b16b148acb5cac2814d93c1c3085b50fa7b62754acc8ec01a.
+const TOOL_CONTRACT_SHA256 = "f4d6e1eca85676a0830821871e2775d7ccbde1ba5d5a8ee396068b862b28610b";
 
 const CLOSED_READ = Object.freeze({
   readOnlyHint: true,

--- a/test/pdf-read-permission-consistency.test.js
+++ b/test/pdf-read-permission-consistency.test.js
@@ -1,0 +1,423 @@
+/**
+ * One rule, applied to the whole read family.
+ *
+ * `/P` governs writes. It does not govern reads. That sentence lives in
+ * `server/qpdf-decrypt.js`, and this suite is what stops it drifting back into
+ * being true of one tool and false of nineteen others — which is exactly the
+ * state it was in before, and the reason the read gate was removed:
+ * `read_pdf_fields` refused an owner-locked, extract-denied AES-256 document by
+ * name while `read_pdf_content` returned 33,173 characters of the same file,
+ * because PDF.js does not implement `/P` and never consulted it.
+ *
+ * Two kinds of assertion, because either alone is escapable.
+ *
+ *   - *Structural*: `encryption.capabilities` is read in exactly one function
+ *     in `server/`. A rule enforced in one place is a rule; a rule enforced in
+ *     two places is two rules that agree today.
+ *   - *Behavioural*: every registered tool that reads a document is called
+ *     against a matched pair of documents identical in everything but `/P` bit
+ *     5, and must treat them the same. The family is derived from the live tool
+ *     list rather than listed here, so a tool that joins it later is tested
+ *     whether or not anybody remembered this file.
+ *
+ * A tool is in the read family if its schema names a PDF to operate on and it
+ * is not in `ENCRYPTED_WRITE_OPERATIONS`, which is the product's own register
+ * of everything that writes a PDF back. Both halves of that come from the
+ * product, not from this suite.
+ *
+ * Fixtures are encrypted here rather than committed, with the runtime the
+ * product itself uses.
+ */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  ENCRYPTED_READ_OPERATIONS,
+  ENCRYPTED_WRITE_OPERATIONS,
+  PdfDecryptionError,
+  decryptPdfForRead,
+  decryptPdfForWrite,
+  pdfPermissionRefusal,
+} from "../server/qpdf-decrypt.js";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const PLAIN_PDF = path.join(REPO_ROOT, "example-fw9.pdf");
+const RUNTIME_ENTRY = path.join(REPO_ROOT, "vendor", "qpdf-wasm", "runtime", "qpdf.mjs");
+const OWNER_PASSWORD = "owner-secret";
+
+/**
+ * The matched pair the whole suite turns on: same source document, same
+ * AES-256, same empty user password, same denial of every modification. One
+ * grants `/P` bit 5 and the other denies it, and nothing else differs. Any
+ * tool that behaves differently across this pair is consulting the bit.
+ */
+const FIXTURE_RECIPES = Object.freeze({
+  extractDenied: ["--encrypt", "--user-password=", `--owner-password=${OWNER_PASSWORD}`,
+    "--bits=256", "--extract=n", "--modify=none", "--"],
+  extractAllowed: ["--encrypt", "--user-password=", `--owner-password=${OWNER_PASSWORD}`,
+    "--bits=256", "--extract=y", "--modify=none", "--"],
+});
+
+async function encryptFixture(sourceBytes, encryptArgs) {
+  const createQpdf = (await import(RUNTIME_ENTRY)).default;
+  const stderr = [];
+  const qpdf = await createQpdf({ print: () => {}, printErr: line => stderr.push(String(line)) });
+  qpdf.FS.writeFile("/in.pdf", new Uint8Array(sourceBytes));
+  let status;
+  try {
+    status = qpdf.callMain([...encryptArgs, "/in.pdf", "/out.pdf"]);
+  } catch (error) {
+    status = Number.isInteger(error?.status) ? error.status : -1;
+  }
+  if (status !== 0) throw new Error(`fixture encryption failed (${status}): ${stderr.join(" ")}`);
+  return Buffer.from(qpdf.FS.readFile("/out.pdf"));
+}
+
+let temporaryRoot;
+let client;
+let transport;
+const fixturePaths = {};
+
+beforeAll(async () => {
+  temporaryRoot = await fs.mkdtemp(path.join(os.tmpdir(), "pdf-tools-permission-consistency-"));
+  const plainBytes = await fs.readFile(PLAIN_PDF);
+  fixturePaths.plain = path.join(temporaryRoot, "plain.pdf");
+  await fs.writeFile(fixturePaths.plain, plainBytes);
+  for (const [name, args] of Object.entries(FIXTURE_RECIPES)) {
+    const target = path.join(temporaryRoot, `${name}.pdf`);
+    await fs.writeFile(target, await encryptFixture(plainBytes, args));
+    fixturePaths[name] = target;
+  }
+  transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [path.join(REPO_ROOT, "server/index.js")],
+    cwd: REPO_ROOT,
+    env: { ALLOWED_DIRECTORIES: [REPO_ROOT, temporaryRoot].join(path.delimiter) },
+    stderr: "ignore",
+  });
+  client = new Client({ name: "pdf-tools-permission-consistency", version: "1.0.0" });
+  await client.connect(transport);
+}, 180_000);
+
+afterAll(async () => {
+  await client?.close();
+  await transport?.close();
+  if (temporaryRoot) await fs.rm(temporaryRoot, { recursive: true, force: true });
+});
+
+/*
+ * How to call each member of the read family with one document. Arguments only
+ * — no expectations live here, because what is asserted is that the *same* call
+ * behaves the same way on two documents, not that any particular call succeeds.
+ *
+ * If a tool joins the read family and is not in this table, the suite fails and
+ * says so. That is deliberate: the alternative is a new tool silently escaping
+ * the rule, which is the failure this whole file exists to prevent.
+ */
+const READ_CALL_RECIPES = Object.freeze({
+  compare_pdfs: (doc, extras) => ({
+    before_pdf_path: doc,
+    after_pdf_path: fixturePaths.plain,
+    include_visual: false,
+    ...(extras.password ? { before_password: extras.password } : {}),
+  }),
+  convert_pdf_to_markdown: (doc, extras) => ({ pdf_path: doc, start_page: 1, end_page: 1, ...extras }),
+  detect_signature_zones: (doc, extras) => ({ pdf_path: doc, ...extras }),
+  display_pdf: doc => ({ pdf_path: doc }),
+  extract_to_csv: (doc, extras) => ({
+    pdf_paths: [doc],
+    output_csv: path.join(temporaryRoot, `${path.basename(doc, ".pdf")}${extras.tag}.csv`),
+  }),
+  get_page_analysis: (doc, extras) => ({ pdf_path: doc, ...extras }),
+  get_pdf_identity: doc => ({ pdf_path: doc }),
+  get_pdf_info: (doc, extras) => ({ pdf_path: doc, ...extras }),
+  get_pdf_resource_uri: doc => ({ pdf_path: doc }),
+  inspect_pdf_accessibility: doc => ({ pdf_path: doc }),
+  read_pdf_bytes: doc => ({ pdf_path: doc, offset: 0, byteCount: 4096 }),
+  read_pdf_content: doc => ({ pdf_path: doc }),
+  read_pdf_fields: (doc, extras) => ({ pdf_path: doc, ...extras }),
+  read_pdf_layout: (doc, extras) => ({ pdf_path: doc, start_page: 1, end_page: 1, ...extras }),
+  read_pdf_pages: doc => ({ pdf_path: doc, start_page: 1, end_page: 1 }),
+  render_pdf_page: (doc, extras) => ({ pdf_path: doc, page: 1, ...extras }),
+  render_pdf_region: (doc, extras) => ({
+    pdf_path: doc, page: 1, x: 0, y: 0, width: 200, height: 200, ...extras,
+  }),
+  search_pdf_text: doc => ({ pdf_path: doc, query: "Name" }),
+  set_active_document: doc => ({ pdf_path: doc }),
+  validate_pdf: (doc, extras) => ({ pdf_path: doc, ...extras }),
+});
+
+const DOCUMENT_PARAMETERS = Object.freeze([
+  "pdf_path", "pdf_paths", "before_pdf_path", "after_pdf_path", "input_path", "input_paths",
+]);
+
+async function readFamily() {
+  const { tools } = await client.listTools();
+  const writes = new Set(Object.keys(ENCRYPTED_WRITE_OPERATIONS));
+  return tools
+    .filter(tool => Object.keys(tool.inputSchema?.properties ?? {})
+      .some(property => DOCUMENT_PARAMETERS.includes(property)))
+    .filter(tool => !writes.has(tool.name))
+    .map(tool => tool.name)
+    .sort();
+}
+
+const responseText = result => (result.content ?? [])
+  .map(entry => entry.text ?? (entry.type === "image" ? `[image:${entry.data?.length ?? 0}]` : ""))
+  .join(" ");
+
+/**
+ * Everything about an outcome that the permission question cares about, and
+ * nothing that would differ between two files merely because they are two
+ * files. Names, sizes and digests are erased; whether the call worked, and what
+ * it refused for if it did not, survives.
+ */
+async function observe(name, document, extras = { tag: "" }) {
+  const build = READ_CALL_RECIPES[name];
+  let result;
+  try {
+    result = await client.callTool({ name, arguments: build(document, extras) });
+  } catch (error) {
+    return { outcome: "transport-error", detail: String(error?.message ?? error).slice(0, 80) };
+  }
+  const text = responseText(result);
+  const normalized = text
+    .replaceAll(path.basename(document), "<fixture>")
+    // Also without the extension, because tools that derive an output name from
+    // the input carry the stem rather than the file name.
+    .replaceAll(path.basename(document, ".pdf"), "<fixture>")
+    .replaceAll(temporaryRoot, "<root>")
+    .replace(/\b[0-9a-f]{64}\b/g, "<sha256>")
+    .replace(/\b\d[\d.,]*\s?(?:KB|MB|bytes)\b/g, "<size>")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (result.isError !== true) return { outcome: "allowed", normalized };
+  if (/\/P '|permissions deny/.test(text)) {
+    return { outcome: "refused-on-/P", normalized };
+  }
+  return { outcome: "refused", normalized };
+}
+
+describe("the permission rule has exactly one home", () => {
+  it("reads /P capabilities in exactly one function in the whole server", async () => {
+    const serverFiles = (await fs.readdir(path.join(REPO_ROOT, "server")))
+      .filter(name => name.endsWith(".js"));
+    const readers = [];
+    for (const file of serverFiles) {
+      const source = await fs.readFile(path.join(REPO_ROOT, "server", file), "utf8");
+      // Comments state the rule and must be allowed to; code that acts on the
+      // bits is what may not be duplicated.
+      const code = source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+      for (const match of code.matchAll(/encryption\??\.capabilities|\bcapabilities\?\.\[/g)) {
+        readers.push({ file, index: match.index });
+      }
+    }
+    // The one legitimate reader is the write branch. The worker validates the
+    // shape it forwards and does not decide anything with it; it is a separate
+    // file and is named here so the exemption is visible rather than pattern-
+    // matched away.
+    const decisionReaders = readers.filter(reader => reader.file !== "qpdf-decrypt-worker.js");
+    expect(decisionReaders.map(reader => reader.file)).toEqual(
+      decisionReaders.map(() => "qpdf-decrypt.js"),
+    );
+    const decryptSource = await fs.readFile(
+      path.join(REPO_ROOT, "server", "qpdf-decrypt.js"), "utf8",
+    );
+    const writeBranch = decryptSource.slice(
+      decryptSource.indexOf("export function writePermissionRefusal"),
+    );
+    // Every capability read sits inside `writePermissionRefusal`, and the read
+    // path therefore cannot be consulting them.
+    const readsInsideWriteBranch = [...writeBranch.matchAll(/encryption\??\.capabilities/g)];
+    expect(readsInsideWriteBranch.length).toBe(decisionReaders.length);
+  });
+
+  it("routes both decryption intents through the same decision function", async () => {
+    const source = await fs.readFile(path.join(REPO_ROOT, "server", "qpdf-decrypt.js"), "utf8");
+    // Each `runDecryptionWorker` call passes exactly one permission callback,
+    // and both of them are this function. A third intent, or a bespoke callback
+    // beside them, is a second rule.
+    expect([...source.matchAll(/pdfPermissionRefusal\(\{\s*\n\s*intent: "(read|write)"/g)]
+      .map(match => match[1]).sort()).toEqual(["read", "write"]);
+    expect(source.match(/runDecryptionWorker\(/g)).toHaveLength(3); // definition + two calls
+    // The read path's old refusal reason is gone entirely. `write_permission_denied`
+    // is a different string and is meant to still be here.
+    expect(source).not.toMatch(/"permission_denied"/);
+    expect(source).toMatch(/"write_permission_denied"/);
+  });
+
+  it("keeps the read registry free of any /P capability to require", () => {
+    expect(Object.keys(ENCRYPTED_READ_OPERATIONS).length).toBeGreaterThan(0);
+    for (const [operation, rules] of Object.entries(ENCRYPTED_READ_OPERATIONS)) {
+      expect(Object.keys(rules), operation).toEqual(["activity"]);
+    }
+    // And the function says so directly: a document that denies everything is
+    // still readable, and the same document is still not writable.
+    const deniesEverything = {
+      encrypted: true,
+      ownerPasswordMatched: false,
+      userPasswordMatched: true,
+      capabilities: { extract: false, accessibility: false, modify: false, modifyforms: false },
+    };
+    for (const operation of Object.keys(ENCRYPTED_READ_OPERATIONS)) {
+      expect(pdfPermissionRefusal({
+        intent: "read", encryption: deniesEverything, suppliedPassword: null, operation,
+      }), operation).toBeNull();
+    }
+    expect(pdfPermissionRefusal({
+      intent: "write", encryption: deniesEverything, suppliedPassword: null, operation: "fill_pdf",
+    })).toBeInstanceOf(PdfDecryptionError);
+    expect(() => pdfPermissionRefusal({
+      intent: "inspect", encryption: deniesEverything, suppliedPassword: null, operation: "fill_pdf",
+    })).toThrow(TypeError);
+  });
+});
+
+describe("every tool that reads a document treats /P the same way", () => {
+  it("has a call recipe for every member of the read family", async () => {
+    const family = await readFamily();
+    expect(family.length).toBeGreaterThan(10);
+    const missing = family.filter(name => !(name in READ_CALL_RECIPES));
+    // If this fails, a tool that reads PDFs has joined the product without
+    // joining this suite. Add it to READ_CALL_RECIPES; do not delete it from
+    // the family.
+    expect(missing).toEqual([]);
+    // The reverse too, so the table cannot rot into describing tools that no
+    // longer exist and quietly stop covering the ones that do.
+    expect(Object.keys(READ_CALL_RECIPES).sort().filter(name => !family.includes(name)))
+      .toEqual([]);
+  }, 60_000);
+
+  it("cannot tell an extract-denied document from an extract-allowed one", async () => {
+    const family = await readFamily();
+    const divergent = [];
+    const allowed = [];
+    for (const name of family) {
+      // Same tag on both sides on purpose: a tool that names an output file
+      // after its inputs must produce a comparable name, or the comparison
+      // measures the test's own bookkeeping rather than the product.
+      const denied = await observe(name, fixturePaths.extractDenied, { tag: "-pair" });
+      const permitted = await observe(name, fixturePaths.extractAllowed, { tag: "-pair" });
+      if (denied.outcome === "allowed") allowed.push(name);
+      if (denied.outcome !== permitted.outcome || denied.normalized !== permitted.normalized) {
+        divergent.push({ name, denied, permitted });
+      }
+    }
+    // The two documents are the same document with one bit flipped, so any
+    // observable difference is the bit being consulted.
+    expect(divergent.map(entry => entry.name)).toEqual([]);
+    // Not vacuous: most of the family really does read these documents, so
+    // "identical" is not "identically refused".
+    expect(allowed.length).toBeGreaterThanOrEqual(Math.ceil(family.length * 0.6));
+  }, 600_000);
+
+  it("refuses no read on /P, whatever else it may refuse on", async () => {
+    // Two ways to be a `/P` refusal, because a gate can be reintroduced with
+    // any wording at all: the message names the bit, or the same call succeeds
+    // on the document that grants it. The second catches a silent one.
+    const family = await readFamily();
+    const onP = [];
+    for (const name of family) {
+      const denied = await observe(name, fixturePaths.extractDenied, { tag: "-p" });
+      if (denied.outcome === "refused-on-/P") {
+        onP.push(`${name} (named the bit)`);
+        continue;
+      }
+      if (denied.outcome === "allowed") continue;
+      const permitted = await observe(name, fixturePaths.extractAllowed, { tag: "-p" });
+      if (permitted.outcome === "allowed") onP.push(`${name} (refused only the denying document)`);
+    }
+    expect(onP).toEqual([]);
+  }, 600_000);
+
+  it("closes the specific gap that prompted this: fields and content now agree", async () => {
+    // The reported defect, pinned as its own case so a regression is legible
+    // rather than one row in a table. read_pdf_fields refused; read_pdf_content
+    // returned the whole document.
+    const fields = await observe("read_pdf_fields", fixturePaths.extractDenied, { tag: "-gap" });
+    const content = await observe("read_pdf_content", fixturePaths.extractDenied, { tag: "-gap" });
+    expect([fields.outcome, content.outcome]).toEqual(["allowed", "allowed"]);
+    // And the read is real, not an empty success: the fields come back matching
+    // the same document read with no encryption at all.
+    const plainFields = await client.callTool({
+      name: "read_pdf_fields", arguments: { pdf_path: fixturePaths.plain },
+    });
+    const deniedFields = await client.callTool({
+      name: "read_pdf_fields", arguments: { pdf_path: fixturePaths.extractDenied },
+    });
+    expect(deniedFields.structuredContent.fieldCount)
+      .toBe(plainFields.structuredContent.fieldCount);
+    expect(deniedFields.structuredContent.fieldCount).toBeGreaterThan(0);
+  }, 120_000);
+
+  it("never leaves a caller worse off for supplying the owner password", async () => {
+    const family = await readFamily();
+    const downgraded = [];
+    for (const name of family) {
+      const without = await observe(name, fixturePaths.extractDenied, { tag: "-nopw" });
+      const withOwner = await observe(
+        name, fixturePaths.extractDenied, { tag: "-ownerpw", password: OWNER_PASSWORD },
+      );
+      if (without.outcome === "allowed" && withOwner.outcome !== "allowed") {
+        downgraded.push({ name, without, withOwner });
+      }
+    }
+    expect(downgraded.map(entry => entry.name)).toEqual([]);
+  }, 600_000);
+});
+
+describe("the write gate is the one that survived, and it still bites", () => {
+  it("refuses the same document a read just returned, and the owner password changes that", async () => {
+    // The pair that proves the rule is asymmetric rather than absent. Same
+    // file, same call site in the product, opposite answers.
+    const read = await observe("read_pdf_fields", fixturePaths.extractDenied, { tag: "-w" });
+    expect(read.outcome).toBe("allowed");
+
+    const refused = await client.callTool({
+      name: "fill_pdf",
+      arguments: {
+        pdf_path: fixturePaths.extractDenied,
+        output_path: path.join(temporaryRoot, "refused.pdf"),
+        field_data: { "topmostSubform[0].Page1[0].f1_1[0]": "attempted" },
+      },
+    });
+    expect(refused.isError).toBe(true);
+    expect(responseText(refused)).toMatch(/permissions deny/);
+    expect(responseText(refused)).toMatch(/modifyforms/);
+    await expect(fs.access(path.join(temporaryRoot, "refused.pdf")))
+      .rejects.toMatchObject({ code: "ENOENT" });
+
+    const written = path.join(temporaryRoot, "owner-authorised.pdf");
+    const allowed = await client.callTool({
+      name: "fill_pdf",
+      arguments: {
+        pdf_path: fixturePaths.extractDenied,
+        output_path: written,
+        field_data: { "topmostSubform[0].Page1[0].f1_1[0]": "authorised" },
+        password: OWNER_PASSWORD,
+      },
+    });
+    expect(allowed.isError).not.toBe(true);
+    // And the protection came back with it: the owner password authorises the
+    // change, not the removal of the lock.
+    const bytes = await fs.readFile(written);
+    expect(bytes.toString("latin1")).toContain("/Encrypt");
+  }, 180_000);
+
+  it("keeps that asymmetry at the module boundary too, not only through the server", async () => {
+    const bytes = await fs.readFile(fixturePaths.extractDenied);
+    const read = await decryptPdfForRead(bytes, null, "read_pdf_fields");
+    try {
+      expect(read.encryption.capabilities.extract).toBe(false);
+      expect(read.plaintext.subarray(0, 5).toString("latin1")).toBe("%PDF-");
+    } finally {
+      read.release();
+    }
+    await expect(decryptPdfForWrite(bytes, null, "fill_pdf"))
+      .rejects.toMatchObject({ reason: "write_permission_denied" });
+  }, 120_000);
+});

--- a/test/qpdf-decrypt-read-only.test.js
+++ b/test/qpdf-decrypt-read-only.test.js
@@ -29,9 +29,9 @@ import {
   PDF_ENCRYPTED_MAX_FILE_BYTES,
   PdfDecryptionError,
   decryptPdfForRead,
+  decryptPdfForWrite,
   isQpdfRuntimeLoaded,
   normalizeSuppliedPassword,
-  pdfPermissionDeniedMessage,
 } from "../server/qpdf-decrypt.js";
 import { PDF_LIB_ENCRYPTED_MESSAGE } from "../server/helpers.js";
 
@@ -140,18 +140,56 @@ describe("encrypted-read scope rule", () => {
     ).rejects.toMatchObject({ reason: "password_rejected" });
   }, 30_000);
 
-  it("refuses the owner-locked document by name when /P denies extraction", async () => {
-    const rejection = await decryptPdfForRead(
-      await readFixture("ownerLockedNoExtract"),
-      null,
-      "read_pdf_fields",
-    ).catch(error => error);
-    expect(rejection).toBeInstanceOf(PdfDecryptionError);
-    expect(rejection.reason).toBe("permission_denied");
-    expect(rejection.message).toContain("extract");
-    // Must not coach the caller around the restriction.
-    expect(rejection.message).not.toMatch(/qpdf|decrypt the file|remove/i);
+  /*
+   * This assertion used to read "refuses the owner-locked document by name when
+   * /P denies extraction", and it was true of this one code path and of nothing
+   * else in the product. The gate it pinned refused `read_pdf_fields` while
+   * `read_pdf_content` returned the same document's full text, because PDF.js
+   * does not implement `/P` and never consulted it. A gate nine sibling tools
+   * walk around protects nothing and teaches the caller that the refusal is
+   * noise. The rule is now that `/P` governs writes only, so the property worth
+   * pinning here is the reverse one: the document is read, and it is read
+   * *because a credential was not required*, not because anything was
+   * overridden.
+   *
+   * See `test/pdf-read-permission-consistency.test.js` for the assertion that
+   * every read tool agrees, which is the part that could not be true before.
+   */
+  it("reads the owner-locked document, because /P does not govern reads", async () => {
+    const denied = await readFixture("ownerLockedNoExtract");
+    const result = await decryptPdfForRead(denied, null, "read_pdf_fields");
+    try {
+      // Derived, not restated: the document really does deny extraction, and
+      // really was read anyway with no password at all.
+      expect(result.encryption.capabilities.extract).toBe(false);
+      expect(result.encryption.userPasswordMatched).toBe(true);
+      expect(result.encryption.ownerPasswordMatched).toBe(false);
+      expect(result.plaintext.subarray(0, 5).toString("latin1")).toBe("%PDF-");
+      expect(result.plaintext.toString("latin1")).not.toContain("/Encrypt");
+    } finally {
+      result.release();
+    }
   }, 30_000);
+
+  it("still refuses to write to that same document without the owner password", async () => {
+    // The half of the old gate that survived, asserted here so the read change
+    // above cannot be mistaken for "permissions stopped mattering". `/P` denies
+    // `modifyforms`, and no credential short of the owner password satisfies it.
+    const denied = await readFixture("ownerLockedNoExtract");
+    const refusal = await decryptPdfForWrite(denied, null, "fill_pdf").catch(error => error);
+    expect(refusal).toBeInstanceOf(PdfDecryptionError);
+    expect(refusal.reason).toBe("write_permission_denied");
+    expect(refusal.message).toContain("modifyforms");
+    // Must not coach the caller around the restriction.
+    expect(refusal.message).not.toMatch(/qpdf|decrypt the file|remove/i);
+
+    const allowed = await decryptPdfForWrite(denied, OWNER_PASSWORD, "fill_pdf");
+    try {
+      expect(allowed.encryption.ownerPasswordMatched).toBe(true);
+    } finally {
+      allowed.release();
+    }
+  }, 60_000);
 
   it("treats the empty string as no password, but keeps whitespace passwords real", async () => {
     expect(normalizeSuppliedPassword("")).toBeNull();
@@ -161,15 +199,29 @@ describe("encrypted-read scope rule", () => {
     // without special handling because it is not the empty password.
     expect(normalizeSuppliedPassword("   ")).toBe("   ");
 
-    // The loophole this closes: an empty string is exactly the credential the
-    // owner-locked document accepts, so treating it as "supplied" would let
-    // any caller claim credentialed access and skip the /P check.
-    await expect(decryptPdfForRead(await readFixture("ownerLockedNoExtract"), "", "extract_to_csv"))
-      .rejects.toMatchObject({ reason: "permission_denied" });
-    // A whitespace password is a wrong password here, not an absent one, so it
-    // is refused as such rather than quietly falling back to the /P check.
+    // The distinction still has to hold on the read path even though nothing on
+    // it turns on `/P` any more, because it is what keeps "" from being
+    // reported as an accepted credential: `""` is absent, so the owner-locked
+    // document opens; `"   "` is a wrong password, so it does not, and the
+    // caller is told the truth about which happened rather than getting a
+    // silent success.
+    const empty = await decryptPdfForRead(
+      await readFixture("ownerLockedNoExtract"), "", "extract_to_csv",
+    );
+    try {
+      expect(empty.encryption.userPasswordMatched).toBe(true);
+      expect(empty.encryption.ownerPasswordMatched).toBe(false);
+    } finally {
+      empty.release();
+    }
     await expect(decryptPdfForRead(await readFixture("ownerLockedNoExtract"), "   ", "extract_to_csv"))
       .rejects.toMatchObject({ reason: "password_rejected" });
+
+    // And it is load-bearing on the write path, where `/P` does still decide:
+    // counting `""` as a supplied credential there would let any caller claim
+    // owner standing against a document whose user password is empty.
+    await expect(decryptPdfForWrite(await readFixture("ownerLockedNoExtract"), "", "fill_pdf"))
+      .rejects.toMatchObject({ reason: "write_permission_denied" });
   }, 60_000);
 
   it("refuses a password it cannot represent instead of silently truncating it", async () => {
@@ -181,22 +233,34 @@ describe("encrypted-read scope rule", () => {
     }
   }, 30_000);
 
-  it("reads the owner-locked document when its own /P grants extraction", async () => {
-    const result = await decryptPdfForRead(
-      await readFixture("ownerLockedExtractAllowed"),
-      null,
-      "extract_to_csv",
-    );
-    try {
-      expect(result.encryption.capabilities.extract).toBe(true);
-      expect(result.encryption.capabilities.modify).toBe(false);
-      expect(result.plaintext.subarray(0, 5).toString("latin1")).toBe("%PDF-");
-    } finally {
-      result.release();
+  it("reads an owner-locked document the same way whichever way its /P bit 5 points", async () => {
+    // The pair that makes the rule falsifiable: same encryption, same empty
+    // user password, same everything except `extract`. Identical plaintext out
+    // of both proves `/P` was not consulted, rather than consulted and
+    // satisfied.
+    const outcomes = [];
+    for (const name of ["ownerLockedNoExtract", "ownerLockedExtractAllowed"]) {
+      const result = await decryptPdfForRead(await readFixture(name), null, "extract_to_csv");
+      try {
+        outcomes.push({
+          name,
+          extract: result.encryption.capabilities.extract,
+          modify: result.encryption.capabilities.modify,
+          header: result.plaintext.subarray(0, 5).toString("latin1"),
+          decrypted: !result.plaintext.toString("latin1").includes("/Encrypt"),
+        });
+      } finally {
+        result.release();
+      }
     }
-  }, 30_000);
+    expect(outcomes.map(outcome => outcome.extract)).toEqual([false, true]);
+    expect(outcomes.every(outcome => outcome.modify === false)).toBe(true);
+    expect(outcomes.every(outcome => outcome.header === "%PDF-" && outcome.decrypted)).toBe(true);
+  }, 60_000);
 
-  it("lets the owner password override the owner's own restrictions", async () => {
+  it("never leaves the owner password worse off than supplying nothing", async () => {
+    // `/P` no longer gates a read, so the owner password cannot *unlock* one.
+    // What it must never do is turn a read that worked into one that does not.
     const result = await decryptPdfForRead(
       await readFixture("ownerLockedNoExtract"),
       OWNER_PASSWORD,
@@ -205,18 +269,25 @@ describe("encrypted-read scope rule", () => {
     try {
       expect(result.encryption.ownerPasswordMatched).toBe(true);
       expect(result.encryption.capabilities.extract).toBe(false);
+      expect(result.plaintext.subarray(0, 5).toString("latin1")).toBe("%PDF-");
     } finally {
       result.release();
     }
   }, 30_000);
 
-  it("grants decryption to exactly the three read-only operations", () => {
+  it("grants decryption to exactly the three read-only operations, and no /P bit to any", () => {
     expect(Object.keys(ENCRYPTED_READ_OPERATIONS).sort())
       .toEqual(["extract_to_csv", "read_pdf_fields", "validate_pdf"]);
-    // `extract` and not `accessibility`: the accessibility bit is granted by
-    // almost every producer and would make the permission check vacuous.
+    // The registry used to carry `capability: "extract"` per entry. It carries
+    // no capability now, and the absence is asserted rather than merely
+    // implied: re-adding one would be re-adding a read gate, and that is a
+    // decision that has to be made against the module header's argument rather
+    // than by filling in a field that looked empty.
     for (const rules of Object.values(ENCRYPTED_READ_OPERATIONS)) {
-      expect(rules.capability).toBe("extract");
+      expect(rules).not.toHaveProperty("capability");
+      expect(rules).not.toHaveProperty("capabilities");
+      expect(typeof rules.activity).toBe("string");
+      expect(rules.activity.length).toBeGreaterThan(0);
     }
   });
 
@@ -360,6 +431,59 @@ describe("cost of an unencrypted document", () => {
   });
 });
 
+describe("pre-parse bounds on the decrypted plaintext", () => {
+  /*
+   * The read path is the only place in the server process where pdf-lib parses
+   * bytes that did not come off disk, so the plaintext gets the same two
+   * pre-parse bounds the mutation path applies. This is defence in depth rather
+   * than a live hole: `qpdf --decrypt` re-serializes the document and launders
+   * hostile cross-reference structure, so no encrypted input reaching these
+   * checks is known to trip them. That makes a purely behavioural test
+   * impossible to write honestly, so the property is split in two — the guards
+   * really do reject, and the read path really does call them — and both halves
+   * are asserted rather than one of them assumed.
+   */
+  it("applies guards that genuinely reject, rather than functions that always pass", async () => {
+    const { assertBoundedPdfStructure, assertBoundedPdfStreamDecodes } =
+      await import("../server/pdf-lib-worker.js");
+    const sparse = Buffer.from(
+      "%PDF-1.7\nxref\n0 1\n0000000000 65535 f\n9999999 1\n0000000009 00000 n\n"
+      + "trailer\n<< /Size 2 >>\nstartxref\n0\n%%EOF\n",
+      "ascii",
+    );
+    expect(() => assertBoundedPdfStructure(sparse)).toThrow(
+      expect.objectContaining({ reason: "sparse_pdf_structure" }),
+    );
+    // And they pass a real document, so "rejects" is discrimination rather than
+    // refusal: this is the very plaintext the read path hands pdf-lib.
+    const decrypted = await decryptPdfForRead(await readFixture("aes256"), USER_PASSWORD, "read_pdf_fields");
+    try {
+      expect(() => assertBoundedPdfStructure(decrypted.plaintext)).not.toThrow();
+      await expect(assertBoundedPdfStreamDecodes(decrypted.plaintext)).resolves.toBeUndefined();
+    } finally {
+      decrypted.release();
+    }
+  }, 60_000);
+
+  it("runs both of them on the plaintext before pdf-lib ever sees it", async () => {
+    const source = await fs.readFile(path.join(REPO_ROOT, "server", "index.js"), "utf8");
+    const body = source.slice(
+      source.indexOf("async function loadEncryptedPdfBytes("),
+      source.indexOf("async function loadPdf("),
+    );
+    expect(body).toContain("assertBoundedPdfStructure(decrypted.plaintext)");
+    expect(body).toContain("await assertBoundedPdfStreamDecodes(decrypted.plaintext)");
+    // Order matters: a bound checked after parsing bounds nothing.
+    expect(body.indexOf("assertBoundedPdfStructure(decrypted.plaintext)"))
+      .toBeLessThan(body.indexOf("PDFDocument.load(decrypted.plaintext)"));
+    expect(body.indexOf("assertBoundedPdfStreamDecodes(decrypted.plaintext)"))
+      .toBeLessThan(body.indexOf("PDFDocument.load(decrypted.plaintext)"));
+    // And the specific refusal survives the catch-all rather than being
+    // rewritten as "the file is malformed".
+    expect(body).toContain("if (error?.code === PDF_RESOURCE_LIMIT_CODE) throw error;");
+  });
+});
+
 describe("read-only decryption through the MCP server", () => {
   let client;
   let transport;
@@ -443,34 +567,47 @@ describe("read-only decryption through the MCP server", () => {
     expect(textOf(wrong)).not.toMatch(/qpdf|in\.pdf|invalid password/i);
   }, 60_000);
 
-  it("refuses the owner-locked document and names the denied permission", async () => {
+  /*
+   * Rewritten, not deleted. This asserted `read_pdf_fields` refusing the
+   * owner-locked document by name — true of that tool and false of the eight
+   * read tools beside it, which is the inconsistency the rule change resolves.
+   * What it asserts now is that the refusal is gone *and* that the read agrees
+   * with the same document read unencrypted, which is the stronger claim: a
+   * gate removed but a decryption that returns rubbish would have satisfied the
+   * old assertion's replacement and not this one.
+   */
+  it("reads the owner-locked document, and reads it correctly", async () => {
+    const plain = await client.callTool({
+      name: "read_pdf_fields",
+      arguments: { pdf_path: fixturePaths.plain },
+    });
     const denied = await client.callTool({
       name: "read_pdf_fields",
       arguments: { pdf_path: fixturePaths.ownerLockedNoExtract },
     });
-    expect(textOf(denied)).toBe(
-      `Error: ${pdfPermissionDeniedMessage("read_pdf_fields")}`,
-    );
-  }, 30_000);
+    expect(denied.isError).not.toBe(true);
+    expect(textOf(denied)).not.toMatch(/permissions deny|\/P '/);
+    expect(denied.structuredContent.fieldCount).toBe(plain.structuredContent.fieldCount);
+    expect(JSON.stringify(denied.structuredContent.fields))
+      .toBe(JSON.stringify(plain.structuredContent.fields));
+  }, 60_000);
 
-  it("extracts to CSV from an owner-locked document only when /P allows it", async () => {
-    const allowedCsv = path.join(temporaryRoot, "allowed.csv");
-    const allowed = await client.callTool({
-      name: "extract_to_csv",
-      arguments: { pdf_paths: [fixturePaths.ownerLockedExtractAllowed], output_csv: allowedCsv },
-    });
-    expect(allowed.isError).not.toBe(true);
-    expect(allowed.structuredContent.field_count).toBeGreaterThan(0);
-    expect(await fs.readFile(allowedCsv, "utf8")).toContain("_filename");
-
-    const deniedCsv = path.join(temporaryRoot, "denied.csv");
-    const denied = await client.callTool({
-      name: "extract_to_csv",
-      arguments: { pdf_paths: [fixturePaths.ownerLockedNoExtract], output_csv: deniedCsv },
-    });
-    expect(textOf(denied)).toContain("permissions deny");
-    // The refusal must not leave a partial artifact behind.
-    await expect(fs.access(deniedCsv)).rejects.toMatchObject({ code: "ENOENT" });
+  it("extracts to CSV from an owner-locked document whichever way its /P points", async () => {
+    const written = [];
+    for (const fixture of ["ownerLockedExtractAllowed", "ownerLockedNoExtract"]) {
+      const csvPath = path.join(temporaryRoot, `${fixture}.csv`);
+      const result = await client.callTool({
+        name: "extract_to_csv",
+        arguments: { pdf_paths: [fixturePaths[fixture]], output_csv: csvPath },
+      });
+      expect(result.isError, fixture).not.toBe(true);
+      expect(result.structuredContent.field_count, fixture).toBeGreaterThan(0);
+      written.push(await fs.readFile(csvPath, "utf8"));
+    }
+    // Same document, same fields, one bit apart. Comparing the two rules out a
+    // gate that merely moved somewhere quieter.
+    expect(written[0]).toContain("_filename");
+    expect(written[1].split("\n")[0]).toBe(written[0].split("\n")[0]);
   }, 60_000);
 
   it("writes an encrypted document back still encrypted", async () => {


### PR DESCRIPTION
## The defect — my design error

The `/P` extraction gate added in #133 protected nothing. On an owner-locked
AES-256 document, through the real server:

```
read_pdf_fields    REFUSED   "...permissions deny content copying and extraction"
read_pdf_content   RETURNED  33,173 characters of the same file
```

The pdfjs-backed tools never consult `/P` at all. Worse than no gate: it
manufactured confidence and inconsistent behaviour while stopping nobody.

## I asked for the gate extended across reads. That was wrong.

**The tool family makes it impossible.** 20 tools take a document and write no
PDF back. Gating text means also gating `read_pdf_bytes` (streams every byte),
`get_pdf_resource_uri` (hands the host the binary) and `display_pdf` — each
delivers strictly *more* than `read_pdf_content`. Exempt them and the hole stays
open; refuse them and we have stopped being a PDF reader. Acrobat, Preview and
Chrome all display owner-locked documents and grey out *Copy*. We have no Copy
menu to grey out — every tool here **is** the copy operation.

**The format will not allow it — measured, and qpdf says so outright.** On modern
encryption the accessibility bit cannot be denied:

```
$ qpdf --encrypt ... --bits=128 --extract=n --accessibility=n --use-aes=y -- in.pdf out.pdf
qpdf: -accessibility=n is ignored for modern encryption formats
$ qpdf --show-encryption out.pdf
extract for accessibility: allowed        extract for any purpose: not allowed
```

Same at AES-256. Only legacy R3 RC4 can deny it, and ISO 32000-2 deprecated bit
10 and requires it set. So honouring the carve-out makes the gate a no-op on
anything encrypted this decade; ignoring it makes us stricter than the
specification's authors intended, against a caller closer to assistive technology
than to copy-paste.

*(My earlier reasoning — accessibility is too universally granted to* substitute
*for extract — is correct, and points the other way here.)*

**Also:** two of our three PDF libraries decline to implement it. pdfjs has no
`/P` support; qpdf decrypts owner-locked documents with no password, which our
own fixtures depend on.

## The write gate stays

It has none of these problems: **complete** (nothing writes without
`decryptPdfForWrite`), **enforceable** (we produce the bytes), and **meaningful**
(modification is what the owner actually restricted).

## One rule, one place

`pdfPermissionRefusal({ intent, encryption, suppliedPassword, operation })` in
`server/qpdf-decrypt.js` — both intents in one function, and the **only** place in
`server/` that reads `encryption.capabilities`, so the asymmetry cannot drift.
`permission_denied` is gone; `write_permission_denied` remains.

## Proof of uniformity

`test/pdf-read-permission-consistency.test.js` derives the read family from the
**live tool list minus `ENCRYPTED_WRITE_OPERATIONS`** — both product-owned — so a
tool added later is covered whether or not anyone remembers this file, and it
fails loudly if it has no call recipe.

Against a matched pair of AES-256 documents identical but for bit 5: no tool can
tell them apart in outcome *or* normalized output; no read refuses on `/P`
(detected by message **and** by "refused only the denying document", so a
silently-worded gate is still caught); the owner password never downgrades a
read; `fill_pdf` still refuses and the owner password flips it, with `/Encrypt`
restored.

Mutation-tested: reintroducing a read gate fails 7 of 10 assertions; a
bland-message version still fails.

## Defence in depth: taken

`loadEncryptedPdfBytes` now runs `assertBoundedPdfStructure` and
`assertBoundedPdfStreamDecodes` on the **plaintext** — 22 ms on 7.2 MB against
314 ms of parsing that follows regardless. Five guard messages claiming "mutation
was stopped before parsing" were corrected; they are a lie on a read.

## Verification

`npm test` — **2359 passed, 0 failed**. `test:node-native` 62/62,
`test:contract:share`, `build:mcpb` (reproducible), `smoke:mcpb` all pass. #139
and #141 ran unmodified; four assertions in #133 and #119 rewritten honestly with
reasons in comments.

## Two pre-existing issues found, neither introduced here

- **The layout oracle was already stale on `origin/master`** — #143 changed
  `package.json` without rebinding it, failing 10 tests in three suites. Rebound
  here; the diff is three lines and no case data changed.
- **`compare_pdfs` fails on any encrypted input** with "Internal output validation
  failed", a bad error for a real condition. Uniform across scenarios, so it does
  not break the rule. Being fixed next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)