### PR TITLE
Broaden source-evidenced math limitation detection

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -104,7 +104,7 @@ created and no model or provider is called.
   status is `partial` and the Markdown declaration, bytes, and digest change.
 - `normalizations` reports page-number, running-header, running-footer, removed
   character, and affected-page counts.
-- Renderer identity is `pdf-tools.layout-markdown-renderer` `1.19.0`.
+- Renderer identity is `pdf-tools.layout-markdown-renderer` `1.20.0`.
 - Source and share-bundle implementations remain byte-identical.
 
 ## Acceptance

--- a/docs/MCP_CONTRACT.md
+++ b/docs/MCP_CONTRACT.md
@@ -208,9 +208,18 @@ vector, failed, caller-limit-truncated, invalid-geometry, output-omission, and
 source-evidenced unreconstructed-mathematics cases are represented as typed
 gaps and cannot receive a complete conversion status. The
 `MATH_NOT_RECONSTRUCTED` code is emitted per page only when an unambiguous
-mathematical glyph occurs, or when a relation and independent cross-font
-evidence occur in the same compact source-item run; ambiguous operator words
-remain undeclared rather than guessed.
+mathematical glyph occurs, when a relation and independent cross-font evidence
+occur in the same compact source-item run, or when one retained source item
+matches a finite merged-equation grammar: an exact named operator, an equals
+sign, and a separate single-letter variable; ambiguous operator names require
+function parentheses. Named operators are
+case-insensitive so real lowercase `lim`, `max`, and `min` notation is covered.
+A lone operator word, `max=5`, `max x=5`, programming declarations such as
+`int x=5`, prose words containing an operator substring, generic configuration
+syntax, a standalone square-root character that may be a table checkmark, and
+raised or lowered text remain undeclared
+rather than guessed. These rules declare source-evidenced math but never
+reconstruct or alter the Markdown body.
 By default, the renderer also removes only source-evidenced page furniture in
 the extreme top or bottom 12 percent of a page: an explicit page-number or
 provenance line, or text repeated in the same band on at least two selected

