### PR TITLE
Report a second writer as a second writer, not as a resource limit

### DIFF
--- a/pdf-toolkit-mcp-share/server/pdf-lib-subprocess.js
+++ b/pdf-toolkit-mcp-share/server/pdf-lib-subprocess.js
@@ -24,6 +24,7 @@ import {
 import { validateAccessibilityInspectionResult } from "./accessibility-inspection.js";
 
 export const PDF_RESOURCE_LIMIT_CODE = "PDF_RESOURCE_LIMIT_EXCEEDED";
+export const PDF_CONCURRENT_MODIFICATION_CODE = "CONCURRENT_MODIFICATION";
 export const PDF_LIB_MUTATION_TOOL_NAMES = new Set([
   "add_signature_field",
   "apply_page_plan",
@@ -139,6 +140,28 @@ function resourceError(reason, cause = null) {
   );
   error.name = "PdfResourceLimitError";
   error.code = PDF_RESOURCE_LIMIT_CODE;
+  error.reason = reason;
+  return error;
+}
+
+// A bound source that no longer matches is not a resource condition. Nothing
+// about the document was too large or too complex; something else wrote to it
+// while this operation ran in isolation. Reporting it through resourceError
+// told the caller to "try a smaller or simpler PDF" about a file whose only
+// problem was a second writer, and it gave one race two different answers:
+// whichever of this check and the commit-time identity checks in index.js
+// happened to notice first decided whether the caller saw a budget message or
+// CONCURRENT_MODIFICATION. Both are the same refusal and now say so. The code
+// and the `CODE: message` shape match backupIdentityError in index.js so the
+// two detectors are indistinguishable to a caller. `reason` is retained, as on
+// resourceError, so the boundary suites can still say which check fired.
+function concurrentModificationError(reason, message, cause = null) {
+  const error = new Error(
+    `${PDF_CONCURRENT_MODIFICATION_CODE}: ${message}`,
+    cause ? { cause } : undefined,
+  );
+  error.name = "PdfConcurrentModificationError";
+  error.code = PDF_CONCURRENT_MODIFICATION_CODE;
   error.reason = reason;
   return error;
 }
@@ -825,7 +848,10 @@ async function revalidateSources(sources, { requirePdfHeader = true } = {}) {
         || current.sha256 !== source.sha256
         || current.fileIdentity.device !== source.file_identity.device
         || current.fileIdentity.inode !== source.file_identity.inode) {
-      throw resourceError("source_drift_before_activation");
+      throw concurrentModificationError(
+        "source_drift_before_activation",
+        "The PDF changed while this mutation ran in isolation. Reload the current document and retry.",
+      );
     }
   }
 }

--- a/server/pdf-lib-subprocess.js
+++ b/server/pdf-lib-subprocess.js
@@ -24,6 +24,7 @@ import {
 import { validateAccessibilityInspectionResult } from "./accessibility-inspection.js";
 
 export const PDF_RESOURCE_LIMIT_CODE = "PDF_RESOURCE_LIMIT_EXCEEDED";
+export const PDF_CONCURRENT_MODIFICATION_CODE = "CONCURRENT_MODIFICATION";
 export const PDF_LIB_MUTATION_TOOL_NAMES = new Set([
   "add_signature_field",
   "apply_page_plan",
@@ -139,6 +140,28 @@ function resourceError(reason, cause = null) {
   );
   error.name = "PdfResourceLimitError";
   error.code = PDF_RESOURCE_LIMIT_CODE;
+  error.reason = reason;
+  return error;
+}
+
+// A bound source that no longer matches is not a resource condition. Nothing
+// about the document was too large or too complex; something else wrote to it
+// while this operation ran in isolation. Reporting it through resourceError
+// told the caller to "try a smaller or simpler PDF" about a file whose only
+// problem was a second writer, and it gave one race two different answers:
+// whichever of this check and the commit-time identity checks in index.js
+// happened to notice first decided whether the caller saw a budget message or
+// CONCURRENT_MODIFICATION. Both are the same refusal and now say so. The code
+// and the `CODE: message` shape match backupIdentityError in index.js so the
+// two detectors are indistinguishable to a caller. `reason` is retained, as on
+// resourceError, so the boundary suites can still say which check fired.
+function concurrentModificationError(reason, message, cause = null) {
+  const error = new Error(
+    `${PDF_CONCURRENT_MODIFICATION_CODE}: ${message}`,
+    cause ? { cause } : undefined,
+  );
+  error.name = "PdfConcurrentModificationError";
+  error.code = PDF_CONCURRENT_MODIFICATION_CODE;
   error.reason = reason;
   return error;
 }
@@ -825,7 +848,10 @@ async function revalidateSources(sources, { requirePdfHeader = true } = {}) {
         || current.sha256 !== source.sha256
         || current.fileIdentity.device !== source.file_identity.device
         || current.fileIdentity.inode !== source.file_identity.inode) {
-      throw resourceError("source_drift_before_activation");
+      throw concurrentModificationError(
+        "source_drift_before_activation",
+        "The PDF changed while this mutation ran in isolation. Reload the current document and retry.",
+      );
     }
   }
 }

