### PR TITLE
Make a signalled shutdown report the signal, not a crash

### DIFF
--- a/pdf-toolkit-mcp-share/server/pdfjs-worker.js
+++ b/pdf-toolkit-mcp-share/server/pdfjs-worker.js
@@ -47,11 +47,18 @@ const MAX_CANVAS_PIXELS = 16 * 1024 * 1024;
 const MAX_PASSWORD_CHARACTERS = 4096;
 const SYSTEM_COMMAND_TIMEOUT_MS = 15_000;
 const PDF_RESOURCE_LIMIT_CODE = "PDF_RESOURCE_LIMIT_EXCEEDED";
+// The two reasons systemRendererShutdownError() can carry. A rejection with one
+// of these says "we tore this renderer down", never "this renderer broke".
+const SYSTEM_RENDERER_SHUTDOWN_REASONS = new Set([
+  "system_renderer_shutdown",
+  "system_renderer_shutdown_terminal",
+]);
 const _require = createRequire(import.meta.url);
 const activeSystemChildren = new Set();
 const activeSystemRenderWorkspaces = new Set();
 const threadSystemCommandWaiters = new Map();
 let systemChildTermination = null;
+let systemChildTerminationFault = false;
 let systemChildTerminationHandlersInstalled = false;
 let systemRenderShutdownStarted = false;
 let systemRenderShutdownTerminal = false;
@@ -1451,6 +1458,43 @@ export function forceTerminateAllPdfjsWorkerSystemChildren() {
   for (const child of activeSystemChildren) killSystemChild(child);
 }
 
