### PR TITLE
Write lowered smaller glyph runs as Unicode subscripts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -378,14 +378,19 @@ default output is byte-identical to non-compact behavior. Links are emitted
 only for a source-validated external http or https annotation target that maps
 to exactly one contiguous run of text on one line; internal destinations,
 actions, other URL schemes, and ambiguous labels stay escaped text. It does
-not reconstruct general equations, subscripts, or fraction bars, but may restore
+not reconstruct general equations or fraction bars, but may restore
 a missing space after a separate `log` source item only in a short, tightly
 bounded math run with same-baseline variable evidence plus an independent
-local math-layout clue. A glyph run the source painted smaller and raised above
-the baseline of the text it is attached to is written as Unicode superscript
-characters when every character of the run has a real superscript form; this
-records how the page is set and does not distinguish an exponent from a
-footnote reference. A small version-pinned registry may recover a legacy
+local math-layout clue. A glyph run the source painted smaller and displaced
+from the baseline of the text it is attached to is written as Unicode
+superscript characters when it was raised and Unicode subscript characters when
+it was lowered, and only when every character of the run has a real form in
+that direction; this records how the page is set, does not distinguish an
+exponent from a footnote reference, and does not assert that a lowered digit is
+an index. Unicode has no subscript capitals and only some lowercase letters, so
+many lowered runs stay flat on coverage alone, and a script the source set
+without a font change and without leaving any of its base's advance unused is
+reported by the text layer as part of that base run and stays flat too. A small version-pinned registry may recover a legacy
 Computer Modern Type-3 character only after exact official-metric, glyph
 program, and operator/text sequence checks. It does
 not run OCR or use an external model. Unsupported visual or structural content

