### PR TITLE
Rebuild the native-canvas crash latch to the standard review demanded

### DIFF
--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -650,9 +650,32 @@ releases instead.
 
 ## Native canvas inside an embedded host (Windows rendering)
 
-Page rasterization (`render_pdf_page`, `render_pdf_region`) needs the `@napi-rs/canvas` native binding. Inside an embedded Electron host such as Claude Desktop, loading it is blocked by default on every platform. `PDF_TOOLS_EMBEDDED_NATIVE_CANVAS=1` lifts the block; any other value, including unset, leaves it in force.
+Page rasterization (`render_pdf_page`, `render_pdf_region`) needs the `@napi-rs/canvas` native binding. Inside an embedded Electron host such as Claude Desktop, loading it is blocked by default on every platform.
 
-Set it where the server is configured. Under MCPB that is the extension manifest's `server.mcp_config.env`.
+| Value | Effect |
+|---|---|
+| unset | Blocked. The default on every platform. |
+| `1` | Opt in, **subject to the crash latch** below. |
+| `0` | Blocked unconditionally. Kill switch; beats everything. |
+| `force` | Allowed, bypassing the latch. How a latched install is recovered. |
+
+Set it where the server is configured. Under MCPB that is the extension manifest's `server.mcp_config.env`. A User-scope Windows environment variable does **not** reach the MCP server subprocess; the manifest is the only channel that works.
+
+`=1` deliberately respects the latch. In the reverted design the flag bypassed it, which meant the recovery mechanism could only ever run on a population that did not exist yet — the default was off, so nothing exercised it. Binding the flag to the latch instead puts today's Windows opt-in users on the same code path a future default would use, which is where the evidence for flipping has to come from.
+
+### The crash latch
+
+A `dlopen` that destabilises Electron hard-crashes the host rather than raising, so no in-process handler can see it and a naive retry crashes on every launch. Recovery therefore has to survive process death.
+
+The guard writes and `fsync`s a marker to `<profiles dir>/native-canvas-attempt.json` immediately before the load, and keeps it there through the first draw — it is cleared only when the request that triggered the load completes. A marker found at the next load means a previous process entered that window and never came back, so native canvas latches off for that install until someone sets `=force`.
+
+Three properties are worth knowing:
+
+- **A load that raises does not latch.** That is a recoverable environment problem such as a missing VC++ runtime; the host is intact and it must stay retryable.
+- **Markers are owned.** Each carries a random token held only in the arming process's memory, so no other server sharing the home directory can clear it. A marker whose pid is still alive reports `concurrent` — refused, but not latched, because nothing has died.
+- **Teardown is not covered, and this is not claimed away.** Holding the marker to process exit cannot distinguish a canvas crash from a user force-quitting the host, and force-quit is common enough that it would latch off nearly every install.
+
+`test/embedded-native-canvas-latch.test.js` drives the real guarded `process.dlopen` with an injected loader. Every guard in it has been checked to go red when removed, including the specific clear-on-link defect that got the first attempt reverted.
 
 ### What is known
 
