### PR TITLE
Give the gate the repository, not a snapshot of its tip

### DIFF
--- a/.github/workflows/pull-request-gate.yml
+++ b/.github/workflows/pull-request-gate.yml
@@ -58,7 +58,16 @@ jobs:
     steps:
       # Pinned by commit SHA, matching the two Windows workflows. A floating
       # tag is a third party's mutable pointer into this repository's build.
+      # fetch-depth: 0 rather than the default depth-1 shallow clone. A shallow
+      # checkout carries no tags and no history, so `git describe` cannot name
+      # the commit and any guard built on it fails closed in CI while passing on
+      # a full-history host - red on both runtimes for a reason that has nothing
+      # to do with the change under test. This gate asserts a repository's
+      # behaviour, so it has to check out the repository, not a snapshot of its
+      # tip.
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:


### PR DESCRIPTION
**My defect, from the day I added the gate.**

`actions/checkout` defaults to a **depth-1 shallow clone**. `pull-request-gate.yml` never set `fetch-depth`, so every run since #150 has had **no tags and no history**.

Anything built on `git describe` therefore cannot name the commit, fails closed, and reports red **on both runtimes** for a reason unrelated to the change under test — while passing on a full-history qualification host.

That last part is what makes it costly: CI and local disagree, and CI is the one that looks wrong. The natural response is to distrust the gate.

**#168** ("Bind the plugin publish guard, and stop it accepting a build it cannot identify") adds exactly such a guard and is red on both runtimes today. The diagnosis is pdf:1's; the bug is mine and predates that PR.

A gate that asserts a repository's behaviour has to check out the repository. `fetch-depth: 0`.

Verification is #168 itself: once this lands, its guard should be able to identify the commit and the red should resolve without touching the guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)