--- a/pdf-toolkit-mcp-share/server/markdown-conversion.js
+++ b/pdf-toolkit-mcp-share/server/markdown-conversion.js
@@ -6,7 +6,7 @@ import {
 
 const RENDERER = Object.freeze({
   name: "pdf-tools.layout-markdown-renderer",
-  version: "1.16.0",
+  version: "1.17.0",
 });
 const SUPPORTED_LAYOUT_IR_VERSION = "1.6.0";
 
@@ -84,8 +84,8 @@ const GAP_CODES = new Set([
 const LIMITATIONS = Object.freeze([
   "Headings are emitted only from consistent enlarged font metrics, centered English-language source structure with section spacing, or numbered or lettered research-paper structure at an established body margin with spacing plus font, size, or exact small-caps evidence. Wrapped heading lines are joined only from matching font and height, a very small vertical gap, and bounded alignment. Narrow vertical labels and ambiguous, very short, or unsupported heading styles remain body text.",
   "A geometrically overlapping initial capital may be joined to its following uppercase word remainder. Line-end hyphens are preserved because source geometry cannot reliably distinguish a split word from an intentional compound. The source Extraction IR retains the original lines.",
-  "A missing space after a separate source text item that is exactly the mathematical operator log is restored only in a short, compact left-to-right math run when a single-letter variable from a different source font resource follows on the same baseline with a small positive geometric gap and independent local math-layout evidence. A missing prose-to-variable space is restored only when a multiword prose item, a separate uppercase letter from a different source font resource, and continuing prose from the original prose font share one baseline with distinct positive boundary gaps, and the same letter/font pair occurs in a nearby compact equation on the same page and column. An inline single-digit stacked fraction is rendered only when consecutive same-font source items, explicit source whitespace, smaller exactly aligned numerator and denominator digits, ordinary prose on both sides, and exactly one thin matching solid-mask bar agree. A small version-pinned registry may recover a legacy Computer Modern Type-3 character only after an exact official-metric family match, exact target and witness glyph-program matches, and a complete operator/text sequence binding. Two witnesses are required unless the source font subset cannot supply them, in which case the entry must declare that font's complete enrolled footprint and every code in it must be present and match. General equations, subscripts, other fraction bars, unregistered raster variants, and other damaged mathematical glyphs remain source reading-order text rather than being guessed.",
-  "A glyph run the source painted smaller and raised above the baseline of the text it is attached to is written as Unicode superscript characters. This records how the page is set and nothing more: a page raises a mathematical exponent and a footnote reference in exactly the same way, so this does not distinguish the two and does not assert that a raised digit is a power. A raised run is written only when every one of its characters has a real Unicode superscript form and the whole run is present on one line, so runs containing ordinary letters or symbols stay flat. A stacked fraction numerator is raised by the same amount but stands clear of the text before it, and is left alone.",
+  "A missing space after a separate source text item that is exactly the mathematical operator log is restored only in a short, compact left-to-right math run when a single-letter variable from a different source font resource follows on the same baseline with a small positive geometric gap and independent local math-layout evidence. A missing prose-to-variable space is restored only when a multiword prose item, a separate uppercase letter from a different source font resource, and continuing prose from the original prose font share one baseline with distinct positive boundary gaps, and the same letter/font pair occurs in a nearby compact equation on the same page and column. An inline single-digit stacked fraction is rendered only when consecutive same-font source items, explicit source whitespace, smaller exactly aligned numerator and denominator digits, ordinary prose on both sides, and exactly one thin matching solid-mask bar agree. A small version-pinned registry may recover a legacy Computer Modern Type-3 character only after an exact official-metric family match, exact target and witness glyph-program matches, and a complete operator/text sequence binding. Two witnesses are required unless the source font subset cannot supply them, in which case the entry must declare that font's complete enrolled footprint and every code in it must be present and match. General equations, other fraction bars, unregistered raster variants, and other damaged mathematical glyphs remain source reading-order text rather than being guessed.",
+  "A glyph run the source painted smaller and displaced from the baseline of the text it is attached to is written as Unicode superscript characters when it was raised and Unicode subscript characters when it was lowered. This records how the page is set and nothing more: a page raises a mathematical exponent and a footnote reference in exactly the same way, so this does not distinguish the two, does not assert that a raised digit is a power, and does not assert that a lowered one is an index. A displaced run is written only when every one of its characters has a real Unicode form in that direction and the whole run is present on one line, so a run stays flat entire rather than being written in part. Unicode subscript coverage is much thinner than superscript coverage, with no capital letters and only some lowercase ones, so many lowered runs stay flat for that reason alone. A stacked fraction numerator is raised by the same amount but stands clear of the text before it, and is left alone. Where the source set a displaced run without changing font and without leaving any of its base's advance unused, the text layer reports it as part of the base run and no displacement survives to be read, so that run stays flat too and is indistinguishable here from text the page never displaced. A line whose source items cannot all be located within its own extracted text, and a line the stacked-fraction projection rebuilt, keep the text they had rather than being partly rewritten.",
   "Lists are emitted only for literal bullet glyphs or decimal markers present in the source text.",
   "Links are emitted only for source-validated http or https annotation targets that map to exactly one contiguous run of text on one line. Internal destinations, actions, other schemes, ambiguous or partially covered labels, and links inside reconstructed tables remain escaped text reported as a conversion gap, and URL-looking source text is escaped to resist host autolinking.",
   "Tables are reconstructed directly only from complete text-item column geometry, clean ruled-rectangle grid evidence, or one unambiguous complete closed grid of bounded axis-aligned solid-mask rectangles. Every text item must fit exactly one cell, aligned partial dividers that evidence merged or spanning topology are rejected, and the first row must carry real header evidence because Markdown imposes header semantics. On an opt-in abstention path, a caller may submit item-to-cell assignments to the read-only verifier; accepted cell content is rebuilt only from a fresh source parse and the grid must agree with all available source-replayed ruling geometry. This proves source-backed content and consistency, not unique topology; ambiguous or unsupported geometry remains rejected. GFM cannot encode row or column spans, so accepted spans retain their authority in structured cells while Markdown places source text once at the anchor and leaves continuation slots empty. Incomplete grids and damaged mathematical glyphs are not interpreted; other ambiguous content remains escaped reading-order text with a conversion gap. Cell artwork is omitted and reported as a vector-content gap; only independently qualified exact legacy glyph variants are recovered.",
@@ -770,7 +770,7 @@ function hasAttachedSmallerOffsetScript(cells, variableIndex) {
 
 /**
  * The characters that have a genuine Unicode superscript form. This map is the
- * safety mechanism of the superscript projection, not a style choice: a raised
+ * safety mechanism of the script projection, not a style choice: a raised
  * token is transcribed only when every one of its characters can be written as
  * a real superscript character, so an arrow, a word, or a multi-letter marker
  * has no form here and is left exactly as the source emitted it. Nothing is
@@ -801,10 +801,65 @@ const SUPERSCRIPT_FORMS = new Map(Object.entries({
   i: "ⁱ",
 }));
 
-// Raised smaller glyph geometry, measured across the pinned legacy TeX corpus.
-// Script size sits near 0.74 of its base and its baseline near 0.36 of the base
-// height above it; the size and rise windows are widened around those
-// observations rather than fitted to one document.
+/**
+ * The characters that have a genuine Unicode subscript form, under exactly the
+ * same whole-run discipline as the superscript map above and with the same
+ * one-code-unit invariant.
+ *
+ * Coverage here is materially thinner, and the holes are the interesting part.
+ * Unicode encodes no subscript capital at all, and among lowercase letters only
+ * a e h i j k l m n o p r s t u v x exist: there is no b, c, d, f, g, q, w, y or
+ * z. The whole-run rule turns every hole into an abstention rather than an
+ * invention, which is the only honest option available. A source item whose
+ * text carries an interior space is left flat for the same reason, because a
+ * lowered space is not a character this map can write and dropping it would
+ * change what the page says.
+ */
+const SUBSCRIPT_FORMS = new Map(Object.entries({
+  0: "₀",
+  1: "₁",
+  2: "₂",
+  3: "₃",
+  4: "₄",
+  5: "₅",
+  6: "₆",
+  7: "₇",
+  8: "₈",
+  9: "₉",
+  "+": "₊",
+  "-": "₋",
+  "−": "₋",
+  "=": "₌",
+  "(": "₍",
+  ")": "₎",
+  a: "ₐ",
+  e: "ₑ",
+  h: "ₕ",
+  i: "ᵢ",
+  j: "ⱼ",
+  k: "ₖ",
+  l: "ₗ",
+  m: "ₘ",
+  n: "ₙ",
+  o: "ₒ",
+  p: "ₚ",
+  r: "ᵣ",
+  s: "ₛ",
+  t: "ₜ",
+  u: "ᵤ",
+  v: "ᵥ",
+  x: "ₓ",
+}));
+
+// Smaller-glyph script geometry, measured across the pinned legacy TeX corpus.
+// Script size sits near 0.74 of its base, and its baseline is displaced from
+// the base's by roughly a third of the base height: raised for a superscript,
+// lowered for a subscript. The size window is shared, and each direction's
+// displacement window is widened around its own observations rather than
+// fitted to one document. A subscript's drop is the more variable of the two
+// because the source scales it against the enclosing formula rather than
+// against the base item, so the observed band runs from an ordinary variable
+// index to the deeper drop a mathematical operator takes.
 //
 // The horizontal window is the one that carries real discriminating work, and
 // it is narrow on purpose. An attached script is set inside its base's advance
@@ -813,25 +868,69 @@ const SUPERSCRIPT_FORMS = new Map(Object.entries({
 // centered over a rule wider than itself, so it starts a visible distance after
 // whatever precedes it. Allowing a gap of up to a word space would transcribe
 // those numerators as superscripts, which is not what the page shows.
-const SUPERSCRIPT_HEIGHT_RATIO_MIN = 0.6;
-const SUPERSCRIPT_HEIGHT_RATIO_MAX = 0.82;
+//
+// The two ceilings differ, and the asymmetry is load-bearing rather than
+// sloppy. The numerator is the pressure on the raised window, and there is no
+// lowered counterpart to it: a denominator does not reach this rule at all. The
+// reason is not the one it looks like. A denominator is not preceded on its own
+// source line by the numerator it hangs under, so the two are never compared;
+// of the fraction bars on the corpus that carry text on both sides, all but
+// four have a denominator that is the first painted item on its line, which
+// this rule never examines because it only ever judges an item against the one
+// before it. In each of the four remaining cases the item beneath the bar is
+// prose or a full-size symbol rather than a small denominator digit, it is
+// level with its predecessor rather than below it, and it is the same size as
+// its predecessor, so the height window rejects it before the gap is consulted
+// and the rise window would reject it independently. So the lowered ceiling is
+// free to sit where the source actually needs it. It needs to be past 0.10: an
+// italic descender is kerned out further than an upright digit, and the
+// corpus's attached lowered runs reach 0.12 before they stop. The next lowered
+// candidate of any kind is at 0.67, where the base is punctuation or a whole
+// word rather than a symbol, so 0.15 sits inside a wide empty band and admits
+// nothing the source did not set attached.
+const SCRIPT_HEIGHT_RATIO_MIN = 0.6;
+const SCRIPT_HEIGHT_RATIO_MAX = 0.82;
 const SUPERSCRIPT_BASELINE_RISE_MIN = 0.28;
 const SUPERSCRIPT_BASELINE_RISE_MAX = 0.45;
+const SUBSCRIPT_BASELINE_RISE_MIN = -0.35;
+const SUBSCRIPT_BASELINE_RISE_MAX = -0.1;
 const SUPERSCRIPT_GAP_MIN = -0.1;
 const SUPERSCRIPT_GAP_MAX = 0.1;
-// Deliberately much wider than the attachment window above, and used only to
-// keep scanning a raised run for a reason to abstain. Widening a window that
-// can only suppress output is safe; widening the one that admits it is not.
-const SUPERSCRIPT_RUN_GAP_MIN = -0.35;
-const SUPERSCRIPT_RUN_GAP_MAX = 0.6;
-const SUPERSCRIPT_RUN_BASELINE_TOLERANCE = 0.1;
+const SUBSCRIPT_GAP_MIN = -0.1;
+const SUBSCRIPT_GAP_MAX = 0.15;
+// Deliberately much wider than the attachment windows above, and used only to
+// keep scanning a displaced run for a reason to abstain. Widening a window that
+// can only suppress output is safe; widening one that admits it is not.
+const SCRIPT_RUN_GAP_MIN = -0.35;
+const SCRIPT_RUN_GAP_MAX = 0.6;
+const SCRIPT_RUN_BASELINE_TOLERANCE = 0.1;
 
+// The two directions a source may set an attached smaller run, each carrying
+// its own displacement and attachment windows and its own alphabet. The signed
+// rise windows do not overlap and do not contain zero, so at most one entry can
+// describe any one pair of items.
+const SCRIPT_KINDS = Object.freeze([
+  Object.freeze({
+    forms: SUPERSCRIPT_FORMS,
+    riseMin: SUPERSCRIPT_BASELINE_RISE_MIN,
+    riseMax: SUPERSCRIPT_BASELINE_RISE_MAX,
+    gapMin: SUPERSCRIPT_GAP_MIN,
+    gapMax: SUPERSCRIPT_GAP_MAX,
+  }),
+  Object.freeze({
+    forms: SUBSCRIPT_FORMS,
+    riseMin: SUBSCRIPT_BASELINE_RISE_MIN,
+    riseMax: SUBSCRIPT_BASELINE_RISE_MAX,
+    gapMin: SUBSCRIPT_GAP_MIN,
+    gapMax: SUBSCRIPT_GAP_MAX,
+  }),
+]);
 
-function superscriptForm(value) {
+function scriptForm(kind, value) {
   if (typeof value !== "string" || value.length === 0) return null;
   let mapped = "";
   for (const character of value) {
-    const form = SUPERSCRIPT_FORMS.get(character);
+    const form = kind.forms.get(character);
     if (form === undefined) return null;
     mapped += form;
   }
@@ -866,55 +965,59 @@ function uprightBaselineY(item) {
 }
 
 /**
- * Whether the source painted `script` as a raised, smaller run attached to
- * `base`: script-sized, its baseline lifted by a script offset, and set with no
- * word gap.
+ * Which direction, if either, the source painted `script` in as a smaller run
+ * attached to `base`: script-sized, its baseline displaced by a script offset,
+ * and set with no word gap. Returns the matching entry of SCRIPT_KINDS, or null
+ * when the pair is not an attached script at all.
  *
- * This is a typographic observation and nothing more. The same geometry carries
- * a mathematical exponent and a footnote reference, and the page raises both
- * identically, so no geometric rule can separate them and this one does not
- * try. Deliberately not consulted: the base item's own text. Requiring the base
- * to end alphanumeric selects the footnote-marker population (a word followed
- * by a digit) and drops genuine raised runs whose base item follows an operator
- * or a comma.
+ * This is a typographic observation and nothing more. The same raised geometry
+ * carries a mathematical exponent and a footnote reference, and the page raises
+ * both identically, so no geometric rule can separate them and this one does
+ * not try. Deliberately not consulted: the base item's own text. Requiring the
+ * base to end alphanumeric selects the footnote-marker population (a word
+ * followed by a digit) and drops genuine raised runs whose base item follows an
+ * operator or a comma.
  *
  * hasAttachedSmallerOffsetScript encodes a related but different observation
  * for the log-spacing projection: it takes the absolute vertical offset between
  * advance-box tops, so it cannot tell a raised glyph from a lowered one, and it
- * is deliberately left alone here. This test needs the signed direction and the
- * true baseline, and folding the two together would either widen that
- * projection's evidence or narrow this one.
+ * is deliberately left alone here. That question is "is a script attached
+ * here at all", which either direction answers equally well; this one needs the
+ * signed direction and the true baseline, because the direction chooses which
+ * alphabet the run has to be written in.
  */
-function isRaisedSmallerScript(base, script) {
+function attachedScriptKind(base, script) {
   const baseHeight = base?.line_height;
   const scriptHeight = script?.line_height;
-  if (!Number.isFinite(baseHeight) || !Number.isFinite(scriptHeight) || !(baseHeight > 0)) return false;
+  if (!Number.isFinite(baseHeight) || !Number.isFinite(scriptHeight) || !(baseHeight > 0)) return null;
   const baseBaseline = uprightBaselineY(base);
   const scriptBaseline = uprightBaselineY(script);
-  if (baseBaseline === null || scriptBaseline === null) return false;
+  if (baseBaseline === null || scriptBaseline === null) return null;
   const gap = operatorVariableGap(base, script);
-  if (gap === null) return false;
+  if (gap === null) return null;
   const ratio = scriptHeight / baseHeight;
+  if (ratio < SCRIPT_HEIGHT_RATIO_MIN || ratio > SCRIPT_HEIGHT_RATIO_MAX) return null;
   const rise = (baseBaseline - scriptBaseline) / baseHeight;
-  return ratio >= SUPERSCRIPT_HEIGHT_RATIO_MIN
-    && ratio <= SUPERSCRIPT_HEIGHT_RATIO_MAX
-    && rise >= SUPERSCRIPT_BASELINE_RISE_MIN
-    && rise <= SUPERSCRIPT_BASELINE_RISE_MAX
-    && gap >= SUPERSCRIPT_GAP_MIN * baseHeight
-    && gap <= SUPERSCRIPT_GAP_MAX * baseHeight;
+  return SCRIPT_KINDS.find(candidate => rise >= candidate.riseMin
+    && rise <= candidate.riseMax
+    && gap >= candidate.gapMin * baseHeight
+    && gap <= candidate.gapMax * baseHeight) ?? null;
 }
 
 /**
- * Whether `next` continues the raised run that `script` started: painted on the
- * same lifted baseline and still attached. Used only to find the end of a run
- * so the whole run can be judged together.
+ * Whether `next` continues the displaced run that `script` started: painted on
+ * the same displaced baseline and still attached. Used only to find the end of
+ * a run so the whole run can be judged together.
  *
- * Deliberately no size condition. A recovered legacy glyph can report a font
- * metric quite unlike its neighbours' while sitting on exactly their baseline,
- * and missing such a member would leave the run looking complete when it is
- * not. This test can only cause abstention, so it is written to over-collect.
+ * Deliberately no size condition, and deliberately no direction condition
+ * either. A run's direction is fixed by the pair that opened it, and anything
+ * sharing that run's baseline belongs to it whatever its own metrics say. A
+ * recovered legacy glyph can report a font metric quite unlike its neighbours'
+ * while sitting on exactly their baseline, and missing such a member would
+ * leave the run looking complete when it is not. This test can only cause
+ * abstention, so it is written to over-collect.
  */
-function continuesRaisedRun(script, next) {
+function continuesScriptRun(script, next) {
   const height = script.line_height;
   if (!Number.isFinite(height) || !(height > 0)) return false;
   const scriptBaseline = uprightBaselineY(script);
@@ -922,9 +1025,9 @@ function continuesRaisedRun(script, next) {
   if (scriptBaseline === null || nextBaseline === null) return false;
   const gap = operatorVariableGap(script, next);
   return gap !== null
-    && Math.abs(nextBaseline - scriptBaseline) <= height * SUPERSCRIPT_RUN_BASELINE_TOLERANCE
-    && gap >= SUPERSCRIPT_RUN_GAP_MIN * height
-    && gap <= SUPERSCRIPT_RUN_GAP_MAX * height;
+    && Math.abs(nextBaseline - scriptBaseline) <= height * SCRIPT_RUN_BASELINE_TOLERANCE
+    && gap >= SCRIPT_RUN_GAP_MIN * height
+    && gap <= SCRIPT_RUN_GAP_MAX * height;
 }
 
 function paintedItems(page) {
@@ -934,7 +1037,7 @@ function paintedItems(page) {
 }
 
 /**
- * Plan the superscript projection for one line.
+ * Plan the script projection for one line.
  *
  * `items` is that line's source items in the order the line records them, and
  * `pageItems` is every painted item on the page. Attachment is judged over the
@@ -942,22 +1045,31 @@ function paintedItems(page) {
  * painted run, and a base never reaches across an explicit space item to claim
  * a script.
  *
- * A raised run is transcribed only in full, and only when this line holds all
- * of it. The source may split one raised run across several items and even
- * across the IR's line grouping, and transcribing the representable prefix
- * would emit a lifted opening parenthesis against a baseline closing one, which
- * misreports the page more badly than leaving the whole run flat. The run is
- * therefore followed across the whole page, which costs nothing in accuracy
- * because a genuinely line-final script has no attached same-baseline
- * neighbour anywhere.
+ * A displaced run is transcribed only in full, in the direction the pair that
+ * opened it was set, and only when this line holds all of it. The source may
+ * split one such run across several items and even across the IR's line
+ * grouping, and transcribing the representable prefix would emit a displaced
+ * opening parenthesis against a baseline closing one, which misreports the page
+ * more badly than leaving the whole run flat. The run is therefore followed
+ * across the whole page, which costs nothing in accuracy because a genuinely
+ * line-final script has no attached same-baseline neighbour anywhere.
  *
  * Returns the per-item projected forms and, when the caller's item list can be
- * located inside line.text, the rewritten line text. Because every projected
+ * located inside `baseText`, that text rewritten. Because every projected
  * character replaces exactly one source code unit, the rewritten text has the
- * same length as line.text and any offsets the caller already holds against the
- * original stay valid.
+ * same length as `baseText` and any offsets the caller already holds against it
+ * stay valid.
+ *
+ * `baseText` defaults to the line's own text and exists so a caller that has
+ * already spaced the line can hand that text in instead. Locating the items is
+ * a sequential scan for each item's exact text, so a projection that only
+ * inserts separators between items leaves every item findable and in order; one
+ * that rewrites item text or merges lines does not, and such a caller must not
+ * pass its result here. Where the scan fails the line keeps its text unchanged
+ * rather than being partly rewritten, which is why a line whose last source
+ * item carries a trailing space the line text dropped stays flat.
  */
-function superscriptLineProjection(line, items, pageItems) {
+function scriptLineProjection(line, items, pageItems, baseText = line.text) {
   const attached = items.filter(item => item
     && item.is_whitespace !== true
     && typeof item.text === "string"
@@ -965,14 +1077,15 @@ function superscriptLineProjection(line, items, pageItems) {
   const lineItemIds = new Set(attached.map(item => item.id));
   const forms = new Map();
   for (let index = 1; index < attached.length; index += 1) {
-    if (!isRaisedSmallerScript(attached[index - 1], attached[index])) continue;
+    const kind = attachedScriptKind(attached[index - 1], attached[index]);
+    if (kind === null) continue;
     const run = [];
     const claimed = new Set();
     for (let tail = attached[index]; tail !== null;) {
-      run.push([tail, lineItemIds.has(tail.id) ? superscriptForm(tail.text) : null]);
+      run.push([tail, lineItemIds.has(tail.id) ? scriptForm(kind, tail.text) : null]);
       claimed.add(tail.id);
       tail = pageItems.find(
-        item => !claimed.has(item.id) && continuesRaisedRun(tail, item),
+        item => !claimed.has(item.id) && continuesScriptRun(tail, item),
       ) ?? null;
     }
     while (index + 1 < attached.length && claimed.has(attached[index + 1].id)) index += 1;
@@ -980,15 +1093,15 @@ function superscriptLineProjection(line, items, pageItems) {
     for (const [item, form] of run) forms.set(item.id, form);
   }
   if (forms.size === 0) return { forms, text: null };
-  const offsets = itemOffsets(line, items);
+  const offsets = itemOffsets({ text: baseText }, items);
   if (offsets === null) return { forms, text: null };
-  let text = line.text;
+  let text = baseText;
   items.forEach((item, index) => {
     const form = forms.get(item.id);
     if (form === undefined) return;
     text = `${text.slice(0, offsets[index].start)}${form}${text.slice(offsets[index].end)}`;
   });
-  return { forms, text: text === line.text ? null : text };
+  return { forms, text: text === baseText ? null : text };
 }
 
 function projectedItemText(forms, item) {
@@ -1389,7 +1502,7 @@ function assignRowToColumns(row, anchors, pageItems) {
   // Emission only: column assignment and the newline rejection below both read
   // the raw source item, so the projection cannot move a cell or admit a run
   // this path would otherwise reject.
-  const { forms } = superscriptLineProjection(row.line, row.cells, pageItems);
+  const { forms } = scriptLineProjection(row.line, row.cells, pageItems);
   for (const item of row.cells) {
     const index = nearestAnchor(anchors, itemStartX(item));
     if (index === -1 || assigned.has(index)) return null;
@@ -1725,9 +1838,9 @@ function tryBuildRectGrid(page, run, clusters, itemById) {
 
     // Emission only. The structural grid, the header evidence, and the
     // newline rejection below all keep reading raw source text, so the
-    // superscript projection cannot change which grid is reconstructed.
-    const superscriptForms = new Map(lineRecords.flatMap(
-      record => [...superscriptLineProjection(record.line, record.allItems, pageItems).forms],
+    // script projection cannot change which grid is reconstructed.
+    const scriptForms = new Map(lineRecords.flatMap(
+      record => [...scriptLineProjection(record.line, record.allItems, pageItems).forms],
     ));
     const grid = cells.map(row => row.map(cell => {
       cell.sort((left, right) => (
@@ -1735,7 +1848,7 @@ function tryBuildRectGrid(page, run, clusters, itemById) {
           || left.item.bbox.x - right.item.bbox.x
       ));
       if (cell.some(entry => /[\r\n]/u.test(entry.item.text) || /[\r\n]/u.test(entry.line.text))) return null;
-      return cell.map(entry => projectedItemText(superscriptForms, entry.item).trim()).filter(Boolean).join(" ");
+      return cell.map(entry => projectedItemText(scriptForms, entry.item).trim()).filter(Boolean).join(" ");
     }));
     if (grid.some(row => row.some(value => value === null))) return { reason: "topology" };
 
@@ -1984,15 +2097,15 @@ function ruledGridSegment(page) {
       previousColumn = column;
     }
     const offsets = itemOffsets(line, allItems);
-    // Cell text is sliced out of the line, so the superscript projection is
+    // Cell text is sliced out of the line, so the script projection is
     // applied to the line text before slicing. It is length-preserving, which
     // is why the offsets recovered against the original string stay correct.
-    const superscript = superscriptLineProjection(line, allItems, pageItems);
-    const lineText = superscript.text ?? line.text;
+    const script = scriptLineProjection(line, allItems, pageItems);
+    const lineText = script.text ?? line.text;
     for (const group of groups) {
       const fragment = offsets === null
         ? allItems.slice(group.start, group.end + 1)
-          .map(item => projectedItemText(superscript.forms, item)).join(" ").trim()
+          .map(item => projectedItemText(script.forms, item)).join(" ").trim()
         : lineText.slice(offsets[group.start].start, offsets[group.end].end).trim();
       if (!fragment) return { segment: null, tableReason: "topology" };
       grid[tableRow][group.column].push({
@@ -2666,20 +2779,24 @@ function renderPage(page, {
         const proseMathText = mathText === null
           ? proseMathVariableSpacedText({ line, cells }, projectionOptions)
           : null;
-        const projectedText = fractionPlan.replacements.get(line.id) ?? mathText ?? proseMathText;
-        // Typographic fidelity only, and only where no structural projection
-        // already rewrote this line. The other projections splice spaces into
-        // line.text at offsets recovered from the original string, so composing
-        // them would require re-deriving those offsets against a rewritten
-        // line; one projection per line keeps every existing rewrite byte-exact.
-        // `joinable` deliberately still follows projectedText alone, because a
-        // superscript changes only which characters are emitted, not whether
-        // the line is a continuable flow.
-        const superscriptText = projectedText === null
-          ? superscriptLineProjection(line, cells, pageItems).text
+        const fractionText = fractionPlan.replacements.get(line.id) ?? null;
+        const projectedText = fractionText ?? mathText ?? proseMathText;
+        // Typographic fidelity only, and applied last so it composes with the
+        // spacing projections instead of being displaced by them. Those two
+        // only splice a separator between two source items, which leaves every
+        // item's own text intact and in order, so the script projection can
+        // recover its offsets against the spaced string just as well as against
+        // the original. The fraction replacement is excluded: it merges two
+        // source lines and rebuilds their text, so the items of neither line
+        // can be located in the result and a projection over it would be
+        // guesswork. `joinable` deliberately still follows projectedText alone,
+        // because a script form changes only which characters are emitted, not
+        // whether the line is a continuable flow.
+        const scriptText = fractionText === null
+          ? scriptLineProjection(line, cells, pageItems, projectedText ?? line.text).text
           : null;
         return {
-          text: renderLine(line, headings.get(line.id), projectedText ?? superscriptText ?? line.text),
+          text: renderLine(line, headings.get(line.id), scriptText ?? projectedText ?? line.text),
           sourceText: line.text,
           normalizable: true,
           line,

--- a/pdf-toolkit-mcp-share/server/output-schemas.js
+++ b/pdf-toolkit-mcp-share/server/output-schemas.js
@@ -1080,7 +1080,7 @@ export const TOOL_SUCCESS_OUTPUT_SCHEMAS = Object.freeze({
     {
       renderer: object({
         name: { const: "pdf-tools.layout-markdown-renderer" },
-        version: { const: "1.16.0" },
+        version: { const: "1.17.0" },
       }),
       conversion_status: enumString(["complete", "partial", "failed"]),
       markdown: string,

--- a/scripts/eval-run-markdown-bakeoff.mjs
+++ b/scripts/eval-run-markdown-bakeoff.mjs
@@ -202,7 +202,7 @@ export function validateMarkdownResult(result, binding) {
     throw new Error(`Markdown conversion failed for ${binding.fixture.id}`);
   }
   const value = result.structuredContent;
-  if (value.renderer?.name !== "pdf-tools.layout-markdown-renderer" || value.renderer?.version !== "1.16.0"
+  if (value.renderer?.name !== "pdf-tools.layout-markdown-renderer" || value.renderer?.version !== "1.17.0"
     || value.options?.include_page_boundaries !== true || value.limits?.max_markdown_bytes !== 200000
     || value.provenance?.source?.file_name !== binding.retained.filename
     || value.provenance?.source?.sha256 !== binding.retained.sha256

--- a/scripts/macos-claude-installed-shannon.mjs
+++ b/scripts/macos-claude-installed-shannon.mjs
@@ -81,7 +81,7 @@ try {
     });
     const value = result.structuredContent;
     assert(!result.isError && value, `Installed conversion failed for pages ${startPage}-${endPage}`);
-    assert(value.renderer?.version === "1.16.0", "Installed Markdown renderer version differs");
+    assert(value.renderer?.version === "1.17.0", "Installed Markdown renderer version differs");
     assert(value.provenance?.layout?.parser_version === "5.4.624", "Installed PDF parser version differs");
     assert(value.provenance?.source?.sha256 === sourceSha256, "Installed conversion source identity differs");
     assert(value.provenance?.layout?.page_range?.start_page === startPage, "Installed conversion start page differs");

--- a/scripts/smoke-mcpb.mjs
+++ b/scripts/smoke-mcpb.mjs
@@ -344,7 +344,7 @@ async function main() {
       arguments: { pdf_path: fixturePath, max_markdown_bytes: 200000 },
     });
     if (markdown.isError
-      || markdown.structuredContent?.renderer?.version !== "1.16.0"
+      || markdown.structuredContent?.renderer?.version !== "1.17.0"
       || markdown.structuredContent?.markdown_bytes !== Buffer.byteLength(markdown.structuredContent?.markdown || "", "utf8")
       || markdown.structuredContent?.markdown_sha256 !== sha256(Buffer.from(markdown.structuredContent?.markdown || "", "utf8"))) {
       throw new Error("Packed convert_pdf_to_markdown contract smoke failed");

--- a/scripts/test-share-contract.mjs
+++ b/scripts/test-share-contract.mjs
@@ -1175,7 +1175,7 @@ async function main() {
       arguments: { pdf_path: fixturePath, max_markdown_bytes: 200000 },
     });
     if (markdown.isError
-      || markdown.structuredContent?.renderer?.version !== "1.16.0"
+      || markdown.structuredContent?.renderer?.version !== "1.17.0"
       || markdown.structuredContent?.markdown_bytes !== Buffer.byteLength(markdown.structuredContent?.markdown || "", "utf8")
       || markdown.structuredContent?.markdown_sha256 !== sha256(Buffer.from(markdown.structuredContent?.markdown || "", "utf8"))) {
       throw new Error("Share convert_pdf_to_markdown contract smoke failed");

--- a/server/markdown-conversion.js
+++ b/server/markdown-conversion.js
@@ -6,7 +6,7 @@ import {
 
 const RENDERER = Object.freeze({
   name: "pdf-tools.layout-markdown-renderer",
-  version: "1.16.0",
+  version: "1.17.0",
 });
 const SUPPORTED_LAYOUT_IR_VERSION = "1.6.0";
 
@@ -84,8 +84,8 @@ const GAP_CODES = new Set([
 const LIMITATIONS = Object.freeze([
   "Headings are emitted only from consistent enlarged font metrics, centered English-language source structure with section spacing, or numbered or lettered research-paper structure at an established body margin with spacing plus font, size, or exact small-caps evidence. Wrapped heading lines are joined only from matching font and height, a very small vertical gap, and bounded alignment. Narrow vertical labels and ambiguous, very short, or unsupported heading styles remain body text.",
   "A geometrically overlapping initial capital may be joined to its following uppercase word remainder. Line-end hyphens are preserved because source geometry cannot reliably distinguish a split word from an intentional compound. The source Extraction IR retains the original lines.",
-  "A missing space after a separate source text item that is exactly the mathematical operator log is restored only in a short, compact left-to-right math run when a single-letter variable from a different source font resource follows on the same baseline with a small positive geometric gap and independent local math-layout evidence. A missing prose-to-variable space is restored only when a multiword prose item, a separate uppercase letter from a different source font resource, and continuing prose from the original prose font share one baseline with distinct positive boundary gaps, and the same letter/font pair occurs in a nearby compact equation on the same page and column. An inline single-digit stacked fraction is rendered only when consecutive same-font source items, explicit source whitespace, smaller exactly aligned numerator and denominator digits, ordinary prose on both sides, and exactly one thin matching solid-mask bar agree. A small version-pinned registry may recover a legacy Computer Modern Type-3 character only after an exact official-metric family match, exact target and witness glyph-program matches, and a complete operator/text sequence binding. Two witnesses are required unless the source font subset cannot supply them, in which case the entry must declare that font's complete enrolled footprint and every code in it must be present and match. General equations, subscripts, other fraction bars, unregistered raster variants, and other damaged mathematical glyphs remain source reading-order text rather than being guessed.",
-  "A glyph run the source painted smaller and raised above the baseline of the text it is attached to is written as Unicode superscript characters. This records how the page is set and nothing more: a page raises a mathematical exponent and a footnote reference in exactly the same way, so this does not distinguish the two and does not assert that a raised digit is a power. A raised run is written only when every one of its characters has a real Unicode superscript form and the whole run is present on one line, so runs containing ordinary letters or symbols stay flat. A stacked fraction numerator is raised by the same amount but stands clear of the text before it, and is left alone.",
+  "A missing space after a separate source text item that is exactly the mathematical operator log is restored only in a short, compact left-to-right math run when a single-letter variable from a different source font resource follows on the same baseline with a small positive geometric gap and independent local math-layout evidence. A missing prose-to-variable space is restored only when a multiword prose item, a separate uppercase letter from a different source font resource, and continuing prose from the original prose font share one baseline with distinct positive boundary gaps, and the same letter/font pair occurs in a nearby compact equation on the same page and column. An inline single-digit stacked fraction is rendered only when consecutive same-font source items, explicit source whitespace, smaller exactly aligned numerator and denominator digits, ordinary prose on both sides, and exactly one thin matching solid-mask bar agree. A small version-pinned registry may recover a legacy Computer Modern Type-3 character only after an exact official-metric family match, exact target and witness glyph-program matches, and a complete operator/text sequence binding. Two witnesses are required unless the source font subset cannot supply them, in which case the entry must declare that font's complete enrolled footprint and every code in it must be present and match. General equations, other fraction bars, unregistered raster variants, and other damaged mathematical glyphs remain source reading-order text rather than being guessed.",
+  "A glyph run the source painted smaller and displaced from the baseline of the text it is attached to is written as Unicode superscript characters when it was raised and Unicode subscript characters when it was lowered. This records how the page is set and nothing more: a page raises a mathematical exponent and a footnote reference in exactly the same way, so this does not distinguish the two, does not assert that a raised digit is a power, and does not assert that a lowered one is an index. A displaced run is written only when every one of its characters has a real Unicode form in that direction and the whole run is present on one line, so a run stays flat entire rather than being written in part. Unicode subscript coverage is much thinner than superscript coverage, with no capital letters and only some lowercase ones, so many lowered runs stay flat for that reason alone. A stacked fraction numerator is raised by the same amount but stands clear of the text before it, and is left alone. Where the source set a displaced run without changing font and without leaving any of its base's advance unused, the text layer reports it as part of the base run and no displacement survives to be read, so that run stays flat too and is indistinguishable here from text the page never displaced. A line whose source items cannot all be located within its own extracted text, and a line the stacked-fraction projection rebuilt, keep the text they had rather than being partly rewritten.",
   "Lists are emitted only for literal bullet glyphs or decimal markers present in the source text.",
   "Links are emitted only for source-validated http or https annotation targets that map to exactly one contiguous run of text on one line. Internal destinations, actions, other schemes, ambiguous or partially covered labels, and links inside reconstructed tables remain escaped text reported as a conversion gap, and URL-looking source text is escaped to resist host autolinking.",
   "Tables are reconstructed directly only from complete text-item column geometry, clean ruled-rectangle grid evidence, or one unambiguous complete closed grid of bounded axis-aligned solid-mask rectangles. Every text item must fit exactly one cell, aligned partial dividers that evidence merged or spanning topology are rejected, and the first row must carry real header evidence because Markdown imposes header semantics. On an opt-in abstention path, a caller may submit item-to-cell assignments to the read-only verifier; accepted cell content is rebuilt only from a fresh source parse and the grid must agree with all available source-replayed ruling geometry. This proves source-backed content and consistency, not unique topology; ambiguous or unsupported geometry remains rejected. GFM cannot encode row or column spans, so accepted spans retain their authority in structured cells while Markdown places source text once at the anchor and leaves continuation slots empty. Incomplete grids and damaged mathematical glyphs are not interpreted; other ambiguous content remains escaped reading-order text with a conversion gap. Cell artwork is omitted and reported as a vector-content gap; only independently qualified exact legacy glyph variants are recovered.",
@@ -770,7 +770,7 @@ function hasAttachedSmallerOffsetScript(cells, variableIndex) {
 
 /**
  * The characters that have a genuine Unicode superscript form. This map is the
- * safety mechanism of the superscript projection, not a style choice: a raised
+ * safety mechanism of the script projection, not a style choice: a raised
  * token is transcribed only when every one of its characters can be written as
  * a real superscript character, so an arrow, a word, or a multi-letter marker
  * has no form here and is left exactly as the source emitted it. Nothing is
@@ -801,10 +801,65 @@ const SUPERSCRIPT_FORMS = new Map(Object.entries({
   i: "ⁱ",
 }));
 
-// Raised smaller glyph geometry, measured across the pinned legacy TeX corpus.
-// Script size sits near 0.74 of its base and its baseline near 0.36 of the base
-// height above it; the size and rise windows are widened around those
-// observations rather than fitted to one document.
+/**
+ * The characters that have a genuine Unicode subscript form, under exactly the
+ * same whole-run discipline as the superscript map above and with the same
+ * one-code-unit invariant.
+ *
+ * Coverage here is materially thinner, and the holes are the interesting part.
+ * Unicode encodes no subscript capital at all, and among lowercase letters only
+ * a e h i j k l m n o p r s t u v x exist: there is no b, c, d, f, g, q, w, y or
+ * z. The whole-run rule turns every hole into an abstention rather than an
+ * invention, which is the only honest option available. A source item whose
+ * text carries an interior space is left flat for the same reason, because a
+ * lowered space is not a character this map can write and dropping it would
+ * change what the page says.
+ */
+const SUBSCRIPT_FORMS = new Map(Object.entries({
+  0: "₀",
+  1: "₁",
+  2: "₂",
+  3: "₃",
+  4: "₄",
+  5: "₅",
+  6: "₆",
+  7: "₇",
+  8: "₈",
+  9: "₉",
+  "+": "₊",
+  "-": "₋",
+  "−": "₋",
+  "=": "₌",
+  "(": "₍",
+  ")": "₎",
+  a: "ₐ",
+  e: "ₑ",
+  h: "ₕ",
+  i: "ᵢ",
+  j: "ⱼ",
+  k: "ₖ",
+  l: "ₗ",
+  m: "ₘ",
+  n: "ₙ",
+  o: "ₒ",
+  p: "ₚ",
+  r: "ᵣ",
+  s: "ₛ",
+  t: "ₜ",
+  u: "ᵤ",
+  v: "ᵥ",
+  x: "ₓ",
+}));
+
+// Smaller-glyph script geometry, measured across the pinned legacy TeX corpus.
+// Script size sits near 0.74 of its base, and its baseline is displaced from
+// the base's by roughly a third of the base height: raised for a superscript,
+// lowered for a subscript. The size window is shared, and each direction's
+// displacement window is widened around its own observations rather than
+// fitted to one document. A subscript's drop is the more variable of the two
+// because the source scales it against the enclosing formula rather than
+// against the base item, so the observed band runs from an ordinary variable
+// index to the deeper drop a mathematical operator takes.
 //
 // The horizontal window is the one that carries real discriminating work, and
 // it is narrow on purpose. An attached script is set inside its base's advance
@@ -813,25 +868,69 @@ const SUPERSCRIPT_FORMS = new Map(Object.entries({
 // centered over a rule wider than itself, so it starts a visible distance after
 // whatever precedes it. Allowing a gap of up to a word space would transcribe
 // those numerators as superscripts, which is not what the page shows.
-const SUPERSCRIPT_HEIGHT_RATIO_MIN = 0.6;
-const SUPERSCRIPT_HEIGHT_RATIO_MAX = 0.82;
+//
+// The two ceilings differ, and the asymmetry is load-bearing rather than
+// sloppy. The numerator is the pressure on the raised window, and there is no
+// lowered counterpart to it: a denominator does not reach this rule at all. The
+// reason is not the one it looks like. A denominator is not preceded on its own
+// source line by the numerator it hangs under, so the two are never compared;
+// of the fraction bars on the corpus that carry text on both sides, all but
+// four have a denominator that is the first painted item on its line, which
+// this rule never examines because it only ever judges an item against the one
+// before it. In each of the four remaining cases the item beneath the bar is
+// prose or a full-size symbol rather than a small denominator digit, it is
+// level with its predecessor rather than below it, and it is the same size as
+// its predecessor, so the height window rejects it before the gap is consulted
+// and the rise window would reject it independently. So the lowered ceiling is
+// free to sit where the source actually needs it. It needs to be past 0.10: an
+// italic descender is kerned out further than an upright digit, and the
+// corpus's attached lowered runs reach 0.12 before they stop. The next lowered
+// candidate of any kind is at 0.67, where the base is punctuation or a whole
+// word rather than a symbol, so 0.15 sits inside a wide empty band and admits
+// nothing the source did not set attached.
+const SCRIPT_HEIGHT_RATIO_MIN = 0.6;
+const SCRIPT_HEIGHT_RATIO_MAX = 0.82;
 const SUPERSCRIPT_BASELINE_RISE_MIN = 0.28;
 const SUPERSCRIPT_BASELINE_RISE_MAX = 0.45;
+const SUBSCRIPT_BASELINE_RISE_MIN = -0.35;
+const SUBSCRIPT_BASELINE_RISE_MAX = -0.1;
 const SUPERSCRIPT_GAP_MIN = -0.1;
 const SUPERSCRIPT_GAP_MAX = 0.1;
-// Deliberately much wider than the attachment window above, and used only to
-// keep scanning a raised run for a reason to abstain. Widening a window that
-// can only suppress output is safe; widening the one that admits it is not.
-const SUPERSCRIPT_RUN_GAP_MIN = -0.35;
-const SUPERSCRIPT_RUN_GAP_MAX = 0.6;
-const SUPERSCRIPT_RUN_BASELINE_TOLERANCE = 0.1;
+const SUBSCRIPT_GAP_MIN = -0.1;
+const SUBSCRIPT_GAP_MAX = 0.15;
+// Deliberately much wider than the attachment windows above, and used only to
+// keep scanning a displaced run for a reason to abstain. Widening a window that
+// can only suppress output is safe; widening one that admits it is not.
+const SCRIPT_RUN_GAP_MIN = -0.35;
+const SCRIPT_RUN_GAP_MAX = 0.6;
+const SCRIPT_RUN_BASELINE_TOLERANCE = 0.1;
 
+// The two directions a source may set an attached smaller run, each carrying
+// its own displacement and attachment windows and its own alphabet. The signed
+// rise windows do not overlap and do not contain zero, so at most one entry can
+// describe any one pair of items.
+const SCRIPT_KINDS = Object.freeze([
+  Object.freeze({
+    forms: SUPERSCRIPT_FORMS,
+    riseMin: SUPERSCRIPT_BASELINE_RISE_MIN,
+    riseMax: SUPERSCRIPT_BASELINE_RISE_MAX,
+    gapMin: SUPERSCRIPT_GAP_MIN,
+    gapMax: SUPERSCRIPT_GAP_MAX,
+  }),
+  Object.freeze({
+    forms: SUBSCRIPT_FORMS,
+    riseMin: SUBSCRIPT_BASELINE_RISE_MIN,
+    riseMax: SUBSCRIPT_BASELINE_RISE_MAX,
+    gapMin: SUBSCRIPT_GAP_MIN,
+    gapMax: SUBSCRIPT_GAP_MAX,
+  }),
+]);
 
-function superscriptForm(value) {
+function scriptForm(kind, value) {
   if (typeof value !== "string" || value.length === 0) return null;
   let mapped = "";
   for (const character of value) {
-    const form = SUPERSCRIPT_FORMS.get(character);
+    const form = kind.forms.get(character);
     if (form === undefined) return null;
     mapped += form;
   }
@@ -866,55 +965,59 @@ function uprightBaselineY(item) {
 }
 
 /**
- * Whether the source painted `script` as a raised, smaller run attached to
- * `base`: script-sized, its baseline lifted by a script offset, and set with no
- * word gap.
+ * Which direction, if either, the source painted `script` in as a smaller run
+ * attached to `base`: script-sized, its baseline displaced by a script offset,
+ * and set with no word gap. Returns the matching entry of SCRIPT_KINDS, or null
+ * when the pair is not an attached script at all.
  *
- * This is a typographic observation and nothing more. The same geometry carries
- * a mathematical exponent and a footnote reference, and the page raises both
- * identically, so no geometric rule can separate them and this one does not
- * try. Deliberately not consulted: the base item's own text. Requiring the base
- * to end alphanumeric selects the footnote-marker population (a word followed
- * by a digit) and drops genuine raised runs whose base item follows an operator
- * or a comma.
+ * This is a typographic observation and nothing more. The same raised geometry
+ * carries a mathematical exponent and a footnote reference, and the page raises
+ * both identically, so no geometric rule can separate them and this one does
+ * not try. Deliberately not consulted: the base item's own text. Requiring the
+ * base to end alphanumeric selects the footnote-marker population (a word
+ * followed by a digit) and drops genuine raised runs whose base item follows an
+ * operator or a comma.
  *
  * hasAttachedSmallerOffsetScript encodes a related but different observation
  * for the log-spacing projection: it takes the absolute vertical offset between
  * advance-box tops, so it cannot tell a raised glyph from a lowered one, and it
- * is deliberately left alone here. This test needs the signed direction and the
- * true baseline, and folding the two together would either widen that
- * projection's evidence or narrow this one.
+ * is deliberately left alone here. That question is "is a script attached
+ * here at all", which either direction answers equally well; this one needs the
+ * signed direction and the true baseline, because the direction chooses which
+ * alphabet the run has to be written in.
  */
-function isRaisedSmallerScript(base, script) {
+function attachedScriptKind(base, script) {
   const baseHeight = base?.line_height;
   const scriptHeight = script?.line_height;
-  if (!Number.isFinite(baseHeight) || !Number.isFinite(scriptHeight) || !(baseHeight > 0)) return false;
+  if (!Number.isFinite(baseHeight) || !Number.isFinite(scriptHeight) || !(baseHeight > 0)) return null;
   const baseBaseline = uprightBaselineY(base);
   const scriptBaseline = uprightBaselineY(script);
-  if (baseBaseline === null || scriptBaseline === null) return false;
+  if (baseBaseline === null || scriptBaseline === null) return null;
   const gap = operatorVariableGap(base, script);
-  if (gap === null) return false;
+  if (gap === null) return null;
   const ratio = scriptHeight / baseHeight;
+  if (ratio < SCRIPT_HEIGHT_RATIO_MIN || ratio > SCRIPT_HEIGHT_RATIO_MAX) return null;
   const rise = (baseBaseline - scriptBaseline) / baseHeight;
-  return ratio >= SUPERSCRIPT_HEIGHT_RATIO_MIN
-    && ratio <= SUPERSCRIPT_HEIGHT_RATIO_MAX
-    && rise >= SUPERSCRIPT_BASELINE_RISE_MIN
-    && rise <= SUPERSCRIPT_BASELINE_RISE_MAX
-    && gap >= SUPERSCRIPT_GAP_MIN * baseHeight
-    && gap <= SUPERSCRIPT_GAP_MAX * baseHeight;
+  return SCRIPT_KINDS.find(candidate => rise >= candidate.riseMin
+    && rise <= candidate.riseMax
+    && gap >= candidate.gapMin * baseHeight
+    && gap <= candidate.gapMax * baseHeight) ?? null;
 }
 
 /**
- * Whether `next` continues the raised run that `script` started: painted on the
- * same lifted baseline and still attached. Used only to find the end of a run
- * so the whole run can be judged together.
+ * Whether `next` continues the displaced run that `script` started: painted on
+ * the same displaced baseline and still attached. Used only to find the end of
+ * a run so the whole run can be judged together.
  *
- * Deliberately no size condition. A recovered legacy glyph can report a font
- * metric quite unlike its neighbours' while sitting on exactly their baseline,
- * and missing such a member would leave the run looking complete when it is
- * not. This test can only cause abstention, so it is written to over-collect.
+ * Deliberately no size condition, and deliberately no direction condition
+ * either. A run's direction is fixed by the pair that opened it, and anything
+ * sharing that run's baseline belongs to it whatever its own metrics say. A
+ * recovered legacy glyph can report a font metric quite unlike its neighbours'
+ * while sitting on exactly their baseline, and missing such a member would
+ * leave the run looking complete when it is not. This test can only cause
+ * abstention, so it is written to over-collect.
  */
-function continuesRaisedRun(script, next) {
+function continuesScriptRun(script, next) {
   const height = script.line_height;
   if (!Number.isFinite(height) || !(height > 0)) return false;
   const scriptBaseline = uprightBaselineY(script);
@@ -922,9 +1025,9 @@ function continuesRaisedRun(script, next) {
   if (scriptBaseline === null || nextBaseline === null) return false;
   const gap = operatorVariableGap(script, next);
   return gap !== null
-    && Math.abs(nextBaseline - scriptBaseline) <= height * SUPERSCRIPT_RUN_BASELINE_TOLERANCE
-    && gap >= SUPERSCRIPT_RUN_GAP_MIN * height
-    && gap <= SUPERSCRIPT_RUN_GAP_MAX * height;
+    && Math.abs(nextBaseline - scriptBaseline) <= height * SCRIPT_RUN_BASELINE_TOLERANCE
+    && gap >= SCRIPT_RUN_GAP_MIN * height
+    && gap <= SCRIPT_RUN_GAP_MAX * height;
 }
 
 function paintedItems(page) {
@@ -934,7 +1037,7 @@ function paintedItems(page) {
 }
 
 /**
- * Plan the superscript projection for one line.
+ * Plan the script projection for one line.
  *
  * `items` is that line's source items in the order the line records them, and
  * `pageItems` is every painted item on the page. Attachment is judged over the
@@ -942,22 +1045,31 @@ function paintedItems(page) {
  * painted run, and a base never reaches across an explicit space item to claim
  * a script.
  *
- * A raised run is transcribed only in full, and only when this line holds all
- * of it. The source may split one raised run across several items and even
- * across the IR's line grouping, and transcribing the representable prefix
- * would emit a lifted opening parenthesis against a baseline closing one, which
- * misreports the page more badly than leaving the whole run flat. The run is
- * therefore followed across the whole page, which costs nothing in accuracy
- * because a genuinely line-final script has no attached same-baseline
- * neighbour anywhere.
+ * A displaced run is transcribed only in full, in the direction the pair that
+ * opened it was set, and only when this line holds all of it. The source may
+ * split one such run across several items and even across the IR's line
+ * grouping, and transcribing the representable prefix would emit a displaced
+ * opening parenthesis against a baseline closing one, which misreports the page
+ * more badly than leaving the whole run flat. The run is therefore followed
+ * across the whole page, which costs nothing in accuracy because a genuinely
+ * line-final script has no attached same-baseline neighbour anywhere.
  *
  * Returns the per-item projected forms and, when the caller's item list can be
- * located inside line.text, the rewritten line text. Because every projected
+ * located inside `baseText`, that text rewritten. Because every projected
  * character replaces exactly one source code unit, the rewritten text has the
- * same length as line.text and any offsets the caller already holds against the
- * original stay valid.
+ * same length as `baseText` and any offsets the caller already holds against it
+ * stay valid.
+ *
+ * `baseText` defaults to the line's own text and exists so a caller that has
+ * already spaced the line can hand that text in instead. Locating the items is
+ * a sequential scan for each item's exact text, so a projection that only
+ * inserts separators between items leaves every item findable and in order; one
+ * that rewrites item text or merges lines does not, and such a caller must not
+ * pass its result here. Where the scan fails the line keeps its text unchanged
+ * rather than being partly rewritten, which is why a line whose last source
+ * item carries a trailing space the line text dropped stays flat.
  */
-function superscriptLineProjection(line, items, pageItems) {
+function scriptLineProjection(line, items, pageItems, baseText = line.text) {
   const attached = items.filter(item => item
     && item.is_whitespace !== true
     && typeof item.text === "string"
@@ -965,14 +1077,15 @@ function superscriptLineProjection(line, items, pageItems) {
   const lineItemIds = new Set(attached.map(item => item.id));
   const forms = new Map();
   for (let index = 1; index < attached.length; index += 1) {
-    if (!isRaisedSmallerScript(attached[index - 1], attached[index])) continue;
+    const kind = attachedScriptKind(attached[index - 1], attached[index]);
+    if (kind === null) continue;
     const run = [];
     const claimed = new Set();
     for (let tail = attached[index]; tail !== null;) {
-      run.push([tail, lineItemIds.has(tail.id) ? superscriptForm(tail.text) : null]);
+      run.push([tail, lineItemIds.has(tail.id) ? scriptForm(kind, tail.text) : null]);
       claimed.add(tail.id);
       tail = pageItems.find(
-        item => !claimed.has(item.id) && continuesRaisedRun(tail, item),
+        item => !claimed.has(item.id) && continuesScriptRun(tail, item),
       ) ?? null;
     }
     while (index + 1 < attached.length && claimed.has(attached[index + 1].id)) index += 1;
@@ -980,15 +1093,15 @@ function superscriptLineProjection(line, items, pageItems) {
     for (const [item, form] of run) forms.set(item.id, form);
   }
   if (forms.size === 0) return { forms, text: null };
-  const offsets = itemOffsets(line, items);
+  const offsets = itemOffsets({ text: baseText }, items);
   if (offsets === null) return { forms, text: null };
-  let text = line.text;
+  let text = baseText;
   items.forEach((item, index) => {
     const form = forms.get(item.id);
     if (form === undefined) return;
     text = `${text.slice(0, offsets[index].start)}${form}${text.slice(offsets[index].end)}`;
   });
-  return { forms, text: text === line.text ? null : text };
+  return { forms, text: text === baseText ? null : text };
 }
 
 function projectedItemText(forms, item) {
@@ -1389,7 +1502,7 @@ function assignRowToColumns(row, anchors, pageItems) {
   // Emission only: column assignment and the newline rejection below both read
   // the raw source item, so the projection cannot move a cell or admit a run
   // this path would otherwise reject.
-  const { forms } = superscriptLineProjection(row.line, row.cells, pageItems);
+  const { forms } = scriptLineProjection(row.line, row.cells, pageItems);
   for (const item of row.cells) {
     const index = nearestAnchor(anchors, itemStartX(item));
     if (index === -1 || assigned.has(index)) return null;
@@ -1725,9 +1838,9 @@ function tryBuildRectGrid(page, run, clusters, itemById) {
 
     // Emission only. The structural grid, the header evidence, and the
     // newline rejection below all keep reading raw source text, so the
-    // superscript projection cannot change which grid is reconstructed.
-    const superscriptForms = new Map(lineRecords.flatMap(
-      record => [...superscriptLineProjection(record.line, record.allItems, pageItems).forms],
+    // script projection cannot change which grid is reconstructed.
+    const scriptForms = new Map(lineRecords.flatMap(
+      record => [...scriptLineProjection(record.line, record.allItems, pageItems).forms],
     ));
     const grid = cells.map(row => row.map(cell => {
       cell.sort((left, right) => (
@@ -1735,7 +1848,7 @@ function tryBuildRectGrid(page, run, clusters, itemById) {
           || left.item.bbox.x - right.item.bbox.x
       ));
       if (cell.some(entry => /[\r\n]/u.test(entry.item.text) || /[\r\n]/u.test(entry.line.text))) return null;
-      return cell.map(entry => projectedItemText(superscriptForms, entry.item).trim()).filter(Boolean).join(" ");
+      return cell.map(entry => projectedItemText(scriptForms, entry.item).trim()).filter(Boolean).join(" ");
     }));
     if (grid.some(row => row.some(value => value === null))) return { reason: "topology" };
 
@@ -1984,15 +2097,15 @@ function ruledGridSegment(page) {
       previousColumn = column;
     }
     const offsets = itemOffsets(line, allItems);
-    // Cell text is sliced out of the line, so the superscript projection is
+    // Cell text is sliced out of the line, so the script projection is
     // applied to the line text before slicing. It is length-preserving, which
     // is why the offsets recovered against the original string stay correct.
-    const superscript = superscriptLineProjection(line, allItems, pageItems);
-    const lineText = superscript.text ?? line.text;
+    const script = scriptLineProjection(line, allItems, pageItems);
+    const lineText = script.text ?? line.text;
     for (const group of groups) {
       const fragment = offsets === null
         ? allItems.slice(group.start, group.end + 1)
-          .map(item => projectedItemText(superscript.forms, item)).join(" ").trim()
+          .map(item => projectedItemText(script.forms, item)).join(" ").trim()
         : lineText.slice(offsets[group.start].start, offsets[group.end].end).trim();
       if (!fragment) return { segment: null, tableReason: "topology" };
       grid[tableRow][group.column].push({
@@ -2666,20 +2779,24 @@ function renderPage(page, {
         const proseMathText = mathText === null
           ? proseMathVariableSpacedText({ line, cells }, projectionOptions)
           : null;
-        const projectedText = fractionPlan.replacements.get(line.id) ?? mathText ?? proseMathText;
-        // Typographic fidelity only, and only where no structural projection
-        // already rewrote this line. The other projections splice spaces into
-        // line.text at offsets recovered from the original string, so composing
-        // them would require re-deriving those offsets against a rewritten
-        // line; one projection per line keeps every existing rewrite byte-exact.
-        // `joinable` deliberately still follows projectedText alone, because a
-        // superscript changes only which characters are emitted, not whether
-        // the line is a continuable flow.
-        const superscriptText = projectedText === null
-          ? superscriptLineProjection(line, cells, pageItems).text
+        const fractionText = fractionPlan.replacements.get(line.id) ?? null;
+        const projectedText = fractionText ?? mathText ?? proseMathText;
+        // Typographic fidelity only, and applied last so it composes with the
+        // spacing projections instead of being displaced by them. Those two
+        // only splice a separator between two source items, which leaves every
+        // item's own text intact and in order, so the script projection can
+        // recover its offsets against the spaced string just as well as against
+        // the original. The fraction replacement is excluded: it merges two
+        // source lines and rebuilds their text, so the items of neither line
+        // can be located in the result and a projection over it would be
+        // guesswork. `joinable` deliberately still follows projectedText alone,
+        // because a script form changes only which characters are emitted, not
+        // whether the line is a continuable flow.
+        const scriptText = fractionText === null
+          ? scriptLineProjection(line, cells, pageItems, projectedText ?? line.text).text
           : null;
         return {
-          text: renderLine(line, headings.get(line.id), projectedText ?? superscriptText ?? line.text),
+          text: renderLine(line, headings.get(line.id), scriptText ?? projectedText ?? line.text),
           sourceText: line.text,
           normalizable: true,
           line,

--- a/server/output-schemas.js
+++ b/server/output-schemas.js
@@ -1080,7 +1080,7 @@ export const TOOL_SUCCESS_OUTPUT_SCHEMAS = Object.freeze({
     {
       renderer: object({
         name: { const: "pdf-tools.layout-markdown-renderer" },
-        version: { const: "1.16.0" },
+        version: { const: "1.17.0" },
       }),
       conversion_status: enumString(["complete", "partial", "failed"]),
       markdown: string,

--- a/test/convert-pdf-to-markdown.test.js
+++ b/test/convert-pdf-to-markdown.test.js
@@ -305,7 +305,7 @@ describe("convert_pdf_to_markdown MCP tool", () => {
     expect(first.isError).not.toBe(true);
     expect(second.structuredContent).toEqual(first.structuredContent);
     expect(first.structuredContent).toMatchObject({
-      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.16.0" },
+      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.17.0" },
       conversion_status: "complete",
       saved_output: null,
       provenance: {

--- a/test/eval/markdown-bakeoff.test.js
+++ b/test/eval/markdown-bakeoff.test.js
@@ -66,7 +66,7 @@ async function handle(message) {
     const pageBoundaries = Array.from({ length: pageCount }, (_, index) => "<!-- PDF page " + (index + 1) + " -->");
     const markdown = pageBoundaries.join("\n\n") + "\n\nINV-1001 fixture evidence\n";
     const value = {
-      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.16.0" },
+      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.17.0" },
       conversion_status: "complete",
       markdown,
       markdown_sha256: digest(Buffer.from(markdown)),
@@ -167,7 +167,7 @@ function resultFor(binding) {
   const markdown = "<!-- PDF page 1 -->\n\nFixture text\n";
   return {
     structuredContent: {
-      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.16.0" },
+      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.17.0" },
       conversion_status: "complete",
       markdown,
       markdown_sha256: sha256(Buffer.from(markdown)),
@@ -255,7 +255,7 @@ describe("Markdown bakeoff renderer version binding", () => {
   });
 
   it("accepts the current renderer version and rejects all superseded ones", () => {
-    expect(validateMarkdownResult(resultFor("1.16.0"), binding).renderer.version).toBe("1.16.0");
+    expect(validateMarkdownResult(resultFor("1.17.0"), binding).renderer.version).toBe("1.17.0");
     for (const stale of ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.6.0", "1.7.0", "1.8.0", "1.9.0", "1.10.0", "1.11.0", "1.12.0", "1.13.0", "1.14.0"]) {
       expect(() => validateMarkdownResult(resultFor(stale), binding), stale)
         .toThrow(/Markdown result evidence is invalid/u);

--- a/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
+++ b/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
@@ -79,14 +79,14 @@
     {
       "role": "markdown_conversion_module",
       "path": "server/markdown-conversion.js",
-      "bytes": 143855,
-      "sha256": "b8d34ce2714e70d140f63455fffa117c97a37db2d3dcc935aaecdcaa900485aa"
+      "bytes": 149933,
+      "sha256": "b5b851146f18e8f7097089216430f00763a0c940e6f0d24acedc70de6382ada7"
     },
     {
       "role": "output_schemas_module",
       "path": "server/output-schemas.js",
       "bytes": 58647,
-      "sha256": "4bd00d2f903a02f1bc82ceea8dce346261e6dc30afa08388896ce6ac5a081b06"
+      "sha256": "e7aa12e341e32023df0b21826cf58bb9d682477e1c1f4a4a1aba2fcb1f1a77ce"
     },
     {
       "role": "package_json",
@@ -131,7 +131,7 @@
       "sha256": "ef40501b2afbe4cd2adfa80480344783bbec1a00e8e9850086a5d044231d1f53"
     }
   ],
-  "validator_source_set_sha256": "850a0c22647a874e4fa60ec0e288099512a4b98181a3d07b8028e9a1ca60ba9a",
+  "validator_source_set_sha256": "6ff03dc68504852dca8f133e80ae44fa4f767facaa63ad8a6b5b3bb2aeecbc89",
   "pdfjs_version": "5.4.624",
   "generation_contract": {
     "source_path": "source.pdf",

--- a/test/fixtures/eval/shannon/manifest.v1.json
+++ b/test/fixtures/eval/shannon/manifest.v1.json
@@ -22,7 +22,7 @@
     "pdf_tools": {
       "slot": "control.current_product.v0",
       "renderer_name": "pdf-tools.layout-markdown-renderer",
-      "renderer_version": "1.16.0",
+      "renderer_version": "1.17.0",
       "parser_name": "pdfjs-dist",
       "parser_version": "5.4.624"
     },

--- a/test/markdown-conversion.test.js
+++ b/test/markdown-conversion.test.js
@@ -372,8 +372,11 @@ describe("layout Markdown renderer", () => {
     // before renderer 1.16.0 added the raised-glyph superscript limitation.
     // This fixture paints nothing raised, so the rendered body and gap codes
     // asserted below are unchanged and only the envelope moved.
+    // Then bc025b37042e9ede92e02bf050998faa5fe9c3306f5f8b251f6fe497dabe0ba2, before renderer 1.17.0 extended the same
+    // rule to lowered runs and Unicode subscripts. This fixture paints nothing
+    // displaced in either direction, so again only the envelope moved.
     expect(createHash("sha256").update(serialized).digest("hex"))
-      .toBe("bc025b37042e9ede92e02bf050998faa5fe9c3306f5f8b251f6fe497dabe0ba2");
+      .toBe("c5f8738869464d87e3add9d8e6907f83537485d8abea97da12cce9de4baa1489");
     const body = result.markdown.split("\n\n## Conversion gaps\n\n", 1)[0];
     expect(JSON.stringify({
       body,
@@ -381,7 +384,7 @@ describe("layout Markdown renderer", () => {
     })).toBe(NON_RECT_EXPECTED);
     expect(result.renderer).toEqual({
       name: "pdf-tools.layout-markdown-renderer",
-      version: "1.16.0",
+      version: "1.17.0",
     });
     expect(result.gaps[0].message).toMatch(/beyond reconstructed ruled or bounded solid-mask table grids/);
     expect(result.limitations.some(value => value.includes("clean ruled-rectangle grid evidence"))).toBe(true);

--- a/test/mcp-contract.test.js
+++ b/test/mcp-contract.test.js
@@ -149,7 +149,11 @@ const EXAMPLE_PDF = path.join(REPO_ROOT, "example-fw9.pdf");
 // glyph run as Unicode superscript characters. No tool name, description,
 // input schema, or read-only annotation changes. Previously
 // edbba3a6444b7603c9e8336a496f5c82b55d8d9ed674b7dbdbca28240386fb52.
-const TOOL_CONTRACT_SHA256 = "cefcfff3fc76324826e1eedcd4e2694d311cfcd1ab7daa9f43dc9e2f496eae5d";
+// 2026-08-14: the same identity becomes 1.17.0, which extends that rule to a
+// lowered smaller glyph run and writes it as Unicode subscript characters. No
+// tool name, description, input schema, or read-only annotation changes.
+// Previously cefcfff3fc76324826e1eedcd4e2694d311cfcd1ab7daa9f43dc9e2f496eae5d.
+const TOOL_CONTRACT_SHA256 = "e5328f44d1f1f01a2f015d756cb13c1980b84c8042cdd1d8470699b9931b67ad";
 
 const CLOSED_READ = Object.freeze({
   readOnlyHint: true,

--- a/test/shannon-subscript-live.test.js
+++ b/test/shannon-subscript-live.test.js
@@ -1,0 +1,417 @@
+import path from "node:path";
+import { beforeAll, describe, expect, it } from "vitest";
+import { hashBoundedPdfFileSafely } from "../server/bounded-pdf-file.js";
+import { renderPdfLayoutToMarkdown } from "../server/markdown-conversion.js";
+import {
+  createPdfjsSubprocessRequest,
+  runPdfjsSubprocess,
+} from "../server/pdfjs-subprocess.js";
+
+const SOURCE = process.env.PDF_TOOLS_SHANNON_SOURCE;
+const SOURCE_SHA256 = "6e4e3411984f3edf99dbfe8b941cb5e8a321379ff0cae6ae5c1f592ad8882ca8";
+const PAGE_COUNT = 55;
+const PAGE_SPAN = 5;
+
+// Both character maps, restated here only so this oracle can build and invert
+// the same two alphabets. No assertion below names an expected token: every
+// comparison has two computed sides, one read out of the emitted Markdown and
+// one derived from the source geometry.
+const SUBSCRIPT_FORMS = new Map(Object.entries({
+  0: "₀",
+  1: "₁",
+  2: "₂",
+  3: "₃",
+  4: "₄",
+  5: "₅",
+  6: "₆",
+  7: "₇",
+  8: "₈",
+  9: "₉",
+  "+": "₊",
+  "-": "₋",
+  "−": "₋",
+  "=": "₌",
+  "(": "₍",
+  ")": "₎",
+  a: "ₐ",
+  e: "ₑ",
+  h: "ₕ",
+  i: "ᵢ",
+  j: "ⱼ",
+  k: "ₖ",
+  l: "ₗ",
+  m: "ₘ",
+  n: "ₙ",
+  o: "ₒ",
+  p: "ₚ",
+  r: "ᵣ",
+  s: "ₛ",
+  t: "ₜ",
+  u: "ᵤ",
+  v: "ᵥ",
+  x: "ₓ",
+}));
+const SUPERSCRIPT_FORMS = new Map(Object.entries({
+  0: "⁰",
+  1: "¹",
+  2: "²",
+  3: "³",
+  4: "⁴",
+  5: "⁵",
+  6: "⁶",
+  7: "⁷",
+  8: "⁸",
+  9: "⁹",
+  "+": "⁺",
+  "-": "⁻",
+  "−": "⁻",
+  "=": "⁼",
+  "(": "⁽",
+  ")": "⁾",
+  n: "ⁿ",
+  i: "ⁱ",
+}));
+const PLAIN_FORMS = new Map([...SUBSCRIPT_FORMS].map(([plain, form]) => [form, plain]));
+const SUBSCRIPT_CHARACTERS = new Set(SUBSCRIPT_FORMS.values());
+const SUPERSCRIPT_CHARACTERS = new Set(SUPERSCRIPT_FORMS.values());
+
+function mappedForm(forms, text) {
+  if (text.length === 0) return null;
+  let mapped = "";
+  for (const character of text) {
+    const form = forms.get(character);
+    if (form === undefined) return null;
+    mapped += form;
+  }
+  return mapped;
+}
+
+function fold(text) {
+  return [...text].map(character => PLAIN_FORMS.get(character) ?? character).join("");
+}
+
+/**
+ * The source's own vertical scale for an item.
+ *
+ * pdf.js reports a glyph height for ordinary runs, and this prefers it. It
+ * reports zero for a collapsed legacy Type-3 item, whose height therefore has
+ * to come from the raw text-space transform instead. Both are numbers the
+ * source supplied; neither is the IR's derived advance box, which is what the
+ * renderer measures. Skipping the zero-height items instead would blind this
+ * oracle to a whole population of bases that the renderer does judge, and an
+ * oracle that cannot see what the renderer emits cannot constrain it.
+ */
+function rawHeight(item) {
+  return item.raw_height > 0 ? item.raw_height : Math.abs(item.raw_transform[3]);
+}
+
+/**
+ * Independent oracle for "smaller, displaced, attached", deliberately derived
+ * from different IR fields than the renderer uses. The renderer recovers a
+ * baseline from the published viewport quad and its ascent ratio, in a
+ * coordinate space whose y grows downward. This reads the source text-space
+ * transform, where the y translation is the baseline itself and grows upward.
+ * The sign of the rise therefore comes out of the opposite subtraction in the
+ * opposite space, so a renderer that inverted the direction would disagree with
+ * this rather than agree with it, which a restatement of its arithmetic could
+ * not detect.
+ */
+function rawScriptGeometry(base, script) {
+  const baseHeight = rawHeight(base);
+  if (!(baseHeight > 0) || !(rawHeight(script) > 0)) return null;
+  // Unrotated, unskewed runs only. A sheared run has no y-axis baseline.
+  for (const item of [base, script]) {
+    if (item.raw_transform.length !== 6 || item.raw_transform[1] !== 0 || item.raw_transform[2] !== 0) {
+      return null;
+    }
+  }
+  return {
+    ratio: rawHeight(script) / baseHeight,
+    rise: (script.raw_transform[5] - base.raw_transform[5]) / baseHeight,
+    gap: (script.bbox.x - (base.bbox.x + base.bbox.width)) / baseHeight,
+  };
+}
+
+const RAISED = Object.freeze({
+  forms: SUPERSCRIPT_FORMS,
+  characters: SUPERSCRIPT_CHARACTERS,
+  riseMin: 0.28,
+  riseMax: 0.45,
+  gapMin: -0.1,
+  gapMax: 0.1,
+});
+const LOWERED = Object.freeze({
+  forms: SUBSCRIPT_FORMS,
+  characters: SUBSCRIPT_CHARACTERS,
+  riseMin: -0.35,
+  riseMax: -0.1,
+  gapMin: -0.1,
+  gapMax: 0.15,
+});
+
+function displacedKind(base, script) {
+  const measured = rawScriptGeometry(base, script);
+  if (measured === null) return null;
+  if (!(measured.ratio >= 0.6 && measured.ratio <= 0.82)) return null;
+  return [RAISED, LOWERED].find(kind => measured.rise >= kind.riseMin
+    && measured.rise <= kind.riseMax
+    && measured.gap >= kind.gapMin
+    && measured.gap <= kind.gapMax) ?? null;
+}
+
+function paintedItems(page) {
+  return page.raw_items.filter(item => item.is_whitespace !== true && item.text.trim().length > 0);
+}
+
+/**
+ * Whether the renderer can splice anything into this line at all.
+ *
+ * It rewrites a line by locating each source item's exact text inside the
+ * line's text, scanning forward, and replacing in place. Where the scan cannot
+ * succeed the line keeps the text it had rather than being partly rewritten:
+ * this document's case is a final source item carrying a trailing space that
+ * the line text dropped. The condition is textual rather than geometric, so
+ * restating it here leaves every geometric judgement above independently
+ * derived.
+ */
+function lineAcceptsSplice(line, items) {
+  let cursor = 0;
+  for (const item of items) {
+    if (typeof item.text !== "string" || item.text.length === 0) return false;
+    const index = line.text.indexOf(item.text, cursor);
+    if (index === -1) return false;
+    cursor = index + item.text.length;
+  }
+  return true;
+}
+
+/**
+ * Every displaced run the source painted on a page, in either direction,
+ * representable or not. Attachment starts inside one line; the run is then
+ * followed by raw text-space baseline equality wherever the source continued
+ * it, including across the IR's line grouping.
+ */
+function displacedRuns(page) {
+  const byId = new Map(page.raw_items.map(item => [item.id, item]));
+  const painted = paintedItems(page);
+  const runs = [];
+  for (const line of page.lines) {
+    const all = line.item_ids.map(id => byId.get(id)).filter(Boolean);
+    const items = all.filter(item => item.is_whitespace !== true && item.text.trim().length > 0);
+    const lineIds = new Set(items.map(item => item.id));
+    const spliceable = lineAcceptsSplice(line, all.filter(item => item.text.length > 0));
+    for (let index = 1; index < items.length; index += 1) {
+      const kind = displacedKind(items[index - 1], items[index]);
+      if (kind === null) continue;
+      const run = [];
+      const claimed = new Set();
+      for (let tail = items[index]; tail;) {
+        run.push(tail);
+        claimed.add(tail.id);
+        tail = painted.find(candidate => !claimed.has(candidate.id)
+          && candidate.raw_transform[5] === tail.raw_transform[5]
+          && candidate.bbox.x >= tail.bbox.x + tail.bbox.width - rawHeight(tail) * 0.35
+          && candidate.bbox.x <= tail.bbox.x + tail.bbox.width + rawHeight(tail) * 0.6);
+      }
+      while (index + 1 < items.length && claimed.has(items[index + 1].id)) index += 1;
+      const source = run.map(item => item.text).join("");
+      const whole = run.every(item => lineIds.has(item.id));
+      runs.push({
+        page: page.page,
+        kind,
+        source,
+        // Representable in this run's own direction, wholly on this line, and
+        // on a line the renderer can rewrite: the conditions it promises are
+        // jointly necessary before it writes anything.
+        transcribable: whole && spliceable && mappedForm(kind.forms, source) !== null,
+        // Whether the other alphabet could have written this run. Used to prove
+        // the direction, not the alphabet, is what separates the two.
+        representableEitherWay: mappedForm(SUBSCRIPT_FORMS, source) !== null
+          && mappedForm(SUPERSCRIPT_FORMS, source) !== null,
+      });
+    }
+  }
+  return runs;
+}
+
+function runsOf(characters, text) {
+  return text.match(new RegExp(`[${[...characters].join("")}]+`, "gu")) ?? [];
+}
+
+function pageBodies(chunks) {
+  const bodies = new Map();
+  for (const chunk of chunks) {
+    const body = chunk.markdown.split("\n## Conversion limitations\n")[0];
+    for (const section of body.split(/<!-- PDF page (\d+) -->/u).slice(1).reduce((pairs, value, index, all) => (
+      index % 2 === 0 ? [...pairs, [Number(value), all[index + 1]]] : pairs
+    ), [])) {
+      bodies.set(section[0], section[1]);
+    }
+  }
+  return bodies;
+}
+
+let converted = null;
+
+async function convertShannon() {
+  const sourceFile = await hashBoundedPdfFileSafely(SOURCE, 250 * 1024 * 1024, {
+    assertPathAllowed: candidate => candidate,
+  });
+  expect(sourceFile.sha256).toBe(SOURCE_SHA256);
+  const source = {
+    canonical_path: sourceFile.canonicalPath,
+    file_identity: sourceFile.fileIdentity,
+    sha256: sourceFile.sha256,
+    size_bytes: sourceFile.sizeBytes,
+  };
+  const pages = [];
+  const chunks = [];
+  for (let startPage = 1; startPage <= PAGE_COUNT; startPage += PAGE_SPAN) {
+    const endPage = Math.min(PAGE_COUNT, startPage + PAGE_SPAN - 1);
+    const response = await runPdfjsSubprocess(createPdfjsSubprocessRequest({
+      operation: "extract_layout_for_markdown",
+      source,
+      password: null,
+      allowedDirectories: [path.dirname(SOURCE)],
+      options: {
+        source_path: SOURCE,
+        source_file_name: path.basename(SOURCE),
+        start_page: startPage,
+        end_page: endPage,
+        max_items: 5000,
+        max_characters: 100_000,
+        max_output_characters: 200_000,
+      },
+    }), { timeoutMs: 60_000 });
+    pages.push(...response.layout.pages);
+    chunks.push(renderPdfLayoutToMarkdown(response.layout, {
+      includePageBoundaries: true,
+      maxMarkdownBytes: 200_000,
+    }));
+  }
+  return { pages, chunks, bodies: pageBodies(chunks) };
+}
+
+describe("external Shannon lowered-glyph transcription", () => {
+  beforeAll(async () => {
+    if (SOURCE) converted = await convertShannon();
+  }, 240_000);
+
+  it.runIf(Boolean(SOURCE))("writes exactly the lowered runs the source painted and can represent", () => {
+    const { pages, bodies } = converted;
+    const runs = pages.flatMap(displacedRuns);
+    const lowered = runs.filter(run => run.kind === LOWERED);
+    const transcribable = lowered.filter(run => run.transcribable);
+
+    // Both sides computed. The renderer must have written every lowered run an
+    // independent reading of the source finds representable and whole, in
+    // document order, and nothing else anywhere on any page.
+    expect(transcribable.length).toBeGreaterThan(0);
+    for (const page of pages) {
+      const expected = transcribable.filter(run => run.page === page.page)
+        .map(run => mappedForm(SUBSCRIPT_FORMS, run.source));
+      expect(runsOf(SUBSCRIPT_CHARACTERS, bodies.get(page.page) ?? ""), `page ${page.page}`).toEqual(expected);
+    }
+
+    // The abstention path is genuinely exercised by this document, so the
+    // equality above is a real constraint and not a vacuous one.
+    expect(lowered.length - transcribable.length).toBeGreaterThan(0);
+  });
+
+  it.runIf(Boolean(SOURCE))("separates the two directions by sign, not by alphabet", () => {
+    const { pages, bodies } = converted;
+    const runs = pages.flatMap(displacedRuns);
+
+    // The rule reads a signed displacement. If it read an absolute one, or
+    // inverted it, these two populations would swap alphabets. Both directions
+    // have to be present for that to mean anything, and the overlapping subset
+    // has to be non-empty: those are the runs whose text both alphabets could
+    // write, so only the measured sign can be choosing between them.
+    const raised = runs.filter(run => run.kind === RAISED && run.transcribable);
+    const lowered = runs.filter(run => run.kind === LOWERED && run.transcribable);
+    expect(raised.length).toBeGreaterThan(0);
+    expect(lowered.length).toBeGreaterThan(0);
+    expect(lowered.filter(run => run.representableEitherWay).length).toBeGreaterThan(0);
+    expect(raised.filter(run => run.representableEitherWay).length).toBeGreaterThan(0);
+
+    for (const page of pages) {
+      const body = bodies.get(page.page) ?? "";
+      expect(runsOf(SUPERSCRIPT_CHARACTERS, body), `raised, page ${page.page}`)
+        .toEqual(raised.filter(run => run.page === page.page)
+          .map(run => mappedForm(SUPERSCRIPT_FORMS, run.source)));
+    }
+
+    // No run is claimed by both windows, so no page can be reported twice.
+    expect(runs.filter(run => run.kind === RAISED).length
+      + runs.filter(run => run.kind === LOWERED).length).toBe(runs.length);
+  });
+
+  it.runIf(Boolean(SOURCE))("only substitutes characters, and never inside the source IR", () => {
+    const { pages, chunks } = converted;
+    const rendered = chunks.map(chunk => chunk.markdown).join("");
+
+    // Folding every subscript back to its plain character has to be total and
+    // length-preserving. That is what makes this a substitution rather than a
+    // rewrite: no character position moved, so nothing around a lowered run can
+    // have been dropped, reordered, or invented.
+    const folded = fold(rendered);
+    expect(folded).not.toBe(rendered);
+    expect(folded.length).toBe(rendered.length);
+    expect(runsOf(SUBSCRIPT_CHARACTERS, folded)).toEqual([]);
+
+    // Folding is total over the whole Unicode subscript repertoire, not just
+    // over the map above. A renderer that invented a form this oracle does not
+    // know would survive every comparison built from that map, and would be
+    // left behind here instead.
+    expect(folded.match(/[₀-ₜᵢ-ᵪⱼ]/gu)).toBeNull();
+
+    // The projection is emission-only: the source Extraction IR the Markdown
+    // was derived from still holds the flat characters the parser reported.
+    const mutated = pages.flatMap(page => [
+      ...page.lines.map(line => line.text),
+      ...page.raw_items.map(item => item.text),
+    ]).filter(text => runsOf(SUBSCRIPT_CHARACTERS, text).length > 0);
+    expect(mutated).toEqual([]);
+  });
+
+  it.runIf(Boolean(SOURCE))("abstains on every character the subscript alphabet cannot write", () => {
+    const { pages } = converted;
+    const lowered = pages.flatMap(displacedRuns).filter(run => run.kind === LOWERED);
+    const abstained = lowered.filter(run => mappedForm(SUBSCRIPT_FORMS, run.source) === null);
+
+    // Every abstention is explained by a character with no subscript form, and
+    // each such character really is absent from the map rather than merely
+    // unused. This is the whole-run rule stated from the other side: the page
+    // carries runs the alphabet cannot finish, and none of them was started.
+    expect(abstained.length).toBeGreaterThan(0);
+    const unwritable = new Set(abstained.flatMap(run => [...run.source]
+      .filter(character => !SUBSCRIPT_FORMS.has(character))));
+    expect(unwritable.size).toBeGreaterThan(0);
+    for (const run of abstained) {
+      expect([...run.source].some(character => unwritable.has(character)), run.source).toBe(true);
+    }
+
+    // Among them, at least one run is unwritable only because of a character
+    // the map deliberately omits while the rest of the run maps cleanly, and at
+    // least one because it carries a space. Both are the cases where emitting a
+    // partial run would have been the tempting mistake.
+    expect(abstained.some(run => [...run.source].filter(character => !SUBSCRIPT_FORMS.has(character)).length === 1
+      && [...run.source].length > 1)).toBe(true);
+    expect(abstained.some(run => run.source.includes(" "))).toBe(true);
+  });
+
+  it.runIf(Boolean(SOURCE))("reports the displaced-glyph rule in its limitations", () => {
+    const [chunk] = converted.chunks;
+    const limitation = chunk.limitations.find(value => value.includes("displaced from the baseline"));
+    expect(limitation).toBeDefined();
+    expect(limitation).toMatch(/subscript characters when it was lowered/i);
+    expect(limitation).toMatch(/does not assert that a lowered one is an index/i);
+    expect(limitation).toMatch(/no capital letters/i);
+    // The two abstentions this document exercises beyond the alphabet are both
+    // published rather than silent.
+    expect(limitation).toMatch(/cannot all be located/i);
+    expect(limitation).toMatch(/without changing font/i);
+    expect(converted.chunks[0].limitations.some(value => value.includes("General equations, other fraction bars")))
+      .toBe(true);
+  });
+});

--- a/test/shannon-superscript-live.test.js
+++ b/test/shannon-superscript-live.test.js
@@ -235,8 +235,9 @@ describe("external Shannon raised-glyph transcription", () => {
 
   it.runIf(Boolean(SOURCE))("reports the raised-glyph rule in its limitations", () => {
     const [chunk] = converted.chunks;
-    const limitation = chunk.limitations.find(value => value.includes("raised above the baseline"));
+    const limitation = chunk.limitations.find(value => value.includes("displaced from the baseline"));
     expect(limitation).toBeDefined();
+    expect(limitation).toMatch(/superscript characters when it was raised/i);
     expect(limitation).toMatch(/footnote reference/i);
     expect(limitation).toMatch(/does not distinguish/i);
   });


### PR DESCRIPTION
Stacked on #157 — base branch is `claude/shannon-table-i`, not master.

The mirror of the superscript rule. #157's rise test is **signed** precisely so lowered runs are rejected; this accepts that branch. **`J1(t)` on page 40 — #157's documented abstention — now renders `J₁(t)`**, so the same test is load-bearing in both directions rather than only rejecting.

672 characters across 48 of 55 pages, all pure substitution: folding every one back reproduces the previous output **byte for byte on every page**. Page 40's twelve superscripts unchanged. All 36 repo fixture PDFs render byte-identical bodies.

## Windows

Ratio 0.60–0.82 shared with #157; lowered rise **−0.35…−0.10**; lowered gap **−0.10…+0.15**. Disjoint from the raised windows and neither contains zero, so at most one direction can claim a pair.

The 0.15 ceiling rather than #157's 0.10 is load-bearing: **46 pairs sit in (0.10, 0.15]** — italic `j` kerned out further than an upright digit — and the next lowered candidate of any kind is at **0.67**. The ceiling sits in measured empty space.

## Unicode coverage decides most of the behaviour

No subscript capitals exist at all, and no `b c d f g q w y z`. So **164 runs stay flat**: 93 are `"i j"` and kin where the space has no form, 29 are `N`, 27 are `y`, one is `log_b` on page 2. Whole-run-or-nothing, as in #157 — a partly lowered run is worse than a flat one.

## Three findings

**The inherited draft dropped subscripts on 14 lines.** The projection ran only when no other projection had touched the line, so any line the `log`- or prose-spacing rules had rewritten silently lost its subscripts (`pi logpi`, `C = logX0.`, and 12 more). #157 never exposed this because no superscript line hits that branch. The projection now composes, running last against the spaced text, since those rules only insert separators *between* items so every item stays locatable. The stacked-fraction replacement still wins — it merges two source lines and rebuilds their text.

**`p(x₁,...,xₙ)` is half delivered and cannot be finished here.** The source sets `x` and its subscript with no `Tf` between them and the base's advance consumed exactly, so pdf.js merges both glyphs into a single item `"xn"` at base height. **The subscript does not exist in the IR to be found.** `x₁` survives only because its `1` is in a different font resource and the `Tf` forces a flush. Corpus-wide, **65 of 619** subscript shifts are absorbed this way. Fixing it means changing extraction, not the renderer; the limitation says so.

**The denominator argument was right in conclusion, wrong in mechanism.** I reasoned that a denominator's predecessor would be the numerator and get rejected on height. Measured across all 325 fraction bars: **321 have no predecessor at all** (first on their IR line), and in the 4 that do, the predecessor is never the numerator. They're still rejected — on both ratio and rise — and admitted denominators are **0**. The comment now carries the measurement instead of my reasoning.

## Mutation testing

**15 caught**, including inventing a form the alphabet shouldn't write (`b: "ᵦ"`) and reverting the composition fix.

**4 uncaught**, all widening or tightening into measured empty space — the rise-floor hole is #157's, unchanged, since nothing sits below −0.252. This document cannot distinguish those bounds. The test isn't weak; the corpus is silent, and that's recorded rather than hidden.

## Version

Renderer **1.16.0 → 1.17.0**: emitted Markdown and the published limitation both differ for the same input, and one identity must name one behaviour. Package version untouched at 0.10.0 — **one bump at 0.11.0 still stands**.

Oracle regenerated: 4 lines, digests and byte count only, **no scored case changed** (verified programmatically across `case_id`/`status`/`status_reason`/`geometry_status`). Share mirror byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)