+// A terminal signal decides this process's exit code, but the shutdown it starts
+// also kills every in-flight system renderer child on purpose, and each kill
+// rejects the render its caller was awaiting. Nothing is left to catch those
+// rejections - the caller is exactly what the shutdown is dismantling - so Node
+// applies its default policy and makes them fatal. On Node 20 that fatal path
+// runs before the deliberate process.exit() below, so an orderly shutdown exits
+// 1 and prints a stack trace: a supervisor reads a requested termination as a
+// crash, and the log reads like one too. On Node 22 the deliberate exit wins.
+// Neither ordering is promised on either runtime, so the signal-to-exit-code
+// contract was only ever holding by luck.
+//
+// Node delivers these as uncaughtException with origin "unhandledRejection" -
+// including the entry module's own rejected top-level await, which never reaches
+// an "unhandledRejection" listener at all - so this is the one place the fault
+// can be seen. Swallow exactly the faults this shutdown manufactured, named by
+// the typed shutdown limit runSystemCommand raises for a child we killed
+// ourselves. Re-raise anything else on the default path and stand the deliberate
+// exit down, so a cleanup that could not be proven, or a bug, still crashes with
+// exit code 1 and Node's own report rather than being buried under a tidy 143.
+function installTerminalShutdownFaultGuard() {
+  const guard = (error, origin) => {
+    if (
+      origin === "unhandledRejection"
+      && error?.code === PDF_RESOURCE_LIMIT_CODE
+      && SYSTEM_RENDERER_SHUTDOWN_REASONS.has(error?.reason)
+    ) {
+      return;
+    }
+    process.removeListener("uncaughtException", guard);
+    systemChildTerminationFault = true;
+    process.nextTick(() => {
+      throw error;
+    });
+  };
+  process.on("uncaughtException", guard);
+}
+
 export function installSystemChildTerminationHandlers() {
   if (systemChildTerminationHandlersInstalled) return;
   systemChildTerminationHandlersInstalled = true;
@@ -1462,8 +1506,16 @@ export function installSystemChildTerminationHandlers() {
   for (const [signal, exitCode] of exitCodes) {
     process.once(signal, () => {
       if (systemChildTermination !== null) return;
+      // The exit code is decided the moment the signal is accepted. Record it
+      // before any teardown runs, so a shutdown that drains the event loop
+      // without reaching the explicit exit below still reports the signal.
+      process.exitCode = exitCode;
+      installTerminalShutdownFaultGuard();
       systemChildTermination = beginPdfjsWorkerSystemShutdown({ terminal: true });
-      void systemChildTermination.finally(() => process.exit(exitCode));
+      void systemChildTermination.finally(() => {
+        if (systemChildTerminationFault) return;
+        process.exit(exitCode);
+      });
     });
   }
 }
@@ -1545,7 +1597,15 @@ export async function runSystemCommand(command, args, {
       } else if (outputOverflow) {
         finish(resourceLimitError("system_renderer_output_limit"));
       } else if (code !== 0 || signal !== null) {
-        finish(new Error("The macOS system PDF renderer could not render this page."));
+        // A child that died after renderer shutdown began died because we killed
+        // it, so it did not fail in any sense the caller should hear. Blaming the
+        // renderer there invents a fault during an orderly teardown and buries
+        // the one fact the caller can act on. Report the same typed shutdown
+        // limit the admission gate raises for a call arriving one moment later.
+        // A child that failed on its own still rejects exactly as before.
+        finish(systemRenderShutdownStarted
+          ? systemRendererShutdownError()
+          : new Error("The macOS system PDF renderer could not render this page."));
       } else {
         finish(null);
       }

--- a/server/pdfjs-worker.js
+++ b/server/pdfjs-worker.js
@@ -47,11 +47,18 @@ const MAX_CANVAS_PIXELS = 16 * 1024 * 1024;
 const MAX_PASSWORD_CHARACTERS = 4096;
 const SYSTEM_COMMAND_TIMEOUT_MS = 15_000;
 const PDF_RESOURCE_LIMIT_CODE = "PDF_RESOURCE_LIMIT_EXCEEDED";
+// The two reasons systemRendererShutdownError() can carry. A rejection with one
+// of these says "we tore this renderer down", never "this renderer broke".
+const SYSTEM_RENDERER_SHUTDOWN_REASONS = new Set([
+  "system_renderer_shutdown",
+  "system_renderer_shutdown_terminal",
+]);
 const _require = createRequire(import.meta.url);
 const activeSystemChildren = new Set();
 const activeSystemRenderWorkspaces = new Set();
 const threadSystemCommandWaiters = new Map();
 let systemChildTermination = null;
+let systemChildTerminationFault = false;
 let systemChildTerminationHandlersInstalled = false;
 let systemRenderShutdownStarted = false;
 let systemRenderShutdownTerminal = false;
@@ -1451,6 +1458,43 @@ export function forceTerminateAllPdfjsWorkerSystemChildren() {
   for (const child of activeSystemChildren) killSystemChild(child);
 }
 
+// A terminal signal decides this process's exit code, but the shutdown it starts
+// also kills every in-flight system renderer child on purpose, and each kill
+// rejects the render its caller was awaiting. Nothing is left to catch those
+// rejections - the caller is exactly what the shutdown is dismantling - so Node
+// applies its default policy and makes them fatal. On Node 20 that fatal path
+// runs before the deliberate process.exit() below, so an orderly shutdown exits
+// 1 and prints a stack trace: a supervisor reads a requested termination as a
+// crash, and the log reads like one too. On Node 22 the deliberate exit wins.
+// Neither ordering is promised on either runtime, so the signal-to-exit-code
+// contract was only ever holding by luck.
+//
+// Node delivers these as uncaughtException with origin "unhandledRejection" -
+// including the entry module's own rejected top-level await, which never reaches
+// an "unhandledRejection" listener at all - so this is the one place the fault
+// can be seen. Swallow exactly the faults this shutdown manufactured, named by
+// the typed shutdown limit runSystemCommand raises for a child we killed
+// ourselves. Re-raise anything else on the default path and stand the deliberate
+// exit down, so a cleanup that could not be proven, or a bug, still crashes with
+// exit code 1 and Node's own report rather than being buried under a tidy 143.
+function installTerminalShutdownFaultGuard() {
+  const guard = (error, origin) => {
+    if (
+      origin === "unhandledRejection"
+      && error?.code === PDF_RESOURCE_LIMIT_CODE
+      && SYSTEM_RENDERER_SHUTDOWN_REASONS.has(error?.reason)
+    ) {
+      return;
+    }
+    process.removeListener("uncaughtException", guard);
+    systemChildTerminationFault = true;
+    process.nextTick(() => {
+      throw error;
+    });
+  };
+  process.on("uncaughtException", guard);
+}
+
 export function installSystemChildTerminationHandlers() {
   if (systemChildTerminationHandlersInstalled) return;
   systemChildTerminationHandlersInstalled = true;
@@ -1462,8 +1506,16 @@ export function installSystemChildTerminationHandlers() {
   for (const [signal, exitCode] of exitCodes) {
     process.once(signal, () => {
       if (systemChildTermination !== null) return;
+      // The exit code is decided the moment the signal is accepted. Record it
+      // before any teardown runs, so a shutdown that drains the event loop
+      // without reaching the explicit exit below still reports the signal.
+      process.exitCode = exitCode;
+      installTerminalShutdownFaultGuard();
       systemChildTermination = beginPdfjsWorkerSystemShutdown({ terminal: true });
-      void systemChildTermination.finally(() => process.exit(exitCode));
+      void systemChildTermination.finally(() => {
+        if (systemChildTerminationFault) return;
+        process.exit(exitCode);
+      });
     });
   }
 }
@@ -1545,7 +1597,15 @@ export async function runSystemCommand(command, args, {
       } else if (outputOverflow) {
         finish(resourceLimitError("system_renderer_output_limit"));
       } else if (code !== 0 || signal !== null) {
-        finish(new Error("The macOS system PDF renderer could not render this page."));
+        // A child that died after renderer shutdown began died because we killed
+        // it, so it did not fail in any sense the caller should hear. Blaming the
+        // renderer there invents a fault during an orderly teardown and buries
+        // the one fact the caller can act on. Report the same typed shutdown
+        // limit the admission gate raises for a call arriving one moment later.
+        // A child that failed on its own still rejects exactly as before.
+        finish(systemRenderShutdownStarted
+          ? systemRendererShutdownError()
+          : new Error("The macOS system PDF renderer could not render this page."));
       } else {
         finish(null);
       }

--- a/test/pdfjs-worker-contract.test.js
+++ b/test/pdfjs-worker-contract.test.js
@@ -344,7 +344,23 @@ setInterval(() => {}, 1000);
     );
   });
 
-  it("kills and reaps an active system renderer before the worker exits on SIGTERM", async () => {
+  // Each terminal signal promises one exit code, and a shutdown that kills its
+  // own renderer child must not report itself as a crash. Both halves failed on
+  // Node 20 before the shutdown fault guard landed, on every one of these three
+  // signals: the deliberately killed child rejected the host's top-level await,
+  // and Node's fatal path beat the deliberate exit, so an orderly shutdown left
+  // exit code 1 and a stack trace on stderr. Node 22 happened to win the same
+  // race the other way, which is why only Node 20 ever showed it. Read the exit
+  // status and the host's real stderr off the process rather than restating
+  // either, so the runtime that loses the race cannot pass.
+  it.each([
+    ["SIGHUP", 129],
+    ["SIGINT", 130],
+    ["SIGTERM", 143],
+  ])("kills and reaps an active system renderer before the worker exits on %s", async (
+    signal,
+    expectedExitCode,
+  ) => {
     if (process.platform === "win32") return;
     const { root, filename: rendererPath } = await fixtureScript(`
 import fs from "node:fs";
@@ -371,15 +387,22 @@ await runSystemCommand(process.execPath, [
     const host = spawn(process.execPath, [hostPath], {
       cwd: root,
       env: { HOME: root, LANG: "C", PATH: process.env.PATH ?? "" },
-      stdio: "ignore",
+      stdio: ["ignore", "ignore", "pipe"],
     });
     hosts.add(host);
+    const stderrChunks = [];
+    host.stderr.on("data", chunk => stderrChunks.push(chunk));
     const rendererPid = Number((await waitForFile(pidPath)).trim());
     const closed = once(host, "close");
-    expect(host.kill("SIGTERM")).toBe(true);
+    expect(host.kill(signal)).toBe(true);
     const [exitCode, exitSignal] = await closed;
     hosts.delete(host);
-    expect({ exitCode, exitSignal }).toEqual({ exitCode: 143, exitSignal: null });
+    const stderr = Buffer.concat(stderrChunks).toString("utf8");
+    expect({ exitCode, exitSignal, stderr }).toEqual({
+      exitCode: expectedExitCode,
+      exitSignal: null,
+      stderr: "",
+    });
     expect(() => process.kill(rendererPid, 0)).toThrow(
       expect.objectContaining({ code: "ESRCH" }),
     );


### PR DESCRIPTION
Found by the Node matrix in #150 on its first real run.

## The defect

A worker killed with SIGTERM is supposed to exit **143**. On Node 20 it exits **1**, with a stack trace on stderr. SIGHUP and SIGINT do the same — they were simply unasserted.

Both runtimes are inside the declared `^20.19.0 || >=22.12.0` range, and this **reproduces on macOS as readily as on Linux**. It has been invisible only because every local run and both Windows workflows use Node 22.

| | SIGTERM | SIGHUP | SIGINT | stderr |
|---|---|---|---|---|
| Node 20.19.0 | **1** | **1** | **1** | full stack trace |
| Node 22.23.2 | 143 | 129 | 130 | empty |

Two user-visible consequences: a supervisor distinguishing "terminated by request" from "crashed" misclassifies an orderly shutdown, and the log reads like a crash too.

## Cause

The terminal shutdown a signal starts kills every in-flight renderer child *on purpose*, and each kill rejects the render its caller was awaiting. Nothing is left to catch those rejections — the caller is exactly what the shutdown is dismantling — so Node makes them fatal. On Node 20 that fatal path runs before the deliberate `process.exit`; on Node 22 the exit wins.

**Neither ordering is promised on either runtime.** The contract was holding by luck on both.

One detail worth recording: Node delivers this as `uncaughtException` with `origin === "unhandledRejection"`, including the entry module's own rejected top-level await, which never reaches an `unhandledRejection` listener at all. Adding one — the obvious fix — is a no-op. That was written first and watched to not work.

## The fix, two halves, each load-bearing

1. `runSystemCommand`'s abnormal-close branch rejects with the existing **typed shutdown limit** when renderer shutdown has begun, rather than inventing a renderer failure for a child we killed ourselves. Nested inside `code !== 0 || signal !== null` and placed after the timeout/overflow branches, so a clean finish still resolves and those still win. A genuine non-shutdown failure rejects byte-identically to today.
2. The signal handler records the exit code up front, then guards the shutdown window against **only** faults carrying that typed reason. Anything else is re-raised on Node's default path and stands the deliberate exit down — so a cleanup that could not be proven, or a bug, still crashes with exit 1 and Node's own report rather than being buried under a tidy 143.

Half 1 is what makes half 2 narrow enough to be safe. Measured: half 1 alone does not fix it (a typed rejection is still a fatal rejection); a blanket suppressor fixes the exit code and hides real faults.

**Never settling the promise during shutdown was considered and is wrong, not merely risky:** `withPrivateSystemRenderWorkspace` deregisters only when the operation settles, and `beginPdfjsWorkerSystemShutdown` awaits that cleanup — a never-settling render deadlocks the shutdown it is part of.

## Test

The single SIGTERM case becomes an `it.each` over all three signals, reads exit status and the host's **real stderr** off the process rather than restating either, and requires stderr to be exactly empty. No new file, so no inventory change.

Non-vacuity, independently re-run on Node 20: with the fix **15/15 green**; with the product reverted and the test kept, **3 red** on the three signals. On Node 22 the reverted code passes — only the runtime that loses the race can see it.

## Verification

`test:node-native` 62 passed on both runtimes. Share mirror `diff -q` clean, `test:contract:share` green. Layout oracle untouched — `server/pdfjs-worker.js` is not in the generator's source set.

Full Node 22 gate: 2,402 passed, the only failures being the three `source-identity` suites hitting the clean-tree gate on a dirty worktree (26/26 when stashed).

**Honest gap:** no Node 20 full gate came back green apart from those clean-tree failures, because the machine was loaded (load average 12–28 from back-to-back gates). `extraction-phase1` failed in all three Node 20 runs but *a different test each time, in a different way*, has no import path to `pdfjs-worker`, and passes 21/21 in isolation. Two controls place it outside this change: clean `origin/master` on Node 20 gives exactly one failure (the target defect), and master plus one unrelated untracked file gives the 12 clean-tree failures plus the target. One Node 20 run on a quiet machine or in CI closes it.

Merge before #150 — the CI matrix stays red on Node 20 until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)