### PR TITLE
Fix the supervisor injectors that were paying the product's budget

### DIFF
--- a/test/eval/docling-macos-supervisor.test.js
+++ b/test/eval/docling-macos-supervisor.test.js
@@ -114,52 +114,67 @@ describe.runIf(RUNS_ON_DARWIN)("native macOS structured-extraction supervisor", 
   // than CPU starvation went wrong and must still fail the suite.
   const SAMPLING_RACE_ERRNOS = [os.constants.errno.EPERM, os.constants.errno.ESRCH];
 
-  /**
-   * Assert every property of a supervised run that does not depend on host
-   * load, then assert the branch the supervisor actually took.
+  /*
+   * CONTAINMENT VS ACCEPTANCE -- the policy this family follows.
    *
-   * Certifying a run requires observing the whole process group inside a
-   * sealed sampling window. On a CPU-starved host the supervisor cannot always
-   * finish that observation, so it fails closed with `enumeration` instead of
-   * certifying what it could not see. That is the correct product behaviour,
-   * which makes the *outcome* a genuine disjunction rather than a constant.
+   * Containment is the contract. "Never certifies what it could not observe",
+   * "never leaks a live process group", "never escapes its session", "declines
+   * cleanly with a truthful reason", and "never emits candidate stdout without
+   * certifying" hold on every host under every load. They are asserted
+   * unconditionally by expectSupervisedInvariants, which every test in this
+   * family calls, and they are the only assertions that may sit outside a
+   * branch.
    *
-   * The disjunction is deliberately narrow. Everything load-independent -- the
-   * drained process group, the schema-valid envelope, the honest claim
-   * boundary, the acceptance biconditional, and the no-stdout-without-
-   * certification rule -- is asserted unconditionally, above the branch. The
-   * failure branch is pinned to one exact failure code and a closed errno set,
-   * so a supervisor that started failing closed for some *other* reason still
-   * fails the suite. Callers add the workload-specific observation assertions
-   * that hold in both branches.
+   * Acceptance is not a universal property, but it is also not automatically a
+   * host-dependent one. What determines whether it may be asserted flatly is
+   * *what decides the outcome*:
    *
-   * @returns {boolean} whether the supervisor certified the run
+   *   1. Host-determined runs -- a real churning workload under the production
+   *      binary, no injected fault. Certification requires completing an
+   *      observation inside a sealed window that a starved host can deny, so
+   *      the outcome is a genuine disjunction. Use expectContainedRun and keep
+   *      the test's own named property above the branch.
+   *
+   *   2. Fault-determined declines -- the injected fault makes declining
+   *      inevitable. Assert the exact failure code and errno with
+   *      expectDeclinedRun.
+   *
+   *   3. Fault-determined acceptances -- the injected fault is supposed to make
+   *      accepting inevitable. Assert it flatly with expectAcceptedRun. When
+   *      such a test flakes under load, the defect is in the injector, not in
+   *      the assertion: an injector must *establish* the state it wants the
+   *      supervisor to observe before reporting its errno, because everything
+   *      it waits for afterwards is charged to the product's sealed 20ms
+   *      SAMPLE_REVALIDATION_BUDGET_NS. Weakening these into disjunctions would
+   *      delete the suite's only coverage of the accept path, since a
+   *      starvation decline is indistinguishable from the decline their
+   *      sibling tests already assert.
+   *
+   * Consequence: no test here needs a quiet host to test what it is named for,
+   * and none is skipped. Category-1 tests keep a visible branch; every other
+   * test asserts one fixed outcome on any host.
    */
-  function expectContainedRun(result) {
+
+  /**
+   * The load-independent contract of a supervised run. Asserted by every test
+   * in this family, never inside a branch.
+   *
+   * `drained` and `escaped` are opt-in because a few tests deliberately
+   * exercise a run that could not be drained; leaving them unset asserts
+   * nothing rather than guessing.
+   */
+  function expectSupervisedInvariants(result, expected = {}) {
     const evidence = result.evidence;
     const observations = evidence.observations;
 
-    // Holds either way: the envelope is schema-valid and honestly labelled.
+    // The envelope is schema-valid and honestly labelled.
     expect(recordValidator(evidence)).toMatchObject({ valid: true });
     expect(evidence.claim_boundary).toContain("Sampled resource observations");
 
-    // Holds either way: nothing survived the run and nothing escaped. A
-    // supervisor that declines to certify must still leave no live process
-    // group behind.
-    expect(observations.original_process_group_empty).toBe(true);
-    expect(observations.escaped_session_detected).toBe(false);
-
-    // Holds either way: the supervisor really observed the group rather than
-    // giving up before looking at it.
-    expect(observations.sample_count).toBeGreaterThan(0);
-    expect(observations.max_group_members).toBeGreaterThan(0);
-    expect(observations.observed_process_identity_count)
-      .toBeGreaterThanOrEqual(observations.max_group_members);
-
-    // Holds either way: acceptance is exactly the conjunction of the clean
-    // observations, so neither branch can be reached by mislabelling the
-    // other. Duplicated from validateSupervisorEvidence on purpose -- the test
-    // keeps the invariant if the harness ever stops enforcing it.
+    // Acceptance is exactly the conjunction of the clean observations, so no
+    // branch can be reached by mislabelling another. Duplicated from
+    // validateSupervisorEvidence on purpose -- the test keeps the invariant if
+    // the harness ever stops enforcing it.
     expect(evidence.controller_accepted).toBe(
       evidence.controller_failure === "none"
       && evidence.controller_errno === 0
@@ -171,6 +186,77 @@ describe.runIf(RUNS_ON_DARWIN)("native macOS structured-extraction supervisor", 
       && !observations.escaped_session_detected
       && observations.original_process_group_empty,
     );
+
+    // Candidate stdout is only ever released by a certified run.
+    if (!evidence.controller_accepted) {
+      expect(result.stdout).toHaveLength(0);
+    }
+
+    if (expected.drained !== undefined) {
+      expect(observations.original_process_group_empty).toBe(expected.drained);
+    }
+    if (expected.escaped !== undefined) {
+      expect(observations.escaped_session_detected).toBe(expected.escaped);
+    }
+  }
+
+  /**
+   * A fault-determined acceptance: the injected fault, not the host, decides
+   * the outcome, so acceptance is asserted flatly. See the policy note above.
+   */
+  function expectAcceptedRun(result, expected = {}) {
+    expectSupervisedInvariants(result, { drained: true, escaped: false, ...expected });
+    expect(result.evidence).toMatchObject({
+      controller_accepted: true,
+      controller_failure: "none",
+      controller_errno: 0,
+      leader: { exit_code: 0, signal: null },
+    });
+  }
+
+  /**
+   * A fault-determined decline: pinned to one exact failure code and errno, so
+   * a supervisor that starts failing closed for some *other* reason -- or that
+   * reports a truthless errno -- still fails the suite.
+   */
+  function expectDeclinedRun(result, failure, errno, expected = {}) {
+    expectSupervisedInvariants(result, { drained: true, ...expected });
+    expect(result.evidence).toMatchObject({
+      controller_accepted: false,
+      controller_failure: failure,
+      controller_errno: errno,
+    });
+    expect(result.stdout).toHaveLength(0);
+  }
+
+  /**
+   * A host-determined run: assert every load-independent property, then assert
+   * the branch the supervisor actually took.
+   *
+   * Certifying a run requires observing the whole process group inside a
+   * sealed sampling window. On a CPU-starved host the supervisor cannot always
+   * finish that observation, so it fails closed with `enumeration` instead of
+   * certifying what it could not see. That is the correct product behaviour,
+   * which makes the *outcome* a genuine disjunction rather than a constant.
+   *
+   * The disjunction is deliberately narrow. The failure branch is pinned to one
+   * exact failure code and a closed errno set. Callers add the workload-specific
+   * observation assertions that hold in both branches, above the branch.
+   *
+   * @returns {boolean} whether the supervisor certified the run
+   */
+  function expectContainedRun(result) {
+    const evidence = result.evidence;
+    const observations = evidence.observations;
+
+    expectSupervisedInvariants(result, { drained: true, escaped: false });
+
+    // Holds either way: the supervisor really observed the group rather than
+    // giving up before looking at it.
+    expect(observations.sample_count).toBeGreaterThan(0);
+    expect(observations.max_group_members).toBeGreaterThan(0);
+    expect(observations.observed_process_identity_count)
+      .toBeGreaterThanOrEqual(observations.max_group_members);
 
     if (evidence.controller_accepted) {
       expect(evidence.controller_failure).toBe("none");
@@ -185,7 +271,6 @@ describe.runIf(RUNS_ON_DARWIN)("native macOS structured-extraction supervisor", 
     // errno that names a sampling race, and never any candidate stdout.
     expect(evidence.controller_failure).toBe("enumeration");
     expect(SAMPLING_RACE_ERRNOS).toContain(evidence.controller_errno);
-    expect(result.stdout).toHaveLength(0);
     return false;
   }
 
@@ -250,19 +335,21 @@ describe.runIf(RUNS_ON_DARWIN)("native macOS structured-extraction supervisor", 
   });
 
   it("accepts only after sampling proves the reserved leader became terminal", async () => {
+    // The injector waits for the leader to actually become terminal before it
+    // reports ESRCH, so the supervisor's WNOWAIT proof is exercised on every
+    // host rather than only on one fast enough to finish the leader's exit
+    // inside SAMPLE_REVALIDATION_BUDGET_NS. Fault-determined acceptance:
+    // asserted flatly, never disjunctively.
     const result = await runFault(
       "sampling_terminal_leader",
       "terminal-during-sampling",
       [15],
       { sampleIntervalMs: 1 },
     );
-    expect(result.evidence).toMatchObject({
-      controller_accepted: true,
-      controller_failure: "none",
-      leader: { exit_code: 0, signal: null },
-      observations: { original_process_group_empty: true },
-    });
+    expectAcceptedRun(result);
     expect(result.evidence.observations.sample_count).toBeGreaterThan(0);
+    // The named property: acceptance came *through* the sampling race path,
+    // not by the injected ESRCH never firing.
     expect(result.evidence.observations.sample_race_count).toBeGreaterThan(0);
   });
 
@@ -312,11 +399,11 @@ describe.runIf(RUNS_ON_DARWIN)("native macOS structured-extraction supervisor", 
     ["crash", [], "leader_exit"],
   ])("fails closed for %s", async (mode, args, failure, overrides = {}) => {
     const result = await run(mode, args, overrides);
+    expectSupervisedInvariants(result, { drained: true, escaped: false });
     expect(result.stdout).toHaveLength(0);
     expect(result.evidence).toMatchObject({
       controller_accepted: false,
       controller_failure: failure,
-      observations: { original_process_group_empty: true },
     });
   });
 
@@ -343,11 +430,7 @@ describe.runIf(RUNS_ON_DARWIN)("native macOS structured-extraction supervisor", 
       [1, 250],
       { sampleIntervalMs: 1 },
     );
-    expect(result.evidence).toMatchObject({
-      controller_accepted: true,
-      controller_failure: "none",
-      observations: { original_process_group_empty: true },
-    });
+    expectAcceptedRun(result);
     expect(result.evidence.observations.sample_race_count).toBeGreaterThan(0);
     expect(result.evidence.observations.observed_process_identity_count).toBeGreaterThan(1);
   });
@@ -359,13 +442,7 @@ describe.runIf(RUNS_ON_DARWIN)("native macOS structured-extraction supervisor", 
       [1, 1000],
       { sampleIntervalMs: 1 },
     );
-    expect(result.stdout).toHaveLength(0);
-    expect(result.evidence).toMatchObject({
-      controller_accepted: false,
-      controller_errno: 1,
-      controller_failure: "enumeration",
-      observations: { original_process_group_empty: true },
-    });
+    expectDeclinedRun(result, "enumeration", os.constants.errno.EPERM);
     expect(result.evidence.observations.sample_race_count).toBeGreaterThan(0);
   });
 
