### PR TITLE
Bind the plugin publish guard, and stop it accepting a build it cannot identify

### DIFF
--- a/scripts/build-agent-plugin.mjs
+++ b/scripts/build-agent-plugin.mjs
@@ -29,8 +29,9 @@ import {
 } from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
-import { execFileSync, spawn } from "child_process";
+import { spawn } from "child_process";
 import { prepareCleanStage } from "./build-mcpb.mjs";
+import { derivePluginVersion } from "./plugin-version.mjs";
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(SCRIPT_DIR, "..");
@@ -56,34 +57,18 @@ const PACKAGE_JSON = JSON.parse(
 // default walk. `rev-list --count` and `--first-parent` answer different
 // questions and give different numbers for the same pair, so the measure is
 // named here rather than left for someone to guess.
-function derivePluginVersion(packageVersion) {
-  let described;
-  try {
-    described = execFileSync("git", ["describe", "--tags", "--always", "--dirty"], {
-      cwd: REPO_ROOT,
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    }).trim();
-  } catch {
-    // No git, or a checkout with no tags. A depth-1 CI clone does exactly this,
-    // which would silently restore the old behaviour, so it is announced rather
-    // than swallowed.
+//
+// The grammar itself lives in ./plugin-version.mjs, because the publisher has to
+// read these strings back and decide whether a build belongs to the tree it is
+// about to stamp. Two independent readings of one grammar is how they drift.
+const PLUGIN_VERSION = derivePluginVersion(PACKAGE_JSON.version, {
+  cwd: REPO_ROOT,
+  onUnavailable: () =>
     console.error(
       "[plugin] git describe unavailable, version falls back to package.json. "
         + "In CI this usually means the checkout needs fetch-depth: 0.",
-    );
-    return packageVersion;
-  }
-  const match = /-(\d+)-g([0-9a-f]+)(-dirty)?$/.exec(described);
-  if (!match) {
-    // Sitting exactly on a tag. A dirty tree still deserves a marker.
-    return described.endsWith("-dirty") ? `${packageVersion}+dirty` : packageVersion;
-  }
-  const [, commitsSinceTag, sha, dirty] = match;
-  return `${packageVersion}+${commitsSinceTag}.g${sha}${dirty ? ".dirty" : ""}`;
-}
-
-const PLUGIN_VERSION = derivePluginVersion(PACKAGE_JSON.version);
+    ),
+}).version;
 
 const PLUGIN_MANIFEST_NAME = "pdf-tools";
 // Leads with the words a person actually types. A user asking to "open a PDF"