--- a/pdf-toolkit-mcp-share/server/markdown-conversion.js
+++ b/pdf-toolkit-mcp-share/server/markdown-conversion.js
@@ -6,7 +6,7 @@ import {
 
 const RENDERER = Object.freeze({
   name: "pdf-tools.layout-markdown-renderer",
-  version: "1.19.0",
+  version: "1.20.0",
 });
 const SUPPORTED_LAYOUT_IR_VERSION = "1.6.0";
 
@@ -1275,13 +1275,31 @@ function hasIndependentMathLayoutEvidence(row, operatorIndex, rows, rowIndex) {
  * fabricated one.
  *
  * A page qualifies when at least one line the renderer emitted as flat
- * reading-order text carries all three of:
+ * reading-order text carries either a source-symbol proof or all three compact
+ * run conditions below.
+ *
+ *   M1 — merged source-symbol proof. A source item on a short left-to-right
+ *        line contains both an alphanumeric character and an unambiguous
+ *        mathematical glyph (`∑`, `∫`, `∞`, `∂`, `∇`, `≈`, `≠`, `∈`,
+ *        `∉`, `⊂`, `⊃`, `⊆`, `⊇`, `⊗`, or `⊕`). The proof is taken from the
+ *        exact retained source item, not inferred from a score over the line.
+ *        A lone glyph is not enough on this route; the existing structural-run
+ *        route below still handles a separately painted operator.
+ *   M2 — merged named-operator proof. One short source item consists only of
+ *        math-run characters and contains a literal `log`, `lim`, `max`,
+ *        `min`, `sum`, or `infinity`, an equals sign, and a separate
+ *        single-letter variable. Only `lim` and `infinity` stand alone; the
+ *        other names require function parentheses. Thus `lim x=0` and
+ *        `max(x)=5` are source evidence, while `max=5`, `max x=5`, `int x=5`,
+ *        `maximum(x)=5`, and `PATH=/tmp` remain ambiguous and do not qualify.
  *
  *   S1 — run shape. The line is upright left-to-right, at most
  *        MATH_RUN_MAX_LINE_CHARACTERS long, holds at least two structural
  *        source items, and *every* one of them is a compact math token
  *        (`compactMathItemText`: one letter, one digit, math punctuation, or
- *        the operator `log`) or a named operator word. This is the same "short
+ *        the operator `log`) or a named operator word. Named operators are
+ *        matched case-insensitively because mathematical papers commonly use
+ *        lowercase `lim`, `max`, and `min`. This is the same "short
  *        compact left-to-right math run" shape the bounded `log`-spacing repair
  *        already uses to recognise a nearby equation, reused verbatim rather
  *        than reinvented.
@@ -1302,10 +1320,15 @@ function hasIndependentMathLayoutEvidence(row, operatorIndex, rows, rowIndex) {
  * can corroborate them, but they are not S2 evidence by themselves: `Max 5`
  * may be prose, a header, or a label. A mathematical symbol or the independent
  * relation-plus-font evidence is required rather than fabricating a loss
- * declaration from an ambiguous word.
+ * declaration from an ambiguous word. M1 and M2 close the source-item
+ * segmentation hole without guessing equation topology or changing the
+ * rendered body.
  *
  * Deliberately rejected as triggers:
  *
+ *   - `√` on the merged-symbol route. Real PDF tables also use this character
+ *     as a checkmark, so source text such as `A2 ≥ 80% √` is not sufficient
+ *     evidence of mathematics without another admitted route.
  *   - A raised or lowered run on its own. The renderer's own limitation prose
  *     states that a page sets a mathematical exponent and a footnote reference
  *     identically, so a raised run cannot distinguish the two and would emit
@@ -1321,9 +1344,13 @@ function hasIndependentMathLayoutEvidence(row, operatorIndex, rows, rowIndex) {
  *     (TEXT_INTEGRITY_SUSPECT) which this one must not duplicate or weaken.
  *   - Character-class scoring over the rendered line text ("this looks mathy").
  *     That is a heuristic guess, not source evidence, and would put a numeric
- *     judgement where this vocabulary allows none.
+ *     judgement where this vocabulary allows none. The merged-item routes use
+ *     exact, enumerated source characters and a finite grammar instead.
  */
-const NAMED_MATH_OPERATOR = /^(?:Lim|Max|Min)$/u;
+const NAMED_MATH_OPERATOR = /^(?:log|lim|max|min|sum|int|infinity)$/iu;
+const MERGED_NAMED_MATH_OPERATOR = /(?:^|[^\p{L}])(log|lim|max|min|sum|infinity)(?=$|[^\p{L}])/iu;
+const SOURCE_MATH_SYMBOL = /[∑∫∞∂∇≈≠∈∉⊂⊃⊆⊇⊗⊕]/u;
+const MERGED_MATH_CHARACTERS = /^[\p{L}\p{M}\p{N}\s()[\]{},.;:+\-*/=^_]+$/u;
 const MATH_RUN_MAX_LINE_CHARACTERS = 80;
 const MATH_RUN_MIN_ITEMS = 2;
 const MATH_RELATION_MIN_ITEMS = 3;
@@ -1353,6 +1380,35 @@ function hasCrossFontRelationEvidence(items) {
   return false;
 }
 
+function hasMergedSourceMathSymbol(items) {
+  return items.some(item => {
+    const text = item.text.trim();
+    return text.length <= MATH_RUN_MAX_LINE_CHARACTERS
+      && SOURCE_MATH_SYMBOL.test(text)
+      && /[\p{L}\p{N}]/u.test(text);
+  });
+}
+
+function isMergedNamedOperatorEquation(value) {
+  const text = String(value).trim();
+  const operatorMatch = MERGED_NAMED_MATH_OPERATOR.exec(text);
+  if (text.length < 3 || text.length > MATH_RUN_MAX_LINE_CHARACTERS
+    || !text.includes("=")
+    || operatorMatch === null
+    || !MERGED_MATH_CHARACTERS.test(text)) return false;
+  const words = text.match(/\p{L}+/gu) ?? [];
+  const operator = operatorMatch[1].toLowerCase();
+  const operatorHasFunctionShape = operator === "lim" || operator === "infinity"
+    || new RegExp(`(?:^|[^\\p{L}])${operator}\\s*\\(`, "iu").test(text);
+  return operatorHasFunctionShape
+    && words.some(word => /^\p{L}$/u.test(word))
+    && words.every(word => /^\p{L}$/u.test(word) || NAMED_MATH_OPERATOR.test(word));
+}
+
+function hasMergedNamedOperatorEquation(items) {
+  return items.some(item => isMergedNamedOperatorEquation(item.text));
+}
+
 function rowHasSymbolicMathOperator(row) {
   return row.cells.some(item => /^[∑∫∞]$/u.test(item.text.trim()));
 }
@@ -1361,9 +1417,11 @@ function isUnreconstructedMathRow(row) {
   const { line } = row;
   if (line.direction !== "ltr" || line.text.length > MATH_RUN_MAX_LINE_CHARACTERS) return false;
   const items = mathRunStructuralItems(row);
+  if (items.length === 0 || items.some(item => containsUnsafeText(item.text))) return false;
+  if (hasMergedSourceMathSymbol(items) || hasMergedNamedOperatorEquation(items)) return true;
   if (items.length < MATH_RUN_MIN_ITEMS
     || !items.every(item => isMathRunItemText(item.text))
-    || items.some(item => containsUnsafeText(item.text))) return false;
+  ) return false;
   return rowHasSymbolicMathOperator(row) || hasCrossFontRelationEvidence(items);
 }
 

--- a/pdf-toolkit-mcp-share/server/output-schemas.js
+++ b/pdf-toolkit-mcp-share/server/output-schemas.js
@@ -1339,7 +1339,7 @@ export const TOOL_SUCCESS_OUTPUT_SCHEMAS = Object.freeze({
     {
       renderer: object({
         name: { const: "pdf-tools.layout-markdown-renderer" },
-        version: { const: "1.19.0" },
+        version: { const: "1.20.0" },
       }),
       conversion_status: enumString(["complete", "partial", "failed"]),
       markdown: string,

--- a/scripts/eval-run-markdown-bakeoff.mjs
+++ b/scripts/eval-run-markdown-bakeoff.mjs
@@ -202,7 +202,7 @@ export function validateMarkdownResult(result, binding) {
     throw new Error(`Markdown conversion failed for ${binding.fixture.id}`);
   }
   const value = result.structuredContent;
-  if (value.renderer?.name !== "pdf-tools.layout-markdown-renderer" || value.renderer?.version !== "1.19.0"
+  if (value.renderer?.name !== "pdf-tools.layout-markdown-renderer" || value.renderer?.version !== "1.20.0"
     || value.options?.include_page_boundaries !== true || value.limits?.max_markdown_bytes !== 200000
     || value.provenance?.source?.file_name !== binding.retained.filename
     || value.provenance?.source?.sha256 !== binding.retained.sha256

--- a/scripts/macos-claude-installed-shannon.mjs
+++ b/scripts/macos-claude-installed-shannon.mjs
@@ -91,7 +91,7 @@ try {
     });
     const value = result.structuredContent;
     assert(!result.isError && value, `Installed conversion failed for pages ${startPage}-${endPage}`);
-    assert(value.renderer?.version === "1.19.0", "Installed Markdown renderer version differs");
+    assert(value.renderer?.version === "1.20.0", "Installed Markdown renderer version differs");
     assert(value.provenance?.layout?.parser_version === "5.4.624", "Installed PDF parser version differs");
     assert(value.provenance?.source?.sha256 === sourceSha256, "Installed conversion source identity differs");
     assert(value.provenance?.layout?.page_range?.start_page === startPage, "Installed conversion start page differs");

--- a/scripts/smoke-mcpb.mjs
+++ b/scripts/smoke-mcpb.mjs
@@ -466,7 +466,7 @@ async function main() {
       arguments: { pdf_path: fixturePath, max_markdown_bytes: 200000 },
     });
     if (markdown.isError
-      || markdown.structuredContent?.renderer?.version !== "1.19.0"
+      || markdown.structuredContent?.renderer?.version !== "1.20.0"
       || markdown.structuredContent?.markdown_bytes !== Buffer.byteLength(markdown.structuredContent?.markdown || "", "utf8")
       || markdown.structuredContent?.markdown_sha256 !== sha256(Buffer.from(markdown.structuredContent?.markdown || "", "utf8"))) {
       throw new Error("Packed convert_pdf_to_markdown contract smoke failed");

--- a/scripts/test-share-contract.mjs
+++ b/scripts/test-share-contract.mjs
@@ -1193,7 +1193,7 @@ async function main() {
       arguments: { pdf_path: fixturePath, max_markdown_bytes: 200000 },
     });
     if (markdown.isError
-      || markdown.structuredContent?.renderer?.version !== "1.19.0"
+      || markdown.structuredContent?.renderer?.version !== "1.20.0"
       || markdown.structuredContent?.markdown_bytes !== Buffer.byteLength(markdown.structuredContent?.markdown || "", "utf8")
       || markdown.structuredContent?.markdown_sha256 !== sha256(Buffer.from(markdown.structuredContent?.markdown || "", "utf8"))) {
       throw new Error("Share convert_pdf_to_markdown contract smoke failed");

--- a/server/markdown-conversion.js
+++ b/server/markdown-conversion.js
@@ -6,7 +6,7 @@ import {
 
 const RENDERER = Object.freeze({
   name: "pdf-tools.layout-markdown-renderer",
-  version: "1.19.0",
+  version: "1.20.0",
 });
 const SUPPORTED_LAYOUT_IR_VERSION = "1.6.0";
 
@@ -1275,13 +1275,31 @@ function hasIndependentMathLayoutEvidence(row, operatorIndex, rows, rowIndex) {
  * fabricated one.
  *
  * A page qualifies when at least one line the renderer emitted as flat
- * reading-order text carries all three of:
+ * reading-order text carries either a source-symbol proof or all three compact
+ * run conditions below.
+ *
+ *   M1 — merged source-symbol proof. A source item on a short left-to-right
+ *        line contains both an alphanumeric character and an unambiguous
+ *        mathematical glyph (`∑`, `∫`, `∞`, `∂`, `∇`, `≈`, `≠`, `∈`,
+ *        `∉`, `⊂`, `⊃`, `⊆`, `⊇`, `⊗`, or `⊕`). The proof is taken from the
+ *        exact retained source item, not inferred from a score over the line.
+ *        A lone glyph is not enough on this route; the existing structural-run
+ *        route below still handles a separately painted operator.
+ *   M2 — merged named-operator proof. One short source item consists only of
+ *        math-run characters and contains a literal `log`, `lim`, `max`,
+ *        `min`, `sum`, or `infinity`, an equals sign, and a separate
+ *        single-letter variable. Only `lim` and `infinity` stand alone; the
+ *        other names require function parentheses. Thus `lim x=0` and
+ *        `max(x)=5` are source evidence, while `max=5`, `max x=5`, `int x=5`,
+ *        `maximum(x)=5`, and `PATH=/tmp` remain ambiguous and do not qualify.
  *
  *   S1 — run shape. The line is upright left-to-right, at most
  *        MATH_RUN_MAX_LINE_CHARACTERS long, holds at least two structural
  *        source items, and *every* one of them is a compact math token
  *        (`compactMathItemText`: one letter, one digit, math punctuation, or
- *        the operator `log`) or a named operator word. This is the same "short
+ *        the operator `log`) or a named operator word. Named operators are
+ *        matched case-insensitively because mathematical papers commonly use
+ *        lowercase `lim`, `max`, and `min`. This is the same "short
  *        compact left-to-right math run" shape the bounded `log`-spacing repair
  *        already uses to recognise a nearby equation, reused verbatim rather
  *        than reinvented.
@@ -1302,10 +1320,15 @@ function hasIndependentMathLayoutEvidence(row, operatorIndex, rows, rowIndex) {
  * can corroborate them, but they are not S2 evidence by themselves: `Max 5`
  * may be prose, a header, or a label. A mathematical symbol or the independent
  * relation-plus-font evidence is required rather than fabricating a loss
- * declaration from an ambiguous word.
+ * declaration from an ambiguous word. M1 and M2 close the source-item
+ * segmentation hole without guessing equation topology or changing the
+ * rendered body.
  *
  * Deliberately rejected as triggers:
  *
+ *   - `√` on the merged-symbol route. Real PDF tables also use this character
+ *     as a checkmark, so source text such as `A2 ≥ 80% √` is not sufficient
+ *     evidence of mathematics without another admitted route.
  *   - A raised or lowered run on its own. The renderer's own limitation prose
  *     states that a page sets a mathematical exponent and a footnote reference
  *     identically, so a raised run cannot distinguish the two and would emit
@@ -1321,9 +1344,13 @@ function hasIndependentMathLayoutEvidence(row, operatorIndex, rows, rowIndex) {
  *     (TEXT_INTEGRITY_SUSPECT) which this one must not duplicate or weaken.
  *   - Character-class scoring over the rendered line text ("this looks mathy").
  *     That is a heuristic guess, not source evidence, and would put a numeric
- *     judgement where this vocabulary allows none.
+ *     judgement where this vocabulary allows none. The merged-item routes use
+ *     exact, enumerated source characters and a finite grammar instead.
  */
-const NAMED_MATH_OPERATOR = /^(?:Lim|Max|Min)$/u;
+const NAMED_MATH_OPERATOR = /^(?:log|lim|max|min|sum|int|infinity)$/iu;
+const MERGED_NAMED_MATH_OPERATOR = /(?:^|[^\p{L}])(log|lim|max|min|sum|infinity)(?=$|[^\p{L}])/iu;
+const SOURCE_MATH_SYMBOL = /[∑∫∞∂∇≈≠∈∉⊂⊃⊆⊇⊗⊕]/u;
+const MERGED_MATH_CHARACTERS = /^[\p{L}\p{M}\p{N}\s()[\]{},.;:+\-*/=^_]+$/u;
 const MATH_RUN_MAX_LINE_CHARACTERS = 80;
 const MATH_RUN_MIN_ITEMS = 2;
 const MATH_RELATION_MIN_ITEMS = 3;
@@ -1353,6 +1380,35 @@ function hasCrossFontRelationEvidence(items) {
   return false;
 }
 
+function hasMergedSourceMathSymbol(items) {
+  return items.some(item => {
+    const text = item.text.trim();
+    return text.length <= MATH_RUN_MAX_LINE_CHARACTERS
+      && SOURCE_MATH_SYMBOL.test(text)
+      && /[\p{L}\p{N}]/u.test(text);
+  });
+}
+
+function isMergedNamedOperatorEquation(value) {
+  const text = String(value).trim();
+  const operatorMatch = MERGED_NAMED_MATH_OPERATOR.exec(text);
+  if (text.length < 3 || text.length > MATH_RUN_MAX_LINE_CHARACTERS
+    || !text.includes("=")
+    || operatorMatch === null
+    || !MERGED_MATH_CHARACTERS.test(text)) return false;
+  const words = text.match(/\p{L}+/gu) ?? [];
+  const operator = operatorMatch[1].toLowerCase();
+  const operatorHasFunctionShape = operator === "lim" || operator === "infinity"
+    || new RegExp(`(?:^|[^\\p{L}])${operator}\\s*\\(`, "iu").test(text);
+  return operatorHasFunctionShape
+    && words.some(word => /^\p{L}$/u.test(word))
+    && words.every(word => /^\p{L}$/u.test(word) || NAMED_MATH_OPERATOR.test(word));
+}
+
+function hasMergedNamedOperatorEquation(items) {
+  return items.some(item => isMergedNamedOperatorEquation(item.text));
+}
+
 function rowHasSymbolicMathOperator(row) {
   return row.cells.some(item => /^[∑∫∞]$/u.test(item.text.trim()));
 }
@@ -1361,9 +1417,11 @@ function isUnreconstructedMathRow(row) {
   const { line } = row;
   if (line.direction !== "ltr" || line.text.length > MATH_RUN_MAX_LINE_CHARACTERS) return false;
   const items = mathRunStructuralItems(row);
+  if (items.length === 0 || items.some(item => containsUnsafeText(item.text))) return false;
+  if (hasMergedSourceMathSymbol(items) || hasMergedNamedOperatorEquation(items)) return true;
   if (items.length < MATH_RUN_MIN_ITEMS
     || !items.every(item => isMathRunItemText(item.text))
-    || items.some(item => containsUnsafeText(item.text))) return false;
+  ) return false;
   return rowHasSymbolicMathOperator(row) || hasCrossFontRelationEvidence(items);
 }
 

--- a/server/output-schemas.js
+++ b/server/output-schemas.js
@@ -1339,7 +1339,7 @@ export const TOOL_SUCCESS_OUTPUT_SCHEMAS = Object.freeze({
     {
       renderer: object({
         name: { const: "pdf-tools.layout-markdown-renderer" },
-        version: { const: "1.19.0" },
+        version: { const: "1.20.0" },
       }),
       conversion_status: enumString(["complete", "partial", "failed"]),
       markdown: string,

--- a/test/convert-pdf-to-markdown.test.js
+++ b/test/convert-pdf-to-markdown.test.js
@@ -305,7 +305,7 @@ describe("convert_pdf_to_markdown MCP tool", () => {
     expect(first.isError).not.toBe(true);
     expect(second.structuredContent).toEqual(first.structuredContent);
     expect(first.structuredContent).toMatchObject({
-      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.19.0" },
+      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.20.0" },
       conversion_status: "complete",
       saved_output: null,
       provenance: {

--- a/test/eval/markdown-bakeoff.test.js
+++ b/test/eval/markdown-bakeoff.test.js
@@ -66,7 +66,7 @@ async function handle(message) {
     const pageBoundaries = Array.from({ length: pageCount }, (_, index) => "<!-- PDF page " + (index + 1) + " -->");
     const markdown = pageBoundaries.join("\n\n") + "\n\nINV-1001 fixture evidence\n";
     const value = {
-      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.19.0" },
+      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.20.0" },
       conversion_status: "complete",
       markdown,
       markdown_sha256: digest(Buffer.from(markdown)),
@@ -167,7 +167,7 @@ function resultFor(binding) {
   const markdown = "<!-- PDF page 1 -->\n\nFixture text\n";
   return {
     structuredContent: {
-      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.19.0" },
+      renderer: { name: "pdf-tools.layout-markdown-renderer", version: "1.20.0" },
       conversion_status: "complete",
       markdown,
       markdown_sha256: sha256(Buffer.from(markdown)),
@@ -255,7 +255,7 @@ describe("Markdown bakeoff renderer version binding", () => {
   });
 
   it("accepts the current renderer version and rejects all superseded ones", () => {
-    expect(validateMarkdownResult(resultFor("1.19.0"), binding).renderer.version).toBe("1.19.0");
+    expect(validateMarkdownResult(resultFor("1.20.0"), binding).renderer.version).toBe("1.20.0");
     for (const stale of ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.6.0", "1.7.0", "1.8.0", "1.9.0", "1.10.0", "1.11.0", "1.12.0", "1.13.0", "1.14.0", "1.15.0", "1.16.0", "1.17.0"]) {
       expect(() => validateMarkdownResult(resultFor(stale), binding), stale)
         .toThrow(/Markdown result evidence is invalid/u);

--- a/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
+++ b/test/fixtures/eval/extraction/phase1/layout-occurrence-oracle.v1.json
@@ -79,14 +79,14 @@
     {
       "role": "markdown_conversion_module",
       "path": "server/markdown-conversion.js",
-      "bytes": 167797,
-      "sha256": "41367341f4f138510d316faa793de280f496e362d2feb34b7fc5f816ca09b341"
+      "bytes": 171071,
+      "sha256": "fda18768b9ca04b44863abaf9fc400dd29299ad546da1357402a0d5131cd2b35"
     },
     {
       "role": "output_schemas_module",
       "path": "server/output-schemas.js",
       "bytes": 69238,
-      "sha256": "8e0489fabf51b899b3c7b128c357cb8f5d6e462989a8e64cbb71a5b24ff94586"
+      "sha256": "06e0ad8cca222902b5e50621f895cc9d84a2c8089471fafd2fb726f4fbc56667"
     },
     {
       "role": "package_json",
@@ -131,7 +131,7 @@
       "sha256": "ef40501b2afbe4cd2adfa80480344783bbec1a00e8e9850086a5d044231d1f53"
     }
   ],
-  "validator_source_set_sha256": "c10ac4f89a1c8b28612a40058c74f14ba5c87a39d1b26186f914f7f17a7e80c8",
+  "validator_source_set_sha256": "a913e9c7290a8c1ee3d601013687f9d34204d531ba1f09a203f13ae86f2bf95b",
   "pdfjs_version": "5.4.624",
   "generation_contract": {
     "source_path": "source.pdf",

--- a/test/fixtures/eval/shannon/manifest.v1.json
+++ b/test/fixtures/eval/shannon/manifest.v1.json
@@ -22,7 +22,7 @@
     "pdf_tools": {
       "slot": "control.current_product.v0",
       "renderer_name": "pdf-tools.layout-markdown-renderer",
-      "renderer_version": "1.19.0",
+      "renderer_version": "1.20.0",
       "parser_name": "pdfjs-dist",
       "parser_version": "5.4.624"
     },

--- a/test/markdown-conversion.test.js
+++ b/test/markdown-conversion.test.js
@@ -391,7 +391,7 @@ describe("layout Markdown renderer", () => {
     // before renderer 1.19.0 added typed page-furniture removal.
     // This non-math fixture keeps its body and gaps; the renderer identity moves.
     expect(createHash("sha256").update(serialized).digest("hex"))
-      .toBe("de1edf936a5b7561ba6942c9d333b7ecb138c6f3892e4c79a4c7f310b1dfd540");
+      .toBe("0c77bf5df3fcfde1ec6b504376a75859daadde63b433d512acb8f107bb5e7d58");
     const body = result.markdown.split("\n\n## Conversion gaps\n\n", 1)[0];
     expect(JSON.stringify({
       body,
@@ -399,7 +399,7 @@ describe("layout Markdown renderer", () => {
     })).toBe(NON_RECT_EXPECTED);
     expect(result.renderer).toEqual({
       name: "pdf-tools.layout-markdown-renderer",
-      version: "1.19.0",
+      version: "1.20.0",
     });
     expect(result.gaps[0].message).toMatch(/beyond reconstructed ruled or bounded solid-mask table grids/);
     expect(result.limitations.some(value => value.includes("clean ruled-rectangle grid evidence"))).toBe(true);

--- a/test/math-not-reconstructed-gap.test.js
+++ b/test/math-not-reconstructed-gap.test.js
@@ -194,6 +194,25 @@ const CORPUS = {
       positionedTextItem(")", { top: 100, left: 131, width: 3.84, eol: true }),
     ],
   }],
+  lowercaseOperatorEquation: [{
+    items: [
+      positionedTextItem("x", { top: 100, left: 100, width: 6, fontName: "f2" }),
+      positionedTextItem("=", { top: 100, left: 107, width: 7 }),
+      positionedTextItem("lim", { top: 100, left: 115, width: 15, eol: true }),
+    ],
+  }],
+  mergedNamedOperatorEquation: [{
+    items: [textItem("lim x=0", { top: 100 })],
+  }],
+  mergedFunctionOperatorEquation: [{
+    items: [textItem("max(x)=5", { top: 100 })],
+  }],
+  mergedSymbolEquation: [{
+    items: [textItem("x ∈ X", { top: 100 })],
+  }],
+  mergedInlineMath: [{
+    items: [textItem("For any x ∈ X, choose y.", { top: 100 })],
+  }],
   relationEquation: [{
     items: [
       positionedTextItem("log", { top: 100, left: 100, width: 12.8 }),
@@ -220,6 +239,27 @@ const CORPUS = {
       positionedTextItem("=", { top: 100, left: 119, width: 7 }),
       positionedTextItem("5", { top: 100, left: 127, width: 5, eol: true }),
     ],
+  }],
+  mergedAmbiguousNamedRelation: [{
+    items: [textItem("max=5", { top: 100 })],
+  }],
+  mergedAmbiguousNamedVariable: [{
+    items: [textItem("max x=5", { top: 100 })],
+  }],
+  mergedProgrammingDeclaration: [{
+    items: [textItem("int x=5", { top: 100 })],
+  }],
+  mergedOperatorSubstring: [{
+    items: [textItem("maximum(x)=5", { top: 100 })],
+  }],
+  mergedConfiguration: [{
+    items: [textItem("PATH=/tmp", { top: 100 })],
+  }],
+  loneMergedSymbol: [{
+    items: [textItem("∑", { top: 100 })],
+  }],
+  checkmarkStatus: [{
+    items: [textItem("A2 ≥ 80% √", { top: 100 })],
   }],
   genericCrossFontRelation: [{
     items: [
@@ -275,6 +315,16 @@ const PRE_CHANGE_BODIES = {
   "footnoteMarker:compact": "<!-- PDF page 1 -->\n\nThe measured throughput was stable²\nacross every observed trial in the study.",
   namedOperatorEquation: "<!-- PDF page 1 -->\n\nC= Lim\nlog N(T)",
   "namedOperatorEquation:compact": "<!-- PDF page 1 -->\n\nC= Lim\nlog N(T)",
+  lowercaseOperatorEquation: "<!-- PDF page 1 -->\n\nx=lim",
+  "lowercaseOperatorEquation:compact": "<!-- PDF page 1 -->\n\nx=lim",
+  mergedNamedOperatorEquation: "<!-- PDF page 1 -->\n\nlim x=0",
+  "mergedNamedOperatorEquation:compact": "<!-- PDF page 1 -->\n\nlim x=0",
+  mergedFunctionOperatorEquation: "<!-- PDF page 1 -->\n\nmax(x)=5",
+  "mergedFunctionOperatorEquation:compact": "<!-- PDF page 1 -->\n\nmax(x)=5",
+  mergedSymbolEquation: "<!-- PDF page 1 -->\n\nx ∈ X",
+  "mergedSymbolEquation:compact": "<!-- PDF page 1 -->\n\nx ∈ X",
+  mergedInlineMath: "<!-- PDF page 1 -->\n\nFor any x ∈ X, choose y.",
+  "mergedInlineMath:compact": "<!-- PDF page 1 -->\n\nFor any x ∈ X, choose y.",
   relationEquation: "<!-- PDF page 1 -->\n\nlogN=5",
   "relationEquation:compact": "<!-- PDF page 1 -->\n\nlogN=5",
   compactRunWithoutMarker: "<!-- PDF page 1 -->\n\nlogN",
@@ -283,6 +333,20 @@ const PRE_CHANGE_BODIES = {
   "namedOperatorWithoutRelation:compact": "<!-- PDF page 1 -->\n\nMax5",
   sameFontNamedRelation: "<!-- PDF page 1 -->\n\nMax=5",
   "sameFontNamedRelation:compact": "<!-- PDF page 1 -->\n\nMax=5",
+  mergedAmbiguousNamedRelation: "<!-- PDF page 1 -->\n\nmax=5",
+  "mergedAmbiguousNamedRelation:compact": "<!-- PDF page 1 -->\n\nmax=5",
+  mergedAmbiguousNamedVariable: "<!-- PDF page 1 -->\n\nmax x=5",
+  "mergedAmbiguousNamedVariable:compact": "<!-- PDF page 1 -->\n\nmax x=5",
+  mergedProgrammingDeclaration: "<!-- PDF page 1 -->\n\nint x=5",
+  "mergedProgrammingDeclaration:compact": "<!-- PDF page 1 -->\n\nint x=5",
+  mergedOperatorSubstring: "<!-- PDF page 1 -->\n\nmaximum(x)=5",
+  "mergedOperatorSubstring:compact": "<!-- PDF page 1 -->\n\nmaximum(x)=5",
+  mergedConfiguration: "<!-- PDF page 1 -->\n\nPATH=/tmp",
+  "mergedConfiguration:compact": "<!-- PDF page 1 -->\n\nPATH=/tmp",
+  loneMergedSymbol: "<!-- PDF page 1 -->\n\n∑",
+  "loneMergedSymbol:compact": "<!-- PDF page 1 -->\n\n∑",
+  checkmarkStatus: "<!-- PDF page 1 -->\n\nA2 ≥ 80% √",
+  "checkmarkStatus:compact": "<!-- PDF page 1 -->\n\nA2 ≥ 80% √",
   genericCrossFontRelation: "<!-- PDF page 1 -->\n\nA=B",
   "genericCrossFontRelation:compact": "<!-- PDF page 1 -->\n\nA=B",
   symbolicOperatorEquation: "<!-- PDF page 1 -->\n\nκ∑",
@@ -347,6 +411,11 @@ describe("MATH_NOT_RECONSTRUCTED typed gap", () => {
   it("declares compact runs proven by a math symbol or a cross-font relation", async () => {
     for (const name of [
       "namedOperatorEquation",
+      "lowercaseOperatorEquation",
+      "mergedNamedOperatorEquation",
+      "mergedFunctionOperatorEquation",
+      "mergedSymbolEquation",
+      "mergedInlineMath",
       "relationEquation",
       "genericCrossFontRelation",
       "symbolicOperatorEquation",
@@ -363,6 +432,13 @@ describe("MATH_NOT_RECONSTRUCTED typed gap", () => {
       "compactRunWithoutMarker",
       "namedOperatorWithoutRelation",
       "sameFontNamedRelation",
+      "mergedAmbiguousNamedRelation",
+      "mergedAmbiguousNamedVariable",
+      "mergedProgrammingDeclaration",
+      "mergedOperatorSubstring",
+      "mergedConfiguration",
+      "loneMergedSymbol",
+      "checkmarkStatus",
       "ruledTable",
     ]) {
       const result = renderPdfLayoutToMarkdown(await layoutFor(name));

--- a/test/mcp-contract.test.js
+++ b/test/mcp-contract.test.js
@@ -173,7 +173,7 @@ const EXAMPLE_PDF = path.join(REPO_ROOT, "example-fw9.pdf");
 // 2026-09-02: add the provider-neutral signing-preparation receipt and align the
 // combined extraction/signing feature line to 0.13.0. Tool names remain stable;
 // the preparation input/output schemas and runtime server version change.
-const TOOL_CONTRACT_SHA256 = "40d9a66e994d1616d19db822d53d8d1213f9843d4a37e72fc1d134379a8b0b31";
+const TOOL_CONTRACT_SHA256 = "7f9fde99a3a88418a1f4011e4d47617da03991df03391bbeba3a0bff6bbf86ae";
 
 const CLOSED_READ = Object.freeze({
   readOnlyHint: true,


### PR DESCRIPTION
## Summary

- broaden `MATH_NOT_RECONSTRUCTED` to source-evidenced lowercase operators and merged-item equations
- retain fail-closed exclusions for prose, ambiguous values, footnotes, table content, and table checkmarks
- keep source/share modules, schemas, tool-contract hashes, and the Phase 1 source-bound oracle aligned

## Measured evidence

- full paired olmOCR-bench run: 1,403 PDFs / 7,019 tests / zero conversion failures
- `arxiv_math` declaration coverage: 146/522 (28.0%) to 220/522 (42.1%)
- 420 fewer silent math-proxy failures; 76 documents gained the declaration and none lost it
- source-content Markdown body byte-identical for 1,403/1,403 documents
- combined headers/footers plus long-tiny-text control rate: 2/328 (0.61%)

## Verification

- affected/adjoining Mac bank: 170 passed, 6 intentional skips
- Node-native: 62 passed, 9 intentional skips
- reproducible share contract: 51 tools, 14 prompts, 122 licensed SBOM components
- source/share parity and `git diff --check` pass

## Claim boundary

This improves detection and declaration of unreconstructed mathematical content. It does not reconstruct equations, improve the directional math pass score, establish competitor superiority, or authorize a public benchmark claim. The first full Mac aggregate encountered unrelated shared-host timing contention; every observed failure was closed by oracle regeneration or isolated passing runs, and aggregate stability remains separately tracked.