@@ -664,14 +687,24 @@ Blocking it is what leaves Windows and Linux with no renderer at all, because `p
 
 ### Why the default has not been flipped
 
-A win32 default was implemented and reverted after review. The crash-survival latch backing it did not hold:
+A win32 default was implemented and reverted after review, because the crash-survival latch backing it did not hold. All four code-level defects that review found are now fixed:
 
-- It cleared its marker the moment `dlopen` returned, covering only the link step — the one step there is already positive evidence for — and leaving first draw and teardown, where this class of instability actually appears, unprotected.
-- It had no lock and no ownership. Two servers sharing a home directory could erase each other's in-flight marker, and surviving concurrent use is the specific bar stated publicly on issue #42.
-- Its remediation strings were unreachable. `@napi-rs/canvas` swallows a `dlopen` throw into its own "Cannot find native binding" text, which `canvasDependencyError` (`server/pdfjs-worker.js:1172-1178`) then rewrites into the generic unavailable-renderer message, so a latched install, an unconfigurable install, and a genuinely broken one are indistinguishable to a user.
-- Its tests asserted the policy function against files the tests themselves wrote. Making the arm and clear functions no-ops left all of them passing.
+| Defect in the reverted latch | Now |
+|---|---|
+| Cleared its marker the moment `dlopen` returned, covering only the link step — the one step there was already positive evidence for | The marker carries a phase and is cleared only when the request that triggered the load completes, so it spans link **and** first draw |
+| No lock and no ownership; two servers sharing a home directory could erase each other's in-flight marker | Each marker carries a token held only in the arming process's memory; a live foreign pid reports `concurrent` rather than being mistaken for a crash |
+| Remediation unreachable — `@napi-rs/canvas` swallows a `dlopen` throw into its own "Cannot find native binding" text, which `canvasDependencyError` then rewrites into the generic unavailable-renderer message | The reason travels out of band through a bound probe and is appended to the renderer error, so a latched install now says it is latched and how to recover |
+| Tests asserted the policy function against files the tests wrote; making arm and clear no-ops left them all passing | `test/embedded-native-canvas-latch.test.js` drives the real guarded `process.dlopen` with an injected loader, and every guard is checked to go red when removed |
 
-**Before flipping this default, at minimum:** a marker that survives past first successful render; per-process ownership or locking; a remediation string that actually reaches the user; a test that drives `installInProcessCanvasNativeGuard` with an injected `dlopen` and asserts state in the returned, thrown, and never-returned cases; a latch arm in the Windows probe that can still record a result when the child crashes; and sustained plus concurrent evidence on a real host, since that is what was promised publicly.
+**The default is still off, and the remaining gates are evidence, not code.** No amount of local work can supply them:
+
+- ≥20 renders across page sizes, plus a concurrent pair, on a real Windows Claude Desktop with no host crash
+- isolation mode observed as `in_process` for each — a run that took the subprocess path never installed this guard and proves nothing about it
+- the latch observed actually latching after at least one real host crash
+- a latch arm in the Windows probe that can still record a result when the child crashes — a hard crash currently takes the probe's own result file with it, which is the one outcome the probe most needs to capture
+- a Linux datapoint before Linux is included; macOS retested or explicitly excluded
+
+The switch itself is `NATIVE_CANVAS_DEFAULT_PLATFORMS` in `server/pdfjs-subprocess.js`, deliberately an empty array. Adding `"win32"` is the entire flip, and a test fails if it is added, so it cannot happen quietly.
 
 Note also that `.github/workflows/windows-render.yml` is `workflow_dispatch` only, so none of this is gated on any PR or push.
 

--- a/pdf-toolkit-mcp-share/server/pdfjs-subprocess.js
+++ b/pdf-toolkit-mcp-share/server/pdfjs-subprocess.js
@@ -1,7 +1,16 @@
 import { spawn } from "node:child_process";
-import { createHash } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
+import {
+  closeSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { chmod, lstat, mkdtemp, realpath, rm } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { Worker } from "node:worker_threads";
@@ -43,6 +52,16 @@ const activeThreadSystemChildren = new Set();
 let inProcessWorkerModulePromise = null;
 let inProcessWorkerModule = null;
 let inProcessCanvasGuardInstalled = false;
+// The native-canvas attempt this process armed, if any: { markerPath, token }.
+// The token is held only in memory, which is what makes ownership decidable -
+// no other process can ever present it, so no other process can clear a marker
+// it does not own.
+let activeNativeCanvasAttempt = null;
+// Why the last native-canvas load was refused, for the renderer error path.
+// It cannot travel on the thrown error: @napi-rs/canvas catches whatever dlopen
+// throws and reports its own "Cannot find native binding" instead, discarding
+// ours. This is read back through a bound probe, see pdfjs-worker.js.
+let lastNativeCanvasBlockReason = null;
 let shutdownInProgress = false;
 let shutdownTerminal = false;
 let gracefulShutdownPromise = null;
@@ -906,6 +925,7 @@ async function runThreadWorker({
 async function loadInProcessWorkerModule() {
   inProcessWorkerModulePromise ??= import("./pdfjs-worker.js").then(worker => {
     worker.bindPdfjsWorkerSystemRendererControllerProbe(() => shutdownInProgress);
+    worker.bindPdfjsWorkerNativeCanvasBlockReasonProbe(() => lastNativeCanvasBlockReason);
     inProcessWorkerModule = worker;
     return worker;
   });
@@ -938,47 +958,294 @@ async function loadInProcessWorkerModule() {
 //
 // That is not enough on its own to trust a default, because the failure this
 // guards against is a hard host crash that no in-process handler can catch. So
-// the default stays OFF everywhere and the flag stays a pure opt-in.
+// the default stays OFF on every platform. What follows is the durable recovery
+// a default would need, kept load-bearing for the opt-in users who are the only
+// available source of the soak evidence a flip requires.
 //
-// A win32 default was implemented and reverted. An adversarial review showed the
-// crash-survival latch backing it did not hold: it cleared its marker the moment
-// dlopen returned, so it covered only the link step, which is the one step two
-// positive datapoints already exist for. The instability this guards against in
-// a Chromium process that already has its own Skia characteristically appears at
-// first draw or teardown, both of which were left unprotected. The mechanism
-// also had no lock and no ownership, so two servers sharing one home directory
-// could erase each other's in-flight marker, and concurrency was the exact
-// condition named publicly on issue #42 as a prerequisite for flipping.
+// A win32 default was implemented and reverted once. The adversarial review that
+// killed it found the crash-survival latch cleared its marker the moment dlopen
+// returned, so it covered only the link step - the one step two positive
+// datapoints already existed for. The instability this guards against, in a
+// Chromium process that already has its own Skia, characteristically appears at
+// first draw. The mechanism also had no ownership, so two servers sharing one
+// home directory could erase each other's in-flight marker, and concurrency was
+// the exact condition named publicly on issue #42 as a prerequisite for
+// flipping. Both defects are addressed below.
+
+// Platforms where native canvas is ON by default inside an embedded host.
+// EMPTY ON PURPOSE. This array is the switch; adding "win32" is the whole flip,
+// and it must not be added until every gate is met:
 //
-// Do not flip this default again without, at minimum: a marker that survives
-// past first successful render, per-process ownership or locking, a remediation
-// string that actually reaches the user (the current one is swallowed by
-// @napi-rs/canvas's own "Cannot find native binding" text and rewritten by
-// canvasDependencyError), and a test that drives installInProcessCanvasNativeGuard
-// with an injected dlopen instead of asserting the policy function against files
-// the test wrote itself.
-export function embeddedNativeCanvasAllowed({ env = process.env } = {}) {
-  return env.PDF_TOOLS_EMBEDDED_NATIVE_CANVAS === "1";
+//   - >= 20 renders across page sizes, plus a concurrent pair, on a real
+//     Windows Claude Desktop with no host crash
+//   - isolation mode observed as "in_process" for each, because a run that took
+//     the subprocess path never installed this guard and proves nothing about it
+//   - this latch fault-injected (test/embedded-native-canvas-latch.test.js) and
+//     observed latching off after at least one real host crash
+//   - a Linux datapoint before Linux is added; macOS retested or excluded
+//
+// macOS is excluded on its own merits regardless: largest installed base, a
+// working system-renderer fallback it can degrade to, and the only platform with
+// an observed canvas-attributed failure.
+const NATIVE_CANVAS_DEFAULT_PLATFORMS = [];
+
+// Marker phases. Both mean "a process entered a window it might not return
+// from"; they differ only in which window, which is worth recording because it
+// is the first thing anyone debugging a latched install will want to know.
+const NATIVE_CANVAS_PHASE_LINKING = "linking";
+const NATIVE_CANVAS_PHASE_DRAWING = "drawing";
+
+// Where the crash-survival marker lives. Mirrors index.js's PROFILES_DIR so it
+// sits with the rest of this server's durable state. An unsubstituted manifest
+// template is treated as absent rather than creating a directory named "${...}".
+export function nativeCanvasMarkerPath(env = process.env) {
+  const configured = typeof env.DEFAULT_PROFILES_DIR === "string"
+    && env.DEFAULT_PROFILES_DIR
+    && !env.DEFAULT_PROFILES_DIR.includes("${")
+    ? env.DEFAULT_PROFILES_DIR
+    : join(homedir(), ".pdf-toolkit-files");
+  return join(configured, "native-canvas-attempt.json");
 }
 
-function installInProcessCanvasNativeGuard() {
-  if (embeddedNativeCanvasAllowed()) return;
+function writeNativeCanvasMarker(markerPath, phase, token) {
+  mkdirSync(dirname(markerPath), { recursive: true });
+  // Write *and* fsync. A marker still sitting in the page cache when the host
+  // dies is exactly the case this mechanism exists for, and would defeat it.
+  const handle = openSync(markerPath, "w");
+  try {
+    writeFileSync(handle, JSON.stringify({
+      phase,
+      token,
+      pid: process.pid,
+      attempted_at: new Date().toISOString(),
+      platform: process.platform,
+      arch: process.arch,
+    }));
+    fsyncSync(handle);
+  } finally {
+    closeSync(handle);
+  }
+}
+
+function processIsAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    // EPERM means the pid exists but belongs to another user, which is still
+    // alive for our purposes.
+    return error?.code === "EPERM";
+  }
+}
+
+// "clear"      - no evidence of an unfinished attempt; proceed.
+// "latched"    - a previous process armed a marker and never came back. Refuse,
+//                durably, until an operator intervenes.
+// "concurrent" - another *live* process is mid-attempt. Refuse this load, but do
+//                not treat it as a crash: nothing has died.
+//
+// The one imprecision worth naming: if a crashed process's pid has since been
+// reused by an unrelated live process, this reports "concurrent" rather than
+// "latched". That still refuses the load, and the next boot with that pid gone
+// latches correctly. It fails toward retryable rather than toward loading.
+export function nativeCanvasLatchState(markerPath = nativeCanvasMarkerPath()) {
+  let raw;
+  try {
+    raw = readFileSync(markerPath, "utf8");
+  } catch {
+    return "clear";
+  }
+  if (raw.trim() === "") return "clear";
+  let record;
+  try {
+    record = JSON.parse(raw);
+  } catch {
+    // An unparseable marker is still evidence that some process armed one and
+    // did not clean up. Treat it as a latch rather than reasoning past it.
+    return "latched";
+  }
+  if (
+    record?.phase !== NATIVE_CANVAS_PHASE_LINKING
+    && record?.phase !== NATIVE_CANVAS_PHASE_DRAWING
+  ) {
+    return "latched";
+  }
+  // Our own in-flight attempt, re-entered. Not a latch, and not a competitor.
+  if (activeNativeCanvasAttempt && record.token === activeNativeCanvasAttempt.token) {
+    return "clear";
+  }
+  return processIsAlive(record.pid) ? "concurrent" : "latched";
+}
+
+function armNativeCanvasAttempt(markerPath) {
+  try {
+    const token = randomBytes(16).toString("hex");
+    writeNativeCanvasMarker(markerPath, NATIVE_CANVAS_PHASE_LINKING, token);
+    activeNativeCanvasAttempt = { markerPath, token };
+    return true;
+  } catch {
+    // If the marker cannot be written, a crash cannot be detected, so the load
+    // must not be attempted at all. Failing closed is the point of the exercise.
+    activeNativeCanvasAttempt = null;
+    return false;
+  }
+}
+
+function advanceNativeCanvasAttempt(phase) {
+  const attempt = activeNativeCanvasAttempt;
+  if (!attempt) return;
+  try {
+    writeNativeCanvasMarker(attempt.markerPath, phase, attempt.token);
+  } catch {
+    // The linking-phase marker is still on disk and still attributable to this
+    // process, so a crash from here is still caught. Nothing to recover.
+  }
+}
+
+function clearNativeCanvasAttempt() {
+  const attempt = activeNativeCanvasAttempt;
+  if (!attempt) return;
+  activeNativeCanvasAttempt = null;
+  let record;
+  try {
+    record = JSON.parse(readFileSync(attempt.markerPath, "utf8"));
+  } catch {
+    // Gone, or unreadable. If it is unreadable it may belong to someone else,
+    // so leave it: a stale marker costs a conservative latch, erasing another
+    // process's in-flight marker costs a missed crash.
+    return;
+  }
+  if (record?.token !== attempt.token) return;
+  try {
+    rmSync(attempt.markerPath, { force: true });
+  } catch {
+    // A stale marker only costs a conservative latch on the next boot.
+  }
+}
+
+// Called when the request that triggered a native-canvas load has completed,
+// either way. Completion means this process survived both the link and the first
+// draw, which is the entire window the marker exists to cover.
+//
+// It does not cover teardown. Covering teardown would mean holding the marker to
+// process exit, which cannot distinguish a canvas-attributed crash from a user
+// force-quitting the host - and force-quit is common enough that it would latch
+// off nearly every install. That limit is real and is not claimed away.
+export function settleNativeCanvasAttempt() {
+  clearNativeCanvasAttempt();
+}
+
+// Policy, in order:
+//   PDF_TOOLS_EMBEDDED_NATIVE_CANVAS=0      always blocks (kill switch)
+//   PDF_TOOLS_EMBEDDED_NATIVE_CANVAS=force  always allows, bypassing the latch,
+//                                           so a latched install can be
+//                                           recovered without deleting state by
+//                                           hand
+//   PDF_TOOLS_EMBEDDED_NATIVE_CANVAS=1      opt in, still subject to the latch
+//   platform in NATIVE_CANVAS_DEFAULT_PLATFORMS   same, and currently never
+//   everything else                         blocks
+//
+// "=1" deliberately respects the latch. In the reverted design the flag bypassed
+// it, which left the entire mechanism dead code for as long as the default was
+// off - it could only ever run on a population that did not yet exist. Binding
+// the flag to the latch instead means today's Windows opt-in users exercise the
+// recovery path, which is where the evidence for a future flip has to come from.
+export function embeddedNativeCanvasAllowed({
+  env = process.env,
+  platform = process.platform,
+  markerPath = null,
+} = {}) {
+  const override = env.PDF_TOOLS_EMBEDDED_NATIVE_CANVAS;
+  if (override === "0") return false;
+  if (override === "force") return true;
+  const requested = override === "1"
+    || NATIVE_CANVAS_DEFAULT_PLATFORMS.includes(platform);
+  if (!requested) return false;
+  return nativeCanvasLatchState(markerPath ?? nativeCanvasMarkerPath(env)) === "clear";
+}
+
+// The reason a load was refused, for the renderer error path to turn into
+// remediation the user can act on. Null when nothing has been refused.
+export function nativeCanvasBlockReason() {
+  return lastNativeCanvasBlockReason;
+}
+
+function refuseNativeCanvasLoad(reason) {
+  lastNativeCanvasBlockReason = reason;
+  const error = new Error(
+    "The native canvas binding is disabled in this embedded PDF host.",
+  );
+  error.code = "PDFJS_EMBEDDED_NATIVE_CANVAS_DISABLED";
+  return error;
+}
+
+function installInProcessCanvasNativeGuard({ dlopen = null } = {}) {
   if (inProcessCanvasGuardInstalled) return;
   inProcessCanvasGuardInstalled = true;
-  const originalDlopen = process.dlopen;
+  // Installed unconditionally, unlike the previous version which returned early
+  // when canvas was allowed. The guard is no longer only a blocker: on an
+  // allowed load it is what arms and phases the crash marker, so skipping it
+  // when allowed would skip the entire recovery mechanism.
+  const originalDlopen = dlopen ?? process.dlopen;
   process.dlopen = function guardedDlopen(module, filename, ...args) {
     const normalizedFilename = String(filename ?? "").replaceAll("\\", "/");
-    if (
-      normalizedFilename.includes("/node_modules/@napi-rs/canvas")
-      || /\/skia\.[^/]+\.node$/i.test(normalizedFilename)
-    ) {
-      const error = new Error(
-        "The native canvas binding is disabled in this embedded PDF host.",
+    const isNativeCanvas = normalizedFilename.includes("/node_modules/@napi-rs/canvas")
+      || /\/skia\.[^/]+\.node$/i.test(normalizedFilename);
+    if (!isNativeCanvas) {
+      return originalDlopen.call(this, module, filename, ...args);
+    }
+
+    // Re-evaluated per load rather than cached at install time, so a latch
+    // written by a previous boot is honoured and an operator override takes
+    // effect without a restart of this code path.
+    const markerPath = nativeCanvasMarkerPath();
+    const latchState = nativeCanvasLatchState(markerPath);
+    if (!embeddedNativeCanvasAllowed({ markerPath })) {
+      throw refuseNativeCanvasLoad(
+        latchState === "clear" ? "disabled_by_policy" : latchState,
       );
-      error.code = "PDFJS_EMBEDDED_NATIVE_CANVAS_DISABLED";
+    }
+    if (!armNativeCanvasAttempt(markerPath)) {
+      throw refuseNativeCanvasLoad("marker_unwritable");
+    }
+
+    lastNativeCanvasBlockReason = null;
+    try {
+      const loaded = originalDlopen.call(this, module, filename, ...args);
+      // The link survived. The remaining exposure is the first draw, so the
+      // marker stays on disk and only changes phase. settleNativeCanvasAttempt()
+      // clears it once the request that triggered this load completes.
+      advanceNativeCanvasAttempt(NATIVE_CANVAS_PHASE_DRAWING);
+      return loaded;
+    } catch (error) {
+      // A raised error is survival: the host is intact, so this must not latch
+      // and permanently disable a recoverable environment problem such as a
+      // missing VC++ runtime or an architecture mismatch.
+      clearNativeCanvasAttempt();
       throw error;
     }
-    return originalDlopen.call(this, module, filename, ...args);
+  };
+}
+
+// Test seam. The guard rewrites process.dlopen, which is process-global and
+// installed once, so a suite cannot exercise it without a way to inject a fake
+// loader and put the real one back.
+export function __installCanvasGuardForTest({ dlopen }) {
+  inProcessCanvasGuardInstalled = false;
+  activeNativeCanvasAttempt = null;
+  lastNativeCanvasBlockReason = null;
+  const savedDlopen = process.dlopen;
+  installInProcessCanvasNativeGuard({ dlopen });
+  const guarded = process.dlopen;
+  return {
+    guardedDlopen: guarded,
+    restore() {
+      process.dlopen = savedDlopen;
+      inProcessCanvasGuardInstalled = false;
+      activeNativeCanvasAttempt = null;
+      lastNativeCanvasBlockReason = null;
+    },
   };
 }
 
@@ -1006,7 +1273,16 @@ async function runInProcessWorker({
   installInProcessCanvasNativeGuard();
   const workerModule = await loadInProcessWorkerModule();
   if (shutdownInProgress) throw resourceLimitError("worker_shutdown_in_progress");
-  const operationResult = await workerModule.executePdfjsWorkerRequest(request);
+  let operationResult;
+  try {
+    operationResult = await workerModule.executePdfjsWorkerRequest(request);
+  } finally {
+    // The request that triggered any native-canvas load has now completed, one
+    // way or the other. Either outcome means this process survived the link and
+    // the first draw, so the crash marker has done its job and comes off. A
+    // thrown error is survival too: the host is intact enough to report it.
+    settleNativeCanvasAttempt();
+  }
   if (signal?.aborted) throw abortError();
   const encodedResult = Buffer.from(JSON.stringify(operationResult.result), "utf8");
   if (encodedResult.length > maxResultBytes) {

--- a/pdf-toolkit-mcp-share/server/pdfjs-subprocess.js
+++ b/pdf-toolkit-mcp-share/server/pdfjs-subprocess.js
@@ -6,6 +6,7 @@ import {
   mkdirSync,
   openSync,
   readFileSync,
+  renameSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
@@ -1009,9 +1010,20 @@ export function nativeCanvasMarkerPath(env = process.env) {
 
 function writeNativeCanvasMarker(markerPath, phase, token) {
   mkdirSync(dirname(markerPath), { recursive: true });
-  // Write *and* fsync. A marker still sitting in the page cache when the host
-  // dies is exactly the case this mechanism exists for, and would defeat it.
-  const handle = openSync(markerPath, "w");
+  // Write to a temp file and rename over the target, rather than truncating the
+  // target in place.
+  //
+  // Truncating is not survivable where it matters. `openSync(path, "w")` empties
+  // the file immediately, so a host that hard-crashes between the truncate and
+  // the completed write leaves a zero-length marker - and an empty marker reads
+  // as "no marker". For the arm that is harmless, because a crash there means
+  // dlopen never ran and nothing needs latching. For the phase advance it is a
+  // hole straight through the mechanism: it destroys a valid `linking` marker in
+  // order to write `drawing`, and a crash inside that window is exactly the
+  // link-to-first-draw crash this exists to catch. Renaming is atomic, so the
+  // marker on disk is always either the previous valid one or the new valid one.
+  const tempPath = `${markerPath}.${process.pid}.${token.slice(0, 8)}.tmp`;
+  const handle = openSync(tempPath, "w");
   try {
     writeFileSync(handle, JSON.stringify({
       phase,
@@ -1021,10 +1033,16 @@ function writeNativeCanvasMarker(markerPath, phase, token) {
       platform: process.platform,
       arch: process.arch,
     }));
+    // fsync the contents before the rename, otherwise the rename can land while
+    // the bytes are still only in the page cache.
     fsyncSync(handle);
   } finally {
     closeSync(handle);
   }
+  // If the write above threw, this is never reached and the temp file is left
+  // behind. That is inert: nothing ever reads a `.tmp` path, and the caller
+  // treats the throw as "could not arm" and refuses the load.
+  renameSync(tempPath, markerPath);
 }
 
 function processIsAlive(pid) {

--- a/pdf-toolkit-mcp-share/server/pdfjs-worker.js
+++ b/pdf-toolkit-mcp-share/server/pdfjs-worker.js
@@ -57,6 +57,11 @@ let systemRenderShutdownStarted = false;
 let systemRenderShutdownTerminal = false;
 let systemCommandSpawnCount = 0;
 let systemRendererControllerShutdownProbe = null;
+// Why the embedded-host guard last refused to load the native canvas binding.
+// Bound from pdfjs-subprocess.js, which owns that decision. It cannot travel on
+// the thrown error: @napi-rs/canvas catches whatever dlopen throws and reports
+// its own "Cannot find native binding" instead, discarding ours.
+let nativeCanvasBlockReasonProbe = null;
 let nextThreadSystemCommandId = 1;
 
 const OPERATION_OPTION_KEYS = new Map([
@@ -1367,6 +1372,48 @@ export function bindPdfjsWorkerSystemRendererControllerProbe(probe) {
   systemRendererControllerShutdownProbe = probe;
 }
 
+export function bindPdfjsWorkerNativeCanvasBlockReasonProbe(probe) {
+  if (typeof probe !== "function") {
+    throw new TypeError("native canvas block reason probe must be a function.");
+  }
+  if (nativeCanvasBlockReasonProbe !== null) {
+    throw new TypeError("native canvas block reason probe is already bound.");
+  }
+  nativeCanvasBlockReasonProbe = probe;
+}
+
+// Turn a refusal reason into something the user can act on.
+//
+// The generic unavailable-renderer message below is true but inert: it tells
+// someone their renderer is missing and that reinstalling will not help, and
+// then leaves them there. When the cause is the crash latch, there is a specific
+// thing to do, and this is the only place it can be said - the guard's own error
+// never survives @napi-rs/canvas.
+function nativeCanvasBlockRemediation() {
+  let reason = null;
+  try {
+    reason = nativeCanvasBlockReasonProbe?.() ?? null;
+  } catch {
+    // A probe that throws must not turn a renderer error into a probe error.
+    return "";
+  }
+  if (reason === "latched") {
+    return " Native page rendering was disabled automatically because a previous"
+      + " attempt to load it never returned, which usually means it crashed this"
+      + " host. Set PDF_TOOLS_EMBEDDED_NATIVE_CANVAS=force to try it again.";
+  }
+  if (reason === "concurrent") {
+    return " Another PDF Tools server on this machine is loading the same binding"
+      + " right now. Retry in a moment.";
+  }
+  if (reason === "marker_unwritable") {
+    return " Native page rendering was refused because its crash-recovery marker"
+      + " could not be written, so a crash could not have been detected. Check"
+      + " that the profiles directory is writable.";
+  }
+  return "";
+}
+
 export async function beginPdfjsWorkerSystemShutdown({ terminal = false } = {}) {
   if (typeof terminal !== "boolean") {
     throw new TypeError("terminal must be a boolean.");
@@ -1740,7 +1787,11 @@ export async function runRendererPolicy(policy, {
       const unavailable = new Error(
         "No PDF page renderer is available in this host. The native canvas "
         + "binding is unavailable or blocked, and no system renderer fallback "
-        + "is configured. Reinstalling dependencies does not resolve this.",
+        + "is configured. Reinstalling dependencies does not resolve this."
+        // Appends nothing unless the embedded-host guard refused for a reason
+        // the user can act on, so the message every existing caller and the
+        // Windows CI probe assert against is byte-identical when it does not.
+        + nativeCanvasBlockRemediation(),
       );
       unavailable.code = "PDF_RENDERER_UNAVAILABLE";
       unavailable.cause = error;

--- a/server/pdfjs-subprocess.js
+++ b/server/pdfjs-subprocess.js
@@ -1,7 +1,16 @@
 import { spawn } from "node:child_process";
-import { createHash } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
+import {
+  closeSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { chmod, lstat, mkdtemp, realpath, rm } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { Worker } from "node:worker_threads";
@@ -43,6 +52,16 @@ const activeThreadSystemChildren = new Set();
 let inProcessWorkerModulePromise = null;
 let inProcessWorkerModule = null;
 let inProcessCanvasGuardInstalled = false;
+// The native-canvas attempt this process armed, if any: { markerPath, token }.
+// The token is held only in memory, which is what makes ownership decidable -
+// no other process can ever present it, so no other process can clear a marker
+// it does not own.
+let activeNativeCanvasAttempt = null;
+// Why the last native-canvas load was refused, for the renderer error path.
+// It cannot travel on the thrown error: @napi-rs/canvas catches whatever dlopen
+// throws and reports its own "Cannot find native binding" instead, discarding
+// ours. This is read back through a bound probe, see pdfjs-worker.js.
+let lastNativeCanvasBlockReason = null;
 let shutdownInProgress = false;
 let shutdownTerminal = false;
 let gracefulShutdownPromise = null;
@@ -906,6 +925,7 @@ async function runThreadWorker({
 async function loadInProcessWorkerModule() {
   inProcessWorkerModulePromise ??= import("./pdfjs-worker.js").then(worker => {
     worker.bindPdfjsWorkerSystemRendererControllerProbe(() => shutdownInProgress);
+    worker.bindPdfjsWorkerNativeCanvasBlockReasonProbe(() => lastNativeCanvasBlockReason);
     inProcessWorkerModule = worker;
     return worker;
   });
@@ -938,47 +958,294 @@ async function loadInProcessWorkerModule() {
 //
 // That is not enough on its own to trust a default, because the failure this
 // guards against is a hard host crash that no in-process handler can catch. So
-// the default stays OFF everywhere and the flag stays a pure opt-in.
+// the default stays OFF on every platform. What follows is the durable recovery
+// a default would need, kept load-bearing for the opt-in users who are the only
+// available source of the soak evidence a flip requires.
 //
-// A win32 default was implemented and reverted. An adversarial review showed the
-// crash-survival latch backing it did not hold: it cleared its marker the moment
-// dlopen returned, so it covered only the link step, which is the one step two
-// positive datapoints already exist for. The instability this guards against in
-// a Chromium process that already has its own Skia characteristically appears at
-// first draw or teardown, both of which were left unprotected. The mechanism
-// also had no lock and no ownership, so two servers sharing one home directory
-// could erase each other's in-flight marker, and concurrency was the exact
-// condition named publicly on issue #42 as a prerequisite for flipping.
+// A win32 default was implemented and reverted once. The adversarial review that
+// killed it found the crash-survival latch cleared its marker the moment dlopen
+// returned, so it covered only the link step - the one step two positive
+// datapoints already existed for. The instability this guards against, in a
+// Chromium process that already has its own Skia, characteristically appears at
+// first draw. The mechanism also had no ownership, so two servers sharing one
+// home directory could erase each other's in-flight marker, and concurrency was
+// the exact condition named publicly on issue #42 as a prerequisite for
+// flipping. Both defects are addressed below.
+
+// Platforms where native canvas is ON by default inside an embedded host.
+// EMPTY ON PURPOSE. This array is the switch; adding "win32" is the whole flip,
+// and it must not be added until every gate is met:
 //
-// Do not flip this default again without, at minimum: a marker that survives
-// past first successful render, per-process ownership or locking, a remediation
-// string that actually reaches the user (the current one is swallowed by
-// @napi-rs/canvas's own "Cannot find native binding" text and rewritten by
-// canvasDependencyError), and a test that drives installInProcessCanvasNativeGuard
-// with an injected dlopen instead of asserting the policy function against files
-// the test wrote itself.
-export function embeddedNativeCanvasAllowed({ env = process.env } = {}) {
-  return env.PDF_TOOLS_EMBEDDED_NATIVE_CANVAS === "1";
+//   - >= 20 renders across page sizes, plus a concurrent pair, on a real
+//     Windows Claude Desktop with no host crash
+//   - isolation mode observed as "in_process" for each, because a run that took
+//     the subprocess path never installed this guard and proves nothing about it
+//   - this latch fault-injected (test/embedded-native-canvas-latch.test.js) and
+//     observed latching off after at least one real host crash
+//   - a Linux datapoint before Linux is added; macOS retested or excluded
+//
+// macOS is excluded on its own merits regardless: largest installed base, a
+// working system-renderer fallback it can degrade to, and the only platform with
+// an observed canvas-attributed failure.
+const NATIVE_CANVAS_DEFAULT_PLATFORMS = [];
+
+// Marker phases. Both mean "a process entered a window it might not return
+// from"; they differ only in which window, which is worth recording because it
+// is the first thing anyone debugging a latched install will want to know.
+const NATIVE_CANVAS_PHASE_LINKING = "linking";
+const NATIVE_CANVAS_PHASE_DRAWING = "drawing";
+
+// Where the crash-survival marker lives. Mirrors index.js's PROFILES_DIR so it
+// sits with the rest of this server's durable state. An unsubstituted manifest
+// template is treated as absent rather than creating a directory named "${...}".
+export function nativeCanvasMarkerPath(env = process.env) {
+  const configured = typeof env.DEFAULT_PROFILES_DIR === "string"
+    && env.DEFAULT_PROFILES_DIR
+    && !env.DEFAULT_PROFILES_DIR.includes("${")
+    ? env.DEFAULT_PROFILES_DIR
+    : join(homedir(), ".pdf-toolkit-files");
+  return join(configured, "native-canvas-attempt.json");
 }
 
-function installInProcessCanvasNativeGuard() {
-  if (embeddedNativeCanvasAllowed()) return;
+function writeNativeCanvasMarker(markerPath, phase, token) {
+  mkdirSync(dirname(markerPath), { recursive: true });
+  // Write *and* fsync. A marker still sitting in the page cache when the host
+  // dies is exactly the case this mechanism exists for, and would defeat it.
+  const handle = openSync(markerPath, "w");
+  try {
+    writeFileSync(handle, JSON.stringify({
+      phase,
+      token,
+      pid: process.pid,
+      attempted_at: new Date().toISOString(),
+      platform: process.platform,
+      arch: process.arch,
+    }));
+    fsyncSync(handle);
+  } finally {
+    closeSync(handle);
+  }
+}
+
+function processIsAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    // EPERM means the pid exists but belongs to another user, which is still
+    // alive for our purposes.
+    return error?.code === "EPERM";
+  }
+}
+
+// "clear"      - no evidence of an unfinished attempt; proceed.
+// "latched"    - a previous process armed a marker and never came back. Refuse,
+//                durably, until an operator intervenes.
+// "concurrent" - another *live* process is mid-attempt. Refuse this load, but do
+//                not treat it as a crash: nothing has died.
+//
+// The one imprecision worth naming: if a crashed process's pid has since been
+// reused by an unrelated live process, this reports "concurrent" rather than
+// "latched". That still refuses the load, and the next boot with that pid gone
+// latches correctly. It fails toward retryable rather than toward loading.
+export function nativeCanvasLatchState(markerPath = nativeCanvasMarkerPath()) {
+  let raw;
+  try {
+    raw = readFileSync(markerPath, "utf8");
+  } catch {
+    return "clear";
+  }
+  if (raw.trim() === "") return "clear";
+  let record;
+  try {
+    record = JSON.parse(raw);
+  } catch {
+    // An unparseable marker is still evidence that some process armed one and
+    // did not clean up. Treat it as a latch rather than reasoning past it.
+    return "latched";
+  }
+  if (
+    record?.phase !== NATIVE_CANVAS_PHASE_LINKING
+    && record?.phase !== NATIVE_CANVAS_PHASE_DRAWING
+  ) {
+    return "latched";
+  }
+  // Our own in-flight attempt, re-entered. Not a latch, and not a competitor.
+  if (activeNativeCanvasAttempt && record.token === activeNativeCanvasAttempt.token) {
+    return "clear";
+  }
+  return processIsAlive(record.pid) ? "concurrent" : "latched";
+}
+
+function armNativeCanvasAttempt(markerPath) {
+  try {
+    const token = randomBytes(16).toString("hex");
+    writeNativeCanvasMarker(markerPath, NATIVE_CANVAS_PHASE_LINKING, token);
+    activeNativeCanvasAttempt = { markerPath, token };
+    return true;
+  } catch {
+    // If the marker cannot be written, a crash cannot be detected, so the load
+    // must not be attempted at all. Failing closed is the point of the exercise.
+    activeNativeCanvasAttempt = null;
+    return false;
+  }
+}
+
+function advanceNativeCanvasAttempt(phase) {
+  const attempt = activeNativeCanvasAttempt;
+  if (!attempt) return;
+  try {
+    writeNativeCanvasMarker(attempt.markerPath, phase, attempt.token);
+  } catch {
+    // The linking-phase marker is still on disk and still attributable to this
+    // process, so a crash from here is still caught. Nothing to recover.
+  }
+}
+
+function clearNativeCanvasAttempt() {
+  const attempt = activeNativeCanvasAttempt;
+  if (!attempt) return;
+  activeNativeCanvasAttempt = null;
+  let record;
+  try {
+    record = JSON.parse(readFileSync(attempt.markerPath, "utf8"));
+  } catch {
+    // Gone, or unreadable. If it is unreadable it may belong to someone else,
+    // so leave it: a stale marker costs a conservative latch, erasing another
+    // process's in-flight marker costs a missed crash.
+    return;
+  }
+  if (record?.token !== attempt.token) return;
+  try {
+    rmSync(attempt.markerPath, { force: true });
+  } catch {
+    // A stale marker only costs a conservative latch on the next boot.
+  }
+}
+
+// Called when the request that triggered a native-canvas load has completed,
+// either way. Completion means this process survived both the link and the first
+// draw, which is the entire window the marker exists to cover.
+//
+// It does not cover teardown. Covering teardown would mean holding the marker to
+// process exit, which cannot distinguish a canvas-attributed crash from a user
+// force-quitting the host - and force-quit is common enough that it would latch
+// off nearly every install. That limit is real and is not claimed away.
+export function settleNativeCanvasAttempt() {
+  clearNativeCanvasAttempt();
+}
+
+// Policy, in order:
+//   PDF_TOOLS_EMBEDDED_NATIVE_CANVAS=0      always blocks (kill switch)
+//   PDF_TOOLS_EMBEDDED_NATIVE_CANVAS=force  always allows, bypassing the latch,
+//                                           so a latched install can be
+//                                           recovered without deleting state by
+//                                           hand
+//   PDF_TOOLS_EMBEDDED_NATIVE_CANVAS=1      opt in, still subject to the latch
+//   platform in NATIVE_CANVAS_DEFAULT_PLATFORMS   same, and currently never
+//   everything else                         blocks
+//
+// "=1" deliberately respects the latch. In the reverted design the flag bypassed
+// it, which left the entire mechanism dead code for as long as the default was
+// off - it could only ever run on a population that did not yet exist. Binding
+// the flag to the latch instead means today's Windows opt-in users exercise the
+// recovery path, which is where the evidence for a future flip has to come from.
+export function embeddedNativeCanvasAllowed({
+  env = process.env,
+  platform = process.platform,
+  markerPath = null,
+} = {}) {
+  const override = env.PDF_TOOLS_EMBEDDED_NATIVE_CANVAS;
+  if (override === "0") return false;
+  if (override === "force") return true;
+  const requested = override === "1"
+    || NATIVE_CANVAS_DEFAULT_PLATFORMS.includes(platform);
+  if (!requested) return false;
+  return nativeCanvasLatchState(markerPath ?? nativeCanvasMarkerPath(env)) === "clear";
+}
+
+// The reason a load was refused, for the renderer error path to turn into
+// remediation the user can act on. Null when nothing has been refused.
+export function nativeCanvasBlockReason() {
+  return lastNativeCanvasBlockReason;
+}
+
+function refuseNativeCanvasLoad(reason) {
+  lastNativeCanvasBlockReason = reason;
+  const error = new Error(
+    "The native canvas binding is disabled in this embedded PDF host.",
+  );
+  error.code = "PDFJS_EMBEDDED_NATIVE_CANVAS_DISABLED";
+  return error;
+}
+
+function installInProcessCanvasNativeGuard({ dlopen = null } = {}) {
   if (inProcessCanvasGuardInstalled) return;
   inProcessCanvasGuardInstalled = true;
-  const originalDlopen = process.dlopen;
+  // Installed unconditionally, unlike the previous version which returned early
+  // when canvas was allowed. The guard is no longer only a blocker: on an
+  // allowed load it is what arms and phases the crash marker, so skipping it
+  // when allowed would skip the entire recovery mechanism.
+  const originalDlopen = dlopen ?? process.dlopen;
   process.dlopen = function guardedDlopen(module, filename, ...args) {
     const normalizedFilename = String(filename ?? "").replaceAll("\\", "/");
-    if (
-      normalizedFilename.includes("/node_modules/@napi-rs/canvas")
-      || /\/skia\.[^/]+\.node$/i.test(normalizedFilename)
-    ) {
-      const error = new Error(
-        "The native canvas binding is disabled in this embedded PDF host.",
+    const isNativeCanvas = normalizedFilename.includes("/node_modules/@napi-rs/canvas")
+      || /\/skia\.[^/]+\.node$/i.test(normalizedFilename);
+    if (!isNativeCanvas) {
+      return originalDlopen.call(this, module, filename, ...args);
+    }
+
+    // Re-evaluated per load rather than cached at install time, so a latch
+    // written by a previous boot is honoured and an operator override takes
+    // effect without a restart of this code path.
+    const markerPath = nativeCanvasMarkerPath();
+    const latchState = nativeCanvasLatchState(markerPath);
+    if (!embeddedNativeCanvasAllowed({ markerPath })) {
+      throw refuseNativeCanvasLoad(
+        latchState === "clear" ? "disabled_by_policy" : latchState,
       );
-      error.code = "PDFJS_EMBEDDED_NATIVE_CANVAS_DISABLED";
+    }
+    if (!armNativeCanvasAttempt(markerPath)) {
+      throw refuseNativeCanvasLoad("marker_unwritable");
+    }
+
+    lastNativeCanvasBlockReason = null;
+    try {
+      const loaded = originalDlopen.call(this, module, filename, ...args);
+      // The link survived. The remaining exposure is the first draw, so the
+      // marker stays on disk and only changes phase. settleNativeCanvasAttempt()
+      // clears it once the request that triggered this load completes.
+      advanceNativeCanvasAttempt(NATIVE_CANVAS_PHASE_DRAWING);
+      return loaded;
+    } catch (error) {
+      // A raised error is survival: the host is intact, so this must not latch
+      // and permanently disable a recoverable environment problem such as a
+      // missing VC++ runtime or an architecture mismatch.
+      clearNativeCanvasAttempt();
       throw error;
     }
-    return originalDlopen.call(this, module, filename, ...args);
+  };
+}
+
+// Test seam. The guard rewrites process.dlopen, which is process-global and
+// installed once, so a suite cannot exercise it without a way to inject a fake
+// loader and put the real one back.
+export function __installCanvasGuardForTest({ dlopen }) {
+  inProcessCanvasGuardInstalled = false;
+  activeNativeCanvasAttempt = null;
+  lastNativeCanvasBlockReason = null;
+  const savedDlopen = process.dlopen;
+  installInProcessCanvasNativeGuard({ dlopen });
+  const guarded = process.dlopen;
+  return {
+    guardedDlopen: guarded,
+    restore() {
+      process.dlopen = savedDlopen;
+      inProcessCanvasGuardInstalled = false;
+      activeNativeCanvasAttempt = null;
+      lastNativeCanvasBlockReason = null;
+    },
   };
 }
 
@@ -1006,7 +1273,16 @@ async function runInProcessWorker({
   installInProcessCanvasNativeGuard();
   const workerModule = await loadInProcessWorkerModule();
   if (shutdownInProgress) throw resourceLimitError("worker_shutdown_in_progress");
-  const operationResult = await workerModule.executePdfjsWorkerRequest(request);
+  let operationResult;
+  try {
+    operationResult = await workerModule.executePdfjsWorkerRequest(request);
+  } finally {
+    // The request that triggered any native-canvas load has now completed, one
+    // way or the other. Either outcome means this process survived the link and
+    // the first draw, so the crash marker has done its job and comes off. A
+    // thrown error is survival too: the host is intact enough to report it.
+    settleNativeCanvasAttempt();
+  }
   if (signal?.aborted) throw abortError();
   const encodedResult = Buffer.from(JSON.stringify(operationResult.result), "utf8");
   if (encodedResult.length > maxResultBytes) {

--- a/server/pdfjs-subprocess.js
+++ b/server/pdfjs-subprocess.js
@@ -6,6 +6,7 @@ import {
   mkdirSync,
   openSync,
   readFileSync,
+  renameSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
@@ -1009,9 +1010,20 @@ export function nativeCanvasMarkerPath(env = process.env) {
 
 function writeNativeCanvasMarker(markerPath, phase, token) {
   mkdirSync(dirname(markerPath), { recursive: true });
-  // Write *and* fsync. A marker still sitting in the page cache when the host
-  // dies is exactly the case this mechanism exists for, and would defeat it.
-  const handle = openSync(markerPath, "w");
+  // Write to a temp file and rename over the target, rather than truncating the
+  // target in place.
+  //
+  // Truncating is not survivable where it matters. `openSync(path, "w")` empties
+  // the file immediately, so a host that hard-crashes between the truncate and
+  // the completed write leaves a zero-length marker - and an empty marker reads
+  // as "no marker". For the arm that is harmless, because a crash there means
+  // dlopen never ran and nothing needs latching. For the phase advance it is a
+  // hole straight through the mechanism: it destroys a valid `linking` marker in
+  // order to write `drawing`, and a crash inside that window is exactly the
+  // link-to-first-draw crash this exists to catch. Renaming is atomic, so the
+  // marker on disk is always either the previous valid one or the new valid one.
+  const tempPath = `${markerPath}.${process.pid}.${token.slice(0, 8)}.tmp`;
+  const handle = openSync(tempPath, "w");
   try {
     writeFileSync(handle, JSON.stringify({
       phase,
@@ -1021,10 +1033,16 @@ function writeNativeCanvasMarker(markerPath, phase, token) {
       platform: process.platform,
       arch: process.arch,
     }));
+    // fsync the contents before the rename, otherwise the rename can land while
+    // the bytes are still only in the page cache.
     fsyncSync(handle);
   } finally {
     closeSync(handle);
   }
+  // If the write above threw, this is never reached and the temp file is left
+  // behind. That is inert: nothing ever reads a `.tmp` path, and the caller
+  // treats the throw as "could not arm" and refuses the load.
+  renameSync(tempPath, markerPath);
 }
 
 function processIsAlive(pid) {

--- a/server/pdfjs-worker.js
+++ b/server/pdfjs-worker.js
@@ -57,6 +57,11 @@ let systemRenderShutdownStarted = false;
 let systemRenderShutdownTerminal = false;
 let systemCommandSpawnCount = 0;
 let systemRendererControllerShutdownProbe = null;
+// Why the embedded-host guard last refused to load the native canvas binding.
+// Bound from pdfjs-subprocess.js, which owns that decision. It cannot travel on
+// the thrown error: @napi-rs/canvas catches whatever dlopen throws and reports
+// its own "Cannot find native binding" instead, discarding ours.
+let nativeCanvasBlockReasonProbe = null;
 let nextThreadSystemCommandId = 1;
 
 const OPERATION_OPTION_KEYS = new Map([
@@ -1367,6 +1372,48 @@ export function bindPdfjsWorkerSystemRendererControllerProbe(probe) {
   systemRendererControllerShutdownProbe = probe;
 }
 
+export function bindPdfjsWorkerNativeCanvasBlockReasonProbe(probe) {
+  if (typeof probe !== "function") {
+    throw new TypeError("native canvas block reason probe must be a function.");
+  }
+  if (nativeCanvasBlockReasonProbe !== null) {
+    throw new TypeError("native canvas block reason probe is already bound.");
+  }
+  nativeCanvasBlockReasonProbe = probe;
+}
+
+// Turn a refusal reason into something the user can act on.
+//
+// The generic unavailable-renderer message below is true but inert: it tells
+// someone their renderer is missing and that reinstalling will not help, and
+// then leaves them there. When the cause is the crash latch, there is a specific
+// thing to do, and this is the only place it can be said - the guard's own error
+// never survives @napi-rs/canvas.
+function nativeCanvasBlockRemediation() {
+  let reason = null;
+  try {
+    reason = nativeCanvasBlockReasonProbe?.() ?? null;
+  } catch {
+    // A probe that throws must not turn a renderer error into a probe error.
+    return "";
+  }
+  if (reason === "latched") {
+    return " Native page rendering was disabled automatically because a previous"
+      + " attempt to load it never returned, which usually means it crashed this"
+      + " host. Set PDF_TOOLS_EMBEDDED_NATIVE_CANVAS=force to try it again.";
+  }
+  if (reason === "concurrent") {
+    return " Another PDF Tools server on this machine is loading the same binding"
+      + " right now. Retry in a moment.";
+  }
+  if (reason === "marker_unwritable") {
+    return " Native page rendering was refused because its crash-recovery marker"
+      + " could not be written, so a crash could not have been detected. Check"
+      + " that the profiles directory is writable.";
+  }
+  return "";
+}
+
 export async function beginPdfjsWorkerSystemShutdown({ terminal = false } = {}) {
   if (typeof terminal !== "boolean") {
     throw new TypeError("terminal must be a boolean.");
@@ -1740,7 +1787,11 @@ export async function runRendererPolicy(policy, {
       const unavailable = new Error(
         "No PDF page renderer is available in this host. The native canvas "
         + "binding is unavailable or blocked, and no system renderer fallback "
-        + "is configured. Reinstalling dependencies does not resolve this.",
+        + "is configured. Reinstalling dependencies does not resolve this."
+        // Appends nothing unless the embedded-host guard refused for a reason
+        // the user can act on, so the message every existing caller and the
+        // Windows CI probe assert against is byte-identical when it does not.
+        + nativeCanvasBlockRemediation(),
       );
       unavailable.code = "PDF_RENDERER_UNAVAILABLE";
       unavailable.cause = error;

--- a/test/embedded-native-canvas-latch.test.js
+++ b/test/embedded-native-canvas-latch.test.js
@@ -11,7 +11,15 @@
 // loader, and asserts on the marker the guard actually left on disk.
 
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -141,6 +149,37 @@ describe("the marker survives past the link, which is the whole point", () => {
     settleNativeCanvasAttempt();
 
     expect(existsSync(markerPath())).toBe(false);
+  });
+
+  it("keeps the previous marker intact when the phase advance cannot be written", () => {
+    // The advance replaces a valid `linking` marker with a `drawing` one. If it
+    // truncated the file in place, a host crash inside that window would leave a
+    // zero-length marker - and an empty marker reads as "no marker", losing the
+    // latch at exactly the link-to-first-draw moment it exists to catch.
+    //
+    // The injected loader makes the profiles directory unwritable from inside
+    // the load, so the advance fails after the linking marker already exists.
+    const guarded = install({
+      dlopen: () => {
+        chmodSync(profilesDir, 0o500);
+        return "loaded";
+      },
+    });
+
+    guarded.call(process, {}, CANVAS_BINDING);
+    chmodSync(profilesDir, 0o700);
+
+    const marker = readMarker();
+    expect(marker.phase).toBe("linking");
+    expect(marker.token).toBeTruthy();
+  });
+
+  it("leaves no temp files behind after a completed cycle", () => {
+    const guarded = install({ dlopen: () => "loaded" });
+    guarded.call(process, {}, CANVAS_BINDING);
+    settleNativeCanvasAttempt();
+
+    expect(readdirSync(profilesDir).filter(name => name.endsWith(".tmp"))).toEqual([]);
   });
 
   it("matches a Windows skia path with backslashes", () => {

--- a/test/embedded-native-canvas-latch.test.js
+++ b/test/embedded-native-canvas-latch.test.js
@@ -1,0 +1,331 @@
+// Fault injection for the embedded-host native-canvas guard.
+//
+// The suite this replaces asserted the policy function against marker files the
+// test wrote itself. That never ran the guard, so it could not have caught the
+// defect that got the win32 default reverted: the guard cleared its marker the
+// instant dlopen returned, covering only the link step while the risk it exists
+// for is the first draw. A test that only writes markers and reads policy agrees
+// with that bug completely.
+//
+// So everything here drives the real guarded process.dlopen with an injected
+// loader, and asserts on the marker the guard actually left on disk.
+
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  __installCanvasGuardForTest,
+  embeddedNativeCanvasAllowed,
+  nativeCanvasBlockReason,
+  nativeCanvasLatchState,
+  nativeCanvasMarkerPath,
+  settleNativeCanvasAttempt,
+} from "../server/pdfjs-subprocess.js";
+
+const CANVAS_BINDING = "/opt/app/node_modules/@napi-rs/canvas/index.node";
+const SKIA_BINDING = "C:\\app\\vendor\\skia.win32-x64-msvc.node";
+const UNRELATED_BINDING = "/opt/app/node_modules/better-sqlite3/build/better_sqlite3.node";
+
+let profilesDir = null;
+let savedProfilesDir;
+let savedFlag;
+let installed = null;
+
+function markerPath() {
+  return nativeCanvasMarkerPath(process.env);
+}
+
+function readMarker() {
+  return JSON.parse(readFileSync(markerPath(), "utf8"));
+}
+
+// A pid that is definitely not running: spawn a trivial process, let it exit,
+// and reuse its number. Beats guessing a high integer, which can collide.
+function deadPid() {
+  return spawnSync(process.execPath, ["-e", ""]).pid;
+}
+
+function install({ dlopen }) {
+  installed = __installCanvasGuardForTest({ dlopen });
+  return installed.guardedDlopen;
+}
+
+beforeEach(() => {
+  profilesDir = mkdtempSync(join(tmpdir(), "pdf-tools-canvas-latch-"));
+  savedProfilesDir = process.env.DEFAULT_PROFILES_DIR;
+  savedFlag = process.env.PDF_TOOLS_EMBEDDED_NATIVE_CANVAS;
+  process.env.DEFAULT_PROFILES_DIR = profilesDir;
+  process.env.PDF_TOOLS_EMBEDDED_NATIVE_CANVAS = "1";
+});
+
+afterEach(() => {
+  installed?.restore();
+  installed = null;
+  if (savedProfilesDir === undefined) delete process.env.DEFAULT_PROFILES_DIR;
+  else process.env.DEFAULT_PROFILES_DIR = savedProfilesDir;
+  if (savedFlag === undefined) delete process.env.PDF_TOOLS_EMBEDDED_NATIVE_CANVAS;
+  else process.env.PDF_TOOLS_EMBEDDED_NATIVE_CANVAS = savedFlag;
+  rmSync(profilesDir, { force: true, recursive: true });
+});
+
+describe("the default is off, and stays off until the gates are met", () => {
+  // This is the accidental-flip alarm. If someone adds "win32" to
+  // NATIVE_CANVAS_DEFAULT_PLATFORMS without the host soak evidence, this is what
+  // says so. Deleting it is the only way to flip the default quietly.
+  it("blocks on every platform when no flag is set", () => {
+    const absent = join(profilesDir, "no-marker.json");
+    for (const platform of ["win32", "darwin", "linux"]) {
+      expect(
+        embeddedNativeCanvasAllowed({ env: {}, platform, markerPath: absent }),
+      ).toBe(false);
+    }
+  });
+
+  it("treats =0 as an unconditional kill switch", () => {
+    const absent = join(profilesDir, "no-marker.json");
+    expect(embeddedNativeCanvasAllowed({
+      env: { PDF_TOOLS_EMBEDDED_NATIVE_CANVAS: "0" },
+      platform: "win32",
+      markerPath: absent,
+    })).toBe(false);
+  });
+
+  it("allows =1 when nothing is latched", () => {
+    const absent = join(profilesDir, "no-marker.json");
+    expect(embeddedNativeCanvasAllowed({
+      env: { PDF_TOOLS_EMBEDDED_NATIVE_CANVAS: "1" },
+      platform: "linux",
+      markerPath: absent,
+    })).toBe(true);
+  });
+});
+
+describe("the marker survives past the link, which is the whole point", () => {
+  it("keeps the marker on disk after dlopen returns, in the drawing phase", () => {
+    // The reverted implementation deleted the marker here. If this file is ever
+    // green with the marker already gone at this point, the latch covers only
+    // the link step again and the default must not be flipped.
+    const guarded = install({ dlopen: () => "loaded" });
+
+    expect(guarded.call(process, {}, CANVAS_BINDING)).toBe("loaded");
+
+    expect(existsSync(markerPath())).toBe(true);
+    const marker = readMarker();
+    expect(marker.phase).toBe("drawing");
+    expect(marker.pid).toBe(process.pid);
+  });
+
+  it("arms the marker before dlopen is called, not after", () => {
+    let phaseSeenDuringLoad = null;
+    const guarded = install({
+      dlopen: () => {
+        // Observed from inside the load: a crash here must find a marker.
+        phaseSeenDuringLoad = readMarker().phase;
+        return "loaded";
+      },
+    });
+
+    guarded.call(process, {}, CANVAS_BINDING);
+
+    expect(phaseSeenDuringLoad).toBe("linking");
+  });
+
+  it("clears the marker only once the triggering request settles", () => {
+    const guarded = install({ dlopen: () => "loaded" });
+    guarded.call(process, {}, CANVAS_BINDING);
+    expect(existsSync(markerPath())).toBe(true);
+
+    settleNativeCanvasAttempt();
+
+    expect(existsSync(markerPath())).toBe(false);
+  });
+
+  it("matches a Windows skia path with backslashes", () => {
+    const guarded = install({ dlopen: () => "loaded" });
+    guarded.call(process, {}, SKIA_BINDING);
+    expect(existsSync(markerPath())).toBe(true);
+  });
+
+  it("leaves unrelated native modules completely alone", () => {
+    const seen = [];
+    const guarded = install({
+      dlopen: (module, filename) => {
+        seen.push(filename);
+        return "loaded";
+      },
+    });
+
+    expect(guarded.call(process, {}, UNRELATED_BINDING)).toBe("loaded");
+
+    expect(seen).toEqual([UNRELATED_BINDING]);
+    expect(existsSync(markerPath())).toBe(false);
+  });
+});
+
+describe("a load that raises is survival, and must not latch", () => {
+  it("clears the marker when dlopen throws", () => {
+    // A missing VC++ runtime or an architecture mismatch raises. The host is
+    // intact, so this has to stay retryable forever; latching it would disable
+    // rendering permanently over a fixable environment problem.
+    const guarded = install({
+      dlopen: () => {
+        throw new Error("Cannot find native binding");
+      },
+    });
+
+    expect(() => guarded.call(process, {}, CANVAS_BINDING)).toThrow(/native binding/);
+
+    expect(existsSync(markerPath())).toBe(false);
+    expect(nativeCanvasLatchState(markerPath())).toBe("clear");
+  });
+});
+
+describe("a load that never returns latches off on the next boot", () => {
+  it("reports latched when a marker is left behind by a dead process", () => {
+    // Simulate the crash: run the guard, never settle, then re-attribute the
+    // marker to a process that no longer exists.
+    //
+    // restore() is load-bearing, not cleanup. A process that died cannot still
+    // be holding its ownership token in memory, and the latch deliberately
+    // recognises its own token as re-entry rather than a crash. Leaving the
+    // token in memory would simulate a process that crashed and kept running.
+    const guarded = install({ dlopen: () => "loaded" });
+    guarded.call(process, {}, CANVAS_BINDING);
+    const marker = readMarker();
+    installed.restore();
+    writeFileSync(markerPath(), JSON.stringify({ ...marker, pid: deadPid() }));
+
+    expect(nativeCanvasLatchState(markerPath())).toBe("latched");
+    expect(embeddedNativeCanvasAllowed({
+      env: { PDF_TOOLS_EMBEDDED_NATIVE_CANVAS: "1" },
+      platform: "win32",
+      markerPath: markerPath(),
+    })).toBe(false);
+  });
+
+  it("refuses the next load and records why", () => {
+    writeFileSync(markerPath(), JSON.stringify({
+      phase: "drawing",
+      token: "someone-elses-token",
+      pid: deadPid(),
+    }));
+    const guarded = install({ dlopen: () => "loaded" });
+
+    expect(() => guarded.call(process, {}, CANVAS_BINDING))
+      .toThrow(/native canvas binding is disabled/);
+
+    expect(nativeCanvasBlockReason()).toBe("latched");
+  });
+
+  it("lets =force recover a latched install without hand-editing state", () => {
+    writeFileSync(markerPath(), JSON.stringify({
+      phase: "drawing",
+      token: "someone-elses-token",
+      pid: deadPid(),
+    }));
+    process.env.PDF_TOOLS_EMBEDDED_NATIVE_CANVAS = "force";
+    const guarded = install({ dlopen: () => "loaded" });
+
+    expect(guarded.call(process, {}, CANVAS_BINDING)).toBe("loaded");
+  });
+
+  it("treats an unparseable marker as a latch rather than reasoning past it", () => {
+    writeFileSync(markerPath(), "{ this is not json");
+    expect(nativeCanvasLatchState(markerPath())).toBe("latched");
+  });
+
+  it("treats an empty marker as no marker", () => {
+    writeFileSync(markerPath(), "");
+    expect(nativeCanvasLatchState(markerPath())).toBe("clear");
+  });
+});
+
+describe("ownership keeps two servers from erasing each other", () => {
+  it("does not clear a marker written by another process", () => {
+    // The reverted design had no ownership at all: any server sharing the home
+    // directory could delete an in-flight marker and destroy the evidence of a
+    // crash that was still in progress.
+    const guarded = install({ dlopen: () => "loaded" });
+    guarded.call(process, {}, CANVAS_BINDING);
+
+    const foreign = { phase: "linking", token: "not-ours", pid: process.pid };
+    writeFileSync(markerPath(), JSON.stringify(foreign));
+    settleNativeCanvasAttempt();
+
+    expect(existsSync(markerPath())).toBe(true);
+    expect(readMarker().token).toBe("not-ours");
+  });
+
+  it("does not latch against its own in-flight attempt", () => {
+    // Re-entry inside one process must not read as a crash. Without this the
+    // second canvas load in a single session would latch the install off,
+    // because the first one legitimately still has its marker on disk.
+    const guarded = install({ dlopen: () => "loaded" });
+    guarded.call(process, {}, CANVAS_BINDING);
+
+    expect(nativeCanvasLatchState(markerPath())).toBe("clear");
+    expect(guarded.call(process, {}, CANVAS_BINDING)).toBe("loaded");
+  });
+
+  it("reports a live foreign attempt as concurrent, not as a crash", () => {
+    // A living process mid-attempt has not crashed. Calling that "latched" would
+    // permanently disable rendering because two servers started at once.
+    writeFileSync(markerPath(), JSON.stringify({
+      phase: "linking",
+      token: "not-ours",
+      pid: process.pid,
+    }));
+
+    expect(nativeCanvasLatchState(markerPath())).toBe("concurrent");
+  });
+
+  it("refuses a concurrent load and records the reason", () => {
+    writeFileSync(markerPath(), JSON.stringify({
+      phase: "linking",
+      token: "not-ours",
+      pid: process.pid,
+    }));
+    const guarded = install({ dlopen: () => "loaded" });
+
+    expect(() => guarded.call(process, {}, CANVAS_BINDING)).toThrow();
+
+    expect(nativeCanvasBlockReason()).toBe("concurrent");
+  });
+});
+
+describe("the marker location", () => {
+  it("ignores an unsubstituted manifest template", () => {
+    const path = nativeCanvasMarkerPath({ DEFAULT_PROFILES_DIR: "${HOME}/.pdf-toolkit-files" });
+    expect(path).not.toContain("${");
+  });
+
+  it("honours a configured profiles directory", () => {
+    const path = nativeCanvasMarkerPath({ DEFAULT_PROFILES_DIR: "/var/state/pdf" });
+    expect(path).toBe(join("/var/state/pdf", "native-canvas-attempt.json"));
+  });
+});
+
+describe("a marker that cannot be written refuses the load", () => {
+  it("fails closed when the marker path is unwritable", () => {
+    // If the marker cannot be written, a crash could not be detected, so the
+    // load must not happen. Failing open here would silently remove the entire
+    // safety mechanism on any machine with a read-only profiles directory.
+    process.env.DEFAULT_PROFILES_DIR = join(profilesDir, "blocked");
+    writeFileSync(join(profilesDir, "blocked"), "not a directory");
+    let loaded = false;
+    const guarded = install({
+      dlopen: () => {
+        loaded = true;
+        return "loaded";
+      },
+    });
+
+    expect(() => guarded.call(process, {}, CANVAS_BINDING)).toThrow();
+
+    expect(loaded).toBe(false);
+    expect(nativeCanvasBlockReason()).toBe("marker_unwritable");
+  });
+});


### PR DESCRIPTION
## Summary

The allowed-directory set was built with a fallback to `~/Documents`, `~/Downloads`, and `~/Desktop` whenever configuration was absent or still carried an unexpanded host template. That failed open. An MCPB host that did not substitute its user configuration silently granted three home folders, so a user who had narrowed the allowed set received a wider one with no indication anywhere in the interface.

This was found while packaging PDF Tools as an [Agent Plugins 1.0.0](https://github.com/agentplugins/agent-plugins-spec) plugin, published 2026-08-06. Under that specification it is not an edge case but the default outcome: the standard expands only `${PLUGIN_ROOT}` and `${PLUGIN_DATA}` and requires all other placeholder-like text to remain literal, so `${user_config.allowed_directories}` never resolves and the fallback fires on every install.

The allowed set is now established only by explicit configuration. An unexpanded template means the server was never configured, which is not a reason to choose a boundary on the user's behalf, so an empty set denies every user path and says so.

## Affected tools

No tool signatures change. The filesystem policy chokepoint is shared, so every path-taking tool is affected in the same way: a path that was previously permitted only by the implicit home-folder grant is now refused with `path_policy_denied`. `list_pdfs` and `fetch_pdf_from_url` additionally resolve their no-argument default differently, described below.

## Changes

- **Fail closed.** `buildAllowedDirectories` no longer falls back to the home folders. Argv still overrides the environment variable, and the list still replaces rather than merges — only the no-configuration case changed.
- **Private store removed from the general allowance.** `PROFILES_DIR` is no longer appended to the allowed set. Profile, signature, and backup handlers reach it by direct path construction with their own containment guards, so ordinary document tools can no longer read it.
- **Empty and template-shaped entries dropped** from a JSON list value. `[""]` resolved to `path.resolve("")`, which is the working directory.
- **Option-terminated argument parsing.** `--allowed-directories` stops at the next `--` option instead of consuming it as a filesystem permission.
- **Browsing default stays inside the allowed set.** With the home folders no longer granted, an unconfigured `DEFAULT_PDF_DIR` resolved to a directory the user had not allowed, so a caller that named no directory was refused for a path it never requested. An explicitly configured default still wins outright.
- **Empty-set refusal message.** `#91` rewrote this message and that wording is preserved unchanged. This adds only the branch it cannot reach: when there is no configured set, the message names the configuration mechanisms rather than reporting a set that does not exist.
- All of the above mirrored into the share runtime, which the MCPB static declaration contract holds byte-identical to source.

