### PR TITLE
Make the partition contract able to fail, and stop pinning a pid race

### DIFF
--- a/test/embedded-native-canvas-latch.test.js
+++ b/test/embedded-native-canvas-latch.test.js
@@ -51,10 +51,58 @@ function readMarker() {
   return JSON.parse(readFileSync(markerPath(), "utf8"));
 }
 
+// The same primitive the guard uses, so "dead" here means what it means there.
+function pidIsAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    // EPERM is another user's live process; only ESRCH is genuinely gone.
+    return error?.code !== "ESRCH";
+  }
+}
+
 // A pid that is definitely not running: spawn a trivial process, let it exit,
-// and reuse its number. Beats guessing a high integer, which can collide.
+// and reuse its number. Beats guessing a high integer, which can collide. The
+// number is probed before it is handed out, because it is only a dead pid if
+// the OS has not already given it to something else.
 function deadPid() {
-  return spawnSync(process.execPath, ["-e", ""]).pid;
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    const pid = spawnSync(process.execPath, ["-e", ""]).pid;
+    if (Number.isInteger(pid) && pid > 0 && !pidIsAlive(pid)) return pid;
+  }
+  throw new Error("could not obtain a pid that is not in use");
+}
+
+// Runs `check` against a marker owned by a process that is not running.
+//
+// Pid reuse is not a defect here, it is the product's documented answer: when a
+// crashed process's number has been handed to an unrelated live process,
+// nativeCanvasLatchState reports "concurrent" rather than "latched" on purpose,
+// failing toward retryable. On a busy host that can happen between deadPid()
+// and the read, and a test that treats it as a latch failure is asserting
+// against one of two intended outcomes.
+//
+// So a failed check is only accepted as a failure once the owner is confirmed
+// still dead; if the OS reused the number under us, the run proved nothing
+// either way and is repeated with a fresh one. A guard that genuinely stopped
+// latching fails on the first pass, because the owner stays dead and the
+// caller's assertions are re-run unweakened every time.
+//
+// The `force` cases below take a bare deadPid() instead: force short-circuits
+// before the latch is consulted, so their outcome does not turn on whether the
+// marker's owner is alive.
+function withDeadOwnerMarker(marker, check) {
+  for (let attempt = 0; ; attempt += 1) {
+    const pid = deadPid();
+    writeFileSync(markerPath(), JSON.stringify({ ...marker, pid }));
+    try {
+      check(pid);
+      return pid;
+    } catch (error) {
+      if (attempt >= 20 || !pidIsAlive(pid)) throw error;
+    }
+  }
 }
 
 function install({ dlopen }) {
@@ -236,28 +284,26 @@ describe("a load that never returns latches off on the next boot", () => {
     guarded.call(process, {}, CANVAS_BINDING);
     const marker = readMarker();
     installed.restore();
-    writeFileSync(markerPath(), JSON.stringify({ ...marker, pid: deadPid() }));
 
-    expect(nativeCanvasLatchState(markerPath())).toBe("latched");
-    expect(embeddedNativeCanvasAllowed({
-      env: { PDF_TOOLS_EMBEDDED_NATIVE_CANVAS: "1" },
-      platform: "win32",
-      markerPath: markerPath(),
-    })).toBe(false);
+    withDeadOwnerMarker(marker, () => {
+      expect(nativeCanvasLatchState(markerPath())).toBe("latched");
+      expect(embeddedNativeCanvasAllowed({
+        env: { PDF_TOOLS_EMBEDDED_NATIVE_CANVAS: "1" },
+        platform: "win32",
+        markerPath: markerPath(),
+      })).toBe(false);
+    });
   });
 
   it("refuses the next load and records why", () => {
-    writeFileSync(markerPath(), JSON.stringify({
-      phase: "drawing",
-      token: "someone-elses-token",
-      pid: deadPid(),
-    }));
     const guarded = install({ dlopen: () => "loaded" });
 
-    expect(() => guarded.call(process, {}, CANVAS_BINDING))
-      .toThrow(/native canvas binding is disabled/);
+    withDeadOwnerMarker({ phase: "drawing", token: "someone-elses-token" }, () => {
+      expect(() => guarded.call(process, {}, CANVAS_BINDING))
+        .toThrow(/native canvas binding is disabled/);
 
-    expect(nativeCanvasBlockReason()).toBe("latched");
+      expect(nativeCanvasBlockReason()).toBe("latched");
+    });
   });
 
   it("lets =force recover a latched install without hand-editing state", () => {

--- a/test/test-runner-contract.test.js
+++ b/test/test-runner-contract.test.js
@@ -25,10 +25,12 @@ import {
 import { parseNodeTestArguments } from "../scripts/run-node-test-suites.mjs";
 import {
   CHECKOUT_LOCAL_MUTATING_TEST_SUITES,
+  DIRECT_CHECKOUT_LOCAL_SCRATCH_ALLOCATORS,
   NON_EXECUTABLE_SOURCE_IDENTITY_REFERENCES,
   REAL_CHECKOUT_SOURCE_IDENTITY_BINDERS,
   REVIEWED_COMPUTED_MODULE_LOADS,
   SERIAL_NATIVE_TEST_FILES,
+  SERIAL_NATIVE_TEST_SUITES,
   SERIAL_RESOURCE_TEST_FILES,
   SERIAL_RESOURCE_TEST_SUITES,
   SOURCE_IDENTITY_TEST_FILES,
@@ -75,6 +77,107 @@ async function findNodeTestFiles(directory = path.join(repoRoot, "test")) {
     matches.push(path.relative(repoRoot, absolutePath).split(path.sep).join("/"));
   }
   return matches.sort();
+}
+
+const TEST_FILE_PATTERN = /\.(?:test|spec)\.(?:[cm]?[jt]sx?)$/;
+
+/*
+ * Vitest globs `**\/*.{test,spec}.?(c|m)[jt]s?(x)` from the project root and
+ * drops `**\/node_modules/**` and `**\/.git/**`. This walk reproduces exactly
+ * that, from the repository root rather than from `test/`, so the partition
+ * check below sees every file Vitest itself would see. Build output is
+ * deliberately still walked: a suite dropped into `dist-ui` or `coverage` is a
+ * file Vitest would try to run, so it is a file this contract has to account
+ * for.
+ *
+ * The one exception is the checkout-local scratch prefix from
+ * DIRECT_CHECKOUT_LOCAL_SCRATCH_ALLOCATORS. Those roots exist only while a
+ * suite is running, so Vitest's own glob - taken once at startup - never sees
+ * them, and walking one that a sibling is deleting is how this becomes a
+ * mysterious ENOENT instead of a partition report.
+ */
+const CHECKOUT_LOCAL_SCRATCH_PREFIX = ".test-tmp-";
+
+async function findRepositoryTestFiles(directory = repoRoot) {
+  const matches = [];
+  let entries;
+  try {
+    entries = await fs.readdir(directory, { withFileTypes: true });
+  } catch (error) {
+    if (error.code === "ENOENT") return matches;
+    throw error;
+  }
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (entry.name === ".git" || entry.name === "node_modules") continue;
+      if (entry.name.startsWith(CHECKOUT_LOCAL_SCRATCH_PREFIX)) continue;
+      matches.push(...await findRepositoryTestFiles(path.join(directory, entry.name)));
+      continue;
+    }
+    if (!entry.isFile() || !TEST_FILE_PATTERN.test(entry.name)) continue;
+    matches.push(
+      path.relative(repoRoot, path.join(directory, entry.name)).split(path.sep).join("/"),
+    );
+  }
+  return matches.sort();
+}
+
+const VITEST_DEFAULT_EXCLUDES = new Set(configDefaults.exclude);
+const GLOB_METACHARACTERS = /[*?[\]{}()!]/;
+
+/*
+ * Vitest's own defaults are dropped rather than matched: both of them exclude a
+ * directory the walk above never enters, so they can only ever remove nothing.
+ * Everything else has to be a literal repository-relative path, which is what
+ * the registries in scripts/test-suite-classification.mjs are made of. A
+ * pattern that is neither fails here loudly instead of being silently resolved
+ * to the empty set, which would make the partition check pass by claiming
+ * nothing.
+ */
+function literalPatterns(patterns, label) {
+  const literals = [];
+  for (const pattern of patterns) {
+    if (VITEST_DEFAULT_EXCLUDES.has(pattern)) continue;
+    if (GLOB_METACHARACTERS.test(pattern)) {
+      throw new Error(`${label} is not a literal repository path: ${pattern}`);
+    }
+    literals.push(pattern);
+  }
+  return literals;
+}
+
+/*
+ * Resolves which project would actually claim each discovered suite, from the
+ * built config on one side and the filesystem on the other. Neither side is the
+ * registry the config imported, so unlike comparing `exclude` with the arrays
+ * that built it, this can disagree with the configuration.
+ *
+ * Returns the claiming project names per discovered file, plus every `include`
+ * entry that names no file on disk. That second list is the quiet failure: a
+ * renamed suite still listed in a registry is excluded from `ordinary` and then
+ * matched by nothing, so it runs in no project at all and reports no error.
+ */
+function resolveProjectClaims(projects, discovered) {
+  const claims = new Map(discovered.map(file => [file, []]));
+  const unmatchedIncludes = [];
+  for (const project of projects) {
+    const name = project.test?.name;
+    const excluded = new Set(
+      literalPatterns(project.test?.exclude ?? [], `project ${name} exclude`),
+    );
+    const included = project.test?.include === undefined
+      ? discovered
+      : literalPatterns(project.test.include, `project ${name} include`);
+    for (const file of included) {
+      if (!claims.has(file)) {
+        unmatchedIncludes.push({ project: name, file });
+        continue;
+      }
+      if (excluded.has(file)) continue;
+      claims.get(file).push(name);
+    }
+  }
+  return { claims, unmatchedIncludes };
 }
 
 const sourceExtensions = Object.freeze([
@@ -560,13 +663,14 @@ describe("aggregate test-runner contract", () => {
       isolate: true,
       sequence: { groupOrder: 0 },
     });
-    expect(byName.get("ordinary")?.exclude).toEqual([
-      ...configDefaults.exclude,
-      ...NODE_TEST_FILES,
-      ...SOURCE_IDENTITY_TEST_FILES,
-      ...SERIAL_RESOURCE_TEST_FILES,
-      ...SERIAL_NATIVE_TEST_FILES,
-    ]);
+    // `ordinary` is the catch-all: it declares no include of its own, so it
+    // claims every suite the exclusive projects do not. What its exclude list
+    // actually achieves is checked against the filesystem in the partition test
+    // below, not by restating the arrays the config imported to build it.
+    expect(byName.get("ordinary")?.include).toBeUndefined();
+    expect(projects.every(project =>
+      (project.test?.exclude ?? []).slice(0, configDefaults.exclude.length)
+        .join("\n") === configDefaults.exclude.join("\n"))).toBe(true);
     expect(byName.get("serial-resource")).toMatchObject({
       include: SERIAL_RESOURCE_TEST_FILES,
       pool: "forks",
@@ -617,10 +721,116 @@ describe("aggregate test-runner contract", () => {
     expect(new Set(SERIAL_RESOURCE_TEST_FILES).size).toBe(
       SERIAL_RESOURCE_TEST_FILES.length,
     );
-    expect(SERIAL_RESOURCE_TEST_FILES.every(file =>
-      !SOURCE_IDENTITY_TEST_FILES.includes(file)
-      && !SERIAL_NATIVE_TEST_FILES.includes(file)
-      && !NODE_TEST_FILES.includes(file))).toBe(true);
+    // Every registry needs an oracle that is not itself. SERIAL_RESOURCE has the
+    // literal list above and SOURCE_IDENTITY is derived from the import graph in
+    // the closure test; SERIAL_NATIVE had neither, so `include:
+    // SERIAL_NATIVE_TEST_FILES` above was checking the config against a value
+    // nothing else constrained.
+    expect(Object.isFrozen(SERIAL_NATIVE_TEST_SUITES)).toBe(true);
+    expect(Object.isFrozen(SERIAL_NATIVE_TEST_FILES)).toBe(true);
+    expect(SERIAL_NATIVE_TEST_FILES).toEqual([
+      "test/pdfjs-subprocess-boundary.test.js",
+      "test/eval/docling-macos-supervisor.test.js",
+    ]);
+    expect(SERIAL_NATIVE_TEST_SUITES.every(suite =>
+      Object.isFrozen(suite) && suite.reason.length > 0)).toBe(true);
+    expect(new Set(SERIAL_NATIVE_TEST_FILES).size).toBe(
+      SERIAL_NATIVE_TEST_FILES.length,
+    );
+
+    // Pairwise, in both directions. The previous version checked only what
+    // SERIAL_RESOURCE overlapped, so a file listed in both SOURCE_IDENTITY and
+    // SERIAL_NATIVE - which two projects would then both include - passed.
+    const registries = Object.entries({
+      NODE_TEST_FILES,
+      SOURCE_IDENTITY_TEST_FILES,
+      SERIAL_RESOURCE_TEST_FILES,
+      SERIAL_NATIVE_TEST_FILES,
+    });
+    const overlaps = [];
+    for (const [leftName, left] of registries) {
+      for (const [rightName, right] of registries) {
+        if (leftName >= rightName) continue;
+        for (const file of left) {
+          if (right.includes(file)) overlaps.push(`${leftName}+${rightName}: ${file}`);
+        }
+      }
+    }
+    expect(overlaps).toEqual([]);
+  });
+
+  it("assigns every discovered Vitest suite to exactly one project", async () => {
+    const config = viteConfigFactory({ command: "build", mode: "test" });
+    const projects = config.test.projects ?? [];
+    const discovered = await findRepositoryTestFiles();
+    const nativeFiles = new Set(NODE_TEST_FILES);
+    const { claims, unmatchedIncludes } = resolveProjectClaims(projects, discovered);
+
+    // The scratch prefix the walk skips has to be the prefix the allocators
+    // actually use, or the walk is skipping nothing and tolerating everything.
+    expect(DIRECT_CHECKOUT_LOCAL_SCRATCH_ALLOCATORS.length).toBeGreaterThan(0);
+    expect(DIRECT_CHECKOUT_LOCAL_SCRATCH_ALLOCATORS.every(allocator =>
+      allocator.prefix.startsWith(CHECKOUT_LOCAL_SCRATCH_PREFIX))).toBe(true);
+
+    // A registry entry naming no file on disk: the suite is excluded from
+    // `ordinary` and included by nothing, so it runs nowhere and says nothing.
+    expect(unmatchedIncludes).toEqual([]);
+
+    const misPartitioned = discovered
+      .filter(file => !nativeFiles.has(file))
+      .map(file => ({ file, projects: claims.get(file) }))
+      .filter(entry => entry.projects.length !== 1);
+    expect(misPartitioned).toEqual([]);
+
+    // node:test suites belong to the native runner and must be claimed by no
+    // Vitest project. Dropping NODE_TEST_FILES from any project's exclude shows
+    // up here rather than as a Vitest run of a node:test file.
+    expect(discovered.filter(file =>
+      nativeFiles.has(file) && claims.get(file).length > 0)).toEqual([]);
+    expect(discovered.filter(file => nativeFiles.has(file)).sort())
+      .toEqual([...NODE_TEST_FILES].sort());
+
+    // No project may be empty: an exclusive project that claims nothing is a
+    // partition that has quietly stopped existing.
+    const claimedByProject = new Map(projects.map(project => [project.test?.name, 0]));
+    for (const names of claims.values()) {
+      for (const name of names) claimedByProject.set(name, claimedByProject.get(name) + 1);
+    }
+    expect([...claimedByProject].filter(([, count]) => count === 0)).toEqual([]);
+    expect(claimedByProject.get("ordinary")).toBe(
+      discovered.length
+      - NODE_TEST_FILES.length
+      - SOURCE_IDENTITY_TEST_FILES.length
+      - SERIAL_RESOURCE_TEST_FILES.length
+      - SERIAL_NATIVE_TEST_FILES.length,
+    );
+
+    // The resolver has to be able to say no, or the three assertions above are
+    // just as vacuous as the exclude comparison they replaced. Same resolver,
+    // same real config, one suite moved into a second project's include and one
+    // include entry renamed - both must be reported.
+    const [movedSuite] = discovered.filter(file =>
+      claims.get(file).length === 1 && claims.get(file)[0] === "ordinary");
+    expect(movedSuite).toBeTruthy();
+    const withDoubleClaim = projects.map(project => (project.test?.name === "serial-native"
+      ? { ...project, test: { ...project.test, include: [...project.test.include, movedSuite] } }
+      : project));
+    expect(resolveProjectClaims(withDoubleClaim, discovered).claims.get(movedSuite))
+      .toEqual(["ordinary", "serial-native"]);
+    const withRenamedEntry = projects.map(project => (project.test?.name === "serial-native"
+      ? {
+          ...project,
+          test: {
+            ...project.test,
+            include: project.test.include.map(file => `${file}.renamed`),
+          },
+        }
+      : project));
+    expect(resolveProjectClaims(withRenamedEntry, discovered).unmatchedIncludes)
+      .toEqual(SERIAL_NATIVE_TEST_FILES.map(file => ({
+        project: "serial-native",
+        file: `${file}.renamed`,
+      })));
   });
 
   it("exposes explicit aggregate and native runner scripts", async () => {


### PR DESCRIPTION
Two test defects. **No product change.**

## 1. The partition contract could not fail

`test-runner-contract.test.js` compared each project's exclude list to **the same arrays `vite.config.mjs` imports to build it**. It constrained the config and never the registries.

Measured against the old test:

| mutation | old | new |
|---|---|---|
| rename a `serial-native` entry → its suite runs in **no** project | **18 passed** | 2 failed |
| double-list `test-runner-contract` → it runs in **two** projects | **36 passed** | 4 failed |
| drop `docling-macos-supervisor` from `serial-native` | **18 passed** | 1 failed |

The middle row is the one to look at: the old contract **ran itself twice and reported green**. I reproduced that independently — with the double-claim applied, the new test fails five ways and visibly executes itself twice while doing it.

**Not all four projects were broken.** `serial-resource` and `source-identity` have the same self-comparison shape but are safe — one has a literal oracle beside it, the other is derived from the import graph. **`serial-native` had no oracle anywhere**, which was the live hole, and the disjointness check only ran from `serial-resource`'s side, so `source-identity ∩ serial-native` was never compared.

The replacement walks the repository the way Vitest globs it, resolves each project's real claim from the built config, and requires every non-native suite claimed exactly once, native suites zero times, no project empty, and no `include` entry naming a file that does not exist. It mutates its own inputs in-test and asserts both a double-include and a renamed entry are reported, so **the resolver itself cannot go vacuous**. Adds the missing `serial-native` oracle and full pairwise disjointness. Patterns that are neither a Vitest default nor a literal path are refused rather than silently resolving to empty.

## 2. A test pinned one of two documented outcomes

`embedded-native-canvas-latch.test.js` wrote a marker owned by `deadPid()` and asserted `"latched"`. But `pdfjs-subprocess.js:1105` documents **in its own comment** that a reused pid makes the guard answer `"concurrent"` instead — deliberately, failing toward retryable. The test pinned one of two correct outcomes and the OS chose which.

**My suggested fix — hold the pid unreusable — does not work, and the reason is worth recording.** The only POSIX way to reserve a pid is an unreaped zombie, and `kill(pid, 0)` *succeeds* on a zombie, so the product would read it as alive and answer `"concurrent"` — precisely the outcome to avoid.

Instead `deadPid()` probes before handing the number out, and assertions re-run with a fresh pid **only when the check failed and the owner is now alive** — exactly when `"concurrent"` is correct. A genuine latch break fails on the first pass, because its owner stays dead. The two `force` cases keep a bare `deadPid()` since `force` short-circuits before the latch is read.

Detection is unchanged: three product mutations against the guard produce identical red before and after.

## Reported, not hidden

One mutation stays uncaught by either version — `processIsAlive` misreading another user's live process as dead. It needs a process owned by a different uid, which a test cannot reliably create without root. Pre-existing.

Full gate: 2484 passed, the only failures being the three `source-identity` suites on the dirty-tree guard. Both changed suites green standalone (49 tests). `server/` untouched, mirrors verified identical, no oracle regeneration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)