### PR TITLE
Wait for module-import telemetry instead of hoping one tick was enough

### DIFF
--- a/test/fixtures/remote-loopback/no-egress-child.mjs
+++ b/test/fixtures/remote-loopback/no-egress-child.mjs
@@ -143,7 +143,7 @@ async function productRun() {
         policy_version: "synthetic-policy-v1",
       },
     )).status);
-    await new Promise(resolve => setImmediate(resolve));
+    await globalThis.__PDF_LOOPBACK_EGRESS_FLUSH();
     emit({
       mode: "product",
       statuses,
@@ -190,7 +190,7 @@ async function calibrationRun() {
       });
     }
   }
-  await new Promise(resolve => setImmediate(resolve));
+  await globalThis.__PDF_LOOPBACK_EGRESS_FLUSH();
   emit({
     mode: "calibration",
     denials,
@@ -289,7 +289,7 @@ async function dynamicLoaderCalibrationRun() {
       });
     }
   }
-  await new Promise(resolve => setImmediate(resolve));
+  await globalThis.__PDF_LOOPBACK_EGRESS_FLUSH();
   emit({
     mode: "dynamic_loader_calibration",
     denials,

--- a/test/fixtures/remote-loopback/no-egress-preload.mjs
+++ b/test/fixtures/remote-loopback/no-egress-preload.mjs
@@ -48,15 +48,51 @@ Object.defineProperty(globalThis, "__PDF_LOOPBACK_EGRESS_RECEIPT", {
 });
 
 const { port1, port2 } = new MessageChannel();
+const flushWaiters = new Map();
+let nextFlushId = 0;
 port1.on("message", message => {
   if (message?.type === "unreviewed_module_import_attempt") {
     telemetry.unreviewed_module_import_attempts += 1;
     if (message.bare_package === true) {
       telemetry.bare_package_import_attempts += 1;
     }
+    return;
+  }
+  if (message?.type === "telemetry_flush_ack") {
+    const resolve = flushWaiters.get(message.id);
+    flushWaiters.delete(message.id);
+    resolve?.();
   }
 });
 port1.unref();
+
+// Every other counter here is incremented synchronously, in this thread, by the
+// guard that denied the attempt. The two module-import counters are not: the
+// resolve hook runs on the loader thread and reports across this port, so the
+// import can have already rejected while its telemetry is still in flight.
+// Reading the receipt after a setImmediate assumed that a single turn of this
+// loop was enough for a cross-thread delivery. Usually it is. On a loaded
+// two-core runner it was not, and the calibration reported zero attempts for
+// exactly those two probes - a security calibration failing to prove its own
+// guards were live. Wait for a round trip instead of for a tick.
+Object.defineProperty(globalThis, "__PDF_LOOPBACK_EGRESS_FLUSH", {
+  value() {
+    const id = nextFlushId;
+    nextFlushId += 1;
+    return new Promise(resolve => {
+      flushWaiters.set(id, resolve);
+      // The port is unreffed so it cannot hold the process open on its own;
+      // hold it only for as long as this round trip is outstanding.
+      port1.ref();
+      port1.postMessage({ type: "telemetry_flush", id });
+    }).finally(() => {
+      if (flushWaiters.size === 0) port1.unref();
+    });
+  },
+  configurable: false,
+  enumerable: false,
+  writable: false,
+});
 register("./no-package-loader.mjs", import.meta.url, {
   data: { port: port2 },
   transferList: [port2],

--- a/test/fixtures/remote-loopback/no-package-loader.mjs
+++ b/test/fixtures/remote-loopback/no-package-loader.mjs
@@ -2,6 +2,17 @@ let telemetryPort;
 
 export function initialize({ port }) {
   telemetryPort = port;
+  // Answer the preload's flush probe. Module-resolution telemetry is posted
+  // from this loader thread, so the main thread cannot know a denial has been
+  // counted just because the import already rejected. A MessagePort delivers
+  // in order, so an ack posted when this handler runs necessarily follows
+  // every attempt message posted before it.
+  port.on("message", message => {
+    if (message?.type === "telemetry_flush") {
+      port.postMessage({ type: "telemetry_flush_ack", id: message.id });
+    }
+  });
+  port.unref?.();
 }
 
 const FIXTURE_DIRECTORY = new URL("./", import.meta.url);


### PR DESCRIPTION
The Node 22 failure on #153, which had nothing to do with #153.

## The defect

The no-egress calibration failed on a two-core runner reporting zero attempts for exactly two of its nine probes:

```
-   "bare_package_import_attempts": 1,
+   "bare_package_import_attempts": 0,
-   "unreviewed_module_import_attempts": 1,
+   "unreviewed_module_import_attempts": 0,
```

Those two are **the only counters not incremented synchronously** by the guard that denied the attempt. Module resolution is denied on the loader thread, which reports the attempt across a MessagePort, so the import can have already rejected while its telemetry is still in flight. The child then read the receipt after a single `setImmediate` — assuming one turn of the main loop is enough for a cross-thread delivery. Usually it is.

## Why it matters more than a red run

This test exists to prove **every guard is live** before it will accept the product's own score of zero attempts. Losing this race means a security calibration quietly failing to calibrate. It failed in the safe direction — it refused to certify — but a calibration that intermittently cannot calibrate trains people to hit rerun.

## The fix

The loader answers a flush probe on the same port it reports on. A MessagePort delivers **in order**, so an ack posted when that handler runs necessarily follows every attempt message posted before it, whatever the latency. The child awaits the round trip rather than a tick.

The port stays unreffed except while a round trip is outstanding, so it still cannot hold the process open. A flush that never returns surfaces as the harness's existing forced-kill assertion rather than as a wrong count — loud, not silent.

## Proof

Rather than rerunning until green, I modelled the real failure: **defer every inbound message by 50 ms while preserving per-port order**, which is what slow cross-thread delivery looks like from the main thread.

- old `setImmediate`: reproduces the CI diff **exactly**, both counters zero, deterministically
- flush round trip: passes

That is stronger evidence than a green rerun, which only shows the race went one way once.

## Context

This is the fourth assertion found today that measures its environment rather than the product — after two wall-clock budgets calibrated to the maintainer's machine (#150) and a memory bound scaled off allocator noise (#153). Different subsystems, one habit: an assertion whose two sides are not independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)