--- a/test/accessibility-inspection-worker.test.js
+++ b/test/accessibility-inspection-worker.test.js
@@ -6,6 +6,7 @@ import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  PDF_CONCURRENT_MODIFICATION_CODE,
   PDF_RESOURCE_LIMIT_CODE,
   createPdfLibInspectionRequest,
   runPdfLibInspection,
@@ -301,7 +302,12 @@ await fs.writeFile(request.sources[0].canonical_path, Buffer.from(${JSON.stringi
         return spawn(command, args, options);
       },
     })).rejects.toMatchObject({
-      code: PDF_RESOURCE_LIMIT_CODE,
+      // Source drift is a concurrent modification, not a resource condition.
+      // The refusal is identical whichever layer makes it, so this must not
+      // drift back to PDF_RESOURCE_LIMIT_CODE: that told the caller to try a
+      // smaller PDF, and it made save-lifecycle's concurrency assertion depend
+      // on which detector machine load let win.
+      code: PDF_CONCURRENT_MODIFICATION_CODE,
       reason: "source_drift_before_activation",
     });
     expect(await fs.readFile(sourcePath)).toEqual(changed);

--- a/test/pdf-lib-subprocess-boundary.test.js
+++ b/test/pdf-lib-subprocess-boundary.test.js
@@ -9,6 +9,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { PDFDocument } from "pdf-lib";
 import {
+  PDF_CONCURRENT_MODIFICATION_CODE,
   PDF_RESOURCE_LIMIT_CODE,
   createPdfLibMutationRequest,
   runPdfLibMutation,
@@ -999,7 +1000,12 @@ await fs.writeFile(request.stage_directory + "/extra.pdf", bytes, { mode: 0o600 
       await fs.writeFile(fixture.sourcePath, "%PDF-1.7\nchanged\n%%EOF\n");
       await atomicTransition("journal_prepared");
     }, { workerPath: fixture.workerPath })).rejects.toMatchObject({
-      code: PDF_RESOURCE_LIMIT_CODE,
+      // Source drift is a concurrent modification, not a resource condition.
+      // The refusal is identical whichever layer makes it, so this must not
+      // drift back to PDF_RESOURCE_LIMIT_CODE: that told the caller to try a
+      // smaller PDF, and it made save-lifecycle's concurrency assertion depend
+      // on which detector machine load let win.
+      code: PDF_CONCURRENT_MODIFICATION_CODE,
       reason: "source_drift_before_activation",
     });
   });

--- a/test/save-lifecycle.test.js
+++ b/test/save-lifecycle.test.js
@@ -817,6 +817,31 @@ describe("canonical save lifecycle", () => {
     await fs.unlink(lockPath);
   }, 30_000);
 
