### PR TITLE
Make plugin folder scope honest and useful

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ store and do not need to be added manually.
 }
 ```
 
+### ChatGPT / Codex Agent Plugin
+
+A fresh Agent Plugin install uses a private PDF Tools workspace. There is no
+folder setup step: when the host is allowed to read a file, it can copy the file
+into that workspace for PDF Tools to process. PDF Tools itself still refuses
+direct paths outside the workspace.
+
+This is a tool boundary, not a confidentiality boundary against the host. If
+ChatGPT is set to Full Access, its broader filesystem permission governs what it
+can import. Optional direct folder access can be configured separately in the
+plugin's `config.json`; a non-empty list replaces the private workspace.
+
 ## Why It's Different
 
 Claude already knows how to read PDFs in limited ways. PDF Tools goes much further:
@@ -49,7 +61,7 @@ Claude already knows how to read PDFs in limited ways. PDF Tools goes much furth
 - **Page organization:** merge, split, rotate, reorder, and apply full page plans in one pass
 - **Extraction and analysis:** page-bounded reads, text search, page/region rendering, CSV export, page-level analysis, metadata, and validation
 - **Local file operations:** PDF Tools reads, renders, edits, and saves files on your machine instead of uploading them to a separate PDF service
-- **Directory sandbox:** Claude Desktop users can choose which local folders PDF Tools may read from or write to
+- **Scoped file operations:** PDF Tools directly reads and writes only its active folders; a host with broader filesystem permission may import files into the private plugin workspace
 
 Text, images, and metadata returned by PDF Tools may be processed by Claude or
 another MCP host. Your host and model provider's data terms apply to that

--- a/docs/FOLDER_SCOPE_THREAT_MODEL.md
+++ b/docs/FOLDER_SCOPE_THREAT_MODEL.md
@@ -1,0 +1,66 @@
+# PDF Tools folder-scope threat model
+
+## Scope and decision
+
+This model covers local PDF file access through the PDF Tools MCP server in
+Claude Desktop, generic stdio hosts, and Agent Plugin hosts such as ChatGPT and
+Codex. It covers direct tool reads and writes plus host-mediated import into the
+private plugin workspace. It does not claim to constrain a desktop host running
+with broader operating-system permission.
+
+A fresh Agent Plugin install uses `${PLUGIN_DATA}/workspace`. Optional direct
+folders replace that workspace through an operator-edited configuration. PDF
+Tools never treats host access to another file as permission to open that source
+path directly.
+
+## Assets and trust boundaries
+
+- User PDFs and output files, including sensitive document content.
+- `${PLUGIN_DATA}/config.json`, which controls direct folder access.
+- The private import workspace and saved PDF Tools state.
+- The boundary between the desktop host and the PDF Tools MCP process.
+- The boundary between tool output and the selected host/model provider.
+
+The host is trusted to enforce the filesystem mode the user selected. PDF Tools
+is trusted to enforce its own canonical path policy. Neither control substitutes
+for the other. Content returned through MCP may leave the local process under
+the host or model provider's data terms.
+
+## Attacker capabilities and non-capabilities
+
+Untrusted PDF content may influence model suggestions but cannot edit the
+allowed-folder configuration through a PDF Tools tool. A caller may supply
+paths, create files in an already allowed directory, and attempt symlink or path
+alias attacks. A Full Access host may read an outside file and copy it into the
+workspace; PDF Tools cannot and does not claim to prevent that host-authorized
+operation. An unprivileged caller is not assumed able to alter the server code
+or operating-system permissions.
+
+## Abuse paths and mitigations
+
+| Abuse path | Likelihood | Impact | Mitigation |
+| --- | --- | --- | --- |
+| PDF Tools directly opens a path outside its active scope | Medium | High | Canonical path checks on every file operation; default Agent Plugin scope is only the private workspace |
+| A workspace symlink redirects access outside `PLUGIN_DATA` | Medium | High | Require a physical directory and a canonical path strictly below canonical `PLUGIN_DATA`; use mode 0700 on POSIX and the inherited plugin-data ACL on Windows; otherwise allow nothing |
+| A tool rewrites its own folder policy | Low | High | Keep config outside the workspace; refuse any configured set that reaches its config; expose only a read-only scope-reporting tool |
+| A Full Access host imports an outside file despite PDF Tools' scope | High when Full Access is selected | Medium to high | Describe this as host-authorized import, not a bypass of direct tool scope; make host permission and provider handling visible to users |
+| A malformed or unresolved configuration broadens access | Medium | High | Fail closed; never fall back to implicit home folders or merge precedence layers |
+| Sensitive content leaves through tool output | Medium | High | State that local file operations do not imply zero egress; host and provider data terms govern returned content |
+
+## Security invariants and validation
+
+- No implicit direct grant to the home directory, Documents, Downloads, or
+  Desktop in Agent Plugin mode.
+- The private workspace never includes its sibling config file.
+- Explicit layers replace rather than union with lower-precedence layers.
+- Malformed configuration and workspace path drift fail closed.
+- Tests must cover outside-path denial, self-configuration denial, POSIX
+  workspace mode, symlink escape, and honest `plugin_workspace` reporting.
+
+## Residual risks
+
+The application host and the PDF Tools process normally run as the same user.
+This design is defense in depth and a clear tool contract, not process isolation
+against a malicious or fully authorized host. Stronger source confidentiality
+requires reducing the host's operating-system access, not adding another PDF
+Tools allowlist entry.

--- a/docs/MCP_CONTRACT.md
+++ b/docs/MCP_CONTRACT.md
@@ -45,6 +45,14 @@ a generic MCP client can still discover and call `read_pdf_bytes`. It is not an
 authorization or confidentiality boundary. Filesystem allowlists and the tool's
 bounded reads remain the enforced controls.
 
+Filesystem scope applies to direct PDF Tools calls. In Agent Plugin mode, a
+fresh install directly accesses only its private `${PLUGIN_DATA}/workspace`.
+A desktop host with broader operating-system permission may copy a file into
+that workspace; this is host-authorized import and is not prevented by the PDF
+Tools path policy. Consequently the active folder list is defense in depth, not
+a source-confidentiality boundary against a Full Access host. Content returned
+through MCP remains subject to the host and model provider's data terms.
+
 Forty tool handlers advertise strict `outputSchema` contracts and return
 `structuredContent`. They also return a human-readable `content` text block so
 non-Apps and older clients remain usable. Successful structured output is

--- a/docs/agent-plugins-packaging.md
+++ b/docs/agent-plugins-packaging.md
@@ -154,26 +154,26 @@ Adding `mcp.json` is gated on the portable allowed-directories work and a publis
 
 ### Portable allowed-directories requirements
 
-**Implementation status.** Requirements 1, 2, 3, and 7 are implemented on this branch, along with the non-greedy argument parsing in requirement 8. The allowed set is now established only by explicit configuration, an unexpanded placeholder is treated as absent configuration rather than as a reason to substitute defaults, the private store is no longer a general user-path allowance, and refusals name neither the allowed set nor the attempted path.
+**Implementation status.** Direct user-folder access is established only by explicit configuration. An unexpanded placeholder never becomes a home-folder grant. When Agent Plugins supplies `PLUGIN_DATA` and no direct folders are configured, PDF Tools creates and uses only `${PLUGIN_DATA}/workspace`. This makes a fresh install useful without treating Documents, Downloads, Desktop, or the rest of `PLUGIN_DATA` as implicitly approved.
 
-The `${PLUGIN_DATA}` config-file layer is now implemented too, along with the self-escalation guard from requirement 5. `${PLUGIN_DATA}/config.json` is the lowest precedence layer, below the CLI flag and the environment variable, and layers are never merged. On first run the server writes a template with an empty list, and every refusal names that exact path, so a fresh install is actionable rather than merely safe. A set that would reach the config file is refused whole rather than trimmed, because an allowed set containing its own config lets a write tool rewrite the boundary on the next launch.
+`${PLUGIN_DATA}/config.json` remains the optional direct-folder layer, below the CLI flag and environment variable, and layers are never merged. A non-empty config replaces the private workspace. The workspace is a physical child directory (mode 0700 on POSIX; inherited plugin-data ACL on Windows); a symlink or other path that resolves outside `PLUGIN_DATA` fails closed. A configured set that reaches its own config file is refused whole rather than trimmed.
 
-Widening deliberately remains a human action: the config file is edited by the operator, not by a tool. A tool that can widen its own sandbox is a privilege-escalation path, and document text is untrusted input this server already refuses to take instructions from.
+Direct-path widening deliberately remains a human action: the config file is edited by the operator, not by a PDF Tools tool. Import is different. A host with filesystem permission may copy a user-selected file into the workspace. That does not widen PDF Tools' direct path boundary; it exercises the host's separate authority.
 
-Still unimplemented: a read-only tool reporting the active set and its source, runtime narrowing, and roots intersection (requirements 4 and 6). The read-only tool is the next useful increment; it was kept out of the config work because adding a tool moves the tool-contract digest and the pinned tool count, which deserves its own change.
+`get_allowed_directories` reports the active set and distinguishes `plugin_workspace` from explicit configuration. Runtime narrowing and MCP roots intersection remain separate future work.
 
-One consequence to carry into release notes: a host that previously relied on the implicit home-folder grant now receives a refusal until directories are configured. That is the intended behavior, and it is a behavior change for existing installs.
+One consequence to carry into release notes: Agent Plugin installs no longer need a folder allowlist merely to start. They use the private import workspace unless the operator opts into direct folders.
 
-1. Precedence, highest first: an explicit CLI flag, then `ALLOWED_DIRECTORIES` in the environment, then a config file under `${PLUGIN_DATA}`. The highest layer that supplies a set wins outright. Layers are never merged, because a union across sources produces a boundary nobody chose.
-2. **No implicit default grant.** When no layer supplies a set, the server serves no file tools and says so actionably. It does not fall back to the user's home folders. The Documents, Downloads, and Desktop defaults in the MCPB manifest are a *host-presented* default the user can see and edit before approving; a server-side constant on a host with no configuration UI is not the same thing and must not be treated as equivalent consent.
+1. Precedence, highest first: explicit CLI flag, `ALLOWED_DIRECTORIES`, non-empty `${PLUGIN_DATA}/config.json`, non-empty well-known home config, then the private plugin workspace. Layers are never merged.
+2. **No implicit user-folder grant.** The private workspace is not Documents, Downloads, Desktop, the home directory, or all of `PLUGIN_DATA`. Without `PLUGIN_DATA`, an unconfigured generic stdio launch still refuses all file paths.
 3. **Unresolved host configuration fails closed.** A value that still contains an unexpanded placeholder means the host did not configure us. That is a refusal, not a reason to substitute a default.
-4. A tool may read the allowed set and may narrow it at runtime. **Widening requires a restart and an edit the agent cannot perform.** A tool that can widen its own sandbox is a privilege-escalation path, and document text is untrusted input the server already refuses to take instructions from (`server/index.js:1238`). An in-process approval prompt is not an authorization boundary.
+4. A tool may read the active set. **Direct widening requires a restart and an edit PDF Tools cannot perform.** The host may independently import a file into the private workspace when its own permission model allows that operation.
 5. The config file and its directory are denied to every tool, compared by canonical path and by `(dev, ino)` rather than by string prefix, so a symlink alias cannot reach it.
 6. If MCP roots are honored, they **intersect** the established set and never replace it. Roots are client-declared, and the protocol constrains nothing about what a client may declare.
 7. Refusals are identical regardless of which precedence layer supplied the set, and identical across every tool.
-8. Tests cover each precedence layer, the empty-configuration refusal, the unexpanded-placeholder refusal, and the narrowing/widening asymmetry — on a host with no user-configuration mechanism at all.
+8. Tests cover each precedence layer, workspace creation and mode, direct access denial outside the workspace, self-configuration denial, symlink escape, and unresolved placeholders.
 
-This is a security boundary, not plumbing. It should carry its own bead and its own tests, and it must not be inferred from the MCPB behavior by analogy.
+This is a PDF Tools direct-call boundary, not a source-confidentiality boundary against the host. Host filesystem permission, PDF Tools path policy, and model-provider data handling are separate controls and must be described separately.
 
 ## Acceptance gates
 

--- a/pdf-toolkit-mcp-share/server/index.js
+++ b/pdf-toolkit-mcp-share/server/index.js
@@ -24,7 +24,16 @@ import {
   degrees as pdfDegrees,
 } from "pdf-lib";
 import { fileURLToPath } from "url";
-import { constants as fsConstants, existsSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from "fs";
+import {
+  chmodSync,
+  constants as fsConstants,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  writeFileSync,
+} from "fs";
 import fs from "fs/promises";
 import path from "path";
 import { homedir, platform as osPlatform } from "os";
@@ -1526,12 +1535,10 @@ function parsePathListValue(rawValue) {
     .filter(Boolean);
 }
 
-// The allowed set is established only by explicit configuration. A host that
-// substitutes nothing — every Agent Plugins 1.0.0 client, and any MCPB host
-// whose substitution failed — leaves this empty, and an empty set denies every
-// user path rather than silently granting the home folders. Failing closed is
-// the point: an unexpanded template means we were never configured, which is
-// not a reason to choose a boundary on the user's behalf.
+// Direct access to user folders is established only by explicit configuration.
+// A host that substitutes nothing never receives an implicit home-folder
+// grant. Agent Plugin installs instead get one private workspace under
+// PLUGIN_DATA; ordinary stdio installs without PLUGIN_DATA still fail closed.
 // Agent Plugins 1.0.0 has no user-configuration mechanism and expands only
 // ${PLUGIN_ROOT} and ${PLUGIN_DATA}, so a plugin install can reach neither the
 // CLI flag nor the environment variable a host would otherwise set. PLUGIN_DATA
@@ -1539,6 +1546,7 @@ function parsePathListValue(rawValue) {
 // survives plugin updates. A plugin data file outranks the well-known home file,
 // while host-supplied argument or environment configuration outranks both.
 const PLUGIN_DATA_CONFIG_NAME = "config.json";
+const PLUGIN_WORKSPACE_DIRECTORY_NAME = "workspace";
 const HOME_CONFIG_DIRECTORY_NAME = ".pdf-tools";
 
 function pluginDataConfigPath() {
@@ -1551,10 +1559,51 @@ function homeConfigPath() {
   return path.join(homedir(), HOME_CONFIG_DIRECTORY_NAME, PLUGIN_DATA_CONFIG_NAME);
 }
 
-// A fresh install has nothing configured and must refuse every path. Writing
-// the template turns "configure the allowed directories somehow" into a named
-// file the user can open. Editing it is a human action the agent cannot
-// perform, which is what keeps widening off the agent's own authority.
+function pluginWorkspacePath() {
+  const pluginData = process.env.PLUGIN_DATA;
+  if (!pluginData || pluginData.includes("${")) return null;
+  return path.join(path.resolve(pluginData), PLUGIN_WORKSPACE_DIRECTORY_NAME);
+}
+
+// Agent Plugin hosts guarantee a private writable PLUGIN_DATA directory but do
+// not currently pass a host-selected folder list to the MCP server. Give a
+// fresh install one useful, narrow place to work without granting the rest of
+// the user's home directory. A full-access host may intentionally import files
+// into this directory; that is host-authorized copying, not direct PDF Tools
+// access to the source path.
+function ensurePluginWorkspace(workspacePath) {
+  if (!workspacePath) return null;
+  const pluginData = path.dirname(workspacePath);
+  try {
+    mkdirSync(pluginData, { recursive: true, mode: 0o700 });
+    if (existsSync(workspacePath)) {
+      const stat = lstatSync(workspacePath);
+      if (!stat.isDirectory() || stat.isSymbolicLink()) {
+        throw new Error("workspace is not a physical directory");
+      }
+    } else {
+      mkdirSync(workspacePath, { mode: 0o700 });
+    }
+    chmodSync(workspacePath, 0o700);
+    const canonicalPluginData = realpathSync.native(pluginData);
+    const canonicalWorkspace = realpathSync.native(workspacePath);
+    if (!isPathInsideDirectory(canonicalWorkspace, canonicalPluginData)
+      || canonicalWorkspace === canonicalPluginData) {
+      throw new Error("workspace resolves outside plugin data");
+    }
+    return { display: workspacePath, canonical: canonicalWorkspace };
+  } catch (error) {
+    console.error(
+      `[pdf-tools] Could not establish the private plugin workspace at ${workspacePath}: ${error.message}. `
+      + "No directories are allowed until the workspace or an explicit configuration is fixed.",
+    );
+    return null;
+  }
+}
+
+// The template is the optional direct-folder override. Editing it is a human
+// action the PDF Tools server cannot perform, which keeps direct path widening
+// off the server's own authority.
 function ensurePluginDataConfigTemplate(configPath) {
   if (!configPath || existsSync(configPath)) return;
   try {
@@ -1562,9 +1611,9 @@ function ensurePluginDataConfigTemplate(configPath) {
     writeFileSync(
       configPath,
       JSON.stringify({
-        _comment: "Folders this server may read and write. Absolute paths only. "
-          + "It replaces any built-in default rather than adding to it, so list every "
-          + "folder you need. Restart the server after editing.",
+        _comment: "Optional folders this server may read and write directly. Absolute paths only. "
+          + "A non-empty list replaces the private plugin workspace rather than adding to it, "
+          + "so list every direct folder you need. Restart the server after editing.",
         allowedDirectories: [],
       }, null, 2) + "\n",
       { mode: 0o600 },
@@ -1635,6 +1684,7 @@ function grantsAccessToOwnConfig(directories, configPath) {
 // get_allowed_directories so an operator can tell where to change it.
 let ALLOWED_DIRECTORY_SOURCE = "none";
 const PLUGIN_DATA_CONFIG_PATH = pluginDataConfigPath();
+const PLUGIN_WORKSPACE_PATH = pluginWorkspacePath();
 const HOME_CONFIG_PATH = homeConfigPath();
 let ALLOWED_DIRECTORY_CONFIG_PATH = PLUGIN_DATA_CONFIG_PATH;
 
@@ -1666,6 +1716,13 @@ function buildAllowedDirectories() {
       if (fromHomeConfig.status !== "absent") {
         configuredDirectories = fromHomeConfig.directories;
         ALLOWED_DIRECTORY_SOURCE = fromHomeConfig.directories.length ? "home_config_file" : "none";
+      } else if (PLUGIN_WORKSPACE_PATH) {
+        ensurePluginDataConfigTemplate(pluginConfigPath);
+        const workspace = ensurePluginWorkspace(PLUGIN_WORKSPACE_PATH);
+        configuredDirectories = workspace ? [workspace.display] : [];
+        boundaryConfigPath = pluginConfigPath;
+        ALLOWED_DIRECTORY_CONFIG_PATH = pluginConfigPath;
+        ALLOWED_DIRECTORY_SOURCE = workspace ? "plugin_workspace" : "none";
       } else {
         configuredDirectories = [];
         ALLOWED_DIRECTORY_SOURCE = "none";
@@ -6838,6 +6895,9 @@ async function handleToolCall(request) {
         const configured = directories.length > 0;
         const summary = configured
           ? `Allowed folders (${ALLOWED_DIRECTORY_SOURCE.replace(/_/g, " ")}):\n${directories.join("\n")}`
+            + (ALLOWED_DIRECTORY_SOURCE === "plugin_workspace"
+              ? "\nYour host may copy files you select into this private workspace. To grant PDF Tools direct access to other folders, edit the config file and restart."
+              : "")
           : `No folders are allowed yet. List them in ${HOME_CONFIG_PATH} under "allowedDirectories", then restart this server.`
             + (PLUGIN_DATA_CONFIG_PATH
               ? ` A plugin-specific file at ${PLUGIN_DATA_CONFIG_PATH} takes precedence when present.`

--- a/pdf-toolkit-mcp-share/server/output-schemas.js
+++ b/pdf-toolkit-mcp-share/server/output-schemas.js
@@ -1469,7 +1469,7 @@ export const TOOL_SUCCESS_OUTPUT_SCHEMAS = Object.freeze({
   get_allowed_directories: object({
     directories: arrayOf(string),
     configured: { type: "boolean" },
-    source: enumString(["argument", "environment", "config_file", "home_config_file", "none", "refused_self_granting"]),
+    source: enumString(["argument", "environment", "config_file", "home_config_file", "plugin_workspace", "none", "refused_self_granting"]),
     config_path: nullable(string),
   }),
   list_signatures: object({

--- a/scripts/build-agent-plugin.mjs
+++ b/scripts/build-agent-plugin.mjs
@@ -77,7 +77,7 @@ const PLUGIN_MANIFEST_NAME = "pdf-tools";
 // request against this string before any tool is loaded, and the previous
 // wording ("inspect, fill, sign, merge...") shared no words with the request.
 const PLUGIN_DESCRIPTION =
-  "Open any PDF already on your computer and work with it: read and search it in an interactive viewer, fill and sign forms, extract text and data, merge, split, and compare documents. Your files never leave your machine.";
+  "Open PDFs on your computer and work with them: read and search, fill and sign forms, extract data, merge, split, and compare. File operations stay local; content returned to your host follows its data terms.";
 
 const PLUGIN_MANIFEST = {
   $schema: "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
@@ -120,7 +120,7 @@ const CODEX_MANIFEST = {
     displayName: "PDF Tools",
     shortDescription: "Local PDF workstation: read, fill, sign, compare, convert.",
     longDescription:
-      "Work with PDFs on your own machine. Read text and layout with real coordinates, convert to Markdown with evidence-backed tables, fill and validate forms, merge, split and reorder pages, compare two documents across several channels, place signatures, and inspect accessibility signals. Files are never uploaded, and the extension only opens folders you have listed.",
+      "Work with PDFs on your own machine. Read text and layout with real coordinates, convert to Markdown with evidence-backed tables, fill and validate forms, merge, split and reorder pages, compare two documents across several channels, place signatures, and inspect accessibility signals. PDF Tools uses a private import workspace by default; direct folder access is optional. Your host's permissions govern which files it may import, and content returned to the host follows its data terms.",
     developerName: "Open Document Alliance",
     category: "Productivity",
     capabilities: ["Document workflows", "Forms", "Extraction", "Safety checks"],
@@ -209,9 +209,9 @@ function smokeLaunch(pluginDir) {
     )));
     const child = spawn(command, args, {
       cwd,
-      // No allowed directories configured: the server starts and lists tools,
-      // and refuses file operations until configured. That is the intended
-      // fail-closed posture, and it is what a fresh install looks like.
+      // The smoke environment has no PLUGIN_DATA, so it exercises the generic
+      // stdio fail-closed posture. Agent Plugin hosts supply PLUGIN_DATA and get
+      // the private import workspace covered by the runtime tests.
       env,
       stdio: ["pipe", "pipe", "pipe"],
     });
@@ -294,9 +294,8 @@ async function main() {
     const { files, bytes } = directoryStats(outputDir);
     console.error(`[plugin] done: ${files} files, ${(bytes / 1024 / 1024).toFixed(1)} MB uncompressed`);
     console.error(`[plugin] layout: plugin.json, mcp.json, .codex-plugin/, assets/, bin/, server/, skills/, node_modules/, dist-ui/`);
-    console.error(`[plugin] note: a fresh install allows no directories. On first run the server`);
-    console.error(`[plugin]       writes \${PLUGIN_DATA}/config.json and every refusal names that`);
-    console.error(`[plugin]       path; the user lists their folders there and restarts.`);
+    console.error(`[plugin] note: a fresh install uses \${PLUGIN_DATA}/workspace as a private import workspace.`);
+    console.error(`[plugin]       Optional direct folder access is configured in \${PLUGIN_DATA}/config.json.`);
   } finally {
     rmSync(stagingDir, { recursive: true, force: true });
   }

--- a/server/index.js
+++ b/server/index.js
@@ -24,7 +24,16 @@ import {
   degrees as pdfDegrees,
 } from "pdf-lib";
 import { fileURLToPath } from "url";
-import { constants as fsConstants, existsSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from "fs";
+import {
+  chmodSync,
+  constants as fsConstants,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  writeFileSync,
+} from "fs";
 import fs from "fs/promises";
 import path from "path";
 import { homedir, platform as osPlatform } from "os";
@@ -1526,12 +1535,10 @@ function parsePathListValue(rawValue) {
     .filter(Boolean);
 }
 
-// The allowed set is established only by explicit configuration. A host that
-// substitutes nothing — every Agent Plugins 1.0.0 client, and any MCPB host
-// whose substitution failed — leaves this empty, and an empty set denies every
-// user path rather than silently granting the home folders. Failing closed is
-// the point: an unexpanded template means we were never configured, which is
-// not a reason to choose a boundary on the user's behalf.
+// Direct access to user folders is established only by explicit configuration.
+// A host that substitutes nothing never receives an implicit home-folder
+// grant. Agent Plugin installs instead get one private workspace under
+// PLUGIN_DATA; ordinary stdio installs without PLUGIN_DATA still fail closed.
 // Agent Plugins 1.0.0 has no user-configuration mechanism and expands only
 // ${PLUGIN_ROOT} and ${PLUGIN_DATA}, so a plugin install can reach neither the
 // CLI flag nor the environment variable a host would otherwise set. PLUGIN_DATA
@@ -1539,6 +1546,7 @@ function parsePathListValue(rawValue) {
 // survives plugin updates. A plugin data file outranks the well-known home file,
 // while host-supplied argument or environment configuration outranks both.
 const PLUGIN_DATA_CONFIG_NAME = "config.json";
+const PLUGIN_WORKSPACE_DIRECTORY_NAME = "workspace";
 const HOME_CONFIG_DIRECTORY_NAME = ".pdf-tools";
 
 function pluginDataConfigPath() {
@@ -1551,10 +1559,51 @@ function homeConfigPath() {
   return path.join(homedir(), HOME_CONFIG_DIRECTORY_NAME, PLUGIN_DATA_CONFIG_NAME);
 }
 
-// A fresh install has nothing configured and must refuse every path. Writing
-// the template turns "configure the allowed directories somehow" into a named
-// file the user can open. Editing it is a human action the agent cannot
-// perform, which is what keeps widening off the agent's own authority.
+function pluginWorkspacePath() {
+  const pluginData = process.env.PLUGIN_DATA;
+  if (!pluginData || pluginData.includes("${")) return null;
+  return path.join(path.resolve(pluginData), PLUGIN_WORKSPACE_DIRECTORY_NAME);
+}
+
+// Agent Plugin hosts guarantee a private writable PLUGIN_DATA directory but do
+// not currently pass a host-selected folder list to the MCP server. Give a
+// fresh install one useful, narrow place to work without granting the rest of
+// the user's home directory. A full-access host may intentionally import files
+// into this directory; that is host-authorized copying, not direct PDF Tools
+// access to the source path.
+function ensurePluginWorkspace(workspacePath) {
+  if (!workspacePath) return null;
+  const pluginData = path.dirname(workspacePath);
+  try {
+    mkdirSync(pluginData, { recursive: true, mode: 0o700 });
+    if (existsSync(workspacePath)) {
+      const stat = lstatSync(workspacePath);
+      if (!stat.isDirectory() || stat.isSymbolicLink()) {
+        throw new Error("workspace is not a physical directory");
+      }
+    } else {
+      mkdirSync(workspacePath, { mode: 0o700 });
+    }
+    chmodSync(workspacePath, 0o700);
+    const canonicalPluginData = realpathSync.native(pluginData);
+    const canonicalWorkspace = realpathSync.native(workspacePath);
+    if (!isPathInsideDirectory(canonicalWorkspace, canonicalPluginData)
+      || canonicalWorkspace === canonicalPluginData) {
+      throw new Error("workspace resolves outside plugin data");
+    }
+    return { display: workspacePath, canonical: canonicalWorkspace };
+  } catch (error) {
+    console.error(
+      `[pdf-tools] Could not establish the private plugin workspace at ${workspacePath}: ${error.message}. `
+      + "No directories are allowed until the workspace or an explicit configuration is fixed.",
+    );
+    return null;
+  }
+}
+
+// The template is the optional direct-folder override. Editing it is a human
+// action the PDF Tools server cannot perform, which keeps direct path widening
+// off the server's own authority.
 function ensurePluginDataConfigTemplate(configPath) {
   if (!configPath || existsSync(configPath)) return;
   try {
@@ -1562,9 +1611,9 @@ function ensurePluginDataConfigTemplate(configPath) {
     writeFileSync(
       configPath,
       JSON.stringify({
-        _comment: "Folders this server may read and write. Absolute paths only. "
-          + "It replaces any built-in default rather than adding to it, so list every "
-          + "folder you need. Restart the server after editing.",
+        _comment: "Optional folders this server may read and write directly. Absolute paths only. "
+          + "A non-empty list replaces the private plugin workspace rather than adding to it, "
+          + "so list every direct folder you need. Restart the server after editing.",
         allowedDirectories: [],
       }, null, 2) + "\n",
       { mode: 0o600 },
@@ -1635,6 +1684,7 @@ function grantsAccessToOwnConfig(directories, configPath) {
 // get_allowed_directories so an operator can tell where to change it.
 let ALLOWED_DIRECTORY_SOURCE = "none";
 const PLUGIN_DATA_CONFIG_PATH = pluginDataConfigPath();
+const PLUGIN_WORKSPACE_PATH = pluginWorkspacePath();
 const HOME_CONFIG_PATH = homeConfigPath();
 let ALLOWED_DIRECTORY_CONFIG_PATH = PLUGIN_DATA_CONFIG_PATH;
 
@@ -1666,6 +1716,13 @@ function buildAllowedDirectories() {
       if (fromHomeConfig.status !== "absent") {
         configuredDirectories = fromHomeConfig.directories;
         ALLOWED_DIRECTORY_SOURCE = fromHomeConfig.directories.length ? "home_config_file" : "none";
+      } else if (PLUGIN_WORKSPACE_PATH) {
+        ensurePluginDataConfigTemplate(pluginConfigPath);
+        const workspace = ensurePluginWorkspace(PLUGIN_WORKSPACE_PATH);
+        configuredDirectories = workspace ? [workspace.display] : [];
+        boundaryConfigPath = pluginConfigPath;
+        ALLOWED_DIRECTORY_CONFIG_PATH = pluginConfigPath;
+        ALLOWED_DIRECTORY_SOURCE = workspace ? "plugin_workspace" : "none";
       } else {
         configuredDirectories = [];
         ALLOWED_DIRECTORY_SOURCE = "none";
@@ -6838,6 +6895,9 @@ async function handleToolCall(request) {
         const configured = directories.length > 0;
         const summary = configured
           ? `Allowed folders (${ALLOWED_DIRECTORY_SOURCE.replace(/_/g, " ")}):\n${directories.join("\n")}`
+            + (ALLOWED_DIRECTORY_SOURCE === "plugin_workspace"
+              ? "\nYour host may copy files you select into this private workspace. To grant PDF Tools direct access to other folders, edit the config file and restart."
+              : "")
           : `No folders are allowed yet. List them in ${HOME_CONFIG_PATH} under "allowedDirectories", then restart this server.`
             + (PLUGIN_DATA_CONFIG_PATH
               ? ` A plugin-specific file at ${PLUGIN_DATA_CONFIG_PATH} takes precedence when present.`

--- a/server/output-schemas.js
+++ b/server/output-schemas.js
@@ -1469,7 +1469,7 @@ export const TOOL_SUCCESS_OUTPUT_SCHEMAS = Object.freeze({
   get_allowed_directories: object({
     directories: arrayOf(string),
     configured: { type: "boolean" },
-    source: enumString(["argument", "environment", "config_file", "home_config_file", "none", "refused_self_granting"]),
+    source: enumString(["argument", "environment", "config_file", "home_config_file", "plugin_workspace", "none", "refused_self_granting"]),
     config_path: nullable(string),
   }),
   list_signatures: object({

--- a/test/documentation-claims.test.js
+++ b/test/documentation-claims.test.js
@@ -320,6 +320,21 @@ describe("documentation capability claims", () => {
     expect(sourceManifest.long_description).toMatch(/returned through MCP may be processed under the selected host or model provider's data terms/i);
     expect(violations).toEqual([]);
   });
+
+  it("keeps host import authority distinct from PDF Tools direct folder scope", async () => {
+    const readme = await readRepositoryFile("README.md");
+    const packaging = await readRepositoryFile("docs/agent-plugins-packaging.md");
+    const threatModel = await readRepositoryFile("docs/FOLDER_SCOPE_THREAT_MODEL.md");
+    const pluginBuilder = await readRepositoryFile("scripts/build-agent-plugin.mjs");
+    const joined = [readme, packaging, threatModel, pluginBuilder].join("\n");
+
+    expect(readme).toMatch(/private PDF Tools workspace/i);
+    expect(packaging).toMatch(/direct-call boundary, not a source-confidentiality boundary/i);
+    expect(threatModel).toMatch(/Full Access host may read an outside file and copy it into the[\s\S]{0,20}workspace/i);
+    expect(pluginBuilder).toMatch(/host's permissions govern which files it may import/i);
+    expect(joined).not.toMatch(/extension only opens folders you have listed/i);
+    expect(joined).not.toMatch(/fresh install allows no directories/i);
+  });
 });
 
 /*

--- a/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
+++ b/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
@@ -85,8 +85,8 @@
     {
       "role": "output_schemas_module",
       "path": "server/output-schemas.js",
-      "bytes": 58647,
-      "sha256": "e7aa12e341e32023df0b21826cf58bb9d682477e1c1f4a4a1aba2fcb1f1a77ce"
+      "bytes": 58667,
+      "sha256": "aea4656646416d46f4e78cabeaa60c6cb7e6bf4f0b33d200cab5499ade55d9ec"
     },
     {
       "role": "package_json",
@@ -131,7 +131,7 @@
       "sha256": "ef40501b2afbe4cd2adfa80480344783bbec1a00e8e9850086a5d044231d1f53"
     }
   ],
-  "validator_source_set_sha256": "436e81164e556c4d384b41a44511693abca94db878b30cdf2ce3b2575e235976",
+  "validator_source_set_sha256": "c4f046ad99aa8989de15bc97d67722ee0abc6f286d4fd13286342872caea9b2d",
   "pdfjs_version": "5.4.624",
   "generation_contract": {
     "source_path": "source.pdf",

--- a/test/get-allowed-directories.test.js
+++ b/test/get-allowed-directories.test.js
@@ -101,7 +101,7 @@ describe("get_allowed_directories", () => {
     expect(structured.directories).toEqual([firstDirectory]);
   }, 30_000);
 
-  it("answers without a refusal when nothing is configured", async () => {
+  it("reports the private import workspace on a fresh plugin install", async () => {
     const emptyPluginData = path.join(tempDirectory, "empty-plugin-data");
     await fs.mkdir(emptyPluginData, { recursive: true });
 
@@ -110,14 +110,17 @@ describe("get_allowed_directories", () => {
       env: { HOME: path.join(tempDirectory, "home"), PLUGIN_DATA: emptyPluginData },
     }, client => client.callTool({ name: "get_allowed_directories", arguments: {} }));
 
-    // Reporting the boundary is not reaching past it, so an unconfigured
-    // server must still answer this question rather than deny it.
+    const workspace = path.join(emptyPluginData, "workspace");
     expect(result.isError).not.toBe(true);
-    expect(result.structuredContent.configured).toBe(false);
-    expect(result.structuredContent.directories).toEqual([]);
-    expect(result.structuredContent.config_path).toBe(
-      path.join(tempDirectory, "home", ".pdf-tools", "config.json"),
-    );
+    expect(result.structuredContent).toMatchObject({
+      configured: true,
+      directories: [workspace],
+      source: "plugin_workspace",
+      config_path: path.join(emptyPluginData, "config.json"),
+    });
+    if (process.platform !== "win32") {
+      expect((await fs.stat(workspace)).mode & 0o777).toBe(0o700);
+    }
   }, 30_000);
 
   it("is annotated read-only and takes no arguments", async () => {

--- a/test/home-config-location.test.js
+++ b/test/home-config-location.test.js
@@ -346,7 +346,7 @@ describe("well-known home allowed-directories configuration", () => {
     await expect(fs.stat(path.join(outside, "config.json"))).rejects.toMatchObject({ code: "ENOENT" });
   }, 30_000);
 
-  it("names the friendly path before plugin data and emits no shell recipe", async () => {
+  it("names the private workspace on a plugin denial and emits no shell recipe", async () => {
     const home = path.join(tempDirectory, "refusal-home");
     const pluginData = path.join(tempDirectory, "refusal-plugin-data");
     await fs.mkdir(pluginData, { recursive: true });
@@ -357,8 +357,8 @@ describe("well-known home allowed-directories configuration", () => {
     }, client => client.callTool({ name: "list_pdfs", arguments: { directory: tempDirectory } }));
 
     const text = textFromToolResult(refusal);
-    expect(text.indexOf(homeConfigPath(home))).toBeGreaterThanOrEqual(0);
-    expect(text.indexOf(homeConfigPath(home))).toBeLessThan(text.indexOf(path.join(pluginData, "config.json")));
+    expect(text).toContain(path.join(pluginData, "workspace"));
+    expect(text).not.toContain(homeConfigPath(home));
     expect(text).not.toMatch(/(?:^|\s)(?:cat|echo|printf|mkdir|tee)\s/);
   }, 30_000);
 });

--- a/test/mcp-contract.test.js
+++ b/test/mcp-contract.test.js
@@ -153,7 +153,7 @@ const EXAMPLE_PDF = path.join(REPO_ROOT, "example-fw9.pdf");
 // lowered smaller glyph run and writes it as Unicode subscript characters. No
 // tool name, description, input schema, or read-only annotation changes.
 // Previously cefcfff3fc76324826e1eedcd4e2694d311cfcd1ab7daa9f43dc9e2f496eae5d.
-const TOOL_CONTRACT_SHA256 = "e5328f44d1f1f01a2f015d756cb13c1980b84c8042cdd1d8470699b9931b67ad";
+const TOOL_CONTRACT_SHA256 = "54287c9c708f3a6db5f0f2a6aab6e03d01c3feb1ac4931a79b3f7e42a91b3afa";
 
 const CLOSED_READ = Object.freeze({
   readOnlyHint: true,

--- a/test/plugin-data-config.test.js
+++ b/test/plugin-data-config.test.js
@@ -245,28 +245,88 @@ describe("first-run bootstrap", () => {
     await removeTestTempDirectory(tempDirectory);
   });
 
-  it("writes the well-known home template on first run and names it in the refusal", async () => {
+  it("creates a private workspace and an optional direct-folder template on first run", async () => {
     const pluginData = path.join(tempDirectory, "fresh-install");
     const home = path.join(tempDirectory, "home");
     await fs.mkdir(pluginData, { recursive: true });
     const pluginConfigPath = path.join(pluginData, "config.json");
-    const configPath = path.join(home, ".pdf-tools", "config.json");
+    const workspace = path.join(pluginData, "workspace");
+    await fs.copyFile(EXAMPLE_PDF, path.join(pluginData, "to-import.pdf"));
 
-    const result = await withServer({
+    const observed = await withServer({
       name: "plugin-data-bootstrap",
       env: { HOME: home, PLUGIN_DATA: pluginData },
-    }, client => client.callTool({
-      name: "list_pdfs",
-      arguments: { directory: tempDirectory },
+    }, async client => ({
+      boundary: await client.callTool({ name: "get_allowed_directories", arguments: {} }),
+      outside: await client.callTool({ name: "list_pdfs", arguments: { directory: pluginData } }),
+      workspace: await client.callTool({ name: "list_pdfs", arguments: { directory: workspace } }),
     }));
 
-    expect(structuredErrorCode(result)).toBe("path_policy_denied");
-    // A fresh install must not merely refuse; it must say where to configure it.
-    expect(textFromToolResult(result)).toContain(configPath);
+    expect(observed.boundary.structuredContent).toMatchObject({
+      directories: [workspace],
+      configured: true,
+      source: "plugin_workspace",
+      config_path: pluginConfigPath,
+    });
+    expect(structuredErrorCode(observed.outside)).toBe("path_policy_denied");
+    expect(structuredErrorCode(observed.workspace)).toBeUndefined();
 
-    const written = JSON.parse(await fs.readFile(configPath, "utf8"));
+    const written = JSON.parse(await fs.readFile(pluginConfigPath, "utf8"));
     expect(written.allowedDirectories).toEqual([]);
-    await expect(fs.stat(pluginConfigPath)).rejects.toMatchObject({ code: "ENOENT" });
+    if (process.platform !== "win32") {
+      expect((await fs.stat(workspace)).mode & 0o777).toBe(0o700);
+    }
+    await expect(fs.stat(path.join(home, ".pdf-tools", "config.json")))
+      .rejects.toMatchObject({ code: "ENOENT" });
+  }, 30_000);
+
+  it("fails closed when the workspace path is a symlink outside plugin data", async () => {
+    const pluginData = path.join(tempDirectory, "symlinked-workspace");
+    const outside = path.join(tempDirectory, "outside-workspace");
+    await fs.mkdir(pluginData, { recursive: true });
+    await fs.mkdir(outside, { recursive: true });
+    await fs.copyFile(EXAMPLE_PDF, path.join(outside, "must-stay-hidden.pdf"));
+    await fs.symlink(outside, path.join(pluginData, "workspace"), process.platform === "win32" ? "junction" : "dir");
+
+    const observed = await withServer({
+      name: "plugin-data-workspace-symlink",
+      env: { HOME: path.join(tempDirectory, "symlink-home"), PLUGIN_DATA: pluginData },
+    }, async client => ({
+      boundary: await client.callTool({ name: "get_allowed_directories", arguments: {} }),
+      listing: await client.callTool({ name: "list_pdfs", arguments: { directory: outside } }),
+    }));
+
+    expect(observed.boundary.structuredContent).toMatchObject({
+      directories: [],
+      configured: false,
+      source: "none",
+    });
+    expect(structuredErrorCode(observed.listing)).toBe("path_policy_denied");
+    expect(textFromToolResult(observed.listing)).not.toContain("must-stay-hidden.pdf");
+  }, 30_000);
+
+  it("can process a host-imported copy without gaining direct access to its source folder", async () => {
+    const pluginData = path.join(tempDirectory, "host-import");
+    const workspace = path.join(pluginData, "workspace");
+    const source = path.join(tempDirectory, "host-import-source");
+    await fs.mkdir(workspace, { recursive: true });
+    await fs.mkdir(source, { recursive: true });
+    await fs.copyFile(EXAMPLE_PDF, path.join(source, "source.pdf"));
+    // This copy represents a separate action by a host that has permission to
+    // read the source. PDF Tools receives authority only over the destination.
+    await fs.copyFile(path.join(source, "source.pdf"), path.join(workspace, "imported.pdf"));
+
+    const observed = await withServer({
+      name: "plugin-data-host-import",
+      env: { HOME: path.join(tempDirectory, "import-home"), PLUGIN_DATA: pluginData },
+    }, async client => ({
+      imported: await client.callTool({ name: "list_pdfs", arguments: { directory: workspace } }),
+      source: await client.callTool({ name: "list_pdfs", arguments: { directory: source } }),
+    }));
+
+    expect(textFromToolResult(observed.imported)).toContain("imported.pdf");
+    expect(structuredErrorCode(observed.source)).toBe("path_policy_denied");
+    expect(textFromToolResult(observed.source)).not.toContain("source.pdf");
   }, 30_000);
 
   it("does not overwrite a config that already exists", async () => {


### PR DESCRIPTION
## Summary

- give fresh Agent Plugin installs a setup-free private `${PLUGIN_DATA}/workspace`
- retain optional explicit direct-folder configuration without merging or self-granting access
- distinguish host filesystem authority, PDF Tools direct-path policy, and provider processing terms
- mirror runtime/schema changes into the share package and regenerate the bound extraction oracle
- add hostile policy tests and a focused folder-scope threat model

## Why

A ChatGPT host with Full Access can copy a file it is already authorized to read into a PDF Tools-accessible folder. The PDF Tools allowlist is therefore a useful direct-tool boundary, not a source-confidentiality boundary for the host itself. This removes mandatory first-run folder setup while preserving that defense in depth and stating the boundary accurately.

## Verification

- focused/adjoining: 180/180
- post-qualification boundary/docs: 101/101
- reproducible share contract: 44 tools, 14 prompts, 122 licensed SBOM components
- Agent Plugin build plus staged stdio smoke: passed
- installed Mac clean-user boundary: outside source refused with `path_policy_denied`; byte-identical workspace import accepted; 4/4 pages read; scope unchanged
- exact landing SHA aggregate on macOS/arm64 Node 22.23.2: 158 files / 2,501 tests passed; 7 files / 109 tests intentionally skipped; native 62 passed / 9 intentionally skipped

## Scope boundaries

This change does not claim that PDF Tools confines a Full Access host. The host may import files it can read. PDF Tools still refuses direct paths outside its selected workspace/folders, and content returned over MCP follows host/provider terms.

No release artifact is committed by this PR.