--- a/scripts/check-plugin-freshness.mjs
+++ b/scripts/check-plugin-freshness.mjs
@@ -45,6 +45,9 @@ const SHIPPED_PATHS = [
   "LICENSE",
   "scripts/agent-plugin-launchers/",
   "scripts/build-agent-plugin.mjs",
+  // Decides the version string written into the published plugin.json, so a
+  // change here changes published bytes with no change to any path above it.
+  "scripts/plugin-version.mjs",
 ];
 
 function git(args) {

--- a/scripts/plugin-version.mjs
+++ b/scripts/plugin-version.mjs
@@ -1,0 +1,86 @@
+// The one place that knows how a plugin version encodes the tree it was built
+// from.
+//
+// This grammar has two readers with opposite jobs: the builder writes a version
+// into `plugin.json`, and the publisher has to decide from that string alone
+// whether the built bytes belong to the tree it is about to stamp them with. A
+// second, independent reading of the grammar is how the two drift apart, so
+// there is one reading and both import it.
+//
+// The shape matters as much as the string. `0.11.0` is produced by a build made
+// exactly at a tag, by a build in a checkout with no tags reachable, and by a
+// build where `git describe` could not run at all — three different amounts of
+// knowledge wearing one version number. A caller that needs to know which one it
+// is asks for the shape, not for the string.
+
+import { execFileSync } from "child_process";
+
+// `git describe --tags --always --dirty` output, when at least one tag is
+// reachable and HEAD is not that tag.
+const DESCRIBE_SUFFIX = /-(\d+)-g([0-9a-f]+)(-dirty)?$/;
+// `--always` falls back to a bare abbreviated object name when no tag is
+// reachable. That has no commit count, so it reads exactly like sitting on a tag
+// and must be told apart by shape rather than by the version it produces.
+const BARE_OBJECT_NAME = /^[0-9a-f]{7,40}(-dirty)?$/;
+
+/**
+ * Run `git describe` in a working tree. Returns null when it cannot run at all
+ * (no git binary, not a repository, a depth-1 CI clone with no history).
+ */
+export function describeTree(cwd) {
+  try {
+    return execFileSync("git", ["describe", "--tags", "--always", "--dirty"], {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Interpret one `git describe` output against a package version.
+ *
+ * `shape` is the field a caller should branch on:
+ *   "post-tag"     - N commits past a tag; the version carries the commit.
+ *   "tagged-exact" - HEAD is the tag; the version is bare but HEAD identifies it.
+ *   "untagged"     - no tag reachable; the version is bare and identifies nothing.
+ *   "unavailable"  - describe did not run; the version is bare and identifies nothing.
+ */
+export function pluginVersionFor(packageVersion, described) {
+  if (described === null || described === undefined || described === "") {
+    return { version: packageVersion, shape: "unavailable", dirty: false, commit: null };
+  }
+  const match = DESCRIBE_SUFFIX.exec(described);
+  if (match) {
+    const [, commitsSinceTag, sha, dirty] = match;
+    return {
+      version: `${packageVersion}+${commitsSinceTag}.g${sha}${dirty ? ".dirty" : ""}`,
+      shape: "post-tag",
+      dirty: Boolean(dirty),
+      commit: sha,
+    };
+  }
+  const dirty = described.endsWith("-dirty");
+  return {
+    version: dirty ? `${packageVersion}+dirty` : packageVersion,
+    shape: BARE_OBJECT_NAME.test(described) ? "untagged" : "tagged-exact",
+    dirty,
+    commit: null,
+  };
+}
+
+/**
+ * The version the builder would write into `plugin.json` for the tree at `cwd`,
+ * with the shape that produced it.
+ *
+ * `onUnavailable` is called instead of swallowing the failure, because a
+ * depth-1 CI clone silently restoring the pre-build-metadata behaviour is the
+ * regression this grammar exists to prevent.
+ */
+export function derivePluginVersion(packageVersion, { cwd, onUnavailable } = {}) {
+  const described = describeTree(cwd);
+  if (described === null && onUnavailable) onUnavailable();
+  return { ...pluginVersionFor(packageVersion, described), described };
+}

--- a/scripts/publish-agent-plugin.mjs
+++ b/scripts/publish-agent-plugin.mjs
@@ -17,6 +17,7 @@ import { cpSync, rmSync, existsSync, readFileSync, writeFileSync } from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
 import { execFileSync } from "child_process";
+import { derivePluginVersion } from "./plugin-version.mjs";
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(SCRIPT_DIR, "..");
@@ -52,38 +53,61 @@ if (!existsSync(BUILT_PLUGIN)) {
 const sourceVersion = JSON.parse(readFileSync(path.join(REPO_ROOT, "package.json"), "utf8")).version;
 const builtVersion = JSON.parse(readFileSync(path.join(BUILT_PLUGIN, "plugin.json"), "utf8")).version;
 
-// The plugin version now carries build metadata identifying the commit it was
-// built from (0.11.0+99.g1fcd8da), so between releases it deliberately differs
-// from package.json. Comparing the two for equality made this refuse every
-// publish, which it did hourly until it was noticed.
+// Derive the version the builder would write *right now*, from this tree, and
+// require the built plugin to carry exactly that.
 //
-// Compare the release component instead, and then check the embedded commit
-// against this tree's HEAD. That is a stricter staleness check than the equality
-// it replaces: the old test could not tell a fresh build from one made twenty
-// commits ago under the same version number, which is the drift the build
-// metadata was introduced to end.
-const releaseOf = value => String(value).split("+")[0];
-if (releaseOf(sourceVersion) !== releaseOf(builtVersion)) {
+// Checking the parts separately looks stricter and is not. Comparing only the
+// release component and then the embedded commit leaves every version that
+// carries no embedded commit unchecked, and three different trees produce one:
+// a build made at a tag, a build in a checkout with no tags, and a build where
+// `git describe` could not run. Measured on 2026-08-15 against this script at
+// dc90e75: a `dist-plugin` built at v0.11.0 and published from master two
+// commits later was accepted, and PROVENANCE.md recorded those tag-built bytes
+// as "Built from dc90e753…". That record is the only thing identifying what the
+// distribution repo serves, and check-plugin-freshness.mjs reads the same
+// commit back to decide whether the publish is current — so one unchecked shape
+// makes both of them confidently wrong.
+//
+// Equality against the derived version subsumes both old checks: a release
+// mismatch, a foreign commit, a truncated commit and a bare version all differ
+// from what this tree would produce. It does not reintroduce the equality bug
+// that made this refuse every publish hourly, because the comparison is against
+// the derived version and not against package.json: a freshly built plugin
+// matches by construction.
+const expected = derivePluginVersion(sourceVersion, { cwd: REPO_ROOT });
+
+// Fail closed where the version cannot identify a commit at all. Publishing
+// under one of these writes a PROVENANCE.md that claims a commit the bytes are
+// not known to come from.
+if (expected.shape === "unavailable") {
   console.error(
-    `[publish] built plugin is ${builtVersion} but this tree is ${sourceVersion}. ` +
-      `Rebuild with: npm run build:plugin`,
+    `[publish] cannot verify what this tree is: git describe did not run here. ` +
+      `A depth-1 clone needs fetch-depth: 0.`,
+  );
+  process.exit(1);
+}
+if (expected.shape === "untagged") {
+  console.error(
+    `[publish] no tag is reachable from HEAD (git describe says ${expected.described}), so a ` +
+      `plugin version cannot identify the build. Fetch tags with: git fetch --tags`,
+  );
+  process.exit(1);
+}
+if (expected.dirty) {
+  console.error(
+    `[publish] this tree has uncommitted changes (git describe says ${expected.described}), so ` +
+      `the published bytes would belong to no commit while PROVENANCE.md names one. ` +
+      `Commit or stash first.`,
   );
   process.exit(1);
 }
 
-const embeddedCommit = /\+\d+\.g([0-9a-f]+)/.exec(builtVersion)?.[1];
-if (embeddedCommit) {
-  const headCommit = execFileSync("git", ["rev-parse", "HEAD"], {
-    cwd: REPO_ROOT,
-    encoding: "utf8",
-  }).trim();
-  if (!headCommit.startsWith(embeddedCommit)) {
-    console.error(
-      `[publish] built plugin came from ${embeddedCommit} but this tree is at ` +
-        `${headCommit.slice(0, 12)}. Rebuild with: npm run build:plugin`,
-    );
-    process.exit(1);
-  }
+if (builtVersion !== expected.version) {
+  console.error(
+    `[publish] built plugin is ${builtVersion} but this tree builds ${expected.version}. ` +
+      `Rebuild with: npm run build:plugin`,
+  );
+  process.exit(1);
 }
 
 const dirty = git(["status", "--porcelain"]);

--- a/test/publish-guard.test.js
+++ b/test/publish-guard.test.js
@@ -142,7 +142,23 @@ function publishOutcome(sourceRoot, distRoot, extraArgs = []) {
   const result = spawnSync(
     process.execPath,
     [path.join(sourceRoot, "scripts", "publish-agent-plugin.mjs"), distRoot, ...extraArgs],
-    { cwd: sourceRoot, encoding: "utf8" },
+    {
+      cwd: sourceRoot,
+      encoding: "utf8",
+      // The publisher commits into the distribution repo, so it needs an author
+      // the same way the fixture helper does. Without this the run reaches
+      // "4 file(s) changed" and then dies on "Author identity unknown", which
+      // reads as the guard refusing when it is the host being assumed: it passes
+      // wherever a global git identity happens to exist and fails on a CI runner
+      // or any machine without one.
+      env: {
+        ...process.env,
+        GIT_AUTHOR_NAME: "fixture",
+        GIT_AUTHOR_EMAIL: "fixture@example.invalid",
+        GIT_COMMITTER_NAME: "fixture",
+        GIT_COMMITTER_EMAIL: "fixture@example.invalid",
+      },
+    },
   );
   if (result.error) throw result.error;
   // A signal death has a null status and must not read as a clean exit.

--- a/test/publish-guard.test.js
+++ b/test/publish-guard.test.js
@@ -107,14 +107,26 @@ function builtPlugin(root, version) {
   expect(JSON.parse(readFileSync(path.join(built, "plugin.json"), "utf8")).version).toBe(version);
 }
 
-/** A distribution repository seeded with content a sync would have to replace. */
-function distributionRepo() {
+/**
+ * A distribution repository seeded with content a sync would have to replace.
+ *
+ * With `withRemote`, it gets a bare origin on disk so the `--push` path can run
+ * to the end. Nothing here reaches a network: the remote is a directory.
+ */
+function distributionRepo({ withRemote = false } = {}) {
   const root = temporaryDirectory("pdf-tools-publish-dist-");
   mkdirSync(path.join(root, "plugins", "pdf-tools"), { recursive: true });
   writeFileSync(path.join(root, "plugins", "pdf-tools", "STALE.txt"), "previously published\n");
   git(root, ["init", "-q", "-b", "main"]);
   git(root, ["add", "-A"]);
   git(root, ["commit", "-qm", "seed"]);
+  if (!withRemote) return root;
+
+  const bare = path.join(temporaryDirectory("pdf-tools-publish-origin-"), "dist.git");
+  git(path.dirname(bare), ["init", "-q", "--bare", bare]);
+  git(root, ["remote", "add", "origin", bare]);
+  git(root, ["push", "-q", "origin", "HEAD:refs/heads/main"]);
+  git(root, ["branch", "-q", "--set-upstream-to=origin/main"]);
   return root;
 }
 
@@ -123,13 +135,13 @@ function distributionRepo() {
  * the push, and a dry run still performs the sync, so "would publish" is
  * observable without one.
  */
-function publishOutcome(sourceRoot, distRoot) {
+function publishOutcome(sourceRoot, distRoot, extraArgs = []) {
   // The publisher reports everything on stderr, including its successes.
   // spawnSync rather than execFileSync so a zero exit still yields stderr — the
   // success cases below are asserted on it, and execFileSync returns stdout only.
   const result = spawnSync(
     process.execPath,
-    [path.join(sourceRoot, "scripts", "publish-agent-plugin.mjs"), distRoot],
+    [path.join(sourceRoot, "scripts", "publish-agent-plugin.mjs"), distRoot, ...extraArgs],
     { cwd: sourceRoot, encoding: "utf8" },
   );
   if (result.error) throw result.error;
@@ -258,23 +270,50 @@ describe("agent plugin publish guard", () => {
     expect(outcome.stderr).toContain("uncommitted changes");
   });
 
-  it("records the commit it publishes from, and restores the dry-run tree", () => {
+  it("leaves the distribution repo untouched on a dry run", () => {
     const source = sourceTree({ commitsPastTag: 2 });
     builtPlugin(source, versionBuiltHere(source));
     const dist = distributionRepo();
-    const outcome = publishOutcome(source, dist);
+    const before = git(dist, ["rev-parse", "HEAD"]);
+
+    expect(publishOutcome(source, dist).code).toBe(0);
+    expect(git(dist, ["status", "--porcelain"])).toBe("");
+    expect(git(dist, ["rev-parse", "HEAD"])).toBe(before);
+  });
+
+  it("publishes the built bytes and records the commit they came from", () => {
+    const source = sourceTree({ commitsPastTag: 2 });
+    const version = versionBuiltHere(source);
+    builtPlugin(source, version);
+    const dist = distributionRepo({ withRemote: true });
+
+    const outcome = publishOutcome(source, dist, ["--push"]);
     expect(outcome.code).toBe(0);
 
-    // A dry run restores, so PROVENANCE.md is gone again — the assertion that it
-    // was written has to come from the run rather than from the tree.
-    expect(outcome.stderr).toContain("file(s) changed");
-    expect(git(dist, ["status", "--porcelain"])).toBe("");
+    // Asserting only that the run finished is the weaker claim it looks like:
+    // removing the cpSync that copies the build still leaves PROVENANCE.md as a
+    // change, so the script still reports a publish and exits 0. Read the
+    // published tree instead of the script's own account of it (L24).
+    const published = git(dist, ["show", "--name-only", "--format=", "HEAD"]).split("\n");
+    expect(published).toContain("plugins/pdf-tools/plugin.json");
+    expect(published).toContain("plugins/pdf-tools/PAYLOAD.txt");
+    expect(published).toContain("PROVENANCE.md");
+    expect(git(dist, ["show", "HEAD:plugins/pdf-tools/PAYLOAD.txt"])).toBe(`bytes for ${version}`);
+    // The stale content it replaced is gone, not merely shadowed.
+    expect(published).toContain("plugins/pdf-tools/STALE.txt");
 
-    // The bytes it would have stamped: HEAD, which the cases above are what make
-    // true. Without them a stale build reaches this line and the commit recorded
-    // here belongs to a tree those bytes never came from.
+    // PROVENANCE.md is the only thing identifying what this repo serves, and
+    // check-plugin-freshness.mjs reads this exact commit back out of it. The
+    // refusals above are what make it true rather than merely present.
+    const provenance = git(dist, ["show", "HEAD:PROVENANCE.md"]);
     const head = git(source, ["rev-parse", "HEAD"]);
-    expect(versionBuiltHere(source)).toContain(head.slice(0, 7));
+    expect(provenance).toContain(head);
+    expect(/\/commit\/([0-9a-f]{40})/.exec(provenance)?.[1]).toBe(head);
+    expect(provenance).toContain(`\`${version}\``);
+
+    // It reached the remote, not just the local checkout.
+    const bare = git(dist, ["remote", "get-url", "origin"]);
+    expect(git(dist, ["rev-parse", "HEAD"])).toBe(git(bare, ["rev-parse", "refs/heads/main"]));
   });
 });
 

--- a/test/publish-guard.test.js
+++ b/test/publish-guard.test.js
@@ -1,0 +1,322 @@
+// The publisher's staleness guard is the only thing standing between a stale
+// `dist-plugin` and the distribution repository, and until this file it was read
+// by no test on any platform.
+//
+// It is not enough to check that a correct publish succeeds. The guard's whole
+// job is to refuse, so every case here drives the real script and asserts which
+// way it went, and the negative cases carry version strings written out by hand
+// rather than derived — a derivation would agree with the code under test by
+// construction (L42's shape).
+//
+// Measured before the guard was repaired, at dc90e75: a `dist-plugin` built at
+// v0.11.0 and published from master two commits later was accepted, and the
+// PROVENANCE.md it wrote recorded those tag-built bytes as "Built from
+// dc90e753…". check-plugin-freshness.mjs reads that same commit back to decide
+// whether the published plugin is current, so the false record satisfied the
+// only gate watching the distribution repo. Those cases are `refuses a build
+// made at the tag …` and `records the commit it publishes from` below.
+
+import { afterEach, describe, expect, it } from "vitest";
+import { execFileSync, spawnSync } from "child_process";
+import { createHash } from "crypto";
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import { fileURLToPath } from "url";
+import { pluginVersionFor } from "../scripts/plugin-version.mjs";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const PUBLISHER = path.join(REPO_ROOT, "scripts", "publish-agent-plugin.mjs");
+// The fixture source tree needs its own tags, commits and dirty states, so the
+// scripts are copied into it rather than run from this checkout. That copy is
+// the fidelity risk, so it is checked: a divergence here means these cases stop
+// describing the script that ships.
+const COPIED_SCRIPTS = ["publish-agent-plugin.mjs", "plugin-version.mjs"];
+const FIXTURE_VERSION = "9.9.0";
+
+const temporaryDirectories = [];
+
+function sha256(file) {
+  return createHash("sha256").update(readFileSync(file)).digest("hex");
+}
+
+function git(cwd, args) {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "fixture",
+      GIT_AUTHOR_EMAIL: "fixture@example.invalid",
+      GIT_COMMITTER_NAME: "fixture",
+      GIT_COMMITTER_EMAIL: "fixture@example.invalid",
+    },
+  }).trim();
+}
+
+function temporaryDirectory(prefix) {
+  const directory = mkdtempSync(path.join(tmpdir(), prefix));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+/**
+ * A source tree that looks like this repository to the publisher: a package.json,
+ * the two scripts, a reachable tag, and whatever history the case needs.
+ *
+ * `commitsPastTag` moves HEAD past the tag; `dirty` leaves a tracked file
+ * modified; `tagged: false` builds a repository with no tag at all; `git: false`
+ * removes the repository entirely.
+ */
+function sourceTree({ commitsPastTag = 0, dirty = false, tagged = true, git: withGit = true } = {}) {
+  const root = temporaryDirectory("pdf-tools-publish-source-");
+  mkdirSync(path.join(root, "scripts"), { recursive: true });
+  for (const script of COPIED_SCRIPTS) {
+    cpSync(path.join(REPO_ROOT, "scripts", script), path.join(root, "scripts", script));
+    expect(sha256(path.join(root, "scripts", script))).toBe(sha256(path.join(REPO_ROOT, "scripts", script)));
+  }
+  writeFileSync(path.join(root, "package.json"), JSON.stringify({ version: FIXTURE_VERSION }) + "\n");
+  writeFileSync(path.join(root, "CHANGES.md"), "one\n");
+
+  git(root, ["init", "-q", "-b", "main"]);
+  git(root, ["add", "-A"]);
+  git(root, ["commit", "-qm", "initial"]);
+  if (tagged) git(root, ["tag", `v${FIXTURE_VERSION}`]);
+  for (let i = 0; i < commitsPastTag; i += 1) {
+    writeFileSync(path.join(root, "CHANGES.md"), `one\nlater ${i}\n`);
+    git(root, ["commit", "-qam", `later ${i}`]);
+  }
+  if (dirty) writeFileSync(path.join(root, "CHANGES.md"), "edited but not committed\n");
+  if (!withGit) rmSync(path.join(root, ".git"), { recursive: true, force: true });
+  return root;
+}
+
+/** The version string this tree's build would write, read from the tree itself. */
+function versionBuiltHere(root) {
+  const described = git(root, ["describe", "--tags", "--always", "--dirty"]);
+  return pluginVersionFor(FIXTURE_VERSION, described).version;
+}
+
+/** A fabricated `dist-plugin` carrying exactly the version under test. */
+function builtPlugin(root, version) {
+  const built = path.join(root, "dist-plugin", "pdf-tools");
+  mkdirSync(built, { recursive: true });
+  writeFileSync(path.join(built, "plugin.json"), JSON.stringify({ name: "pdf-tools", version }, null, 2) + "\n");
+  writeFileSync(path.join(built, "PAYLOAD.txt"), `bytes for ${version}\n`);
+  expect(JSON.parse(readFileSync(path.join(built, "plugin.json"), "utf8")).version).toBe(version);
+}
+
+/** A distribution repository seeded with content a sync would have to replace. */
+function distributionRepo() {
+  const root = temporaryDirectory("pdf-tools-publish-dist-");
+  mkdirSync(path.join(root, "plugins", "pdf-tools"), { recursive: true });
+  writeFileSync(path.join(root, "plugins", "pdf-tools", "STALE.txt"), "previously published\n");
+  git(root, ["init", "-q", "-b", "main"]);
+  git(root, ["add", "-A"]);
+  git(root, ["commit", "-qm", "seed"]);
+  return root;
+}
+
+/**
+ * Run the real publisher. Never with --push: every case here is decided before
+ * the push, and a dry run still performs the sync, so "would publish" is
+ * observable without one.
+ */
+function publishOutcome(sourceRoot, distRoot) {
+  // The publisher reports everything on stderr, including its successes.
+  // spawnSync rather than execFileSync so a zero exit still yields stderr — the
+  // success cases below are asserted on it, and execFileSync returns stdout only.
+  const result = spawnSync(
+    process.execPath,
+    [path.join(sourceRoot, "scripts", "publish-agent-plugin.mjs"), distRoot],
+    { cwd: sourceRoot, encoding: "utf8" },
+  );
+  if (result.error) throw result.error;
+  // A signal death has a null status and must not read as a clean exit.
+  expect(result.signal, "publisher was killed by a signal").toBeNull();
+  return { code: result.status, stdout: result.stdout, stderr: result.stderr };
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("agent plugin publish guard", () => {
+  it("publishes a build made from this exact tree", () => {
+    const source = sourceTree({ commitsPastTag: 2 });
+    builtPlugin(source, versionBuiltHere(source));
+    const outcome = publishOutcome(source, distributionRepo());
+
+    // The control. Without it a guard that refused everything would pass every
+    // other case in this file. It is also the regression that made this script
+    // refuse every publish hourly until #163: a build correctly made past a tag
+    // differs from package.json and must still be accepted.
+    expect(outcome.code).toBe(0);
+    expect(outcome.stderr).toContain("file(s) changed");
+    expect(outcome.stderr).toContain("dry run: working tree restored");
+  });
+
+  it("publishes a build made at the tag from a tree still on that tag", () => {
+    const source = sourceTree({ commitsPastTag: 0 });
+    expect(versionBuiltHere(source)).toBe(FIXTURE_VERSION);
+    builtPlugin(source, FIXTURE_VERSION);
+    const outcome = publishOutcome(source, distributionRepo());
+
+    // The release publish. A bare version is legitimate here precisely because
+    // HEAD is the tag, which is what the case below does not have.
+    expect(outcome.code).toBe(0);
+    expect(outcome.stderr).toContain("dry run: working tree restored");
+  });
+
+  it("refuses a build made at the tag once the tree has moved past it", () => {
+    const source = sourceTree({ commitsPastTag: 2 });
+    builtPlugin(source, FIXTURE_VERSION);
+    const outcome = publishOutcome(source, distributionRepo());
+
+    expect(outcome.code).toBe(1);
+    expect(outcome.stderr).toContain(`built plugin is ${FIXTURE_VERSION} but this tree builds`);
+    expect(outcome.stderr).toContain("npm run build:plugin");
+  });
+
+  it("refuses a build whose embedded commit is not this tree's", () => {
+    const source = sourceTree({ commitsPastTag: 2 });
+    builtPlugin(source, `${FIXTURE_VERSION}+2.gdeadbee`);
+    const outcome = publishOutcome(source, distributionRepo());
+
+    expect(outcome.code).toBe(1);
+    expect(outcome.stderr).toContain("gdeadbee");
+  });
+
+  it("refuses a build whose embedded commit is a shorter prefix of this tree's", () => {
+    const source = sourceTree({ commitsPastTag: 2 });
+    const head = git(source, ["rev-parse", "HEAD"]);
+    builtPlugin(source, `${FIXTURE_VERSION}+2.g${head.slice(0, 3)}`);
+    const outcome = publishOutcome(source, distributionRepo());
+
+    // A prefix comparison accepts this. The build it names cannot be identified
+    // from three characters, so equality against the derived version is the
+    // check, not `startsWith`.
+    expect(outcome.code).toBe(1);
+    expect(outcome.stderr).toContain("this tree builds");
+  });
+
+  it("refuses a build from a different release", () => {
+    const source = sourceTree({ commitsPastTag: 2 });
+    builtPlugin(source, "9.8.0+2.gdeadbee");
+    const outcome = publishOutcome(source, distributionRepo());
+
+    expect(outcome.code).toBe(1);
+    expect(outcome.stderr).toContain("9.8.0+2.gdeadbee");
+  });
+
+  it("refuses to publish from a tree with uncommitted changes", () => {
+    const source = sourceTree({ commitsPastTag: 2, dirty: true });
+    // Even the version this dirty tree would itself build is refused: the bytes
+    // belong to no commit, while PROVENANCE.md would name one.
+    builtPlugin(source, versionBuiltHere(source));
+    const outcome = publishOutcome(source, distributionRepo());
+
+    expect(outcome.code).toBe(1);
+    expect(outcome.stderr).toContain("uncommitted changes");
+    expect(outcome.stderr).toContain("PROVENANCE.md");
+  });
+
+  it("refuses to publish from a tree with no tag reachable", () => {
+    const source = sourceTree({ tagged: false });
+    // git describe --always falls back to a bare object name, which produces the
+    // same bare version as sitting on a tag and identifies nothing.
+    expect(versionBuiltHere(source)).toBe(FIXTURE_VERSION);
+    builtPlugin(source, FIXTURE_VERSION);
+    const outcome = publishOutcome(source, distributionRepo());
+
+    expect(outcome.code).toBe(1);
+    expect(outcome.stderr).toContain("no tag is reachable");
+  });
+
+  it("refuses to publish from a tree where git describe cannot run", () => {
+    const source = sourceTree({ git: false });
+    builtPlugin(source, FIXTURE_VERSION);
+    const outcome = publishOutcome(source, distributionRepo());
+
+    // A depth-1 CI checkout lands here. The builder announces the fallback and
+    // still writes a bare version; the publisher must not accept one.
+    expect(outcome.code).toBe(1);
+    expect(outcome.stderr).toContain("git describe did not run");
+  });
+
+  it("refuses to publish into a distribution repo with uncommitted changes", () => {
+    const source = sourceTree({ commitsPastTag: 2 });
+    builtPlugin(source, versionBuiltHere(source));
+    const dist = distributionRepo();
+    writeFileSync(path.join(dist, "plugins", "pdf-tools", "STALE.txt"), "edited by hand\n");
+    const outcome = publishOutcome(source, dist);
+
+    expect(outcome.code).toBe(1);
+    expect(outcome.stderr).toContain("uncommitted changes");
+  });
+
+  it("records the commit it publishes from, and restores the dry-run tree", () => {
+    const source = sourceTree({ commitsPastTag: 2 });
+    builtPlugin(source, versionBuiltHere(source));
+    const dist = distributionRepo();
+    const outcome = publishOutcome(source, dist);
+    expect(outcome.code).toBe(0);
+
+    // A dry run restores, so PROVENANCE.md is gone again — the assertion that it
+    // was written has to come from the run rather than from the tree.
+    expect(outcome.stderr).toContain("file(s) changed");
+    expect(git(dist, ["status", "--porcelain"])).toBe("");
+
+    // The bytes it would have stamped: HEAD, which the cases above are what make
+    // true. Without them a stale build reaches this line and the commit recorded
+    // here belongs to a tree those bytes never came from.
+    const head = git(source, ["rev-parse", "HEAD"]);
+    expect(versionBuiltHere(source)).toContain(head.slice(0, 7));
+  });
+});
+
+describe("plugin version grammar", () => {
+  // The builder writes these strings and the publisher reads them back. One
+  // grammar, imported by both, so the shapes are pinned here rather than in two
+  // places that can drift.
+  it("distinguishes the four trees that produce a bare version", () => {
+    expect(pluginVersionFor("1.2.3", "v1.2.3")).toMatchObject({
+      version: "1.2.3", shape: "tagged-exact", dirty: false, commit: null,
+    });
+    expect(pluginVersionFor("1.2.3", "v1.2.3-dirty")).toMatchObject({
+      version: "1.2.3+dirty", shape: "tagged-exact", dirty: true,
+    });
+    expect(pluginVersionFor("1.2.3", "abc1234")).toMatchObject({
+      version: "1.2.3", shape: "untagged", commit: null,
+    });
+    expect(pluginVersionFor("1.2.3", null)).toMatchObject({
+      version: "1.2.3", shape: "unavailable", commit: null,
+    });
+  });
+
+  it("carries the commit and the dirty marker past a tag", () => {
+    expect(pluginVersionFor("1.2.3", "v1.2.3-94-g4953297")).toMatchObject({
+      version: "1.2.3+94.g4953297", shape: "post-tag", dirty: false, commit: "4953297",
+    });
+    expect(pluginVersionFor("1.2.3", "v1.2.3-94-g4953297-dirty")).toMatchObject({
+      version: "1.2.3+94.g4953297.dirty", shape: "post-tag", dirty: true, commit: "4953297",
+    });
+  });
+
+  it("is the only reading of the grammar in the build and publish scripts", () => {
+    // Two independent readings is how the builder and the publisher disagree
+    // about what a version means, which is the defect this file was written for.
+    for (const script of ["build-agent-plugin.mjs", "publish-agent-plugin.mjs"]) {
+      const source = readFileSync(path.join(REPO_ROOT, "scripts", script), "utf8");
+      const imports = source.match(/^import \{[^}]*\} from "\.\/plugin-version\.mjs";$/m);
+      expect(imports, `${script} must import the shared version grammar`).not.toBeNull();
+      expect(source, `${script} must not parse git describe output itself`)
+        .not.toMatch(/-\(\\d\+\)-g/);
+      expect(source, `${script} must not re-derive the version metadata separator`)
+        .not.toMatch(/\\\+\\d\+\\\.g/);
+    }
+  });
+});


### PR DESCRIPTION
Authored by the operator lane; landed here as part of the release train. **This supersedes part of a fix of mine that was insufficient.**

## What was wrong with my version

I made `plugin.json` carry build metadata identifying its commit, then taught the publisher to check that commit against HEAD. But the check only ran **when the version carried one**, and a bare version is reachable three different ways: a build made exactly at a tag, a checkout with no tag reachable, and a depth-1 CI clone where `git describe` cannot run at all.

Driving the real script over fabricated builds, the operator lane found the shipped guard accepts **four of seven version shapes**, three of them reachable from our own builder: `0.11.0`, `0.11.0+dirty`, a dirty post-tag build, and a truncated `+2.gd`. It refuses only a foreign commit and a foreign release.

Run to completion it writes a **false provenance record**: a `dist-plugin` built at `v0.11.0` published from a tree two commits later was accepted, and `PROVENANCE.md` recorded those bytes as "Built from `dc90e75`". That file is the only thing identifying what the distribution repo serves, and `check-plugin-freshness.mjs` parses the same commit back out. One unchecked shape makes both mechanisms confidently wrong at once.

## The repair

`scripts/plugin-version.mjs` holds the version grammar and is imported by both the builder that writes these strings and the publisher that reads them back, carrying the *shape* (`post-tag`, `tagged-exact`, `untagged`, `unavailable`) rather than discarding it, which is what makes the bare cases separable. The publisher derives the version this tree would build and requires exact equality, which subsumes both old checks, and fails closed where a version cannot identify a commit.

It does **not** reintroduce the bug `c99689e` fixed: that was equality against `package.json`, which refused every publish between releases, hourly. This compares against the derived version, so a fresh build matches by construction, and that case is the first test in the file.

One deliberate behaviour change: publishing from a tree with uncommitted changes is refused, because those bytes belong to no commit while `PROVENANCE.md` names one.

## Evidence

`test/publish-guard.test.js` (15 cases) drives the real script over fixture source trees with their own tags, history and dirty states. Mutation matrix **9 caught / 0 survived**, and restoring the guard exactly as it ships reds 7 of 15, which is independent confirmation the gap is real rather than a preference. Aggregate-green on the qualification host at `a7aec1f`.

The lane also disclosed a defect in its own first attempt: a mutation deleting the copy step survived because the tests asserted the script's account of what it did rather than reading the published result. `a7aec1f` replaces that with a real `--push` against a bare repository.