@@ -376,33 +453,23 @@ describe.runIf(RUNS_ON_DARWIN)("native macOS structured-extraction supervisor", 
       [1, 1000],
       { sampleIntervalMs: 1 },
     );
-    expect(result.stdout).toHaveLength(0);
-    expect(result.evidence).toMatchObject({
-      controller_accepted: false,
-      controller_errno: 3,
-      controller_failure: "enumeration",
-      observations: { original_process_group_empty: true },
-    });
+    expectDeclinedRun(result, "enumeration", os.constants.errno.ESRCH);
   });
 
   it("accepts sampling EPERM only after the real child is absent between two ESRCH probes", async () => {
-    // The child can be discovered by either the group snapshot or the separate
-    // child enumeration before it vanishes inside the supervisor's sealed 20ms
-    // sampling-revalidation budget (SAMPLE_REVALIDATION_BUDGET_NS). The latter
-    // is still a complete exercise of the vanish proof even when the group
-    // snapshot raced just before fork. Separate coverage above pins the group
-    // observation count for multiple live children.
+    // The injector waits for the real child to be gone *and reaped* before it
+    // reports EPERM, so the supervisor still has to run the entire two-probe
+    // vanish proof inside SAMPLE_REVALIDATION_BUDGET_NS -- it just no longer
+    // has to outrun the candidate's sleep to do it. This is the suite's only
+    // coverage of the accept side of the vanish proof; its sibling above
+    // asserts the decline, so a disjunction here would collapse the two.
     const result = await runFault(
       "sampling_vanish_eperm",
       "multiple-children",
       [1, 15],
       { sampleIntervalMs: 1 },
     );
-    expect(result.evidence).toMatchObject({
-      controller_accepted: true,
-      controller_failure: "none",
-      observations: { original_process_group_empty: true },
-    });
+    expectAcceptedRun(result);
     expect(result.evidence.observations.sample_race_count).toBeGreaterThan(0);
   });
 
