### PR TITLE
Fail fast on invalid benchmark output

### DIFF
--- a/docs/EVALUATION.md
+++ b/docs/EVALUATION.md
@@ -261,7 +261,10 @@ npm run eval:olmocr -- verify --bench-root /absolute/path/to/olmOCR-bench
 
 A full release-candidate run and score run on a POSIX Linux or macOS host and
 use exclusive, atomic, mode-`0600` JSON outputs outside the repository.
-Existing outputs are never overwritten:
+Before it reads the corpus or starts the candidate, the command requires the
+output parent to be a canonical existing directory and the output target to be
+absent. The same checks run again at publication, and existing outputs are never
+overwritten:
 
 ```bash
 npm run eval:olmocr -- run \

--- a/scripts/eval-olmocr-bench.mjs
+++ b/scripts/eval-olmocr-bench.mjs
@@ -501,18 +501,30 @@ async function evaluatorBinding() {
   };
 }
 
-async function writeAtomicExclusive(filename, value) {
+export async function validateOutputDestination(filename) {
+  if (!path.isAbsolute(filename) || path.resolve(filename) !== filename) {
+    throw new Error("Evaluation output must be an absolute normalized path");
+  }
   if (filename === REPO_ROOT || filename.startsWith(`${REPO_ROOT}${path.sep}`)) {
     throw new Error("Evaluation output must be written outside the repository");
   }
   const parent = path.dirname(filename);
-  await canonicalDirectory(parent, "output directory");
+  try {
+    await canonicalDirectory(parent, "output directory");
+  } catch (error) {
+    throw new Error(`Output directory is unavailable or unsafe: ${parent}`, { cause: error });
+  }
   try {
     await fs.lstat(filename);
     throw new Error(`Output already exists: ${filename}`);
   } catch (error) {
     if (error.code !== "ENOENT") throw error;
   }
+  return { filename, parent };
+}
+
+async function writeAtomicExclusive(filename, value) {
+  const { parent } = await validateOutputDestination(filename);
   const temporary = path.join(parent, `.${path.basename(filename)}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`);
   const bytes = Buffer.from(`${JSON.stringify(value, null, 2)}\n`);
   const handle = await fs.open(temporary, fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL, 0o600);
@@ -946,11 +958,12 @@ function assertReferenceReplay(report, run, manifest) {
   };
 }
 
-async function main() {
+export async function runOlmocrBench(argv = process.argv.slice(2), dependencies = {}) {
   if (!["linux", "darwin"].includes(process.platform)) {
     throw new Error("The olmOCR-bench gate requires a POSIX Linux or macOS host");
   }
-  const options = parseArguments(process.argv.slice(2));
+  const options = parseArguments(argv);
+  if (options.outputPath) await validateOutputDestination(options.outputPath);
   const { manifest, binding: manifestBinding } = await loadManifest(options.manifestPath);
   const [corpus, evaluator] = await Promise.all([
     verifyCorpus(options.benchRoot, manifest),
@@ -972,7 +985,8 @@ async function main() {
   }
   if (options.command === "run") {
     const candidate = await candidateBinding();
-    const { selected, records } = await runConversions({
+    const conversionRunner = dependencies.runConversions ?? runConversions;
+    const { selected, records } = await conversionRunner({
       benchRoot: options.benchRoot,
       pdfs: corpus.pdfs,
       limit: options.limit,
@@ -1068,7 +1082,7 @@ async function main() {
 }
 
 if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
-  main().catch(error => {
+  runOlmocrBench().catch(error => {
     process.stderr.write(`${error.stack ?? error.message}\n`);
     process.exitCode = 1;
   });

--- a/test/eval/olmocr-bench-scorer.test.js
+++ b/test/eval/olmocr-bench-scorer.test.js
@@ -15,6 +15,7 @@ import {
 } from "./olmocr-bench-scorer.js";
 import {
   canonicalJson,
+  runOlmocrBench,
   validateRunReport,
 } from "../../scripts/eval-olmocr-bench.mjs";
 
@@ -27,6 +28,36 @@ const FIXTURE_ROOT = path.resolve(
 );
 
 describe("olmOCR-bench directional scorer and retained compatibility profile", () => {
+  it("rejects an unavailable or occupied output before processing any document", async () => {
+    const temporaryRoot = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "pdf-tools-olmocr-output-"));
+    const root = await fs.realpath(temporaryRoot);
+    try {
+      const existingOutput = path.join(root, "existing.json");
+      await fs.writeFile(existingOutput, "occupied\n");
+      let documentsProcessed = 0;
+      const conversionRunner = async () => {
+        documentsProcessed += 1;
+        throw new Error("conversion runner must not start");
+      };
+
+      await expect(runOlmocrBench([
+        "run",
+        "--bench-root", path.join(root, "bench-does-not-need-to-exist"),
+        "--output", path.join(root, "missing-parent", "result.json"),
+      ], { runConversions: conversionRunner })).rejects.toThrow(/Output directory is unavailable or unsafe/u);
+      expect(documentsProcessed).toBe(0);
+
+      await expect(runOlmocrBench([
+        "run",
+        "--bench-root", path.join(root, "bench-does-not-need-to-exist"),
+        "--output", existingOutput,
+      ], { runConversions: conversionRunner })).rejects.toThrow(`Output already exists: ${existingOutput}`);
+      expect(documentsProcessed).toBe(0);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   const runReport = () => {
     const runtimeSources = [
       { path: "package.json", size_bytes: 1, sha256: "a".repeat(64) },

--- a/test/read-pdf-layout.test.js
+++ b/test/read-pdf-layout.test.js
@@ -1387,8 +1387,10 @@ describe("Extraction IR v1.2.0 evidence blocks", () => {
 
   it("rejects independent replay forgeries for every new evidence block and is deterministic", async () => {
     const fixture = fakeOperatorFixture([2, 1], [rectPath(4), null]);
-    const first = await runFake([{ ...fixture, items: [textItem({ text: "evidence", x: 50, top: 50 })] }]);
-    const second = await runFake([{ ...fixture, items: [textItem({ text: "evidence", x: 50, top: 50 })] }]);
+    const sourceBytes = await pdfBytes(1);
+    const page = { ...fixture, items: [textItem({ text: "evidence", x: 50, top: 50 })] };
+    const first = await runFake([page], { pdfBytes: sourceBytes });
+    const second = await runFake([page], { pdfBytes: sourceBytes });
     expect(second.result).toEqual(first.result);
     const mutations = [
       layout => { layout.pages[0].ruled_rects.items[0].x += 1; },


### PR DESCRIPTION
## Summary

- validate the benchmark output path before reading the corpus or launching PDF Tools
- reject missing or unsafe output parents and occupied targets immediately
- repeat the no-overwrite checks during final atomic publication
- make the layout determinism test reuse one exact PDF byte source rather than compare time-varying generated files

## Regression coverage

- proves an unavailable parent processes zero documents
- proves an occupied output processes zero documents and remains untouched
- reproduces and closes the CI-only fake-PDF hash flake under Node 20.19
- affected suites pass on Linux under Node 20.19 and 22, and on macOS under the project Node 22 runtime

## Scope

The product change is limited to the offline olmOCR benchmark runner. The additional test-only correction makes an existing layout determinism assertion compare two runs over the same source bytes. Shipped PDF behavior and benchmark claim policy are unchanged.
