### PR TITLE
Fix one load-sensitive suite, and recapture the stale Shannon pins

### DIFF
--- a/scripts/macos-claude-installed-shannon.mjs
+++ b/scripts/macos-claude-installed-shannon.mjs
@@ -11,14 +11,24 @@ if (!process.argv[2] || !process.argv[3]) {
   throw new Error("Usage: macos-claude-installed-shannon.mjs <installed-extension-dir> <shannon-pdf>");
 }
 
+// Pins recaptured 2026-08-15 against the shipped v0.11.0 MCPB
+// (sha256 24179fb68790014407d3af34bb1da68b15cfe31907f7ff733df45d013f3e2dd4),
+// unpacked and driven over stdio with the Shannon paper fetched from the URL in
+// test/fixtures/eval/shannon/manifest.v1.json.
+//
+// The previous pins were captured before the Type-3 recovery and superscript
+// work and had drifted a long way: 68 gaps against 26, and 434 replacement
+// characters against 6. Those two numbers are a quality measurement, so stale
+// pins here understate the product by a factor of four and seventy.
+//
 const EXPECTED_SOURCE_SHA256 = "6e4e3411984f3edf99dbfe8b941cb5e8a321379ff0cae6ae5c1f592ad8882ca8";
-const EXPECTED_MARKDOWN_SHA256 = "4cdc3a17728bb07100752ad841745a5ecf49a0aade0cd39af69bca899217e203";
-const EXPECTED_TOOL_CONTRACT_SHA256 = "53d965e366b16adf2a0fa90dfe837ca98d29a8f41c1adf8b9e8f661ea3bb7d95";
+const EXPECTED_MARKDOWN_SHA256 = "b9bd7ca7db26fe807f294565c39de8d4fe9337908afa74cd7e2896a800c92991";
+const EXPECTED_TOOL_CONTRACT_SHA256 = "cefcfff3fc76324826e1eedcd4e2694d311cfcd1ab7daa9f43dc9e2f496eae5d";
 const EXPECTED_PAGE_COUNT = 55;
-const EXPECTED_GAP_COUNT = 68;
-const EXPECTED_REPLACEMENT_CHARACTER_COUNT = 434;
+const EXPECTED_GAP_COUNT = 26;
+const EXPECTED_REPLACEMENT_CHARACTER_COUNT = 6;
 const EXPECTED_ALPHA_COUNT = 49;
-const EXPECTED_MARKDOWN_BYTES = 183927;
+const EXPECTED_MARKDOWN_BYTES = 187663;
 const PAGE_SPAN = 10;
 
 function sha256(bytes) {
@@ -59,7 +69,7 @@ const chunks = [];
 try {
   await client.connect(transport);
   const tools = await client.listTools();
-  assert(tools.tools.length === 43, `Expected 43 installed tools, received ${tools.tools.length}`);
+  assert(tools.tools.length === 44, `Expected 44 installed tools, received ${tools.tools.length}`);
   assert(
     sha256(Buffer.from(JSON.stringify(tools.tools))) === EXPECTED_TOOL_CONTRACT_SHA256,
     "Installed tool contract differs from the reviewed build",

--- a/test/eval/extraction-docling-model-helper.test.js
+++ b/test/eval/extraction-docling-model-helper.test.js
@@ -4,7 +4,15 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Every test here spawns a Python interpreter synchronously, several of them more
+// than once. Vitest's default ceiling is 5 seconds, which was never a decision
+// about this file: interpreter startup plus filesystem work exceeds it whenever
+// the box is busy, and the suite then reports a timeout that reads as a product
+// defect. Nothing here asserts speed, so the ceiling is raised to a value that
+// only trips if the helper has genuinely hung.
+vi.setConfig({ testTimeout: 60_000 });
 import { canonicalJson } from "./extraction-phase1-protocol.js";
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");


### PR DESCRIPTION
Two independent fixes, both from #164 and from the 0.11.0 release.

## Docling helper timeout

All seven tests in `extraction-docling-model-helper` spawn a Python interpreter synchronously and none set a timeout, so every one inherited vitest's 5000ms default. That ceiling was the framework's rather than a decision about this file, and it failed a release gate as `Test timed out in 5000ms`, which reads as a product defect.

Nothing there asserts speed, so it is now 60s: high enough to only trip if the helper has genuinely hung. 12 pass.

## The Shannon pins were stale in six places, not two

| Pin | Was | Now |
|---|---|---|
| Tool count | 43 | 44 |
| Gap count | 68 | **26** |
| Replacement characters | 434 | **6** |
| Markdown bytes | 183,927 | 187,663 |
| Markdown SHA | `4cdc3a17…` | `b9bd7ca7…` |
| Tool contract SHA | `53d965e3…` | `cefcfff3…` |

Two of those are quality measurements rather than identity checks. Gaps fell from 68 to 26 and replacement characters from 434 to 6 across the Type-3 recovery and superscript work, so anyone running this script would have read a large improvement as a large regression.

Recaptured against the **shipped v0.11.0 MCPB** (`24179fb6…`), unpacked and driven over stdio, with the Shannon paper fetched from the URL in the corpus manifest and its bytes verified against the reviewed source hash. Exits 0 against that build. The header now records what the pins were captured against and when.

## What I deliberately did not change

`save-lifecycle > creates only one H0 backup under concurrent first mutations` fails because the losing call returns the server's resource-budget error rather than `CONCURRENT_MODIFICATION`: it starved in the queue instead of being rejected by the lock. Making the assertion accept either message would weaken a test that exists to prove exactly one backup and one rejection, and whether that starvation path is correct product behaviour is a design question rather than a test tweak. Left for #164.