@@ -413,13 +480,7 @@ describe.runIf(RUNS_ON_DARWIN)("native macOS structured-extraction supervisor", 
       [15],
       { deadlineMs: 3000, sampleIntervalMs: 1 },
     );
-    expect(result.stdout).toHaveLength(0);
-    expect(result.evidence).toMatchObject({
-      controller_accepted: false,
-      controller_errno: 5,
-      controller_failure: "enumeration",
-      observations: { original_process_group_empty: true },
-    });
+    expectDeclinedRun(result, "enumeration", os.constants.errno.EIO);
     expect(result.evidence.observations.sample_race_count).toBeGreaterThan(0);
   });
 
@@ -428,6 +489,16 @@ describe.runIf(RUNS_ON_DARWIN)("native macOS structured-extraction supervisor", 
     // being discovered by the supervisor's separate child enumeration. The
     // injected EPERM, fail-closed result, and surviving sentinel prove this
     // path; the multiple-live-children test above pins the group count itself.
+    //
+    // KNOWN COVERAGE GAP (measured, pre-existing, not load-related). Because
+    // this PID resolves through the *children* source, its own enumeration
+    // already blocks: the escaped child is still a direct child of the leader,
+    // so source_contains_pid never returns 0. Deleting both ESRCH signal probes
+    // from prove_process_vanished -- so that source absence alone proves a PID
+    // gone -- leaves the whole suite green, idle and under contention alike.
+    // Closing it needs a fixture whose PID is discovered by the *group*
+    // snapshot and is absent from the group while still alive, e.g. an
+    // orphaned grandchild that setsid()s: no candidate mode produces one today.
     const sentinel = path.join(root, "sampling-escape-eperm-sentinel");
     const result = await runFault(
       "sampling_escape_eperm",
@@ -435,13 +506,7 @@ describe.runIf(RUNS_ON_DARWIN)("native macOS structured-extraction supervisor", 
       [sentinel],
       { sampleIntervalMs: 1 },
     );
-    expect(result.stdout).toHaveLength(0);
-    expect(result.evidence).toMatchObject({
-      controller_accepted: false,
-      controller_errno: 1,
-      controller_failure: "enumeration",
-      observations: { original_process_group_empty: true },
-    });
+    expectDeclinedRun(result, "enumeration", os.constants.errno.EPERM);
     await waitForFile(sentinel, 2500);
   });
 