## Test evidence

`test/sandbox-boundary-findings.test.js` is new and covers each behavior. It failed seven of eight cases against the implementation this replaces.

The browsing-default cases were verified load-bearing by mutation: restoring the previous default makes the first case fail, and restoring the fix returns it to green. `test/list-pdfs-default-directory.test.js` from #91 passes unmodified against this branch, so the two default-resolution designs agree.

Full aggregate on macOS ARM64, rebased onto `c2fc630`:

```
Test Files  135 passed | 4 skipped (139)
Tests       2096 passed | 85 skipped (2181)
node-native pass 62, fail 0
```

Run on macOS rather than Linux: the server-spawning suites are sensitive to worker-fork behaviour and to per-test time budgets under load, and `test/fuzz-malformed-pdfs.test.js` alone takes about 271s here. A Linux run that reports timeouts in those suites is not necessarily reporting a defect.

## Behavior change

A host that relied on the implicit home-folder grant now receives a refusal until directories are configured. This is intended, and it is a change for existing installs. The alternative — re-granting the old defaults once on upgrade — would reintroduce the silent grant being removed.

## Not addressed here

Two related findings are real and deliberately out of scope, being TOCTOU rather than configuration: three handlers resolve a path and then open it without the `O_NOFOLLOW` and identity-rebind treatment used elsewhere, and policy denials raised during an atomic-output re-check are rewrapped as `ATOMIC_OUTPUT_DIRECTORY_CHANGED` rather than surfacing as denials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
