### PR TITLE
Make three refusals tell the caller what to do

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,13 @@ the source's protection before it is staged. Two rules follow:
 
 `merge_pdfs` refuses unless every source carries byte-identical protection,
 because N sources with different or absent encryption make "the source's
-encryption" undefined.
+encryption" undefined. The refusal names both routes that work — sources whose
+`/Encrypt` dictionary really is one dictionary (copies of one protected
+document, or the parts `split_pdf` made of it), or unprotected copies the
+caller re-protects afterwards — and names the trap, because encrypting two
+documents in two qpdf runs with one password does *not* produce one protection:
+`/O` and `/U` mix in per-run material (a random salt at `/R` 6, the document's
+own `/ID` at `/R` 4 and below).
 
 All three phases run inside the isolated pdf-lib child, with qpdf on its own
 worker thread. That placement is forced: the child stages its output to disk, so
@@ -221,7 +227,7 @@ Measured against an AES-256 PDF produced with
 | `add_signature_field`, `apply_signature`, `prepare_signing_packet`, `apply_text` | qpdf + pdf-lib worker | **Real.** Need `modify` (they draw into the page content stream); `prepare_signing_packet` needs `modifyforms` as well. |
 | `render_pdf_page`, `render_pdf_region`, `get_page_analysis` | PDF.js plus pdf-lib geometry | None in practice. PDF.js uses the password, but the pdf-lib geometry load still fails. |
 | `detect_signature_zones` | PDF.js plus pdf-lib geometry | None in practice. It degrades through `ignoreEncryption` and succeeds only on the committed header-malformed R4 oracle; a well-formed AES-128 or AES-256 file fails. |
-| `compare_pdfs` | PDF.js plus pdf-lib geometry | None. With `include_visual` it reports the pdf-lib limit; without it, the run still ends in `internal_validation_error` (pre-existing, unrelated to the password). |
+| `compare_pdfs` | PDF.js plus pdf-lib geometry | None, and it now says so once. Any encrypted input is refused as `PDF_ENCRYPTED_COMPARISON_UNSUPPORTED`, naming which side, whatever the passwords and `include_visual` say. It used to answer three different ways: "requires its password", the pdf-lib limit, or `internal_validation_error` when `include_visual` was false. |
 | `extract_to_csv` | qpdf + pdf-lib | **Partial.** No `password` parameter (one password cannot serve a list of documents), so it reads an encrypted document only when that document opens without a password and its `/P` allows `extract`. |
 | `read_pdf_content`, `read_pdf_pages`, `search_pdf_text` | PDF.js | None reachable. No `password` parameter exists, so an encrypted PDF cannot be opened. |
 | `inspect_pdf_accessibility` | pdf-lib | None, and it says so: it rejects a `password` argument outright. |
@@ -338,9 +344,14 @@ regions in that same PDF.js view, including nonzero origins, rotated CropBoxes,
 and UserUnit scaling, while reporting raw pixels unavailable.
 
 `compare_pdfs` reads both inputs through immutable source descriptors, refuses
-documents over 20 pages instead of comparing prefixes, and reports typed
-coverage for semantic, text, structure, form-field, annotation, metadata, and
-visual channels. Ambiguous repeated pages remain unresolved. The default mode
+documents over 20 pages instead of comparing prefixes, refuses an encrypted
+input outright — pdf-lib supplies its raw page geometry and its page renderer,
+and cannot decrypt, so no password helps — and reports typed coverage for
+semantic, text, structure, form-field, annotation, metadata, and visual
+channels. Its coverage vocabulary is derived from the document-observation
+vocabulary in `server/pdf-observations.js` rather than restated, because a
+reason present in one and missing from the other used to surface as
+`internal_validation_error`. Ambiguous repeated pages remain unresolved. The default mode
 may suppress reversible metadata or visual noise, while forensic mode reports
 it; neither mode claims that no reported changes proves document equivalence.
 

--- a/docs/MCP_CONTRACT.md
+++ b/docs/MCP_CONTRACT.md
@@ -142,8 +142,11 @@ were observed under this policy. It never sets an equivalence claim, and an
 empty reported set is not proof that the files are semantically identical.
 
 Comparison refuses page-cap prefixes, changed sources, malformed PDFs,
-password failures, output-cap truncation, unknown input fields, and invalid
-internal semantics. Public errors use stable typed messages and do not include
+encrypted inputs, output-cap truncation, unknown input fields, and invalid
+internal semantics. Encryption is a single refusal rather than a password
+failure: PDF.js decrypts the text, form, annotation and metadata channels, but
+raw page geometry and page rendering go through pdf-lib, which cannot decrypt,
+so no password makes a comparison run and the refusal says so. Public errors use stable typed messages and do not include
 input paths, passwords, or lower-level parser and filesystem text. Native raw
 RGBA is the only visual comparison sensor; an unavailable native renderer is
 typed partial coverage rather than a system-renderer substitution.

--- a/docs/OUTPUT_SCHEMAS.md
+++ b/docs/OUTPUT_SCHEMAS.md
@@ -76,9 +76,13 @@ source-identity, and isolated-resource errors remain structured and do not
 include parser diagnostics or passwords.
 
 `compare_pdfs` has stable structured failures for page-cap refusal, source
-identity races, password requirements or rejection, unsupported parsing,
-filesystem policy denial, unavailable inputs, output-cap refusal, and internal
-validation failure. Success validates complete source-page alignment coverage,
+identity races, encrypted inputs, unsupported parsing, filesystem policy
+denial, unavailable inputs, output-cap refusal, and internal validation
+failure. An encrypted input is one refusal
+(`PDF_ENCRYPTED_COMPARISON_UNSUPPORTED`) whatever the password arguments say,
+because comparison takes raw page geometry and page rendering through pdf-lib,
+which cannot decrypt; the message names which input was protected and where an
+encrypted document can be read instead. Success validates complete source-page alignment coverage,
 known sorted coverage reasons, evidence geometry and digests, change/facet
 relations, summary counts, zero server network/persistence effects, and a full
 comparison-envelope digest before leaving the server.