@@ -452,17 +517,41 @@ describe.runIf(RUNS_ON_DARWIN)("native macOS structured-extraction supervisor", 
       [32, 1000],
       { deadlineMs: 3000, sampleIntervalMs: 1 },
     );
-    expect(result.stdout).toHaveLength(0);
-    expect(result.evidence).toMatchObject({
-      controller_accepted: false,
-      controller_errno: 1,
-      controller_failure: "enumeration",
-      observations: { original_process_group_empty: true },
-    });
-    expect(result.evidence.observations.max_group_members).toBe(33);
-    expect(result.evidence.observations.sample_race_count).toBeGreaterThan(2);
-    expect(result.evidence.observations.elapsed_continuous_ns)
-      .toBeLessThan(500 * 1e6);
+    const observations = result.evidence.observations;
+
+    // The setup really did present many independently inaccessible PIDs: the
+    // fault only arms on a snapshot of the full 33-member group, and each of
+    // the 32 children becomes inspectable again after only four probes.
+    expect(observations.max_group_members).toBe(33);
+
+    // The named property. Given one shared, monotonic budget the supervisor
+    // exhausts it partway through the group and fails closed. Given a budget
+    // that reset per PID, every child would clear its four probes inside its
+    // own fresh 20ms window and the run would be *certified*. So the decline
+    // -- with EPERM, the errno of the PIDs that were never re-proven -- is the
+    // discriminator, and it is load-independent: starving the host only makes
+    // the shared budget run out sooner.
+    expectDeclinedRun(result, "enumeration", os.constants.errno.EPERM);
+
+    // How *many* PIDs fit inside one 20ms budget is a measurement of host
+    // speed, not of the supervisor: idle this host fits four, under load one.
+    // The previous `sample_race_count > 2` therefore asserted the opposite of
+    // the property in the test name -- heavier load means stronger evidence of
+    // sharing but a smaller count -- and was the assertion that failed under
+    // contention. What is load-independent is the direction of the bound: with
+    // one shared budget the supervisor must run out *before* it has revalidated
+    // all 32 inaccessible children; with a per-PID budget it would revalidate
+    // every one of them.
+    expect(observations.sample_race_count).toBeGreaterThanOrEqual(1);
+    expect(observations.sample_race_count)
+      .toBeLessThan(observations.max_group_members - 1);
+
+    // The retired wall-clock bound (`elapsed_continuous_ns < 500ms`) is
+    // deliberately not replaced. The campaign clock is dominated by spawning
+    // and forking 33 processes -- 132ms idle, 477ms under contention on this
+    // host -- while the whole quantity under test is at most 20ms, so it could
+    // never have discriminated one budget from thirty-two. It only measured
+    // how loaded the host was.
   });
 
   it("blocks before disappearance proof when sampling reaches the outer deadline", async () => {
@@ -472,13 +561,7 @@ describe.runIf(RUNS_ON_DARWIN)("native macOS structured-extraction supervisor", 
       [1, 1000],
       { deadlineMs: 100, sampleIntervalMs: 1 },
     );
-    expect(result.stdout).toHaveLength(0);
-    expect(result.evidence).toMatchObject({
-      controller_accepted: false,
-      controller_errno: 1,
-      controller_failure: "enumeration",
-      observations: { original_process_group_empty: true },
-    });
+    expectDeclinedRun(result, "enumeration", os.constants.errno.EPERM);
     expect(result.evidence.observations.elapsed_continuous_ns)
       .toBeGreaterThanOrEqual(100 * 1e6);
   });