+  /**
+   * Two writers, one document. Exactly one may commit; the other must be
+   * refused, must leave nothing behind, and must be told why.
+   *
+   * Two independent layers can notice the loser's document changed under it,
+   * and which one notices first is a genuine race decided by machine load:
+   *
+   *   - `revalidateSources` in server/pdf-lib-subprocess.js, when the isolated
+   *     worker returns and the bound input no longer hashes to what it bound.
+   *     Reached when the winner commits while the loser is still in isolation,
+   *     which is the common ordering on a slow or busy box.
+   *   - the identity checks in `persistPdfMutation` and the mutation lock in
+   *     server/index.js, reached when the loser gets past the first check and
+   *     the winner commits during the commit sequence itself. The common
+   *     ordering on an idle box, where both workers return together.
+   *
+   * This assertion used to pin the second ordering, so a two-core CI runner
+   * failed it while the product was behaving correctly. The fix was not to
+   * accept both messages -- that would let a real resource failure, a spawn
+   * failure or a timeout pass as a concurrency refusal, and this test would
+   * stop proving the loser was refused *for concurrency*. Instead the first
+   * layer was corrected to report the refusal it is actually making, so both
+   * orderings now produce one answer and the assertion holds on any hardware.
+   * Regressing either layer back to a resource-budget message fails here.
+   */
   it("creates only one H0 backup under concurrent first mutations", async () => {
     const pdfPath = path.join(TMP_DIR, "w9-working.pdf");
     const originalHash = await sha256(pdfPath);
@@ -850,9 +875,24 @@ describe("canonical save lifecycle", () => {
     expect((await fs.readdir(path.join(PROFILE_DIR, "backups"))).filter(entry => entry.endsWith(".pdf"))).toEqual([
       path.basename(backupPath),
     ]);
+    // The loser is refused at one of two points, and neither may leave a
+    // half-written document, an orphaned transaction directory or a second
+    // lineage behind. Whichever layer refused it, the tree looks the same.
+    expect((await fs.readdir(TMP_DIR)).filter(name => name.startsWith(".pdf-tools-"))).toEqual([]);
+    expect(
+      (await fs.readdir(path.join(PROFILE_DIR, "backups"))).filter(name => name.includes(".mutation-")),
+    ).toEqual([]);
+    expect(await topLevelPdfs()).toEqual(["w9-managed-source.pdf", "w9-working.pdf"]);
     const reopened = await PDFDocument.load(await fs.readFile(pdfPath));
     const value = reopened.getForm().getTextField(NAME_FIELD).getText();
     expect(value).toBe(left.isError === true ? "Concurrent right" : "Concurrent left");
+    // The server answered the loser rather than dying with it.
+    const active = await client.callTool({ name: "get_active_document", arguments: {} });
+    expect(active.structuredContent).toMatchObject({
+      active_path: pdfPath,
+      backup_path: backupPath,
+      last_mutation_tool: "fill_pdf",
+    });
   }, 30_000);
 
   it("makes a managed page-edit output canonical, then mutates that output in place", async () => {


### PR DESCRIPTION
Blocks #160. Found by the Node 20 gate; **it is not the flake it looks like.**

## The diagnosis is not a timeout

`save-lifecycle` failed on the two-core runner expecting `CONCURRENT_MODIFICATION` and receiving *"PDF processing exceeded its isolated resource budget"*. The obvious reading — slow box, starved wall-clock budget — is wrong. Instrumenting the error gives `reason: source_drift_before_activation`.

**The product has two independent, both-correct detectors for the same concurrent modification:**

| detector | where | fires when |
|---|---|---|
| `revalidateSources` | `pdf-lib-subprocess.js:845` | the isolated worker returns and the bound input no longer hashes to what it bound — the winner committed while the loser was still in isolation (busy machine) |
| identity checks | `index.js:2227`, `2646-2727` | commit time (idle machine) |

They disagreed about what had happened. One race, two answers, decided by machine load. Instrumented under contention, one 16-iteration run hit the first **5×** and the second **11×** — both orderings are routine production behaviour, not an exotic edge.

## The part that matters more than the red test

A user who concurrently edited a PDF was told to **"try a smaller or simpler PDF"** — about a file whose only problem was a second writer. The advice was wrong and the typed code was wrong. This was a product defect wearing a flaky test as a disguise.

## The fix is in the product

A bound source that no longer matches is not a resource condition. It now reports `CONCURRENT_MODIFICATION` in the same `CODE: message` shape as the commit-time detector, so the two are indistinguishable to a caller. The internal `reason` is retained, as on `resourceError`, so the boundary suites can still say which check fired.

**Explicitly not fixed by accepting either error.** That was rejected in #165 and is wrong on the merits: a real OOM, spawn failure, or timeout would then pass as a concurrency refusal — the same "two sides not independent" defect this class keeps producing. No budget raised, nothing skipped on CI, nothing runtime-conditional. The assertion is true on any hardware because the product gives one answer.

The test also gained the invariants that actually matter rather than only the error string: no transaction residue, no leftover mutation lock, exact top-level PDF set, server still answering.

## Non-vacuity

| mutant | result |
|---|---|
| restore old classification only | **7/20 fail** under the contention that previously failed 7/12 — still discriminates budget from race |
| defeat source drift + all three identity gates | **passes** — the mutation lock catches it. Genuine defence in depth |
| the above + non-exclusive lock | **fails deterministically**, nothing succeeds — catches a broken product, not a slow one |

20/20 under contention that previously failed 7/12; 22/22 for the suite at load average 75. I re-ran it here under induced load: 22/22.

## Contract change to review

Two boundary suites (`accessibility-inspection-worker.test.js:304`, `pdf-lib-subprocess-boundary.test.js:1002`) pinned the old classification and are updated. **That is the part of this diff most worth your eye** — it is the contract deliberately being changed.

Full `npm test` on Node 20.19 and Node 22.23: identical, 2478 passed, the only failures being the three `source-identity` suites hitting the dirty-tree guard. Share mirror byte-identical. `server/index.js` untouched; no oracle regeneration needed.

## Siblings reported, not fixed

`embedded-native-canvas-latch.test.js:241` and `:260` — `pdfjs-subprocess.js:1105` *documents in a comment* that PID reuse makes it report `"concurrent"` rather than `"latched"`, and the test pins one of the two. Same defect, same remedy shape. Also: `exitedProcessId` duplicated across three files, six unpolled `process.kill(pid, 0)` probes where `waitForProcessToDisappear` exists, and `test-runner-contract.test.js:563` comparing the config against the same frozen arrays the config imports. Left alone to keep this diff single-purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)