### PR TITLE
Tell a caller when a readable page still hides unread visual content

### DIFF
--- a/pdf-toolkit-mcp-share/server/index.js
+++ b/pdf-toolkit-mcp-share/server/index.js
@@ -41,7 +41,10 @@ import {
   withToolOutputSchema,
 } from "./output-schemas.js";
 import { publicAccessibilityInspectionError } from "./accessibility-inspection.js";
-import { renderPdfLayoutToMarkdown } from "./markdown-conversion.js";
+import {
+  deriveUnreadVisualContentPages,
+  renderPdfLayoutToMarkdown,
+} from "./markdown-conversion.js";
 import {
   normalizeTableProposalCells,
   verifyTableProposalAgainstRegion,
@@ -5496,6 +5499,16 @@ async function handleToolCall(request) {
             emitTableProposals,
           });
           const pagesNeedingVision = deriveMarkdownVisionRouting(layout);
+          // The middle routing case. pages_needing_vision answers "can this
+          // page be read at all without vision?"; a mostly-text page with an
+          // uninterpreted plot answers yes and stays out of it, correctly.
+          // This projection answers the separate question the prose gap
+          // already answers and no machine-readable field did: which readable
+          // pages carry content the conversion reported and did not read.
+          const pagesWithUnreadVisualContent = deriveUnreadVisualContentPages(
+            rendered.pages,
+            pagesNeedingVision,
+          );
 
           let savedOutput = null;
           if (outputBinding) {
@@ -5537,6 +5550,11 @@ async function handleToolCall(request) {
           const payload = {
             ...renderedPayload,
             pages_needing_vision: pagesNeedingVision,
+            // Omitted when empty, so a document that reports no unread visual
+            // content keeps the exact structured result it had before.
+            ...(pagesWithUnreadVisualContent.length > 0
+              ? { pages_with_unread_visual_content: pagesWithUnreadVisualContent }
+              : {}),
             saved_output: savedOutput,
             ...(tableProposals !== undefined ? { table_proposals: tableProposals } : {}),
           };
@@ -5548,6 +5566,9 @@ async function handleToolCall(request) {
             ...(rendered.gaps.length > 0 ? [`Coverage gaps: ${rendered.gaps.map(gap => `page ${gap.page}: ${gap.code}`).join(", ")}.`] : []),
             ...(pagesNeedingVision.length > 0
               ? [`Vision routing: use render_pdf_page for pages ${pagesNeedingVision.map(entry => entry.page).join(", ")}.`]
+              : []),
+            ...(pagesWithUnreadVisualContent.length > 0
+              ? [`Unread visual content (pages ${pagesWithUnreadVisualContent.map(entry => entry.page).join(", ")}): read as text, and also carrying visual content this conversion reported and did not read. Use render_pdf_page if that content matters; what it depicts is not known here.`]
               : []),
             "No OCR, external model, hidden link-target recovery, or table inference beyond complete source-bound text, ruled, or painted grids was performed.",
             rendered.markdown,

--- a/pdf-toolkit-mcp-share/server/markdown-conversion.js
+++ b/pdf-toolkit-mcp-share/server/markdown-conversion.js
@@ -94,6 +94,40 @@ const LIMITATIONS = Object.freeze([
   "Unsafe control characters and malformed UTF-16 surrogates are replaced with the Unicode replacement character and reported as conversion gaps.",
 ]);
 
+// The two gap codes that report page content the conversion saw and did not
+// read. Every other gap code reports something about text, links, table
+// topology, or a retention limit, none of which is by itself a reason to look
+// at the page. Declared below LIMITATIONS on purpose: a contract test reads
+// the GAP_CODES block above literally as the published gap-code list, so a
+// second code list inside it would be read as a published gap code.
+const UNREAD_VISUAL_GAP_CODES = Object.freeze([
+  "IMAGE_CONTENT_NOT_RENDERED",
+  "VECTOR_CONTENT_NOT_INTERPRETED",
+]);
+
+/**
+ * Project already-reported gaps onto the one routing case no field covers: a
+ * page whose text read successfully -- so it is correctly absent from
+ * pages_needing_vision, which means "cannot be read without vision" -- and
+ * which the conversion nevertheless reported as carrying visual content it did
+ * not read. Shannon page 40 is that case: mostly text, plus plots inside a
+ * table that the converter reports and does not interpret.
+ *
+ * This infers nothing. It re-keys gap codes the result already carries so a
+ * host can route on them without parsing prose, and it asserts nothing about
+ * what the unread content depicts or where on the page it sits.
+ */
+export function deriveUnreadVisualContentPages(pages, pagesNeedingVision) {
+  const alreadyRouted = new Set((pagesNeedingVision ?? []).map(entry => entry.page));
+  return (pages ?? []).flatMap(page => {
+    if (alreadyRouted.has(page.page)) return [];
+    const gapCodes = UNREAD_VISUAL_GAP_CODES.filter(
+      code => (page.gaps ?? []).some(gap => gap.code === code),
+    );
+    return gapCodes.length > 0 ? [{ page: page.page, gap_codes: gapCodes }] : [];
+  });
+}
+
 function assertion(condition, message) {
   if (!condition) throw new Error(`Invalid Markdown conversion semantics: ${message}`);
 }
@@ -2998,6 +3032,23 @@ export function validateMarkdownConversionSemantics(result, { layout = null } = 
       flattenedGaps,
     );
     assertion(result.markdown === expectedMarkdown, "markdown does not match the bound layout IR");
+  }
+
+  // Additive routing projection owned by the handler, which is also the only
+  // layer that knows pages_needing_vision. The renderer payload carries
+  // neither field, so bind the projection only where its inputs exist. An
+  // empty projection must omit the key entirely, so a document with no unread
+  // visual content keeps the exact result it had before the field existed.
+  if (result.pages_needing_vision !== undefined
+    || result.pages_with_unread_visual_content !== undefined) {
+    const expectedUnread = deriveUnreadVisualContentPages(result.pages, result.pages_needing_vision);
+    if (expectedUnread.length === 0) {
+      assertion(result.pages_with_unread_visual_content === undefined,
+        "an empty unread-visual-content projection must omit the field");
+    } else {
+      assertion(sameJson(result.pages_with_unread_visual_content, expectedUnread),
+        "pages_with_unread_visual_content is not the exact projection of the reported page gaps");
+    }
   }
 
   // Verified-vision proposal packets are additive and optional. The renderer

--- a/pdf-toolkit-mcp-share/server/output-schemas.js
+++ b/pdf-toolkit-mcp-share/server/output-schemas.js
@@ -591,6 +591,18 @@ const visionRoutingPage = object({
   page: integer,
   reasons: arrayOf(routingReason),
 });
+// A page that read fine as text -- so it is absent from pages_needing_vision,
+// which means "cannot be read without vision" -- and that the conversion
+// reported as carrying visual content it did not read. The codes are the exact
+// gap codes already reported for that page, not a new judgement about it.
+const unreadVisualGapCode = enumString([
+  "IMAGE_CONTENT_NOT_RENDERED",
+  "VECTOR_CONTENT_NOT_INTERPRETED",
+]);
+const unreadVisualContentPage = object({
+  page: integer,
+  gap_codes: arrayOf(unreadVisualGapCode),
+});
 const layoutRawPageSpace = object({
   basis: { const: "pdf_default_user_space" },
   unit: { const: "pdf_user_unit" },
@@ -1090,6 +1102,10 @@ export const TOOL_SUCCESS_OUTPUT_SCHEMAS = Object.freeze({
       limits: object({ max_markdown_bytes: { type: "integer", minimum: 1, maximum: 200000 } }),
       pages: arrayOf(markdownPage),
       pages_needing_vision: arrayOf(visionRoutingPage),
+      // Present only when at least one readable page reports unread visual
+      // content, so a document with none keeps its exact prior result. Like
+      // table_proposals, deliberately absent from the required list below.
+      pages_with_unread_visual_content: arrayOf(unreadVisualContentPage),
       gaps: arrayOf(markdownGap),
       limitations: stringArray,
       normalizations: object({

--- a/pop.mjs
+++ b/pop.mjs
@@ -1,0 +1,21 @@
+import path from "node:path"; import fs from "node:fs/promises";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+const REPO = process.cwd();
+const files = process.argv.slice(2);
+const t = new StdioClientTransport({ command: process.execPath, args:[path.join(REPO,"server/index.js")],
+  cwd: REPO, env:{ ALLOWED_DIRECTORIES:[REPO,"/Users/silverbook/Sites/pdf-tools-extraction-sidecars"].join(path.delimiter) }, stderr:"ignore" });
+const c = new Client({name:"pop",version:"1.0.0"}); await c.connect(t);
+let docsHit = 0, pagesHit = 0, docsTried = 0;
+for (const f of files) {
+  try {
+    const r = await c.callTool({ name:"convert_pdf_to_markdown",
+      arguments:{ pdf_path: f, start_page: 1, end_page: 3 } }, undefined, {timeout:120000});
+    const sc = r.structuredContent ?? {}; docsTried += 1;
+    const u = sc.pages_with_unread_visual_content ?? [];
+    if (u.length) { docsHit += 1; pagesHit += u.length;
+      console.log(`HIT ${path.basename(f)}: ${JSON.stringify(u).slice(0,120)}`); }
+  } catch {}
+}
+console.log(`\ntried=${docsTried} docs_with_unread_visual=${docsHit} pages=${pagesHit}`);
+await c.close();

--- a/server/index.js
+++ b/server/index.js
@@ -41,7 +41,10 @@ import {
   withToolOutputSchema,
 } from "./output-schemas.js";
 import { publicAccessibilityInspectionError } from "./accessibility-inspection.js";
-import { renderPdfLayoutToMarkdown } from "./markdown-conversion.js";
+import {
+  deriveUnreadVisualContentPages,
+  renderPdfLayoutToMarkdown,
+} from "./markdown-conversion.js";
 import {
   normalizeTableProposalCells,
   verifyTableProposalAgainstRegion,
@@ -5496,6 +5499,16 @@ async function handleToolCall(request) {
             emitTableProposals,
           });
           const pagesNeedingVision = deriveMarkdownVisionRouting(layout);
+          // The middle routing case. pages_needing_vision answers "can this
+          // page be read at all without vision?"; a mostly-text page with an
+          // uninterpreted plot answers yes and stays out of it, correctly.
+          // This projection answers the separate question the prose gap
+          // already answers and no machine-readable field did: which readable
+          // pages carry content the conversion reported and did not read.
+          const pagesWithUnreadVisualContent = deriveUnreadVisualContentPages(
+            rendered.pages,
+            pagesNeedingVision,
+          );
 
           let savedOutput = null;
           if (outputBinding) {
@@ -5537,6 +5550,11 @@ async function handleToolCall(request) {
           const payload = {
             ...renderedPayload,
             pages_needing_vision: pagesNeedingVision,
+            // Omitted when empty, so a document that reports no unread visual
+            // content keeps the exact structured result it had before.
+            ...(pagesWithUnreadVisualContent.length > 0
+              ? { pages_with_unread_visual_content: pagesWithUnreadVisualContent }
+              : {}),
             saved_output: savedOutput,
             ...(tableProposals !== undefined ? { table_proposals: tableProposals } : {}),
           };
@@ -5548,6 +5566,9 @@ async function handleToolCall(request) {
             ...(rendered.gaps.length > 0 ? [`Coverage gaps: ${rendered.gaps.map(gap => `page ${gap.page}: ${gap.code}`).join(", ")}.`] : []),
             ...(pagesNeedingVision.length > 0
               ? [`Vision routing: use render_pdf_page for pages ${pagesNeedingVision.map(entry => entry.page).join(", ")}.`]
+              : []),
+            ...(pagesWithUnreadVisualContent.length > 0
+              ? [`Unread visual content (pages ${pagesWithUnreadVisualContent.map(entry => entry.page).join(", ")}): read as text, and also carrying visual content this conversion reported and did not read. Use render_pdf_page if that content matters; what it depicts is not known here.`]
               : []),
             "No OCR, external model, hidden link-target recovery, or table inference beyond complete source-bound text, ruled, or painted grids was performed.",
             rendered.markdown,

--- a/server/markdown-conversion.js
+++ b/server/markdown-conversion.js
@@ -94,6 +94,40 @@ const LIMITATIONS = Object.freeze([
   "Unsafe control characters and malformed UTF-16 surrogates are replaced with the Unicode replacement character and reported as conversion gaps.",
 ]);
 
+// The two gap codes that report page content the conversion saw and did not
+// read. Every other gap code reports something about text, links, table
+// topology, or a retention limit, none of which is by itself a reason to look
+// at the page. Declared below LIMITATIONS on purpose: a contract test reads
+// the GAP_CODES block above literally as the published gap-code list, so a
+// second code list inside it would be read as a published gap code.
+const UNREAD_VISUAL_GAP_CODES = Object.freeze([
+  "IMAGE_CONTENT_NOT_RENDERED",
+  "VECTOR_CONTENT_NOT_INTERPRETED",
+]);
+
+/**
+ * Project already-reported gaps onto the one routing case no field covers: a
+ * page whose text read successfully -- so it is correctly absent from
+ * pages_needing_vision, which means "cannot be read without vision" -- and
+ * which the conversion nevertheless reported as carrying visual content it did
+ * not read. Shannon page 40 is that case: mostly text, plus plots inside a
+ * table that the converter reports and does not interpret.
+ *
+ * This infers nothing. It re-keys gap codes the result already carries so a
+ * host can route on them without parsing prose, and it asserts nothing about
+ * what the unread content depicts or where on the page it sits.
+ */
+export function deriveUnreadVisualContentPages(pages, pagesNeedingVision) {
+  const alreadyRouted = new Set((pagesNeedingVision ?? []).map(entry => entry.page));
+  return (pages ?? []).flatMap(page => {
+    if (alreadyRouted.has(page.page)) return [];
+    const gapCodes = UNREAD_VISUAL_GAP_CODES.filter(
+      code => (page.gaps ?? []).some(gap => gap.code === code),
+    );
+    return gapCodes.length > 0 ? [{ page: page.page, gap_codes: gapCodes }] : [];
+  });
+}
+
 function assertion(condition, message) {
   if (!condition) throw new Error(`Invalid Markdown conversion semantics: ${message}`);
 }
@@ -2998,6 +3032,23 @@ export function validateMarkdownConversionSemantics(result, { layout = null } = 
       flattenedGaps,
     );
     assertion(result.markdown === expectedMarkdown, "markdown does not match the bound layout IR");
+  }
+
+  // Additive routing projection owned by the handler, which is also the only
+  // layer that knows pages_needing_vision. The renderer payload carries
+  // neither field, so bind the projection only where its inputs exist. An
+  // empty projection must omit the key entirely, so a document with no unread
+  // visual content keeps the exact result it had before the field existed.
+  if (result.pages_needing_vision !== undefined
+    || result.pages_with_unread_visual_content !== undefined) {
+    const expectedUnread = deriveUnreadVisualContentPages(result.pages, result.pages_needing_vision);
+    if (expectedUnread.length === 0) {
+      assertion(result.pages_with_unread_visual_content === undefined,
+        "an empty unread-visual-content projection must omit the field");
+    } else {
+      assertion(sameJson(result.pages_with_unread_visual_content, expectedUnread),
+        "pages_with_unread_visual_content is not the exact projection of the reported page gaps");
+    }
   }
 
   // Verified-vision proposal packets are additive and optional. The renderer

--- a/server/output-schemas.js
+++ b/server/output-schemas.js
@@ -591,6 +591,18 @@ const visionRoutingPage = object({
   page: integer,
   reasons: arrayOf(routingReason),
 });
+// A page that read fine as text -- so it is absent from pages_needing_vision,
+// which means "cannot be read without vision" -- and that the conversion
+// reported as carrying visual content it did not read. The codes are the exact
+// gap codes already reported for that page, not a new judgement about it.
+const unreadVisualGapCode = enumString([
+  "IMAGE_CONTENT_NOT_RENDERED",
+  "VECTOR_CONTENT_NOT_INTERPRETED",
+]);
+const unreadVisualContentPage = object({
+  page: integer,
+  gap_codes: arrayOf(unreadVisualGapCode),
+});
 const layoutRawPageSpace = object({
   basis: { const: "pdf_default_user_space" },
   unit: { const: "pdf_user_unit" },
@@ -1090,6 +1102,10 @@ export const TOOL_SUCCESS_OUTPUT_SCHEMAS = Object.freeze({
       limits: object({ max_markdown_bytes: { type: "integer", minimum: 1, maximum: 200000 } }),
       pages: arrayOf(markdownPage),
       pages_needing_vision: arrayOf(visionRoutingPage),
+      // Present only when at least one readable page reports unread visual
+      // content, so a document with none keeps its exact prior result. Like
+      // table_proposals, deliberately absent from the required list below.
+      pages_with_unread_visual_content: arrayOf(unreadVisualContentPage),
       gaps: arrayOf(markdownGap),
       limitations: stringArray,
       normalizations: object({

--- a/test/convert-pdf-to-markdown.test.js
+++ b/test/convert-pdf-to-markdown.test.js
@@ -32,6 +32,29 @@ async function makeStructureFixture(targetPath) {
   await fs.writeFile(targetPath, await document.save({ useObjectStreams: false }));
 }
 
+// A page a reader would call text with a figure on it: enough prose that the
+// text layer is the page's substance, plus one raster paint the conversion
+// reports and does not read. That is the routing case pages_needing_vision
+// deliberately does not cover.
+async function makeFigureFixture(targetPath) {
+  const document = await PDFDocument.create();
+  const page = document.addPage([612, 792]);
+  const font = await document.embedFont(StandardFonts.Helvetica);
+  const raster = await document.embedPng(await fs.readFile(
+    path.join(REPO_ROOT, "test/fixtures/eval/extraction/source-images/raster-clean.png"),
+  ));
+  page.drawImage(raster, { x: 72, y: 260, width: 300, height: 200 });
+  for (let index = 0; index < 10; index += 1) {
+    page.drawText(`Paragraph line ${index} discussing the figure printed below it.`, {
+      x: 72,
+      y: 700 - index * 16,
+      size: 11,
+      font,
+    });
+  }
+  await fs.writeFile(targetPath, await document.save({ useObjectStreams: false }));
+}
+
 const GRID_COLUMNS = [72, 220, 360, 480];
 const GRID_ROWS = [
   ["Region", "Q1", "Q2", "Q3"],
@@ -235,6 +258,7 @@ describe("convert_pdf_to_markdown MCP tool", () => {
   let linkFixture;
   let rotatedLinkFixture;
   let hostileLinkFixture;
+  let figureFixture;
 
   beforeAll(async () => {
     temporaryRoot = await fs.mkdtemp(path.join(os.tmpdir(), "pdf-tools-markdown-"));
@@ -249,6 +273,7 @@ describe("convert_pdf_to_markdown MCP tool", () => {
     linkFixture = path.join(temporaryRoot, "link.pdf");
     rotatedLinkFixture = path.join(temporaryRoot, "link-rotated.pdf");
     hostileLinkFixture = path.join(temporaryRoot, "link-hostile.pdf");
+    figureFixture = path.join(temporaryRoot, "text-with-figure.pdf");
     await makeStructureFixture(structureFixture);
     await makeDenseFixture(denseFixture);
     await makeGeometryFixture(geometryFixture);
@@ -260,6 +285,7 @@ describe("convert_pdf_to_markdown MCP tool", () => {
     await makeLinkFixture(linkFixture);
     await makeLinkFixture(rotatedLinkFixture, { rotation: 90, crop: true });
     await makeLinkFixture(hostileLinkFixture, { url: "https://example.com/a(b)c" });
+    await makeFigureFixture(figureFixture);
     transport = new StdioClientTransport({
       command: process.execPath,
       args: [path.join(REPO_ROOT, "server/index.js")],
@@ -608,6 +634,92 @@ describe("convert_pdf_to_markdown MCP tool", () => {
       cursor = index + fragment.length;
     }
   }, 30_000);
+
+  it("routes readable pages that carry visual content the conversion did not read", async () => {
+    // Oracle: read_pdf_layout reports the source paint evidence per page
+    // straight from the extractor. The field under test is built from emitted
+    // Markdown gap codes and from pages_needing_vision, so the two sides are
+    // computed from different evidence and can disagree.
+    const projectionFromSource = (layoutPages, pagesNeedingVision) => {
+      const routed = new Set(pagesNeedingVision.map(entry => entry.page));
+      return layoutPages
+        .filter(page => page.modality_hint !== "unknown" && !routed.has(page.page))
+        .map(page => ({
+          page: page.page,
+          gap_codes: [
+            ...page.has_image_operations ? ["IMAGE_CONTENT_NOT_RENDERED"] : [],
+            ...page.has_vector_paint_operations ? ["VECTOR_CONTENT_NOT_INTERPRETED"] : [],
+          ],
+        }))
+        .filter(entry => entry.gap_codes.length > 0);
+    };
+
+    const cases = [
+      [structureFixture, 1],
+      [figureFixture, 1],
+      [MIXED, 2],
+      [TABLE, 1],
+      [ROTATED_CROP, 1],
+    ];
+    const observed = [];
+    for (const [pdfPath, endPage] of cases) {
+      const [layout, markdown] = await Promise.all([
+        client.callTool({
+          name: "read_pdf_layout",
+          arguments: { pdf_path: pdfPath, end_page: endPage, max_output_characters: 200000 },
+        }),
+        client.callTool({
+          name: "convert_pdf_to_markdown",
+          arguments: { pdf_path: pdfPath, end_page: endPage, max_markdown_bytes: 200000 },
+        }),
+      ]);
+      expect(layout.isError, pdfPath).not.toBe(true);
+      expect(markdown.isError, pdfPath).not.toBe(true);
+      const content = markdown.structuredContent;
+      const expected = projectionFromSource(
+        layout.structuredContent.pages,
+        content.pages_needing_vision,
+      );
+      if (expected.length === 0) {
+        // A document with nothing to add keeps the exact result it had before
+        // this field existed: no empty array, no key.
+        expect(Object.hasOwn(content, "pages_with_unread_visual_content"), pdfPath).toBe(false);
+        expect(markdown.content?.[0]?.text ?? "", pdfPath).not.toContain("Unread visual content");
+      } else {
+        expect(content.pages_with_unread_visual_content, pdfPath).toEqual(expected);
+        // Every code claimed here is a gap the same result already reported
+        // for that page, so the field asserts nothing new.
+        for (const entry of content.pages_with_unread_visual_content) {
+          const reported = content.gaps
+            .filter(gap => gap.page === entry.page)
+            .map(gap => gap.code);
+          expect(reported, `${pdfPath} page ${entry.page}`)
+            .toEqual(expect.arrayContaining(entry.gap_codes));
+        }
+        // Non-overlap with the strong field is the whole point of a separate
+        // field: these pages read fine and are not claimed to need vision.
+        const routed = new Set(content.pages_needing_vision.map(entry => entry.page));
+        expect(content.pages_with_unread_visual_content
+          .filter(entry => routed.has(entry.page)), pdfPath).toEqual([]);
+        expect(markdown.content?.[0]?.text ?? "").toContain("Unread visual content");
+      }
+      observed.push({
+        pdfPath,
+        entries: content.pages_with_unread_visual_content ?? [],
+        routedWithPaint: layout.structuredContent.pages.filter(page =>
+          (page.has_image_operations || page.has_vector_paint_operations)
+          && content.pages_needing_vision.some(entry => entry.page === page.page)).length,
+      });
+    }
+
+    // The case list has to keep exercising all four situations, or the loop
+    // above could pass while covering only one of them.
+    const codes = new Set(observed.flatMap(item => item.entries).flatMap(entry => entry.gap_codes));
+    expect(codes.has("VECTOR_CONTENT_NOT_INTERPRETED")).toBe(true);
+    expect(codes.has("IMAGE_CONTENT_NOT_RENDERED")).toBe(true);
+    expect(observed.some(item => item.entries.length === 0)).toBe(true);
+    expect(observed.some(item => item.routedWithPaint > 0)).toBe(true);
+  }, 60_000);
 
   it("keeps rotated and cropped geometry bounded and deterministic", async () => {
     const request = {

--- a/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
+++ b/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
@@ -79,14 +79,14 @@
     {
       "role": "markdown_conversion_module",
       "path": "server/markdown-conversion.js",
-      "bytes": 149933,
-      "sha256": "b5b851146f18e8f7097089216430f00763a0c940e6f0d24acedc70de6382ada7"
+      "bytes": 152629,
+      "sha256": "0fab4012d10e6bfee768693b67eea475b44978328077c8ea19f6f711de8cd2ef"
     },
     {
       "role": "output_schemas_module",
       "path": "server/output-schemas.js",
-      "bytes": 58647,
-      "sha256": "e7aa12e341e32023df0b21826cf58bb9d682477e1c1f4a4a1aba2fcb1f1a77ce"
+      "bytes": 59476,
+      "sha256": "3b66cfc721fa58e4216b47222f797ead378846d7347b030769f2b9fd33571906"
     },
     {
       "role": "package_json",
@@ -131,7 +131,7 @@
       "sha256": "ef40501b2afbe4cd2adfa80480344783bbec1a00e8e9850086a5d044231d1f53"
     }
   ],
-  "validator_source_set_sha256": "6ff03dc68504852dca8f133e80ae44fa4f767facaa63ad8a6b5b3bb2aeecbc89",
+  "validator_source_set_sha256": "114ff5d366b6add106ad0b29049cb4656175eb8dc2dd0cf03e367049777b360f",
   "pdfjs_version": "5.4.624",
   "generation_contract": {
     "source_path": "source.pdf",

--- a/test/markdown-conversion.test.js
+++ b/test/markdown-conversion.test.js
@@ -10,6 +10,7 @@ import {
   validatePdfLayoutSourceEvidence,
 } from "../server/layout-extraction.js";
 import {
+  deriveUnreadVisualContentPages,
   renderPdfLayoutToMarkdown,
   validateMarkdownConversionSemantics,
 } from "../server/markdown-conversion.js";
@@ -1410,6 +1411,82 @@ describe("layout Markdown renderer", () => {
     expect(result.limitations.some(value => value.includes("clean ruled-rectangle grid evidence"))).toBe(true);
     expect(result.limitations.some(value => value.includes("Cell artwork is omitted and reported as a vector-content gap"))).toBe(true);
     expect(result.limitations.some(value => value.includes("Links are emitted only for source-validated http or https annotation targets"))).toBe(true);
+  });
+
+  it("projects unread visual content onto exactly the readable pages the source paints", async () => {
+    const layout = await validatedSyntheticLayout([
+      // Text only: nothing painted, so nothing to route.
+      { items: [textItem("Plain prose only", { top: 50 })] },
+      // Text plus an image paint: reads fine, carries unread visual content.
+      { items: [textItem("Prose beside a figure", { top: 50 })], operations: [1] },
+      // Image with no text: the strong routing field owns this page.
+      { items: [], operations: [1] },
+      // Text plus a vector paint: the Shannon page 40 shape.
+      { items: [textItem("Prose beside a plot", { top: 50 })], operations: [2] },
+    ]);
+    const result = renderPdfLayoutToMarkdown(layout);
+
+    // Independent oracle. The projection under test reads emitted gap codes;
+    // this reads the source paint evidence the extractor recorded, so a
+    // projection that dropped a code, shifted a page, or kept a routed page
+    // disagrees with it instead of agreeing by construction.
+    const paintedPages = layout.pages
+      .filter(page => page.modality_hint !== "unknown")
+      .map(page => ({
+        page: page.page,
+        gap_codes: [
+          ...page.has_image_operations ? ["IMAGE_CONTENT_NOT_RENDERED"] : [],
+          ...page.has_vector_paint_operations ? ["VECTOR_CONTENT_NOT_INTERPRETED"] : [],
+        ],
+      }))
+      .filter(entry => entry.gap_codes.length > 0);
+    // The one page the source painted and left textless is the one the strong
+    // field claims, so the projection must give it up.
+    const routed = layout.pages
+      .filter(page => page.modality_hint === "image-only-candidate")
+      .map(page => ({ page: page.page, reasons: ["no_text_layer", "image_dominated"] }));
+    expect(routed.length).toBe(1);
+    const expected = paintedPages.filter(
+      entry => !routed.some(route => route.page === entry.page),
+    );
+    expect(expected.length).toBe(paintedPages.length - routed.length);
+
+    expect(deriveUnreadVisualContentPages(result.pages, routed)).toEqual(expected);
+    // Both painted-and-readable pages survive, and they carry different codes,
+    // so neither code can be dropped without this failing.
+    expect(new Set(expected.flatMap(entry => entry.gap_codes)).size).toBe(2);
+    // A document whose painted pages are all routed projects nothing at all.
+    expect(deriveUnreadVisualContentPages(result.pages, paintedPages)).toEqual([]);
+
+    const payload = {
+      ...result,
+      pages_needing_vision: routed,
+      pages_with_unread_visual_content: expected,
+    };
+    expect(validateMarkdownConversionSemantics(payload, { layout })).toBe(payload);
+    const tampered = [
+      ["is not the exact projection", { ...payload, pages_with_unread_visual_content: expected.slice(1) }],
+      ["is not the exact projection", {
+        ...payload,
+        pages_with_unread_visual_content: expected.map(entry => ({ ...entry, page: entry.page + 1 })),
+      }],
+      ["is not the exact projection", { ...payload, pages_with_unread_visual_content: paintedPages }],
+      ["is not the exact projection", {
+        ...payload,
+        pages_with_unread_visual_content: expected.map(entry => ({ ...entry, gap_codes: [] })),
+      }],
+      ["must omit the field", {
+        ...payload,
+        pages_needing_vision: paintedPages,
+        pages_with_unread_visual_content: [],
+      }],
+    ];
+    for (const [message, candidate] of tampered) {
+      expect(() => validateMarkdownConversionSemantics(candidate, { layout })).toThrow(message);
+    }
+    // The renderer payload carries neither field, so it must stay acceptable
+    // exactly as the renderer produced it.
+    expect(validateMarkdownConversionSemantics(result, { layout })).toBe(result);
   });
 
   it("escapes block syntax at every physical line start, not just the first", async () => {

--- a/test/mcp-contract.test.js
+++ b/test/mcp-contract.test.js
@@ -153,7 +153,13 @@ const EXAMPLE_PDF = path.join(REPO_ROOT, "example-fw9.pdf");
 // lowered smaller glyph run and writes it as Unicode subscript characters. No
 // tool name, description, input schema, or read-only annotation changes.
 // Previously cefcfff3fc76324826e1eedcd4e2694d311cfcd1ab7daa9f43dc9e2f496eae5d.
-const TOOL_CONTRACT_SHA256 = "e5328f44d1f1f01a2f015d756cb13c1980b84c8042cdd1d8470699b9931b67ad";
+// 2026-08-19: the structured output gains pages_with_unread_visual_content,
+// which republishes the visual-content gap codes a page already reported in a
+// field a caller can act on. It adds no judgement the gaps did not already
+// carry. No tool name, description, input schema, or read-only annotation
+// changes. Previously
+// e5328f44d1f1f01a2f015d756cb13c1980b84c8042cdd1d8470699b9931b67ad.
+const TOOL_CONTRACT_SHA256 = "112518da26bdd0a3c9423f7eed1e925dc0453c62740ba5a5fc825286a51c125e";
 
 const CLOSED_READ = Object.freeze({
   readOnlyHint: true,

--- a/test/shannon-unread-visual-live.test.js
+++ b/test/shannon-unread-visual-live.test.js
@@ -1,0 +1,128 @@
+import path from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+// Point PDF_TOOLS_SHANNON_SOURCE at a local copy of the paper to run this.
+// The digest below is the identity check the other Shannon lanes use, not an
+// expectation about content.
+const SOURCE = process.env.PDF_TOOLS_SHANNON_SOURCE;
+const SOURCE_SHA256 = "6e4e3411984f3edf99dbfe8b941cb5e8a321379ff0cae6ae5c1f592ad8882ca8";
+const PAGE_COUNT = 55;
+const PAGE_SPAN = 10;
+const REPO_ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..");
+
+/**
+ * Independent oracle. The routing projection is built from emitted Markdown
+ * gap codes; this reads the extractor's own per-page paint evidence out of
+ * read_pdf_layout. A projection that lost a page, shifted a page, or kept a
+ * page the strong field already claims disagrees with this.
+ */
+function projectionFromSource(layoutPages, pagesNeedingVision) {
+  const routed = new Set(pagesNeedingVision.map(entry => entry.page));
+  return layoutPages
+    .filter(page => page.modality_hint !== "unknown" && !routed.has(page.page))
+    .map(page => ({
+      page: page.page,
+      gap_codes: [
+        ...page.has_image_operations ? ["IMAGE_CONTENT_NOT_RENDERED"] : [],
+        ...page.has_vector_paint_operations ? ["VECTOR_CONTENT_NOT_INTERPRETED"] : [],
+      ],
+    }))
+    .filter(entry => entry.gap_codes.length > 0);
+}
+
+describe("external Shannon unread-visual-content routing", () => {
+  let client = null;
+  let transport = null;
+  let chunks = null;
+
+  beforeAll(async () => {
+    if (!SOURCE) return;
+    transport = new StdioClientTransport({
+      command: process.execPath,
+      args: [path.join(REPO_ROOT, "server/index.js")],
+      cwd: REPO_ROOT,
+      env: { ALLOWED_DIRECTORIES: path.dirname(SOURCE) },
+      stderr: "ignore",
+    });
+    client = new Client({ name: "shannon-unread-visual", version: "1.0.0" });
+    await client.connect(transport);
+    chunks = [];
+    for (let startPage = 1; startPage <= PAGE_COUNT; startPage += PAGE_SPAN) {
+      const endPage = Math.min(PAGE_COUNT, startPage + PAGE_SPAN - 1);
+      const range = { pdf_path: SOURCE, start_page: startPage, end_page: endPage };
+      const [layout, markdown] = await Promise.all([
+        client.callTool({
+          name: "read_pdf_layout",
+          arguments: { ...range, max_items: 5000, max_characters: 100000, max_output_characters: 200000 },
+        }),
+        client.callTool({
+          name: "convert_pdf_to_markdown",
+          arguments: { ...range, max_items: 5000, max_characters: 100000, max_markdown_bytes: 200000 },
+        }),
+      ]);
+      expect(layout.isError, `pages ${startPage}-${endPage}`).not.toBe(true);
+      expect(markdown.isError, `pages ${startPage}-${endPage}`).not.toBe(true);
+      chunks.push({ layout: layout.structuredContent, markdown: markdown.structuredContent });
+    }
+    expect(chunks[0].markdown.provenance.source.sha256).toBe(SOURCE_SHA256);
+  }, 300_000);
+
+  afterAll(async () => {
+    await client?.close();
+    await transport?.close();
+  });
+
+  it.runIf(Boolean(SOURCE))("lists every readable page the source paints and no other", () => {
+    for (const chunk of chunks) {
+      const expected = projectionFromSource(
+        chunk.layout.pages,
+        chunk.markdown.pages_needing_vision,
+      );
+      const emitted = chunk.markdown.pages_with_unread_visual_content;
+      if (expected.length === 0) expect(emitted).toBeUndefined();
+      else expect(emitted).toEqual(expected);
+    }
+    // The paper does carry painted pages, so the loop above is not vacuous.
+    const listed = chunks.flatMap(chunk => chunk.markdown.pages_with_unread_visual_content ?? []);
+    expect(listed.length).toBeGreaterThan(0);
+  });
+
+  it.runIf(Boolean(SOURCE))("routes the plotted table page that reads fine as text", () => {
+    // Locate the page by what it is rather than by its number: the one page
+    // whose converted text carries the paper's Table I heading. Its plots are
+    // painted, so it reports unread visual content, and its text read
+    // successfully, so it is correctly absent from pages_needing_vision.
+    const tablePages = chunks.flatMap(chunk => chunk.markdown.pages
+      .map(page => ({ page: page.page, chunk }))
+      .filter(({ page }) => {
+        const body = pageBody(chunk.markdown.markdown, page);
+        return /^TABLE I$/mu.test(body);
+      }));
+    expect(tablePages).toHaveLength(1);
+    const [{ page, chunk }] = tablePages;
+
+    const body = pageBody(chunk.markdown.markdown, page);
+    // "Reads fine as text" has to mean something measurable, or the claim that
+    // this page does not need vision is untested.
+    expect(body.replace(/<!-- PDF page \d+ -->/u, "").trim().length).toBeGreaterThan(100);
+    expect(chunk.markdown.pages_needing_vision.map(entry => entry.page)).not.toContain(page);
+
+    const entry = chunk.markdown.pages_with_unread_visual_content
+      .find(candidate => candidate.page === page);
+    const sourcePage = chunk.layout.pages.find(candidate => candidate.page === page);
+    expect(sourcePage.has_vector_paint_operations).toBe(true);
+    expect(entry).toEqual({ page, gap_codes: ["VECTOR_CONTENT_NOT_INTERPRETED"] });
+    // Every code is a gap the same result already reported for that page.
+    expect(chunk.markdown.gaps.filter(gap => gap.page === page).map(gap => gap.code))
+      .toEqual(expect.arrayContaining(entry.gap_codes));
+  });
+});
+
+function pageBody(markdown, page) {
+  const start = markdown.indexOf(`<!-- PDF page ${page} -->`);
+  if (start === -1) return "";
+  const next = markdown.indexOf(`<!-- PDF page ${page + 1} -->`, start);
+  return markdown.slice(start, next === -1 ? undefined : next);
+}


### PR DESCRIPTION
## The gap

`convert_pdf_to_markdown` already reports `VECTOR_CONTENT_NOT_INTERPRETED` in its coverage gaps — **in prose**. Nothing structured carried it, so a vision-capable host reading the response saw `pages_needing_vision: []` and was never told there was anything to look at.

Those two outputs are **not** in conflict, and I first misread them as such. `pages_needing_vision` answers *"can this page be read at all without vision?"* (`path_segment_count >= 1000 && textLength < 30`). Shannon page 40 is mostly text, so it correctly stays out.

What had no signal at all is the middle case: **a page that reads fine and still contains something the converter did not interpret.** Shannon's Table I is exactly that — five small plots nobody is ever told about.

## What this adds

`pages_with_unread_visual_content` republishes **the gap codes that page already reported**, in a field a caller can act on. It forms no new opinion about the content, carries no geometry it cannot derive, and never claims the thing is a chart.

A separate field rather than a new reason inside `pages_needing_vision`, because that field means "unreadable without vision" and these pages are readable — saying otherwise would be a false statement made to fix a missing one, and it feeds the `documentKind` classifier.

## Population — measured, and thin

Across the first three pages of 35 fixture documents plus the Shannon paper: **exactly one document, one page.**

Worth stating plainly rather than burying. But the fixture corpus is almost entirely synthetic — forms and small generated PDFs built to exercise code paths — so it contains nearly nothing resembling the documents where this matters (papers with figures, reports with charts). **The corpus cannot really answer the question.** The failure is demonstrated; the breadth is not.

I'd rather hand you that than a number dressed up to justify the change. If you'd sooner not carry a field on this evidence, closing it is a reasonable call and I won't re-litigate it.

## Verification

160 tests green across the five affected suites, including a new live test derived from the real document. Tool contract digest re-pinned — the structured output changed; no tool name, description, input schema, or annotation did. Layout oracle regenerated: source-identity digests only, no scored case changed. Share mirror byte-identical across all three server files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)