@@ -502,10 +585,10 @@ describe.runIf(RUNS_ON_DARWIN)("native macOS structured-extraction supervisor", 
     const result = await run("leader-exit-live-descendant", [sentinel], {
       leaderExitGraceMs: 0,
     });
+    expectSupervisedInvariants(result, { drained: true, escaped: false });
     expect(result.evidence).toMatchObject({
       controller_accepted: false,
       controller_failure: "live_descendants",
-      observations: { original_process_group_empty: true },
     });
     await new Promise(resolve => setTimeout(resolve, 1000));
     await expect(fs.access(sentinel)).rejects.toThrow();
@@ -527,14 +610,12 @@ describe.runIf(RUNS_ON_DARWIN)("native macOS structured-extraction supervisor", 
         sampleIntervalMs: 5,
       },
     );
+    expectSupervisedInvariants(result, { drained: true, escaped: false });
     expect(result.stdout).toHaveLength(0);
     expect(result.evidence).toMatchObject({
       controller_accepted: false,
       controller_failure: "physical_footprint_limit",
-      observations: {
-        max_group_members: 2,
-        original_process_group_empty: true,
-      },
+      observations: { max_group_members: 2 },
     });
     expect(result.evidence.observations.observed_process_identity_count)
       .toBeGreaterThan(1);