--- a/pdf-toolkit-mcp-share/server/index.js
+++ b/pdf-toolkit-mcp-share/server/index.js
@@ -49,8 +49,11 @@ import {
   validatePdfObservationSemantics,
 } from "./pdf-observations.js";
 import {
+  PDF_COMPARISON_ENCRYPTED_CODE,
   PDF_COMPARISON_RENDERER,
   buildPdfComparison,
+  isPdfComparisonEncryptedFailure,
+  pdfComparisonEncryptedError,
   publicPdfComparisonError,
 } from "./pdf-comparison.js";
 import {
@@ -1765,23 +1768,138 @@ function comparisonSourceChangedError() {
   return error;
 }
 
-async function inspectComparisonDocument(resolvedPath, {
-  side,
-  password,
-  maxPages,
-  includeVisual,
-}) {
-  const observed = await runPdfjsOperation(resolvedPath, {
-    operation: "observe_document",
-    password,
-    options: { max_pages: maxPages, max_output_characters: 200_000 },
-  });
+/**
+ * Whether an encrypted document is what stopped this comparison step.
+ *
+ * Three shapes mean the same thing here, and all three used to surface as
+ * something else. PDF.js reports a missing or rejected password, which is true
+ * but useless advice on this tool — no password makes an encrypted comparison
+ * run. pdf-lib's geometry step reports the honest "no decryption support"
+ * limit, which is the family message but does not say which input it was. And
+ * with `include_visual: false` neither fired at all: the comparison completed,
+ * carried `RAW_PAGE_GEOMETRY_UNAVAILABLE` into its structure channel, and was
+ * rejected by its own semantics validator as an internal fault.
+ */
+function comparisonEncryptionFailure(error, side) {
+  // `isPdfComparisonEncryptedFailure` covers the typed code and both message
+  // signatures, including one that has crossed a boundary which dropped its
+  // `code`. Matching on the message rather than on identity matters here: the
+  // pdf-lib limit is raised inside the PDF.js subprocess and travels back as
+  // text.
+  const encrypted = error?.code === "PASSWORD_REQUIRED"
+    || error?.code === "PASSWORD_INCORRECT"
+    || comparisonSawPdfLibEncryptionLimit(error)
+    || isPdfComparisonEncryptedFailure(error);
+  return encrypted ? pdfComparisonEncryptedError([side]) : null;
+}
+
+/**
+ * The shared pdf-lib "no decryption support" limit, matched wherever it came
+ * from.
+ *
+ * `includes` rather than `===`: the page renderer raises this inside the PDF.js
+ * subprocess, so it reaches the server as text that a boundary may have
+ * prefixed or annotated. An equality check that stops matching does not fail
+ * loudly — it silently reclassifies a true statement about encryption as
+ * `invalid_input`, "the arguments or PDF inputs are invalid", about a call
+ * whose arguments were fine.
+ */
+function comparisonSawPdfLibEncryptionLimit(error) {
+  return typeof error?.message === "string"
+    && error.message.includes(PDF_LIB_ENCRYPTED_MESSAGE);
+}
+
+/**
+ * Whether the document PDF.js just observed carries an `/Encrypt` dictionary.
+ *
+ * PDF.js reports the security handler's filter name for a protected document
+ * and `null` for an unprotected one, and the observation this comparison had to
+ * make anyway already carries it — so this costs nothing, needs no second
+ * parse, and does not depend on pdf-lib having been able to read the document.
+ * It is the case a password error never reaches: the caller supplied the right
+ * password, PDF.js opened the file, and the comparison would otherwise have run
+ * on geometry pdf-lib could not supply.
+ */
+function comparisonInputIsEncrypted(observation) {
+  const filterName = observation?.metadata?.info?.values?.EncryptFilterName;
+  return typeof filterName === "string" && filterName.length > 0;
+}
+
+async function observeComparisonDocument(resolvedPath, { side, password, maxPages }) {
+  let observed;
+  try {
+    observed = await runPdfjsOperation(resolvedPath, {
+      operation: "observe_document",
+      password,
+      options: { max_pages: maxPages, max_output_characters: 200_000 },
+    });
+  } catch (error) {
+    throw comparisonEncryptionFailure(error, side) ?? error;
+  }
   if (observed.result.pages.total_count > maxPages) {
     const error = new Error(`Comparison supports at most ${maxPages} pages per document.`);
     error.code = "COMPARISON_PAGE_LIMIT_EXCEEDED";
     throw error;
   }
   validatePdfObservationSemantics(observed.result);
+  if (comparisonInputIsEncrypted(observed.result)) throw pdfComparisonEncryptedError([side]);
+  return { side, observed };
+}
+
+/**
+ * Observes both inputs before either is inspected further.
+ *
+ * Encryption is the one failure worth collecting from both sides rather than
+ * reporting from the first: a caller with two protected documents should be
+ * told that once, not led through them one at a time. Every other failure still
+ * stops at the first input that raised it.
+ */
+async function observeComparisonDocuments(requests) {
+  const observations = [];
+  const encryptedSides = [];
+  for (const request of requests) {
+    try {
+      observations.push(await observeComparisonDocument(request.resolvedPath, request));
+    } catch (error) {
+      if (error?.code !== PDF_COMPARISON_ENCRYPTED_CODE) {
+        // Whichever input failed first still decides the answer, exactly as it
+        // did before: an encrypted `before` is reported even when `after` turns
+        // out to be unreadable, and an unreadable `before` is reported without
+        // `after` being consulted at all.
+        if (encryptedSides.length > 0) throw pdfComparisonEncryptedError(encryptedSides);
+        throw error;
+      }
+      encryptedSides.push(request.side);
+    }
+  }
+  if (encryptedSides.length > 0) throw pdfComparisonEncryptedError(encryptedSides);
+  return observations;
+}
+
+/**
+ * Layout and visual evidence for one already-observed comparison input.
+ *
+ * `observeComparisonDocument` has already refused an encrypted document, so
+ * nothing here should meet one — but the pdf-lib geometry step inside the page
+ * renderer can still raise the family's encryption message for a document whose
+ * `/Encrypt` dictionary the observation could not report (bounded metadata can
+ * omit a key). The wrapper below turns that into the same typed refusal rather
+ * than letting it fall through to "the arguments or PDF inputs are invalid".
+ */
+async function inspectComparisonDocument(resolvedPath, options) {
+  try {
+    return await inspectComparisonDocumentChannels(resolvedPath, options);
+  } catch (error) {
+    throw comparisonEncryptionFailure(error, options.side) ?? error;
+  }
+}
+
+async function inspectComparisonDocumentChannels(resolvedPath, {
+  side,
+  observed,
+  password,
+  includeVisual,
+}) {
   const layoutChunks = [];
   for (let startPage = 1; startPage <= observed.result.pages.total_count; startPage += 10) {
     const layoutChunk = await runPdfjsOperation(resolvedPath, {
@@ -6218,8 +6336,12 @@ async function handleToolCall(request) {
           const started = performance.now();
           const beforePath = resolvePath(beforePdfPath);
           const afterPath = resolvePath(afterPdfPath);
-          const before = await inspectComparisonDocument(beforePath, { side: "before", password: beforePassword, maxPages, includeVisual });
-          const after = await inspectComparisonDocument(afterPath, { side: "after", password: afterPassword, maxPages, includeVisual });
+          const [beforeObservation, afterObservation] = await observeComparisonDocuments([
+            { side: "before", resolvedPath: beforePath, password: beforePassword, maxPages },
+            { side: "after", resolvedPath: afterPath, password: afterPassword, maxPages },
+          ]);
+          const before = await inspectComparisonDocument(beforePath, { ...beforeObservation, password: beforePassword, includeVisual });
+          const after = await inspectComparisonDocument(afterPath, { ...afterObservation, password: afterPassword, includeVisual });
           const sourceImmutability = {
             before: await verifyComparisonSourceUnchanged(beforePath, before.initial_source),
             after: await verifyComparisonSourceUnchanged(afterPath, after.initial_source),
@@ -6241,20 +6363,17 @@ async function handleToolCall(request) {
             structuredContent: payload,
           };
         } catch (error) {
-          // The comparison classifier turns any unrecognized Error into
-          // "arguments or PDF inputs are invalid", which is false when the
-          // inputs were fine and only pdf-lib's inability to decrypt stopped
-          // the run. Say what actually happened.
-          // PDF_PARSE_FAILED is the closest code the sealed comparison error
-          // enum already carries; adding a new one would change an oracle-bound
-          // schema module. The message states the real cause either way.
-          if (error?.message === PDF_LIB_ENCRYPTED_MESSAGE) {
-            return createTypedToolError({
-              code: "PDF_PARSE_FAILED",
-              message: PDF_LIB_ENCRYPTED_MESSAGE,
-            });
-          }
-          return createTypedToolError(publicPdfComparisonError(error));
+          // `publicPdfComparisonError` recognises the comparison's own refusal
+          // by code *and* by message signature, so one that lost its `code`
+          // crossing a boundary still classifies. The pdf-lib limit is the one
+          // signal it cannot see — that constant lives in server/helpers.js and
+          // the comparison module's import graph is deliberately closed against
+          // it — so this layer translates it, and does so before the classifier
+          // can report a valid call as an invalid one.
+          const failure = comparisonSawPdfLibEncryptionLimit(error)
+            ? pdfComparisonEncryptedError([])
+            : error;
+          return createTypedToolError(publicPdfComparisonError(failure));
         }
       }
 

--- a/pdf-toolkit-mcp-share/server/output-schemas.js
+++ b/pdf-toolkit-mcp-share/server/output-schemas.js
@@ -393,6 +393,10 @@ const pdfComparisonError = object({
       "COMPARISON_PAGE_LIMIT_EXCEEDED",
       "COMPARISON_SOURCE_BINDING_MISMATCH",
       "COMPARISON_SOURCE_CHANGED",
+      // An encrypted input, which pdf-lib cannot decrypt for the page geometry
+      // and page rendering this comparison needs. Distinct from
+      // PDF_PARSE_FAILED because the document parsed perfectly well.
+      "PDF_ENCRYPTED_COMPARISON_UNSUPPORTED",
       "PDF_PARSE_FAILED",
       "invalid_input",
     ]),

--- a/pdf-toolkit-mcp-share/server/pdf-comparison.js
+++ b/pdf-toolkit-mcp-share/server/pdf-comparison.js
@@ -1,5 +1,8 @@
 import { createHash } from "node:crypto";
-import { validatePdfObservationSemantics } from "./pdf-observations.js";
+import {
+  PDF_OBSERVATION_COVERAGE_REASONS,
+  validatePdfObservationSemantics,
+} from "./pdf-observations.js";
 
 export const PDF_COMPARISON_SCHEMA_VERSION = "1.0";
 export const PDF_COMPARISON_ENGINE = Object.freeze({
@@ -31,29 +34,38 @@ export const PDF_COMPARISON_CHANNELS = Object.freeze([
   "visual",
 ]);
 
-const PDF_COMPARISON_COVERAGE_REASONS = new Set([
+export const PDF_COMPARISON_SIDES = Object.freeze(["before", "after"]);
+
+// Reasons the comparison raises itself, rather than inheriting from a document
+// observation. `TEXT_EXTRACTION_TRUNCATED` is per side because it describes one
+// document's layout extraction; the visual reasons describe the run.
+const PDF_COMPARISON_OWN_COVERAGE_REASONS = Object.freeze([
   "VISUAL_NOT_REQUESTED",
   "VISUAL_RENDERER_UNAVAILABLE",
   "VISUAL_ALIGNED_PAGE_COMPARISON_SKIPPED",
-  ...["BEFORE", "AFTER"].flatMap(side => [
-    `${side}_PAGE_LIMIT_REACHED`,
-    `${side}_PAGE_PARSE_UNAVAILABLE`,
-    `${side}_PAGE_PARSE_PARTIAL`,
-    `${side}_OUTPUT_LIMIT_PAGES_OMITTED`,
-    `${side}_METADATA_PARSE_UNAVAILABLE`,
-    `${side}_METADATA_LIMIT_REACHED`,
-    `${side}_OUTPUT_LIMIT_METADATA_OMITTED`,
-    `${side}_FORM_FIELD_PARSE_UNAVAILABLE`,
-    `${side}_FORM_FIELD_PAGE_LIMIT_REACHED`,
-    `${side}_FIELD_LIMIT_REACHED`,
-    `${side}_WIDGET_OBSERVATION_LIMIT_REACHED`,
-    `${side}_OUTPUT_LIMIT_FORM_FIELDS_OMITTED`,
-    `${side}_ANNOTATION_PARSE_UNAVAILABLE`,
-    `${side}_ANNOTATION_PAGE_LIMIT_REACHED`,
-    `${side}_ANNOTATION_LIMIT_REACHED`,
-    `${side}_OUTPUT_LIMIT_ANNOTATIONS_OMITTED`,
-    `${side}_TEXT_EXTRACTION_TRUNCATED`,
-  ]),
+]);
+const PDF_COMPARISON_OWN_SIDED_COVERAGE_REASONS = Object.freeze([
+  "TEXT_EXTRACTION_TRUNCATED",
+]);
+
+/*
+ * Built from the observation vocabulary rather than restated beside it.
+ *
+ * `derivePdfComparisonCoverage` copies every reason a document observation
+ * carries into a comparison channel with the side's name in front, so this set
+ * has to be a superset of that vocabulary or the comparison's own semantics
+ * validator rejects a payload it just built. It was not: three observation
+ * reasons — `RAW_PAGE_GEOMETRY_UNAVAILABLE`, `FORM_FIELD_PAGE_GEOMETRY_PARTIAL`
+ * and `ANNOTATION_PAGE_PARSE_PARTIAL` — were missing, and any document that
+ * raised one turned a valid comparison into "Internal output validation
+ * failed". Deriving the set closes all three and cannot drift again.
+ */
+export const PDF_COMPARISON_COVERAGE_REASONS = new Set([
+  ...PDF_COMPARISON_OWN_COVERAGE_REASONS,
+  ...PDF_COMPARISON_SIDES.flatMap(side => [
+    ...Object.values(PDF_OBSERVATION_COVERAGE_REASONS).flat(),
+    ...PDF_COMPARISON_OWN_SIDED_COVERAGE_REASONS,
+  ].map(reason => `${side.toUpperCase()}_${reason}`)),
 ]);
 
 export const PDF_COMPARISON_RENDERER = Object.freeze({
@@ -1038,8 +1050,126 @@ export function buildPdfComparison({
   return result;
 }
 
+export const PDF_COMPARISON_ENCRYPTED_CODE = "PDF_ENCRYPTED_COMPARISON_UNSUPPORTED";
+
+/**
+ * The phrase every encrypted-comparison refusal contains, used to recognise one
+ * that has lost its `code`.
+ *
+ * `error.code` is an own property of an Error instance and does not survive
+ * anything that rebuilds the error from its message — a structured clone, a
+ * subprocess or worker boundary, a transport that carries `{ message }`. When
+ * that happens the refusal falls through every branch below and is re-reported
+ * as `invalid_input`, "the arguments or PDF inputs are invalid", which is both
+ * wrong and exactly the class of useless refusal this work exists to remove.
+ * Matching the text as well as the code means the classification survives a
+ * boundary that the code does not.
+ */
+const PDF_COMPARISON_ENCRYPTED_SIGNATURE =
+  "compare_pdfs cannot compare an encrypted document";
+
+/**
+ * Whether this failure is an encrypted comparison input, however it arrived.
+ *
+ * Two signals, not one: the typed code, and this module's own refusal text as a
+ * substring, so a wrapper that prefixes or annotates the message cannot turn a
+ * true statement about encryption into a false one about arguments.
+ *
+ * The *other* encryption signal — the shared pdf-lib "no decryption support"
+ * limit raised by the page renderer — is deliberately not matched here. It
+ * belongs to `server/helpers.js`, and this module's static import graph is
+ * closed and asserted by the extraction scorer
+ * (`test/eval/extraction-phase1-generation-verifiers.test.js`), which must not
+ * transitively acquire pdf-lib. `server/index.js` owns that translation
+ * instead, converting the pdf-lib limit into a typed refusal before it ever
+ * reaches this classifier.
+ */
+export function isPdfComparisonEncryptedFailure(error) {
+  if (error?.code === PDF_COMPARISON_ENCRYPTED_CODE) return true;
+  const message = typeof error?.message === "string" ? error.message : "";
+  return message.includes(PDF_COMPARISON_ENCRYPTED_SIGNATURE);
+}
+
+/**
+ * The refusal for an encrypted comparison input.
+ *
+ * `compare_pdfs` reads text, form fields, annotations and metadata through
+ * PDF.js, which decrypts, but it takes each page's raw geometry — and, when the
+ * visual channel is requested, every rendered page — through pdf-lib, which has
+ * no decryption support at all. So the password arguments genuinely cannot make
+ * this comparison run, and the message says that instead of asking for a
+ * password again or reporting an internal fault.
+ *
+ * The named alternatives are the three tools that accept a password and read
+ * entirely through PDF.js, which is the same set `PDF_LIB_ENCRYPTED_MESSAGE`
+ * names; `test/encrypted-pdf-password-truth.test.js` proves each of them really
+ * does open an encrypted document with the password, so the advice cannot rot
+ * into naming a tool that does not work.
+ *
+ * `sides` is whichever of the two inputs were found encrypted, in comparison
+ * order. An empty list is allowed: it means an encrypted input was detected
+ * somewhere in the run without the side being attributable, which is better
+ * reported vaguely than reported as an internal error.
+ */
+export function pdfComparisonEncryptedMessage(sides) {
+  const named = sides.length === 0
+    ? "A comparison input is encrypted"
+    : sides.length === PDF_COMPARISON_SIDES.length
+      ? "Both comparison inputs are encrypted"
+      : `The ${sides[0]} comparison input is encrypted`;
+  return `${named}, and compare_pdfs cannot compare an encrypted document. It reads text, form `
+    + "fields, annotations and metadata with PDF.js, which does decrypt, but it takes every page's "
+    + "raw geometry — and every rendered page, when the visual channel is requested — through "
+    + "pdf-lib, which has no decryption support, so supplying a password here will not help. "
+    + "Rather than report a comparison of whichever channels survive, it stops. Decrypt both "
+    + "documents first (for example with qpdf) and compare the decrypted copies. To read an "
+    + "encrypted PDF as it is, use read_pdf_layout, convert_pdf_to_markdown, or get_pdf_info, "
+    + "which accept a password and decrypt with PDF.js.";
+}
+
+export function pdfComparisonEncryptedError(sides) {
+  const ordered = PDF_COMPARISON_SIDES.filter(side => sides.includes(side));
+  const error = new Error(pdfComparisonEncryptedMessage(ordered));
+  error.code = PDF_COMPARISON_ENCRYPTED_CODE;
+  error.encryptedSides = Object.freeze(ordered);
+  return error;
+}
+
+/**
+ * The catch-all, which has to earn its place because it is where every
+ * unrecognised failure lands.
+ *
+ * "The compare_pdfs arguments or PDF inputs are invalid" on its own is the same
+ * useless-refusal shape as the bugs above: true, and no help at all. The
+ * argument that is actually wrong is nearly always the password, because every
+ * other tool in this server takes `password` and this one does not — and a
+ * rejected unknown argument produces this text identically for every other
+ * argument the caller varies, which makes it read like a failure of the
+ * document rather than of the call.
+ *
+ * The accepted names are published in the tool's own input schema, so repeating
+ * them here reveals nothing. What must NOT appear is anything the caller sent:
+ * an unknown argument's *name* is caller data and is deliberately never echoed,
+ * which `test/compare-pdfs.test.js` pins with a sentinel.
+ */
+export const PDF_COMPARISON_INVALID_INPUT_MESSAGE =
+  "The compare_pdfs arguments or PDF inputs are invalid. It accepts only before_pdf_path, "
+  + "after_pdf_path, before_password, after_password, mode, max_pages, include_visual and "
+  + "max_output_characters, and rejects any other argument. Note that the passwords are named "
+  + "before_password and after_password — compare_pdfs takes two documents, so it has no single "
+  + "'password' argument. Both paths must be absolute paths on this machine.";
+
 export function publicPdfComparisonError(error) {
   const code = error?.code;
+  // Checked first, and by evidence rather than by code alone, so a refusal that
+  // crossed a boundary which dropped its `code` is still reported as what it is
+  // instead of falling through to the catch-all below.
+  if (isPdfComparisonEncryptedFailure(error)) {
+    return {
+      code: PDF_COMPARISON_ENCRYPTED_CODE,
+      message: pdfComparisonEncryptedMessage(error.encryptedSides ?? []),
+    };
+  }
   if (code === "COMPARISON_PAGE_LIMIT_EXCEEDED") {
     return { code, message: "A comparison input exceeds the requested whole-document page limit." };
   }
@@ -1078,7 +1208,7 @@ export function publicPdfComparisonError(error) {
     return { code: "PDF_PARSE_FAILED", message: "A comparison input could not be parsed as a supported PDF." };
   }
   if (error instanceof TypeError || typeof error?.message === "string") {
-    return { code: "invalid_input", message: "The compare_pdfs arguments or PDF inputs are invalid." };
+    return { code: "invalid_input", message: PDF_COMPARISON_INVALID_INPUT_MESSAGE };
   }
   return { code: "tool_execution_failed", message: "The PDFs could not be compared." };
 }

--- a/pdf-toolkit-mcp-share/server/pdf-observations.js
+++ b/pdf-toolkit-mcp-share/server/pdf-observations.js
@@ -13,6 +13,51 @@ export const PDF_OBSERVATION_LIMITS = Object.freeze({
   max_metadata_characters: 32_768,
 });
 
+/**
+ * Every coverage reason a document observation may carry, by channel.
+ *
+ * This vocabulary does not stay inside `get_pdf_info`. `compare_pdfs` copies
+ * each observation reason into one of its own channels with a `BEFORE_` or
+ * `AFTER_` prefix, and its semantics validator rejects a payload carrying a
+ * reason it does not recognise — which turned a perfectly good comparison of
+ * two encrypted documents into "Internal output validation failed", because
+ * `RAW_PAGE_GEOMETRY_UNAVAILABLE` had never been added to the comparison's
+ * copy of this list. So the list lives here, next to the code that emits it,
+ * `validatePdfObservationSemantics` rejects anything outside it, and
+ * `server/pdf-comparison.js` builds its own set from it rather than restating
+ * it. A reason added in one place and forgotten in the other is no longer
+ * expressible.
+ */
+export const PDF_OBSERVATION_COVERAGE_REASONS = Object.freeze({
+  pages: Object.freeze([
+    "OUTPUT_LIMIT_PAGES_OMITTED",
+    "PAGE_LIMIT_REACHED",
+    "PAGE_PARSE_PARTIAL",
+    "PAGE_PARSE_UNAVAILABLE",
+    "RAW_PAGE_GEOMETRY_UNAVAILABLE",
+  ]),
+  metadata: Object.freeze([
+    "METADATA_LIMIT_REACHED",
+    "METADATA_PARSE_UNAVAILABLE",
+    "OUTPUT_LIMIT_METADATA_OMITTED",
+  ]),
+  form_fields: Object.freeze([
+    "FIELD_LIMIT_REACHED",
+    "FORM_FIELD_PAGE_GEOMETRY_PARTIAL",
+    "FORM_FIELD_PAGE_LIMIT_REACHED",
+    "FORM_FIELD_PARSE_UNAVAILABLE",
+    "OUTPUT_LIMIT_FORM_FIELDS_OMITTED",
+    "WIDGET_OBSERVATION_LIMIT_REACHED",
+  ]),
+  annotations: Object.freeze([
+    "ANNOTATION_LIMIT_REACHED",
+    "ANNOTATION_PAGE_LIMIT_REACHED",
+    "ANNOTATION_PAGE_PARSE_PARTIAL",
+    "ANNOTATION_PARSE_UNAVAILABLE",
+    "OUTPUT_LIMIT_ANNOTATIONS_OMITTED",
+  ]),
+});
+
 const OBSERVATION_COORDINATE_SPACES = Object.freeze({
   display: "pdfjs_viewport_top_left_points",
   native: "pdf_user_space_bottom_left_points",
@@ -777,6 +822,16 @@ export function validatePdfObservationSemantics(payload) {
     `${channel} coverage reasons are not unique and sorted`);
     semanticAssertion(coverage.reason_codes.length > 0 || coverage.status === "supported",
       `${channel} unavailable or partial coverage has no reason`);
+    // Every reason has to be one this module publishes, because `compare_pdfs`
+    // inherits this vocabulary and refuses a reason it has never heard of. An
+    // unregistered reason fails here, on the tool that emitted it, instead of
+    // reappearing downstream as an internal validation error.
+    semanticAssertion(
+      coverage.reason_codes.every(
+        reason => PDF_OBSERVATION_COVERAGE_REASONS[channel].includes(reason),
+      ),
+      `${channel} coverage carries a reason outside the published vocabulary`,
+    );
     semanticAssertion(
       coverage.status === coverageStatus(channel, coverage.reason_codes, channelObservation[channel]),
       `${channel} coverage status does not follow its evidence and reasons`,

--- a/pdf-toolkit-mcp-share/server/qpdf-decrypt.js
+++ b/pdf-toolkit-mcp-share/server/qpdf-decrypt.js
@@ -434,12 +434,31 @@ export const PDF_REPROTECT_CHANGED_MESSAGE =
   + "encryption are unchanged before saving it, and refuses rather than write a document whose "
   + "security differs from the original's.";
 
+/*
+ * The refusal a caller sees when a merge's sources are not one protection.
+ *
+ * The rule itself is not negotiable — see `mergeProtectionRefusal` — so the
+ * whole job of this text is to leave the caller with something they can
+ * actually do. It names both routes that work, and it names the trap, because
+ * the obvious reading of "the same encryption" is "the same password" and that
+ * is not enough: `/Encrypt` stores `/O` and `/U`, which are derived from
+ * material that is fresh per encryption run — a random salt at `/R` 6, the
+ * document's own `/ID` at `/R` 4 and below — so two documents encrypted in two
+ * separate qpdf runs with one password still carry two different protections.
+ * A caller who is not told that will hit it, retry with the same password, and
+ * get the same refusal.
+ */
 export const PDF_MERGE_MIXED_ENCRYPTION_MESSAGE =
   "These PDFs cannot be merged: they are not all protected the same way, so there is no single "
   + "protection the merged document could carry. PDF Tools gives a merged document the encryption "
   + "its sources share, and will not choose one source's protection over another's or drop it. "
-  + "Merge documents that share the same encryption and password, or decrypt them first and "
-  + "protect the result yourself.";
+  + "Two routes work. Either merge sources whose /Encrypt dictionary is byte-identical — copies of "
+  + "one protected document, or pieces of one protected document, such as the parts split_pdf "
+  + "produces, which keep that document's exact encryption. Or decrypt every source first (for "
+  + "example with qpdf), merge the unprotected copies, and protect the merged file yourself. "
+  + "Encrypting each source separately with the same password is not enough: every encryption run "
+  + "mixes in fresh material — a random salt at /R 6, and the document's own /ID at /R 4 and "
+  + "below — so the stored /O and /U values differ even when the password you typed was identical.";
 
 /**
  * Refusal text for a mutation the document's own `/P` denies.

--- a/server/index.js
+++ b/server/index.js
@@ -49,8 +49,11 @@ import {
   validatePdfObservationSemantics,
 } from "./pdf-observations.js";
 import {
+  PDF_COMPARISON_ENCRYPTED_CODE,
   PDF_COMPARISON_RENDERER,
   buildPdfComparison,
+  isPdfComparisonEncryptedFailure,
+  pdfComparisonEncryptedError,
   publicPdfComparisonError,
 } from "./pdf-comparison.js";
 import {
@@ -1765,23 +1768,138 @@ function comparisonSourceChangedError() {
   return error;
 }
 
-async function inspectComparisonDocument(resolvedPath, {
-  side,
-  password,
-  maxPages,
-  includeVisual,
-}) {
-  const observed = await runPdfjsOperation(resolvedPath, {
-    operation: "observe_document",
-    password,
-    options: { max_pages: maxPages, max_output_characters: 200_000 },
-  });
+/**
+ * Whether an encrypted document is what stopped this comparison step.
+ *
+ * Three shapes mean the same thing here, and all three used to surface as
+ * something else. PDF.js reports a missing or rejected password, which is true
+ * but useless advice on this tool — no password makes an encrypted comparison
+ * run. pdf-lib's geometry step reports the honest "no decryption support"
+ * limit, which is the family message but does not say which input it was. And
+ * with `include_visual: false` neither fired at all: the comparison completed,
+ * carried `RAW_PAGE_GEOMETRY_UNAVAILABLE` into its structure channel, and was
+ * rejected by its own semantics validator as an internal fault.
+ */
+function comparisonEncryptionFailure(error, side) {
+  // `isPdfComparisonEncryptedFailure` covers the typed code and both message
+  // signatures, including one that has crossed a boundary which dropped its
+  // `code`. Matching on the message rather than on identity matters here: the
+  // pdf-lib limit is raised inside the PDF.js subprocess and travels back as
+  // text.
+  const encrypted = error?.code === "PASSWORD_REQUIRED"
+    || error?.code === "PASSWORD_INCORRECT"
+    || comparisonSawPdfLibEncryptionLimit(error)
+    || isPdfComparisonEncryptedFailure(error);
+  return encrypted ? pdfComparisonEncryptedError([side]) : null;
+}
+
+/**
+ * The shared pdf-lib "no decryption support" limit, matched wherever it came
+ * from.
+ *
+ * `includes` rather than `===`: the page renderer raises this inside the PDF.js
+ * subprocess, so it reaches the server as text that a boundary may have
+ * prefixed or annotated. An equality check that stops matching does not fail
+ * loudly — it silently reclassifies a true statement about encryption as
+ * `invalid_input`, "the arguments or PDF inputs are invalid", about a call
+ * whose arguments were fine.
+ */
+function comparisonSawPdfLibEncryptionLimit(error) {
+  return typeof error?.message === "string"
+    && error.message.includes(PDF_LIB_ENCRYPTED_MESSAGE);
+}
+
+/**
+ * Whether the document PDF.js just observed carries an `/Encrypt` dictionary.
+ *
+ * PDF.js reports the security handler's filter name for a protected document
+ * and `null` for an unprotected one, and the observation this comparison had to
+ * make anyway already carries it — so this costs nothing, needs no second
+ * parse, and does not depend on pdf-lib having been able to read the document.
+ * It is the case a password error never reaches: the caller supplied the right
+ * password, PDF.js opened the file, and the comparison would otherwise have run
+ * on geometry pdf-lib could not supply.
+ */
+function comparisonInputIsEncrypted(observation) {
+  const filterName = observation?.metadata?.info?.values?.EncryptFilterName;
+  return typeof filterName === "string" && filterName.length > 0;
+}
+
+async function observeComparisonDocument(resolvedPath, { side, password, maxPages }) {
+  let observed;
+  try {
+    observed = await runPdfjsOperation(resolvedPath, {
+      operation: "observe_document",
+      password,
+      options: { max_pages: maxPages, max_output_characters: 200_000 },
+    });
+  } catch (error) {
+    throw comparisonEncryptionFailure(error, side) ?? error;
+  }
   if (observed.result.pages.total_count > maxPages) {
     const error = new Error(`Comparison supports at most ${maxPages} pages per document.`);
     error.code = "COMPARISON_PAGE_LIMIT_EXCEEDED";
     throw error;
   }
   validatePdfObservationSemantics(observed.result);
+  if (comparisonInputIsEncrypted(observed.result)) throw pdfComparisonEncryptedError([side]);
+  return { side, observed };
+}
+
+/**
+ * Observes both inputs before either is inspected further.
+ *
+ * Encryption is the one failure worth collecting from both sides rather than
+ * reporting from the first: a caller with two protected documents should be
+ * told that once, not led through them one at a time. Every other failure still
+ * stops at the first input that raised it.
+ */
+async function observeComparisonDocuments(requests) {
+  const observations = [];
+  const encryptedSides = [];
+  for (const request of requests) {
+    try {
+      observations.push(await observeComparisonDocument(request.resolvedPath, request));
+    } catch (error) {
+      if (error?.code !== PDF_COMPARISON_ENCRYPTED_CODE) {
+        // Whichever input failed first still decides the answer, exactly as it
+        // did before: an encrypted `before` is reported even when `after` turns
+        // out to be unreadable, and an unreadable `before` is reported without
+        // `after` being consulted at all.
+        if (encryptedSides.length > 0) throw pdfComparisonEncryptedError(encryptedSides);
+        throw error;
+      }
+      encryptedSides.push(request.side);
+    }
+  }
+  if (encryptedSides.length > 0) throw pdfComparisonEncryptedError(encryptedSides);
+  return observations;
+}
+
+/**
+ * Layout and visual evidence for one already-observed comparison input.
+ *
+ * `observeComparisonDocument` has already refused an encrypted document, so
+ * nothing here should meet one — but the pdf-lib geometry step inside the page
+ * renderer can still raise the family's encryption message for a document whose
+ * `/Encrypt` dictionary the observation could not report (bounded metadata can
+ * omit a key). The wrapper below turns that into the same typed refusal rather
+ * than letting it fall through to "the arguments or PDF inputs are invalid".
+ */
+async function inspectComparisonDocument(resolvedPath, options) {
+  try {
+    return await inspectComparisonDocumentChannels(resolvedPath, options);
+  } catch (error) {
+    throw comparisonEncryptionFailure(error, options.side) ?? error;
+  }
+}
+
+async function inspectComparisonDocumentChannels(resolvedPath, {
+  side,
+  observed,
+  password,
+  includeVisual,
+}) {
   const layoutChunks = [];
   for (let startPage = 1; startPage <= observed.result.pages.total_count; startPage += 10) {
     const layoutChunk = await runPdfjsOperation(resolvedPath, {
@@ -6218,8 +6336,12 @@ async function handleToolCall(request) {
           const started = performance.now();
           const beforePath = resolvePath(beforePdfPath);
           const afterPath = resolvePath(afterPdfPath);
-          const before = await inspectComparisonDocument(beforePath, { side: "before", password: beforePassword, maxPages, includeVisual });
-          const after = await inspectComparisonDocument(afterPath, { side: "after", password: afterPassword, maxPages, includeVisual });
+          const [beforeObservation, afterObservation] = await observeComparisonDocuments([
+            { side: "before", resolvedPath: beforePath, password: beforePassword, maxPages },
+            { side: "after", resolvedPath: afterPath, password: afterPassword, maxPages },
+          ]);
+          const before = await inspectComparisonDocument(beforePath, { ...beforeObservation, password: beforePassword, includeVisual });
+          const after = await inspectComparisonDocument(afterPath, { ...afterObservation, password: afterPassword, includeVisual });
           const sourceImmutability = {
             before: await verifyComparisonSourceUnchanged(beforePath, before.initial_source),
             after: await verifyComparisonSourceUnchanged(afterPath, after.initial_source),
@@ -6241,20 +6363,17 @@ async function handleToolCall(request) {
             structuredContent: payload,
           };
         } catch (error) {
-          // The comparison classifier turns any unrecognized Error into
-          // "arguments or PDF inputs are invalid", which is false when the
-          // inputs were fine and only pdf-lib's inability to decrypt stopped
-          // the run. Say what actually happened.
-          // PDF_PARSE_FAILED is the closest code the sealed comparison error
-          // enum already carries; adding a new one would change an oracle-bound
-          // schema module. The message states the real cause either way.
-          if (error?.message === PDF_LIB_ENCRYPTED_MESSAGE) {
-            return createTypedToolError({
-              code: "PDF_PARSE_FAILED",
-              message: PDF_LIB_ENCRYPTED_MESSAGE,
-            });
-          }
-          return createTypedToolError(publicPdfComparisonError(error));
+          // `publicPdfComparisonError` recognises the comparison's own refusal
+          // by code *and* by message signature, so one that lost its `code`
+          // crossing a boundary still classifies. The pdf-lib limit is the one
+          // signal it cannot see — that constant lives in server/helpers.js and
+          // the comparison module's import graph is deliberately closed against
+          // it — so this layer translates it, and does so before the classifier
+          // can report a valid call as an invalid one.
+          const failure = comparisonSawPdfLibEncryptionLimit(error)
+            ? pdfComparisonEncryptedError([])
+            : error;
+          return createTypedToolError(publicPdfComparisonError(failure));
         }
       }
 

--- a/server/output-schemas.js
+++ b/server/output-schemas.js
@@ -393,6 +393,10 @@ const pdfComparisonError = object({
       "COMPARISON_PAGE_LIMIT_EXCEEDED",
       "COMPARISON_SOURCE_BINDING_MISMATCH",
       "COMPARISON_SOURCE_CHANGED",
+      // An encrypted input, which pdf-lib cannot decrypt for the page geometry
+      // and page rendering this comparison needs. Distinct from
+      // PDF_PARSE_FAILED because the document parsed perfectly well.
+      "PDF_ENCRYPTED_COMPARISON_UNSUPPORTED",
       "PDF_PARSE_FAILED",
       "invalid_input",
     ]),

--- a/server/pdf-comparison.js
+++ b/server/pdf-comparison.js
@@ -1,5 +1,8 @@
 import { createHash } from "node:crypto";
-import { validatePdfObservationSemantics } from "./pdf-observations.js";
+import {
+  PDF_OBSERVATION_COVERAGE_REASONS,
+  validatePdfObservationSemantics,
+} from "./pdf-observations.js";
 
 export const PDF_COMPARISON_SCHEMA_VERSION = "1.0";
 export const PDF_COMPARISON_ENGINE = Object.freeze({
@@ -31,29 +34,38 @@ export const PDF_COMPARISON_CHANNELS = Object.freeze([
   "visual",
 ]);
 
-const PDF_COMPARISON_COVERAGE_REASONS = new Set([
+export const PDF_COMPARISON_SIDES = Object.freeze(["before", "after"]);
+
+// Reasons the comparison raises itself, rather than inheriting from a document
+// observation. `TEXT_EXTRACTION_TRUNCATED` is per side because it describes one
+// document's layout extraction; the visual reasons describe the run.
+const PDF_COMPARISON_OWN_COVERAGE_REASONS = Object.freeze([
   "VISUAL_NOT_REQUESTED",
   "VISUAL_RENDERER_UNAVAILABLE",
   "VISUAL_ALIGNED_PAGE_COMPARISON_SKIPPED",
-  ...["BEFORE", "AFTER"].flatMap(side => [
-    `${side}_PAGE_LIMIT_REACHED`,
-    `${side}_PAGE_PARSE_UNAVAILABLE`,
-    `${side}_PAGE_PARSE_PARTIAL`,
-    `${side}_OUTPUT_LIMIT_PAGES_OMITTED`,
-    `${side}_METADATA_PARSE_UNAVAILABLE`,
-    `${side}_METADATA_LIMIT_REACHED`,
-    `${side}_OUTPUT_LIMIT_METADATA_OMITTED`,
-    `${side}_FORM_FIELD_PARSE_UNAVAILABLE`,
-    `${side}_FORM_FIELD_PAGE_LIMIT_REACHED`,
-    `${side}_FIELD_LIMIT_REACHED`,
-    `${side}_WIDGET_OBSERVATION_LIMIT_REACHED`,
-    `${side}_OUTPUT_LIMIT_FORM_FIELDS_OMITTED`,
-    `${side}_ANNOTATION_PARSE_UNAVAILABLE`,
-    `${side}_ANNOTATION_PAGE_LIMIT_REACHED`,
-    `${side}_ANNOTATION_LIMIT_REACHED`,
-    `${side}_OUTPUT_LIMIT_ANNOTATIONS_OMITTED`,
-    `${side}_TEXT_EXTRACTION_TRUNCATED`,
-  ]),
+]);
+const PDF_COMPARISON_OWN_SIDED_COVERAGE_REASONS = Object.freeze([
+  "TEXT_EXTRACTION_TRUNCATED",
+]);
+
+/*
+ * Built from the observation vocabulary rather than restated beside it.
+ *
+ * `derivePdfComparisonCoverage` copies every reason a document observation
+ * carries into a comparison channel with the side's name in front, so this set
+ * has to be a superset of that vocabulary or the comparison's own semantics
+ * validator rejects a payload it just built. It was not: three observation
+ * reasons — `RAW_PAGE_GEOMETRY_UNAVAILABLE`, `FORM_FIELD_PAGE_GEOMETRY_PARTIAL`
+ * and `ANNOTATION_PAGE_PARSE_PARTIAL` — were missing, and any document that
+ * raised one turned a valid comparison into "Internal output validation
+ * failed". Deriving the set closes all three and cannot drift again.
+ */
+export const PDF_COMPARISON_COVERAGE_REASONS = new Set([
+  ...PDF_COMPARISON_OWN_COVERAGE_REASONS,
+  ...PDF_COMPARISON_SIDES.flatMap(side => [
+    ...Object.values(PDF_OBSERVATION_COVERAGE_REASONS).flat(),
+    ...PDF_COMPARISON_OWN_SIDED_COVERAGE_REASONS,
+  ].map(reason => `${side.toUpperCase()}_${reason}`)),
 ]);
 
 export const PDF_COMPARISON_RENDERER = Object.freeze({
@@ -1038,8 +1050,126 @@ export function buildPdfComparison({
   return result;
 }
 
+export const PDF_COMPARISON_ENCRYPTED_CODE = "PDF_ENCRYPTED_COMPARISON_UNSUPPORTED";
+
+/**
+ * The phrase every encrypted-comparison refusal contains, used to recognise one
+ * that has lost its `code`.
+ *
+ * `error.code` is an own property of an Error instance and does not survive
+ * anything that rebuilds the error from its message — a structured clone, a
+ * subprocess or worker boundary, a transport that carries `{ message }`. When
+ * that happens the refusal falls through every branch below and is re-reported
+ * as `invalid_input`, "the arguments or PDF inputs are invalid", which is both
+ * wrong and exactly the class of useless refusal this work exists to remove.
+ * Matching the text as well as the code means the classification survives a
+ * boundary that the code does not.
+ */
+const PDF_COMPARISON_ENCRYPTED_SIGNATURE =
+  "compare_pdfs cannot compare an encrypted document";
+
+/**
+ * Whether this failure is an encrypted comparison input, however it arrived.
+ *
+ * Two signals, not one: the typed code, and this module's own refusal text as a
+ * substring, so a wrapper that prefixes or annotates the message cannot turn a
+ * true statement about encryption into a false one about arguments.
+ *
+ * The *other* encryption signal — the shared pdf-lib "no decryption support"
+ * limit raised by the page renderer — is deliberately not matched here. It
+ * belongs to `server/helpers.js`, and this module's static import graph is
+ * closed and asserted by the extraction scorer
+ * (`test/eval/extraction-phase1-generation-verifiers.test.js`), which must not
+ * transitively acquire pdf-lib. `server/index.js` owns that translation
+ * instead, converting the pdf-lib limit into a typed refusal before it ever
+ * reaches this classifier.
+ */
+export function isPdfComparisonEncryptedFailure(error) {
+  if (error?.code === PDF_COMPARISON_ENCRYPTED_CODE) return true;
+  const message = typeof error?.message === "string" ? error.message : "";
+  return message.includes(PDF_COMPARISON_ENCRYPTED_SIGNATURE);
+}
+
+/**
+ * The refusal for an encrypted comparison input.
+ *
+ * `compare_pdfs` reads text, form fields, annotations and metadata through
+ * PDF.js, which decrypts, but it takes each page's raw geometry — and, when the
+ * visual channel is requested, every rendered page — through pdf-lib, which has
+ * no decryption support at all. So the password arguments genuinely cannot make
+ * this comparison run, and the message says that instead of asking for a
+ * password again or reporting an internal fault.
+ *
+ * The named alternatives are the three tools that accept a password and read
+ * entirely through PDF.js, which is the same set `PDF_LIB_ENCRYPTED_MESSAGE`
+ * names; `test/encrypted-pdf-password-truth.test.js` proves each of them really
+ * does open an encrypted document with the password, so the advice cannot rot
+ * into naming a tool that does not work.
+ *
+ * `sides` is whichever of the two inputs were found encrypted, in comparison
+ * order. An empty list is allowed: it means an encrypted input was detected
+ * somewhere in the run without the side being attributable, which is better
+ * reported vaguely than reported as an internal error.
+ */
+export function pdfComparisonEncryptedMessage(sides) {
+  const named = sides.length === 0
+    ? "A comparison input is encrypted"
+    : sides.length === PDF_COMPARISON_SIDES.length
+      ? "Both comparison inputs are encrypted"
+      : `The ${sides[0]} comparison input is encrypted`;
+  return `${named}, and compare_pdfs cannot compare an encrypted document. It reads text, form `
+    + "fields, annotations and metadata with PDF.js, which does decrypt, but it takes every page's "
+    + "raw geometry — and every rendered page, when the visual channel is requested — through "
+    + "pdf-lib, which has no decryption support, so supplying a password here will not help. "
+    + "Rather than report a comparison of whichever channels survive, it stops. Decrypt both "
+    + "documents first (for example with qpdf) and compare the decrypted copies. To read an "
+    + "encrypted PDF as it is, use read_pdf_layout, convert_pdf_to_markdown, or get_pdf_info, "
+    + "which accept a password and decrypt with PDF.js.";
+}
+
+export function pdfComparisonEncryptedError(sides) {
+  const ordered = PDF_COMPARISON_SIDES.filter(side => sides.includes(side));
+  const error = new Error(pdfComparisonEncryptedMessage(ordered));
+  error.code = PDF_COMPARISON_ENCRYPTED_CODE;
+  error.encryptedSides = Object.freeze(ordered);
+  return error;
+}
+
+/**
+ * The catch-all, which has to earn its place because it is where every
+ * unrecognised failure lands.
+ *
+ * "The compare_pdfs arguments or PDF inputs are invalid" on its own is the same
+ * useless-refusal shape as the bugs above: true, and no help at all. The
+ * argument that is actually wrong is nearly always the password, because every
+ * other tool in this server takes `password` and this one does not — and a
+ * rejected unknown argument produces this text identically for every other
+ * argument the caller varies, which makes it read like a failure of the
+ * document rather than of the call.
+ *
+ * The accepted names are published in the tool's own input schema, so repeating
+ * them here reveals nothing. What must NOT appear is anything the caller sent:
+ * an unknown argument's *name* is caller data and is deliberately never echoed,
+ * which `test/compare-pdfs.test.js` pins with a sentinel.
+ */
+export const PDF_COMPARISON_INVALID_INPUT_MESSAGE =
+  "The compare_pdfs arguments or PDF inputs are invalid. It accepts only before_pdf_path, "
+  + "after_pdf_path, before_password, after_password, mode, max_pages, include_visual and "
+  + "max_output_characters, and rejects any other argument. Note that the passwords are named "
+  + "before_password and after_password — compare_pdfs takes two documents, so it has no single "
+  + "'password' argument. Both paths must be absolute paths on this machine.";
+
 export function publicPdfComparisonError(error) {
   const code = error?.code;
+  // Checked first, and by evidence rather than by code alone, so a refusal that
+  // crossed a boundary which dropped its `code` is still reported as what it is
+  // instead of falling through to the catch-all below.
+  if (isPdfComparisonEncryptedFailure(error)) {
+    return {
+      code: PDF_COMPARISON_ENCRYPTED_CODE,
+      message: pdfComparisonEncryptedMessage(error.encryptedSides ?? []),
+    };
+  }
   if (code === "COMPARISON_PAGE_LIMIT_EXCEEDED") {
     return { code, message: "A comparison input exceeds the requested whole-document page limit." };
   }
@@ -1078,7 +1208,7 @@ export function publicPdfComparisonError(error) {
     return { code: "PDF_PARSE_FAILED", message: "A comparison input could not be parsed as a supported PDF." };
   }
   if (error instanceof TypeError || typeof error?.message === "string") {
-    return { code: "invalid_input", message: "The compare_pdfs arguments or PDF inputs are invalid." };
+    return { code: "invalid_input", message: PDF_COMPARISON_INVALID_INPUT_MESSAGE };
   }
   return { code: "tool_execution_failed", message: "The PDFs could not be compared." };
 }

--- a/server/pdf-observations.js
+++ b/server/pdf-observations.js
@@ -13,6 +13,51 @@ export const PDF_OBSERVATION_LIMITS = Object.freeze({
   max_metadata_characters: 32_768,
 });
 
+/**
+ * Every coverage reason a document observation may carry, by channel.
+ *
+ * This vocabulary does not stay inside `get_pdf_info`. `compare_pdfs` copies
+ * each observation reason into one of its own channels with a `BEFORE_` or
+ * `AFTER_` prefix, and its semantics validator rejects a payload carrying a
+ * reason it does not recognise — which turned a perfectly good comparison of
+ * two encrypted documents into "Internal output validation failed", because
+ * `RAW_PAGE_GEOMETRY_UNAVAILABLE` had never been added to the comparison's
+ * copy of this list. So the list lives here, next to the code that emits it,
+ * `validatePdfObservationSemantics` rejects anything outside it, and
+ * `server/pdf-comparison.js` builds its own set from it rather than restating
+ * it. A reason added in one place and forgotten in the other is no longer
+ * expressible.
+ */
+export const PDF_OBSERVATION_COVERAGE_REASONS = Object.freeze({
+  pages: Object.freeze([
+    "OUTPUT_LIMIT_PAGES_OMITTED",
+    "PAGE_LIMIT_REACHED",
+    "PAGE_PARSE_PARTIAL",
+    "PAGE_PARSE_UNAVAILABLE",
+    "RAW_PAGE_GEOMETRY_UNAVAILABLE",
+  ]),
+  metadata: Object.freeze([
+    "METADATA_LIMIT_REACHED",
+    "METADATA_PARSE_UNAVAILABLE",
+    "OUTPUT_LIMIT_METADATA_OMITTED",
+  ]),
+  form_fields: Object.freeze([
+    "FIELD_LIMIT_REACHED",
+    "FORM_FIELD_PAGE_GEOMETRY_PARTIAL",
+    "FORM_FIELD_PAGE_LIMIT_REACHED",
+    "FORM_FIELD_PARSE_UNAVAILABLE",
+    "OUTPUT_LIMIT_FORM_FIELDS_OMITTED",
+    "WIDGET_OBSERVATION_LIMIT_REACHED",
+  ]),
+  annotations: Object.freeze([
+    "ANNOTATION_LIMIT_REACHED",
+    "ANNOTATION_PAGE_LIMIT_REACHED",
+    "ANNOTATION_PAGE_PARSE_PARTIAL",
+    "ANNOTATION_PARSE_UNAVAILABLE",
+    "OUTPUT_LIMIT_ANNOTATIONS_OMITTED",
+  ]),
+});
+
 const OBSERVATION_COORDINATE_SPACES = Object.freeze({
   display: "pdfjs_viewport_top_left_points",
   native: "pdf_user_space_bottom_left_points",
@@ -777,6 +822,16 @@ export function validatePdfObservationSemantics(payload) {
     `${channel} coverage reasons are not unique and sorted`);
     semanticAssertion(coverage.reason_codes.length > 0 || coverage.status === "supported",
       `${channel} unavailable or partial coverage has no reason`);
+    // Every reason has to be one this module publishes, because `compare_pdfs`
+    // inherits this vocabulary and refuses a reason it has never heard of. An
+    // unregistered reason fails here, on the tool that emitted it, instead of
+    // reappearing downstream as an internal validation error.
+    semanticAssertion(
+      coverage.reason_codes.every(
+        reason => PDF_OBSERVATION_COVERAGE_REASONS[channel].includes(reason),
+      ),
+      `${channel} coverage carries a reason outside the published vocabulary`,
+    );
     semanticAssertion(
       coverage.status === coverageStatus(channel, coverage.reason_codes, channelObservation[channel]),
       `${channel} coverage status does not follow its evidence and reasons`,

--- a/server/qpdf-decrypt.js
+++ b/server/qpdf-decrypt.js
@@ -434,12 +434,31 @@ export const PDF_REPROTECT_CHANGED_MESSAGE =
   + "encryption are unchanged before saving it, and refuses rather than write a document whose "
   + "security differs from the original's.";
 
+/*
+ * The refusal a caller sees when a merge's sources are not one protection.
+ *
+ * The rule itself is not negotiable — see `mergeProtectionRefusal` — so the
+ * whole job of this text is to leave the caller with something they can
+ * actually do. It names both routes that work, and it names the trap, because
+ * the obvious reading of "the same encryption" is "the same password" and that
+ * is not enough: `/Encrypt` stores `/O` and `/U`, which are derived from
+ * material that is fresh per encryption run — a random salt at `/R` 6, the
+ * document's own `/ID` at `/R` 4 and below — so two documents encrypted in two
+ * separate qpdf runs with one password still carry two different protections.
+ * A caller who is not told that will hit it, retry with the same password, and
+ * get the same refusal.
+ */
 export const PDF_MERGE_MIXED_ENCRYPTION_MESSAGE =
   "These PDFs cannot be merged: they are not all protected the same way, so there is no single "
   + "protection the merged document could carry. PDF Tools gives a merged document the encryption "
   + "its sources share, and will not choose one source's protection over another's or drop it. "
-  + "Merge documents that share the same encryption and password, or decrypt them first and "
-  + "protect the result yourself.";
+  + "Two routes work. Either merge sources whose /Encrypt dictionary is byte-identical — copies of "
+  + "one protected document, or pieces of one protected document, such as the parts split_pdf "
+  + "produces, which keep that document's exact encryption. Or decrypt every source first (for "
+  + "example with qpdf), merge the unprotected copies, and protect the merged file yourself. "
+  + "Encrypting each source separately with the same password is not enough: every encryption run "
+  + "mixes in fresh material — a random salt at /R 6, and the document's own /ID at /R 4 and "
+  + "below — so the stored /O and /U values differ even when the password you typed was identical.";
 
 /**
  * Refusal text for a mutation the document's own `/P` denies.

--- a/test/compare-pdfs.test.js
+++ b/test/compare-pdfs.test.js
@@ -7,6 +7,12 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { PDFDocument, PDFName, PDFNumber, StandardFonts, degrees, rgb } from "pdf-lib";
 import { validateStructuredToolResult } from "../server/output-schemas.js";
+import {
+  pdfComparisonEncryptedError,
+  pdfComparisonEncryptedMessage,
+  publicPdfComparisonError,
+} from "../server/pdf-comparison.js";
+import { PDF_LIB_ENCRYPTED_MESSAGE } from "../server/helpers.js";
 import { createTestTempDirectory, removeTestTempDirectory } from "./helpers/temp-directory.js";
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -16,6 +22,15 @@ const ENCRYPTED = path.join(
   REPO_ROOT,
   "test/fixtures/eval/extraction/oracles/layout-encrypted-qpdf-r4.pdf",
 );
+const ENCRYPTED_PROVENANCE = path.join(
+  REPO_ROOT,
+  "test/fixtures/eval/extraction/oracles/layout-encrypted-qpdf-r4.provenance.json",
+);
+
+// The generic text every internal-validation failure carries. compare_pdfs used
+// to answer an encrypted document with this, and no assertion below may ever be
+// satisfied by it again.
+const INTERNAL_VALIDATION_TEXT = "Internal output validation failed";
 
 const PAIRS = Object.freeze({
   identical: ["comparison-base.pdf", []],
@@ -367,6 +382,26 @@ describe("compare_pdfs deterministic product", () => {
     });
     expect(unknown.isError).toBe(true);
     expect(JSON.stringify(unknown)).not.toContain(inputSentinel);
+    /*
+     * A rejected argument produces this same text whatever else the caller
+     * varies, so it reads like a failure of the documents rather than of the
+     * call — which is exactly how an encrypted-comparison report was once
+     * misread as the encryption refusal being swallowed. The single most likely
+     * mistake is `password`, because every other tool in this server takes one
+     * and this tool takes two, so the refusal says so by name.
+     */
+    const unknownText = unknown.content?.map(part => part.text ?? "").join("\n") ?? "";
+    expect(unknownText).toContain("before_password");
+    expect(unknownText).toContain("after_password");
+    expect(unknownText).toMatch(/no single 'password' argument/);
+    expect(unknownText).toContain("absolute");
+    // Naming the accepted arguments is safe — they are in the published input
+    // schema. Naming the caller's own rejected key is not, and never happens.
+    const advertised = (await client.listTools()).tools
+      .find(item => item.name === "compare_pdfs");
+    for (const name of Object.keys(advertised.inputSchema.properties)) {
+      expect(unknownText, name).toContain(name);
+    }
 
     const pathSentinel = "PRIVATE_INTERNAL_PATH_SENTINEL";
     const missing = await client.callTool({
@@ -406,8 +441,243 @@ describe("compare_pdfs deterministic product", () => {
       },
     });
     expect(protectedResult.isError).toBe(true);
-    expect(protectedResult.structuredContent.error.code).toBe("PASSWORD_INCORRECT");
+    // A wrong password used to be reported as a wrong password, which implied
+    // the right one would work. It would not: no password makes an encrypted
+    // comparison run, so the refusal is the encryption one either way.
+    expect(protectedResult.structuredContent.error.code)
+      .toBe("PDF_ENCRYPTED_COMPARISON_UNSUPPORTED");
     expect(JSON.stringify(protectedResult)).not.toContain(passwordSentinel);
+  });
+
+  /*
+   * An encrypted comparison input is a real, user-correctable condition, and it
+   * used to be reported three different ways depending on arguments the caller
+   * had no reason to connect to encryption:
+   *
+   *   - no password              -> "A comparison input requires its password",
+   *                                 which asks for something that cannot help;
+   *   - correct password         -> the pdf-lib limit, with no side named;
+   *   - correct password and     -> "Internal output validation failed for
+   *     include_visual: false       compare_pdfs", because the observation's
+   *                                 RAW_PAGE_GEOMETRY_UNAVAILABLE reached the
+   *                                 comparison's structure channel, which had
+   *                                 never heard of it.
+   *
+   * All three are now one refusal that names the side, the cause, and what to
+   * do. These cases pin that, and every one of them asserts the absence of the
+   * internal-validation text so the third can never come back quietly.
+   */
+  describe("encrypted comparison inputs", () => {
+    let passwords;
+
+    beforeAll(async () => {
+      passwords = JSON.parse(await fs.readFile(ENCRYPTED_PROVENANCE, "utf8")).passwords;
+    });
+
+    const compare = async args => await client.callTool({
+      name: "compare_pdfs",
+      arguments: { max_output_characters: 200_000, ...args },
+    });
+    const textOf = result => result.content?.map(part => part.text ?? "").join("\n") ?? "";
+
+    it("refuses with the same named message however the encrypted input is reached", async () => {
+      const cases = [
+        ["both, no password", ["before", "after"], {
+          before_pdf_path: ENCRYPTED, after_pdf_path: ENCRYPTED,
+        }],
+        ["both, correct passwords", ["before", "after"], {
+          before_pdf_path: ENCRYPTED, after_pdf_path: ENCRYPTED,
+          before_password: passwords.user, after_password: passwords.user,
+        }],
+        // The case that produced the internal error: no render is requested, so
+        // the pdf-lib geometry step never refuses and the comparison used to
+        // complete and then fail its own semantics validator.
+        ["both, correct passwords, no visual", ["before", "after"], {
+          before_pdf_path: ENCRYPTED, after_pdf_path: ENCRYPTED,
+          before_password: passwords.user, after_password: passwords.user,
+          include_visual: false,
+        }],
+        ["before only", ["before"], {
+          before_pdf_path: ENCRYPTED, after_pdf_path: BASE,
+          before_password: passwords.user,
+        }],
+        ["after only", ["after"], {
+          before_pdf_path: BASE, after_pdf_path: ENCRYPTED,
+          after_password: passwords.user,
+        }],
+        ["both, wrong passwords", ["before", "after"], {
+          before_pdf_path: ENCRYPTED, after_pdf_path: ENCRYPTED,
+          before_password: passwords.wrong_password_oracle,
+          after_password: passwords.wrong_password_oracle,
+        }],
+      ];
+      for (const [label, sides, args] of cases) {
+        const result = await compare(args);
+        expect(result.isError, label).toBe(true);
+        // Asserted on the SERVED response, at the MCP boundary. A module that
+        // returns the right thing is not the same claim as a caller receiving
+        // it: the code and the text have to survive every classifier between
+        // the refusal and the wire.
+        expect(result.structuredContent.error.code, label)
+          .toBe("PDF_ENCRYPTED_COMPARISON_UNSUPPORTED");
+        // Literal phrases, deliberately not routed through the message helper,
+        // so a gutted or re-swallowed message cannot satisfy this by agreeing
+        // with itself.
+        expect(textOf(result), label)
+          .toContain("cannot compare an encrypted document");
+        expect(textOf(result), label)
+          .toContain("supplying a password here will not help");
+        // The two ways this has actually been swallowed before.
+        expect(textOf(result), label).not.toContain(INTERNAL_VALIDATION_TEXT);
+        expect(result.structuredContent.error.code, label).not.toBe("invalid_input");
+        expect(textOf(result), label)
+          .not.toContain("The compare_pdfs arguments or PDF inputs are invalid");
+        // And still exactly the server's own text, so tool and module agree.
+        expect(textOf(result), label).toBe(pdfComparisonEncryptedMessage(sides));
+        expect(JSON.stringify(result), label).not.toContain(passwords.user);
+        expect(JSON.stringify(result), label)
+          .not.toContain(passwords.wrong_password_oracle);
+      }
+    }, 120_000);
+
+    it("keeps the refusal classified when it arrives without its error code", () => {
+      /*
+       * `error.code` is an own property of an Error and does not survive a
+       * boundary that rebuilds the error from its message. When that happened
+       * the refusal fell through to `invalid_input`, "the arguments or PDF
+       * inputs are invalid" — a false statement about a call whose arguments
+       * were fine, and indistinguishable from a genuine argument mistake.
+       */
+      const carried = pdfComparisonEncryptedError(["before"]);
+      expect(publicPdfComparisonError(carried).code)
+        .toBe("PDF_ENCRYPTED_COMPARISON_UNSUPPORTED");
+      // Same refusal, rebuilt from text alone.
+      const stripped = new Error(pdfComparisonEncryptedMessage(["before"]));
+      expect(stripped.code).toBeUndefined();
+      expect(publicPdfComparisonError(stripped).code)
+        .toBe("PDF_ENCRYPTED_COMPARISON_UNSUPPORTED");
+      // And a real argument mistake must still classify as one, or the guard
+      // above would just be swallowing everything in the other direction.
+      expect(publicPdfComparisonError(new Error("Unknown compare_pdfs argument: nope.")).code)
+        .toBe("invalid_input");
+    });
+
+    it("translates the pdf-lib limit in the layer that is allowed to see it", async () => {
+      /*
+       * The other encryption signal is the shared pdf-lib "no decryption
+       * support" message, raised by the page renderer inside the PDF.js
+       * subprocess. It cannot be matched in server/pdf-comparison.js: that
+       * module's static import graph is closed and asserted by
+       * test/eval/extraction-phase1-generation-verifiers.test.js, and importing
+       * server/helpers.js for the constant would pull pdf-lib into the
+       * extraction scorer's graph. So server/index.js owns the translation, and
+       * both halves of that split are pinned here — otherwise the next edit
+       * "simplifies" one of them and the refusal silently degrades to
+       * invalid_input again.
+       */
+      const comparison = await fs.readFile(
+        path.join(REPO_ROOT, "server/pdf-comparison.js"), "utf8",
+      );
+      expect(comparison).not.toMatch(/from\s+"\.\/helpers\.js"/);
+      const server = await fs.readFile(path.join(REPO_ROOT, "server/index.js"), "utf8");
+      // Substring, never equality: a subprocess boundary may prefix the text,
+      // and an equality check that stops matching fails silently rather than
+      // loudly.
+      expect(server).toMatch(
+        /function comparisonSawPdfLibEncryptionLimit[\s\S]{0,400}?\.includes\(PDF_LIB_ENCRYPTED_MESSAGE\)/,
+      );
+      // Scoped to the comparison's own classifier. Other tools keep their own
+      // equality checks against this constant, and those are not this test's
+      // business.
+      const classifier = server.slice(
+        server.indexOf("function comparisonEncryptionFailure"),
+        server.indexOf("function comparisonInputIsEncrypted"),
+      );
+      expect(classifier.length).toBeGreaterThan(0);
+      expect(classifier).toContain("comparisonSawPdfLibEncryptionLimit(error)");
+      expect(classifier).not.toMatch(/message === PDF_LIB_ENCRYPTED_MESSAGE/);
+      // The constant it matches is the real one the family publishes.
+      expect(PDF_LIB_ENCRYPTED_MESSAGE).toMatch(/no decryption support/);
+    });
+
+    it("says which input, why it stops, and what the caller can do instead", () => {
+      // Derived from the message rather than restated beside it: a rewrite that
+      // drops any of these propositions fails here.
+      for (const [sides, subject] of [
+        [["before"], "The before comparison input is encrypted"],
+        [["after"], "The after comparison input is encrypted"],
+        [["before", "after"], "Both comparison inputs are encrypted"],
+        [[], "A comparison input is encrypted"],
+      ]) {
+        expect(pdfComparisonEncryptedMessage(sides)).toContain(subject);
+      }
+      const message = pdfComparisonEncryptedMessage(["before", "after"]);
+      // Why: the incidental pdf-lib step, named as the family names it.
+      expect(message).toMatch(/pdf-lib/);
+      expect(message).toMatch(/no decryption support/);
+      // And therefore why the password arguments are not the answer.
+      expect(message).toMatch(/supplying a password here will not help/);
+      expect(message).not.toMatch(/provide the correct password/i);
+      expect(message).not.toMatch(/ignoreEncryption/);
+      // That it stops rather than reporting a thinner comparison.
+      expect(message).toMatch(/it stops/);
+      // What to do, and where an encrypted document can actually be read. The
+      // named tools are exactly the ones the pdf-lib family message names, and
+      // test/encrypted-pdf-password-truth.test.js proves each of them opens an
+      // encrypted document with its password.
+      expect(message).toMatch(/Decrypt both documents first \(for example with qpdf\)/);
+      for (const tool of ["read_pdf_layout", "convert_pdf_to_markdown", "get_pdf_info"]) {
+        expect(PDF_LIB_ENCRYPTED_MESSAGE, tool).toContain(tool);
+        expect(message, tool).toContain(tool);
+      }
+      expect(message).not.toContain(INTERNAL_VALIDATION_TEXT);
+    });
+
+    it("reports missing raw page geometry as coverage, not as an internal fault", async () => {
+      /*
+       * The other half of the same defect, and the half that has nothing to do
+       * with encryption. `observe_document` reads raw page geometry with
+       * pdf-lib and falls back to PDF.js when it cannot, recording
+       * RAW_PAGE_GEOMETRY_UNAVAILABLE. The comparison copied that into its
+       * structure channel and then rejected it as an unknown reason, so any
+       * unprotected document pdf-lib cannot parse but PDF.js can — here, one
+       * whose %PDF- marker has been overwritten, the same damage the encrypted
+       * layout oracle carries deliberately — answered with "Internal output
+       * validation failed" instead of a partial comparison.
+       */
+      const damaged = path.join(tempDirectory, "damaged-header-base.pdf");
+      const bytes = Buffer.from(await fs.readFile(BASE));
+      bytes.write("xxxxx", 0, "latin1");
+      await fs.writeFile(damaged, bytes);
+      const result = await compare({
+        before_pdf_path: damaged,
+        after_pdf_path: path.join(FIXTURES, PAIRS.material_text[0]),
+        include_visual: false,
+      });
+      expect(textOf(result)).not.toContain(INTERNAL_VALIDATION_TEXT);
+      expect(result.isError).not.toBe(true);
+      expect(validateStructuredToolResult("compare_pdfs", result)).toBe(result);
+      expect(result.structuredContent.coverage.structure).toEqual({
+        status: "partial",
+        reason_codes: ["BEFORE_RAW_PAGE_GEOMETRY_UNAVAILABLE"],
+      });
+      expect(result.structuredContent.status).toBe("partial");
+      expect(result.structuredContent.summary.no_reported_changes).toBe(false);
+      expect(result.structuredContent.limitations)
+        .toContain("structure:BEFORE_RAW_PAGE_GEOMETRY_UNAVAILABLE");
+    }, 60_000);
+
+    it("still compares two unprotected documents, which is the advice it gives", async () => {
+      // The refusal tells the caller to compare decrypted copies. That has to
+      // remain a real route, so the same run proves it.
+      const result = await compare({
+        before_pdf_path: BASE,
+        after_pdf_path: path.join(FIXTURES, PAIRS.material_text[0]),
+      });
+      expect(result.isError).not.toBe(true);
+      expect(validateStructuredToolResult("compare_pdfs", result)).toBe(result);
+      expect(result.structuredContent.status).toEqual(expect.any(String));
+    }, 60_000);
   });
 
   it("fails rather than dropping raw changes at the structured-output cap", async () => {

--- a/test/encrypted-pdf-password-truth.test.js
+++ b/test/encrypted-pdf-password-truth.test.js
@@ -285,6 +285,104 @@ describe.skipIf(!QPDF.available)("encrypted PDF password truthfulness (qpdf pres
     }
   }, 90_000);
 
+  it("refuses an encrypted comparison usefully, rather than as an internal fault", async () => {
+    // compare_pdfs cannot decrypt: PDF.js gives it text, forms, annotations and
+    // metadata, but page geometry and page rendering go through pdf-lib. What
+    // it must never do is report that as an internal error, which is what it
+    // did whenever the visual channel was switched off and the encrypted
+    // observation's RAW_PAGE_GEOMETRY_UNAVAILABLE reached its structure
+    // channel. Both argument shapes are checked, because that is exactly the
+    // difference that used to change the answer.
+    for (const includeVisual of [true, false]) {
+      const result = await callTool("compare_pdfs", {
+        before_pdf_path: encryptedPath,
+        after_pdf_path: encryptedPath,
+        before_password: USER_PASSWORD,
+        after_password: USER_PASSWORD,
+        include_visual: includeVisual,
+      });
+      const text = toolText(result);
+      const label = `include_visual: ${includeVisual}`;
+      expect(result.isError, label).toBe(true);
+      expect(text, label).not.toMatch(/Internal output validation failed/);
+      expect(result.structuredContent.error.code, label)
+        .toBe("PDF_ENCRYPTED_COMPARISON_UNSUPPORTED");
+      // Same three obligations as every other refusal in this family: what was
+      // wrong, why the password cannot fix it, and where an encrypted document
+      // can actually be read.
+      expect(text, label).toContain("Both comparison inputs are encrypted");
+      expect(text, label).toMatch(/pdf-lib, which has no decryption support/);
+      expect(text, label).toMatch(/supplying a password here will not help/);
+      for (const named of PDFJS_PASSWORD_TOOLS) expect(text, `${label} ${named}`).toContain(named);
+      expect(text, label).not.toContain(USER_PASSWORD);
+      // The other way this refusal has been lost: re-reported as a generic
+      // argument fault, which is a false statement about a valid call.
+      expect(result.structuredContent.error.code, label).not.toBe("invalid_input");
+      expect(text, label).not.toContain("arguments or PDF inputs are invalid");
+    }
+  }, 180_000);
+
+  it("tells a caller who used 'password' that this tool names two", async () => {
+    // compare_pdfs is the only read tool that takes two documents and therefore
+    // two password arguments. Every other tool here takes `password`, so that
+    // is what a caller reaches for — and an unknown argument is refused with a
+    // message that used to name nothing at all, making a perfectly good call
+    // look like a broken document.
+    const result = await callTool("compare_pdfs", {
+      before_pdf_path: encryptedPath,
+      after_pdf_path: encryptedPath,
+      password: USER_PASSWORD,
+    });
+    const text = toolText(result);
+    expect(result.isError).toBe(true);
+    expect(text).toContain("before_password");
+    expect(text).toContain("after_password");
+    expect(text).not.toContain(USER_PASSWORD);
+  }, 60_000);
+
+  it("refuses a mixed-encryption merge with the two routes that would work", async () => {
+    // Encrypting two documents with one password does not give them one
+    // protection — the salts and /ID differ per run — so the merge is refused.
+    // The refusal has to say that, because "I used the same password" is
+    // exactly what the caller will have done.
+    const second = path.join(tempDirectory, "aes256-encrypted-second.pdf");
+    const encrypt = spawnSync("qpdf", [
+      "--encrypt", `--user-password=${USER_PASSWORD}`, `--owner-password=${USER_PASSWORD}`,
+      "--bits=256", "--", PLAINTEXT_PDF, second,
+    ], { encoding: "utf8" });
+    expect(encrypt.status, encrypt.stderr).toBe(0);
+
+    const refused = await callTool("merge_pdfs", {
+      input_paths: [encryptedPath, second],
+      output_path: path.join(tempDirectory, "merged-mixed.pdf"),
+      password: USER_PASSWORD,
+    });
+    const text = toolText(refused);
+    expect(refused.isError).toBe(true);
+    // Asserted on the served response at the MCP boundary. merge_pdfs raises
+    // this inside the isolated pdf-lib child, so the whole message has to
+    // survive a process boundary to reach the caller at all.
+    expect(text).toContain("not all protected the same way");
+    expect(text).toContain("Encrypting each source separately with the same password is not enough");
+    expect(text).toMatch(/byte-identical/);
+    expect(text).toMatch(/protect the merged file yourself/);
+    expect(text).not.toContain(USER_PASSWORD);
+    await expect(fs.access(path.join(tempDirectory, "merged-mixed.pdf"))).rejects.toThrow();
+
+    // And the route it names is real: copies of one protected document share
+    // one /Encrypt dictionary and merge.
+    const copy = path.join(tempDirectory, "aes256-encrypted-copy.pdf");
+    await fs.writeFile(copy, encryptedBytes);
+    const merged = path.join(tempDirectory, "merged-identical.pdf");
+    const accepted = await callTool("merge_pdfs", {
+      input_paths: [encryptedPath, copy],
+      output_path: merged,
+      password: USER_PASSWORD,
+    });
+    expect(accepted.isError, toolText(accepted)).not.toBe(true);
+    expect((await fs.readFile(merged)).toString("latin1")).toContain("/Encrypt");
+  }, 180_000);
+
   it("never advertises a usable password on a pdf-lib-backed tool", async () => {
     // The schema text is the other place the claim can drift.
     const { tools } = await client.listTools();

--- a/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
+++ b/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
@@ -85,8 +85,8 @@
     {
       "role": "output_schemas_module",
       "path": "server/output-schemas.js",
-      "bytes": 51968,
-      "sha256": "b6de24f6a9734d402322877a7270fca2924eafd571e67667c392c3fd3a6d9557"
+      "bytes": 52229,
+      "sha256": "295f2fcb3af55d0a5360d3773d3293b125f9596354c13c650abd26313dbef466"
     },
     {
       "role": "package_json",
@@ -103,14 +103,14 @@
     {
       "role": "pdf_comparison_module",
       "path": "server/pdf-comparison.js",
-      "bytes": 63849,
-      "sha256": "a41676ca02c3e29cd3735c5f6f59181e46f9365533067f54e8cc8cc4ef20ad9d"
+      "bytes": 70886,
+      "sha256": "447712f35c848edff91649366de6e20d719095c2dbe401a1b8a3bb4da01a8787"
     },
     {
       "role": "pdf_observations_module",
       "path": "server/pdf-observations.js",
-      "bytes": 40995,
-      "sha256": "45acccc57758f557affb5612c3c0f0e3a9fc63d9e06f6760aabb8544ea309eb5"
+      "bytes": 43255,
+      "sha256": "7eca5efe0658f3f5512567d4da0aa193bebea470a441db5269d5369f24d582d2"
     },
     {
       "role": "pdfjs_package",
@@ -125,7 +125,7 @@
       "sha256": "6e4429db62fcbe1dd73141d8c20a48b564d41f8bf8920d88775846995e1daf94"
     }
   ],
-  "validator_source_set_sha256": "47ed405f9df0b4efc6f3d05d4e5074c543737f1cac6389689400ab49de8b5050",
+  "validator_source_set_sha256": "fb4cc8a4cc8219e077836599f49398e0d72664630d607845153fc76ef0aba818",
   "pdfjs_version": "5.4.624",
   "generation_contract": {
     "source_path": "source.pdf",

--- a/test/mcp-contract.test.js
+++ b/test/mcp-contract.test.js
@@ -125,7 +125,18 @@ const EXAMPLE_PDF = path.join(REPO_ROOT, "example-fw9.pdf");
 // tool never removes or weakens a document's protection. No tool gains or loses
 // a parameter, and no write description changes. Previously
 // 565e4e6c9debad5b16b148acb5cac2814d93c1c3085b50fa7b62754acc8ec01a.
-const TOOL_CONTRACT_SHA256 = "f4d6e1eca85676a0830821871e2775d7ccbde1ba5d5a8ee396068b862b28610b";
+//
+// 2026-08-10: compare_pdfs gains one advertised error code,
+// PDF_ENCRYPTED_COMPARISON_UNSUPPORTED. An encrypted comparison input was
+// reported three different ways depending on arguments the caller had no reason
+// to connect to encryption — "requires its password", the pdf-lib limit, or
+// "Internal output validation failed" when include_visual was false — and none
+// of them said which input it was or that no password can help. The refusal is
+// now one typed outcome. PDF_PARSE_FAILED would have been a lie: the document
+// parses. No input schema changes, so the trajectory tool-contract fixture is
+// unaffected. Previously
+// f4d6e1eca85676a0830821871e2775d7ccbde1ba5d5a8ee396068b862b28610b.
+const TOOL_CONTRACT_SHA256 = "a4d831d49d97c8605c06bda0fccad7bcbd399106b9fb980040a1b5f25e7a1e4b";
 
 const CLOSED_READ = Object.freeze({
   readOnlyHint: true,

--- a/test/pdf-comparison.test.js
+++ b/test/pdf-comparison.test.js
@@ -1,10 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
+  PDF_COMPARISON_COVERAGE_REASONS,
+  PDF_COMPARISON_SIDES,
   alignComparisonPages,
   derivePdfComparisonCoverage,
   diffComparisonRgba,
   normalizeComparisonText,
 } from "../server/pdf-comparison.js";
+import { PDF_OBSERVATION_COVERAGE_REASONS } from "../server/pdf-observations.js";
 
 function page(pageNumber, text, { width = 100, height = 100, rotation = 0 } = {}) {
   return {
@@ -388,5 +391,57 @@ describe("PDF comparison primitives", () => {
       .toEqual({ status: "unavailable", reason_codes: ["VISUAL_RENDERER_UNAVAILABLE"] });
     expect(derivePdfComparisonCoverage([document("before"), document("after")], false).visual)
       .toEqual({ status: "unavailable", reason_codes: ["VISUAL_NOT_REQUESTED"] });
+  });
+
+  /*
+   * `derivePdfComparisonCoverage` copies every reason a document observation
+   * carries into a comparison channel with the side's name in front, and
+   * `validatePdfComparisonSemantics` then rejects any reason the comparison
+   * does not recognise. So the comparison's vocabulary has to be a superset of
+   * the observation's, and for three reasons it was not:
+   * RAW_PAGE_GEOMETRY_UNAVAILABLE, FORM_FIELD_PAGE_GEOMETRY_PARTIAL and
+   * ANNOTATION_PAGE_PARSE_PARTIAL. A document raising any of them turned a
+   * valid comparison into "Internal output validation failed for compare_pdfs".
+   *
+   * Both sides of this are read from the modules that own them, so a reason
+   * added to an observation and forgotten here fails immediately instead of
+   * waiting for a document that happens to raise it.
+   */
+  it("recognises every reason a document observation can hand it, on both sides", () => {
+    const observationReasons = Object.values(PDF_OBSERVATION_COVERAGE_REASONS).flat();
+    expect(observationReasons.length).toBeGreaterThan(0);
+    expect(new Set(observationReasons).size).toBe(observationReasons.length);
+    expect(PDF_COMPARISON_SIDES).toEqual(["before", "after"]);
+    for (const side of PDF_COMPARISON_SIDES) {
+      for (const reason of observationReasons) {
+        const prefixed = `${side.toUpperCase()}_${reason}`;
+        expect(PDF_COMPARISON_COVERAGE_REASONS.has(prefixed), prefixed).toBe(true);
+      }
+    }
+    // And the prefixing really is what the derivation does, so the check above
+    // is testing the same strings the comparison will actually produce.
+    const supported = { status: "supported", reason_codes: [] };
+    const document = side => ({
+      side,
+      observation: {
+        coverage: {
+          pages: { status: "partial", reason_codes: [...PDF_OBSERVATION_COVERAGE_REASONS.pages] },
+          metadata: supported,
+          form_fields: supported,
+          annotations: supported,
+        },
+      },
+      layout: { truncation: { truncated: false }, pages: [] },
+      renders: [],
+    });
+    const derived = derivePdfComparisonCoverage(
+      [document("before"), document("after")],
+      false,
+    );
+    expect(derived.structure.reason_codes.length)
+      .toBe(PDF_OBSERVATION_COVERAGE_REASONS.pages.length * 2);
+    for (const reason of derived.structure.reason_codes) {
+      expect(PDF_COMPARISON_COVERAGE_REASONS.has(reason), reason).toBe(true);
+    }
   });
 });

--- a/test/qpdf-reprotect-write-paths.test.js
+++ b/test/qpdf-reprotect-write-paths.test.js
@@ -30,6 +30,7 @@ import {
 } from "../server/pdf-lib-subprocess.js";
 import {
   ENCRYPTED_WRITE_OPERATIONS,
+  PDF_MERGE_MIXED_ENCRYPTION_MESSAGE,
   mergeProtectionRefusal,
   sameProtection,
   usesWeakCrypto,
@@ -363,7 +364,79 @@ describe("merge_pdfs refuses when the sources' protection is not one protection"
     ).catch(error => error);
     expect(failure).toBeInstanceOf(Error);
     expect(failure.message).toContain("not all protected the same way");
+    // And this is precisely the trap the refusal has to name, because the
+    // caller did supply one password for both documents and will otherwise
+    // read "the same encryption" as "the same password" and retry.
+    expect(failure.message).toContain(
+      "Encrypting each source separately with the same password is not enough",
+    );
   }, 120_000);
+
+  /*
+   * The rule above is not negotiable; what a caller can do about it is. These
+   * cases pin the guidance itself, and then prove each named route works, so
+   * the message can never drift into advice that cannot be followed.
+   */
+  describe("the refusal tells the caller what would work", () => {
+    it("names why, what is wrong, and both routes that succeed", () => {
+      const message = PDF_MERGE_MIXED_ENCRYPTION_MESSAGE;
+      // What was wrong, and why it stops rather than choosing for the caller.
+      expect(message).toContain("not all protected the same way");
+      expect(message).toMatch(/will not choose one source's protection over another's or drop it/);
+      // Route one: sources whose stored protection really is one protection.
+      expect(message).toMatch(/byte-identical/);
+      expect(message).toMatch(/copies of one protected document/);
+      expect(message).toMatch(/split_pdf/);
+      // Route two: take the protection off first, and put it back yourself.
+      expect(message).toMatch(/decrypt every source first \(for example with qpdf\)/i);
+      expect(message).toMatch(/protect the merged file yourself/);
+      // The trap, with the reason it is a trap rather than a bare warning.
+      expect(message).toMatch(/same password is not enough/);
+      expect(message).toMatch(/\/R 6/);
+      expect(message).toMatch(/\/ID/);
+      expect(message).toMatch(/\/O and \/U/);
+      // It must not offer the one thing PDF Tools will never do.
+      expect(message).not.toMatch(/remove the password/i);
+    });
+
+    it("merges the pieces split_pdf makes of one protected document", async () => {
+      // Route one, as the message states it. split_pdf re-protects each part
+      // with --copy-encryption, so the parts carry the source's exact /Encrypt
+      // dictionary and are therefore one protection.
+      const source = fixtures.aes256;
+      const parts = await mutate(
+        "split_pdf",
+        [await bindSource(source)],
+        USER_PASSWORD,
+        { page_ranges: "1-2,3-4" },
+      );
+      expect(parts).toHaveLength(2);
+      expect(encryptDictionary(parts[0])).toBe(encryptDictionary(source));
+      expect(encryptDictionary(parts[1])).toBe(encryptDictionary(source));
+      const [merged] = await mutate(
+        "merge_pdfs",
+        [await bindSource(parts[0]), await bindSource(parts[1])],
+        USER_PASSWORD,
+        {},
+      );
+      await expectProtectionPreserved(source, merged, USER_PASSWORD, "merge split parts");
+    }, 180_000);
+
+    it("merges unprotected copies, which the caller may then protect", async () => {
+      // Route two. Decryption is the caller's step, so this stands in for it
+      // with the plaintext the fixtures were built from: the merge itself must
+      // succeed and produce an unprotected document, which is what leaves the
+      // caller free to protect the result however they choose.
+      const [merged] = await mutate(
+        "merge_pdfs",
+        [await bindSource(fixtures.plain), await bindSource(fixtures.plain)],
+        null,
+        {},
+      );
+      expect(encryptDictionary(merged)).toBeNull();
+      expect(await opensWith(merged, null)).toBe(true);
+    }, 120_000);
+  });
 });
 
 describe("the rules, without a worker", () => {


### PR DESCRIPTION
Three refusals that were correct and useless — each named a problem the caller
could not act on.

## 1. `compare_pdfs` reported a real condition as an internal fault

**Root cause was enum drift, and it was never about encryption.**
`server/pdf-comparison.js` restated the observation module's coverage reasons by
hand and had missed three, so `validatePdfComparisonSemantics` rejected a payload
the comparison had just built correctly. Confirmed against pristine
`origin/master`: an **unprotected** PDF with a damaged `%PDF-` marker hits the
same path. The list is now **derived** from `PDF_OBSERVATION_COVERAGE_REASONS`
rather than restated, so the two cannot disagree.

It also answered **three different ways** depending on arguments the caller had no
reason to connect to encryption (`include_visual` changed which failure surfaced).
Now uniform and up front, code `PDF_ENCRYPTED_COMPARISON_UNSUPPORTED`, naming which
side is encrypted and pointing at the tools that do accept a password.

**Routing it through `decryptPdfForRead` was considered and rejected:** the only
pdf-lib use is page geometry PDF.js already supplies as `fallbackPageGeometry`, so
it would put the QPDF runtime in a third host and add 16×input alongside two sets
of rendered pages — to buy a value already in hand.

## 2. `merge_pdfs` gave advice that does not work

The strictness is unchanged and still refuses unless every source shares a
byte-identical `/Encrypt`. But the old message said *"merge documents that share
the same encryption and password"* — which is the exact trap: separate encryption
runs mix in fresh material (random salt at R6, the document's `/ID` at R≤4), so
identical passwords still produce different `/O` and `/U`.

Now names the two routes that **do** work — copies of one protected document, or
the parts `split_pdf` produces, which keep that document's exact encryption — both
verified before being claimed, and both now regression tests so the advice cannot
rot.

## 3. `invalid_input`, which came out of my own mistake

I probed the fix with `before_path`/`after_path` instead of
`before_pdf_path`/`after_pdf_path`, got the generic reply, and reported the fix as
not landing. The fix was fine. The message was not — it named no argument and read
like a failure of the documents.

It now lists what the tool accepts and notes that a tool taking two documents has
no single `password` argument. The rejected key is still never echoed.

## Two classification fragilities closed

Either would have silently reclassified encryption as bad input:

- the refusal was recognised **only by `error.code`**, which does not survive an
  error rebuilt from its message → now matched by code **or** message signature;
- the pdf-lib limit was matched by **exact string equality**, despite being raised
  in the PDF.js subprocess and returning as text → now a substring match.

Verified: a typed error, a `code`-stripped rebuild, and a prefixed
`"PDF.js subprocess failed: …"` all classify correctly; a real argument mistake
still returns `invalid_input`.

## Assertions moved to the served response

The tests already called the real server, but did not assert the **negative**, and
one text check routed through the message helper — so a gutted-but-self-consistent
message could have passed. Now pinned on the served response: the typed code,
literal phrases (not via the constant), `code !== "invalid_input"`, and absence of
`"Internal output validation failed"`.

`merge_pdfs` was checked the same way and is unaffected — its refusal survives the
child-process boundary intact.

## Verification

`npm test` — **2372 passed, 0 failed**. `test:contract:share`, `build:mcpb`
(byte-identical double build) and `smoke:mcpb` all pass. Layout oracle regenerated:
only source identities moved, no case data.

Docs corrected — `CLAUDE.md` documented the internal error as a known defect, and
`MCP_CONTRACT.md` / `OUTPUT_SCHEMAS.md` both listed "password failures" for
comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)