### PR TITLE
Stop the publish guard rejecting the version it now asks for

### DIFF
--- a/scripts/publish-agent-plugin.mjs
+++ b/scripts/publish-agent-plugin.mjs
@@ -51,12 +51,39 @@ if (!existsSync(BUILT_PLUGIN)) {
 // must not be the thing that quietly ships.
 const sourceVersion = JSON.parse(readFileSync(path.join(REPO_ROOT, "package.json"), "utf8")).version;
 const builtVersion = JSON.parse(readFileSync(path.join(BUILT_PLUGIN, "plugin.json"), "utf8")).version;
-if (sourceVersion !== builtVersion) {
+
+// The plugin version now carries build metadata identifying the commit it was
+// built from (0.11.0+99.g1fcd8da), so between releases it deliberately differs
+// from package.json. Comparing the two for equality made this refuse every
+// publish, which it did hourly until it was noticed.
+//
+// Compare the release component instead, and then check the embedded commit
+// against this tree's HEAD. That is a stricter staleness check than the equality
+// it replaces: the old test could not tell a fresh build from one made twenty
+// commits ago under the same version number, which is the drift the build
+// metadata was introduced to end.
+const releaseOf = value => String(value).split("+")[0];
+if (releaseOf(sourceVersion) !== releaseOf(builtVersion)) {
   console.error(
     `[publish] built plugin is ${builtVersion} but this tree is ${sourceVersion}. ` +
       `Rebuild with: npm run build:plugin`,
   );
   process.exit(1);
+}
+
+const embeddedCommit = /\+\d+\.g([0-9a-f]+)/.exec(builtVersion)?.[1];
+if (embeddedCommit) {
+  const headCommit = execFileSync("git", ["rev-parse", "HEAD"], {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+  }).trim();
+  if (!headCommit.startsWith(embeddedCommit)) {
+    console.error(
+      `[publish] built plugin came from ${embeddedCommit} but this tree is at ` +
+        `${headCommit.slice(0, 12)}. Rebuild with: npm run build:plugin`,
+    );
+    process.exit(1);
+  }
 }
 
 const dirty = git(["status", "--porcelain"]);


### PR DESCRIPTION
**The published plugin is stale right now, and this is why.**

The plugin version now carries build metadata identifying its commit, so between releases it deliberately differs from `package.json`. `publish-agent-plugin.mjs` compared the two for equality and refused:

```
[publish] built plugin is 0.10.0+99.g1fcd8da but this tree is 0.10.0. Rebuild with: npm run build:plugin
```

It has failed on every hourly run since, so the distribution repo has been serving an older build. That is precisely the failure the publisher was built to prevent, reintroduced by the change meant to make its labelling honest. Mine, and caught by checking the publisher after the release rather than assuming it worked.

**The fix compares the release component, then checks the embedded commit against HEAD.** That is stricter than the equality it replaces: the old test could not distinguish a fresh build from one made twenty commits earlier under the same version number, which is the drift the build metadata exists to end.

Verified end to end. Build, then publish dry run: previously exited 1 at the version check, now syncs 12 changed files and restores the tree.