@@ -549,14 +630,11 @@ describe.runIf(RUNS_ON_DARWIN)("native macOS structured-extraction supervisor", 
       leaderExitGraceMs: 1000,
       sampleIntervalMs: 5,
     });
+    expectSupervisedInvariants(result, { drained: true, escaped: true });
     expect(result.stdout).toHaveLength(0);
     expect(result.evidence).toMatchObject({
       controller_accepted: false,
       controller_failure: "escaped_session",
-      observations: {
-        escaped_session_detected: true,
-        original_process_group_empty: true,
-      },
     });
     expect(result.evidence.observations.max_group_members).toBe(2);
     expect(result.evidence.observations.observed_process_identity_count)
@@ -616,14 +694,11 @@ describe.runIf(RUNS_ON_DARWIN)("native macOS structured-extraction supervisor", 
         physicalFootprintMaxBytes: 64 * 1024 * 1024,
       },
     );
+    expectSupervisedInvariants(result, { drained: true, escaped: true });
     expect(result.stdout).toHaveLength(0);
     expect(result.evidence).toMatchObject({
       controller_accepted: false,
       controller_failure: "escaped_session",
-      observations: {
-        escaped_session_detected: true,
-        original_process_group_empty: true,
-      },
     });
     expect(result.evidence.observations.observed_process_identity_count)
       .toBeGreaterThanOrEqual(3);
@@ -634,13 +709,10 @@ describe.runIf(RUNS_ON_DARWIN)("native macOS structured-extraction supervisor", 
   it("detects an observed escaped session, rejects output, and kills the known child", async () => {
     const sentinel = path.join(root, "escaped-session-sentinel");
     const result = await run("escaped-session", [sentinel]);
+    expectSupervisedInvariants(result, { drained: true, escaped: true });
     expect(result.evidence).toMatchObject({
       controller_accepted: false,
       controller_failure: "escaped_session",
-      observations: {
-        escaped_session_detected: true,
-        original_process_group_empty: true,
-      },
     });
     await new Promise(resolve => setTimeout(resolve, 1500));
     await expect(fs.access(sentinel)).rejects.toThrow();
@@ -653,13 +725,10 @@ describe.runIf(RUNS_ON_DARWIN)("native macOS structured-extraction supervisor", 
   ])("reports cleanup failure without killing an escaped PID after the %s identity boundary changes", async fault => {
     const sentinel = path.join(root, `${fault}-sentinel`);
     const result = await runFault(fault, "escaped-session", [sentinel]);
+    expectSupervisedInvariants(result, { drained: true, escaped: true });
     expect(result.evidence).toMatchObject({
       controller_accepted: false,
       controller_failure: "cleanup",
-      observations: {
-        escaped_session_detected: true,
-        original_process_group_empty: true,
-      },
     });
     await waitForFile(sentinel, 2500);
   });
@@ -670,10 +739,10 @@ describe.runIf(RUNS_ON_DARWIN)("native macOS structured-extraction supervisor", 
     ["continuous_clock_jump", "deadline"],
   ])("rejects injected controller fault %s", async (fault, expectedFailure) => {
     const result = await runFault(fault);
+    expectSupervisedInvariants(result, { drained: true, escaped: false });
     expect(result.evidence).toMatchObject({
       controller_accepted: false,
       controller_failure: expectedFailure,
-      observations: { original_process_group_empty: true },
     });
   });
 
@@ -683,19 +752,18 @@ describe.runIf(RUNS_ON_DARWIN)("native macOS structured-extraction supervisor", 
     ["prelease_timeout", "child_setup", { deadlineMs: 100 }, 0],
   ])("publishes bounded lease-free evidence for %s", async (fault, expectedFailure, overrides, expectedStage) => {
     const result = await runFault(fault, "sleep", [5000], overrides);
+    expectSupervisedInvariants(result, { drained: true, escaped: false });
     expect(result.lease).toBeNull();
     expect(result.stdout).toHaveLength(0);
     expect(result.evidence).toMatchObject({
       controller_accepted: false,
       controller_failure: expectedFailure,
       child_setup_stage: expectedStage,
-      observations: { original_process_group_empty: true },
     });
     expect(
       result.evidence.leader.exit_code !== null
       || result.evidence.leader.signal !== null,
     ).toBe(true);
-    expect(recordValidator(result.evidence)).toMatchObject({ valid: true });
   });
 
   it("uses the parent-owned lease to clean up a crashed supervisor", async () => {

--- a/test/eval/native/docling-macos-supervisor.c
+++ b/test/eval/native/docling-macos-supervisor.c
@@ -874,6 +874,44 @@ static bool receive_testing_feedback(unsigned char expected) {
   return read_exact(testing_feedback_read, &observed, 1) &&
          observed == expected;
 }
+
+typedef enum {
+  TESTING_CONDITION_LEADER_TERMINAL,
+  TESTING_CONDITION_PID_REAPED,
+} testing_condition;
+
+/*
+ * Fault injectors that want the supervisor to observe an already-settled
+ * world must settle it here, before reporting the injected errno. Anything
+ * they wait for after reporting is charged to SAMPLE_REVALIDATION_BUDGET_NS,
+ * the sealed 20ms window the supervisor gets to re-prove an EPERM/ESRCH PID,
+ * which turns an injected outcome into a bet on host scheduling. Waiting
+ * first is charged to the outer campaign deadline instead. The bound is
+ * generous and failing it reports ETIMEDOUT, which no sampling-race errno
+ * set accepts, so an injector that never settles fails a test loudly rather
+ * than degrading into the ordinary decline.
+ */
+static bool wait_for_testing_condition(testing_condition condition,
+                                       pid_t pid) {
+  for (unsigned attempt = 0; attempt < 30000; attempt += 1) {
+    if (condition == TESTING_CONDITION_LEADER_TERMINAL) {
+      bool terminal = false;
+      if (!leader_has_exited(pid, &terminal)) {
+        return false;
+      }
+      if (terminal) {
+        return true;
+      }
+    } else if (kill(pid, 0) != 0 && errno == ESRCH) {
+      return true;
+    }
+    struct timespec delay = {.tv_sec = 0, .tv_nsec = 100000};
+    while (nanosleep(&delay, &delay) != 0 && errno == EINTR) {
+    }
+  }
+  errno = ETIMEDOUT;
+  return false;
+}
 #endif
 
 static bool sample_process_details(pid_t pid, pid_t pgid,
@@ -888,8 +926,19 @@ static bool sample_process_details(pid_t pid, pid_t pgid,
       return false;
     }
     notified = true;
-    struct timespec delay = {.tv_sec = 0, .tv_nsec = 20000000};
-    while (nanosleep(&delay, &delay) != 0 && errno == EINTR) {
+    /*
+     * Establish the state the supervisor is supposed to react to, rather
+     * than signalling the leader and sleeping a fixed span in the hope it
+     * wins the race. The previous fixed 20ms sleep was exactly one
+     * SAMPLE_REVALIDATION_BUDGET_NS long, so on a loaded host the leader
+     * had not reached its terminal state by the time the budget it has to
+     * be proven inside had already started, and a fault-determined
+     * acceptance silently became a host-determined one. Waiting here is
+     * charged to the outer campaign deadline instead: the revalidation
+     * budget does not start until this call returns.
+     */
+    if (!wait_for_testing_condition(TESTING_CONDITION_LEADER_TERMINAL, pid)) {
+      return false;
     }
     errno = ESRCH;
     return false;
@@ -943,8 +992,22 @@ static bool sample_process_details(pid_t pid, pid_t pgid,
         errno = EPERM;
         return false;
       }
+    } else if (strcmp(fault, "sampling_vanish_eperm") == 0) {
+      /*
+       * The property under test is "an EPERM PID may be accepted once, and
+       * only once, its absence has been proven twice over" -- not "a
+       * candidate child's 15ms sleep finishes inside the supervisor's 20ms
+       * revalidation budget". Make the absence real before reporting EPERM.
+       * The supervisor still has to run the entire two-probe vanish proof
+       * (source re-enumeration plus a signal probe) inside its sealed
+       * budget; it just no longer has to outrun the candidate to do so.
+       */
+      if (!wait_for_testing_condition(TESTING_CONDITION_PID_REAPED, pid)) {
+        return false;
+      }
+      errno = EPERM;
+      return false;
     } else if (strcmp(fault, "sampling_persistent_eperm") == 0 ||
-               strcmp(fault, "sampling_vanish_eperm") == 0 ||
                strcmp(fault, "sampling_escape_eperm") == 0 ||
                strcmp(fault, "sampling_outer_deadline_eperm") == 0) {
       errno = EPERM;


### PR DESCRIPTION
Finishes the family #138 deliberately left half done. Three tests remained that
failed **deterministically under CPU contention**.

## I asked the wrong question

I framed it as *containment properties vs acceptance outcomes*. Applying that
would have destroyed two of the three tests. The real axis is **what decides the
outcome**:

| kind | rule |
|---|---|
| Real workload, production binary | Certification genuinely depends on finishing inside a window a starved host can deny. Real disjunction — #138's shape is correct. |
| Injected fault forcing a **decline** | Assert exact failure code and errno. |
| Injected fault forcing an **accept**, yet it flakes | **The injector is the defect, not the assertions.** |

That last case is the finding. An injector must **establish** the state it wants
observed **before** reporting its errno — everything it waits for afterwards is
charged against the product's sealed 20 ms `SAMPLE_REVALIDATION_BUDGET_NS`. Both
accept-path flakes were injectors that armed and hoped.

The precedent was already in the file: the counter-based injector
(`EPERM for the first 3 probes`) has never flaked; the two wall-clock ones are
exactly the two that did.

**Consequence: no test here needs a quiet host, and none is skipped.** The
declared-precondition escape hatch proved unnecessary — the better outcome, since
a skip can never be mistaken for a pass.

## Per test

1. **`accepts sampling EPERM only after the real child is absent…`** — injector now
   waits for the child to be genuinely gone *and reaped* before reporting EPERM.
   **Not moving a threshold:** the 20 ms product constant is untouched and the
   supervisor still runs the whole two-probe proof inside it; what is removed is
   the candidate's 15 ms sleep being paid *out of the budget under test*.
2. **`shares one monotonic retry budget…`** — was asserting **the opposite of its
   own name**. It required `sample_race_count > 2`, but heavier load exhausts a
   *shared* budget sooner, which is stronger evidence of sharing. Replaced with the
   load-independent discriminator: a per-PID budget would let all 32 children
   certify, so the decline *is* the proof. A 500 ms timing assertion is **retired,
   not replaced** — the campaign clock is dominated by forking 33 processes and
   could never have discriminated 1 budget from 32.
3. **`accepts only after sampling proves the reserved leader became terminal`** —
   injector slept *exactly* one revalidation budget before returning ESRCH. Now
   waits on `leader_has_exited` (WNOWAIT, the real proof).

Family-wide: `expectSupervisedInvariants` asserts the load-independent spine and is
called by all ~20 tests, never inside a branch.

## The C change is test apparatus — verified, not asserted

Every edit sits inside `#if defined(PDF_TOOLS_SUPERVISOR_TESTING)`. Compiling this
source and `origin/master`'s with production flags yields **byte-identical
binaries** — independently reproduced by the reviewer.

## Mutation evidence — 8, all under 12-process load

Seven caught. M5 (per-PID budget) is caught **by exactly one test: the restructured
#2**; M6 and M7 by #1 and #3 respectively — so each rewritten test retains unique
or primary teeth for its own property.

**Reported, not counted:**
- **One inert mutation** — deleting a call site made `-Werror` reject the unused
  function, so the suite never ran. Discarded and replaced.
- **One genuinely survives (pre-existing coverage gap).** Deleting *both* liveness
  probes from `prove_process_vanished` passes 54/54, idle and loaded: every escape
  fixture resolves through the *children* source, where the escaped child is still
  a direct child, so the probes never decide anything. Closing it needs an orphaned
  grandchild that `setsid()`s, which no candidate mode produces. Recorded as a
  `KNOWN COVERAGE GAP` comment at the test rather than left silent.

## Pass rates

**Before:** test 1 fails at 12-process load; tests 2 and 3 surface at 40 processes.
**After:** **7/7 at 12 processes, 7/7 idle**, 5/5 for the injector-fixed tests at 40.

`npm test` — 2372 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)