### PR TITLE
Add secure Lumin loopback OAuth helper

### DIFF
--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -70,6 +70,27 @@ host and operating system being claimed.
 - PDF.js text extraction and canvas-backed page/region rendering are lazy loaded to avoid startup overhead.
 - Interactive viewer UI lives in `ui/`, built to `dist-ui/` via Vite.
 
+### Lumin OAuth preparation
+
+`server/lumin-oauth-loopback.js` is an internal native-app OAuth helper. It is
+packaged for source parity but is not registered as an MCP tool and does not
+run merely because the server starts. Provider request transport remains
+disabled in `server/lumin-sign-v1-mapper.js`.
+
+Lumin currently registers `http://127.0.0.1/callback` for public PKCE clients
+and ignores the loopback port when matching the redirect. At authorization
+time the helper binds an operating-system-selected port on `127.0.0.1` and
+sends `http://127.0.0.1:<port>/callback` in the request. Keep the IP literal
+and `/callback` path exact. Do not switch this to `localhost`, a fixed port, a
+non-loopback listener, or a custom URI scheme without new provider evidence.
+
+The helper uses PKCE S256, a separate random state value, a one-use callback,
+strict callback parameter and Host validation, bounded inputs and responses,
+and a public-client token exchange with no client secret. It never writes or
+logs the verifier, authorization code, or returned tokens. Credential storage,
+refresh, revocation, signing request transport, callback verification, and
+provider artifact handling are separate incomplete product boundaries.
+
 ## Data flow (ASCII map)
 
 ```

--- a/package-for-friend.js
+++ b/package-for-friend.js
@@ -58,6 +58,7 @@ export const SHARE_FILES = [
   "server/helpers.js",
   "server/index.js",
   "server/layout-extraction.js",
+  "server/lumin-oauth-loopback.js",
   "server/lumin-sign-v1-mapper.js",
   "server/markdown-conversion.js",
   "server/markdown-output-transaction.js",

--- a/pdf-toolkit-mcp-share/server/lumin-oauth-loopback.js
+++ b/pdf-toolkit-mcp-share/server/lumin-oauth-loopback.js
@@ -1,0 +1,406 @@
+import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
+import http from "node:http";
+
+export const LUMIN_OAUTH_AUTHORIZATION_ENDPOINT = "https://auth.luminpdf.com/oauth2/auth";
+export const LUMIN_OAUTH_TOKEN_ENDPOINT = "https://auth.luminpdf.com/oauth2/token";
+export const LUMIN_OAUTH_REGISTERED_REDIRECT_URI = "http://127.0.0.1/callback";
+
+const CALLBACK_HOST = "127.0.0.1";
+const CALLBACK_PATH = "/callback";
+const MAX_CALLBACK_URL_BYTES = 8 * 1024;
+const MAX_TOKEN_RESPONSE_BYTES = 64 * 1024;
+const MAX_CLIENT_ID_BYTES = 512;
+const MAX_CODE_BYTES = 4096;
+const MAX_ERROR_BYTES = 256;
+const MAX_SCOPES = 32;
+const MIN_TIMEOUT_MS = 10;
+const MAX_TIMEOUT_MS = 10 * 60 * 1000;
+const SCOPE_PATTERN = /^[A-Za-z0-9][A-Za-z0-9:._-]{0,127}$/;
+
+function oauthError(code, message) {
+  const error = new Error(message);
+  Object.defineProperty(error, "code", {
+    value: code,
+    enumerable: true,
+    writable: false,
+    configurable: false,
+  });
+  return error;
+}
+
+function assertBoundedString(value, { maxBytes, name }) {
+  if (typeof value !== "string" || value !== value.trim() || value.length === 0) {
+    throw oauthError("LUMIN_OAUTH_CONFIGURATION_INVALID", `Invalid ${name}.`);
+  }
+  if (Buffer.byteLength(value, "utf8") > maxBytes) {
+    throw oauthError("LUMIN_OAUTH_CONFIGURATION_INVALID", `Invalid ${name}.`);
+  }
+  return value;
+}
+
+function validateClientId(value) {
+  const clientId = assertBoundedString(value, { maxBytes: MAX_CLIENT_ID_BYTES, name: "client ID" });
+  if (/\s/.test(clientId) || /[\u0000-\u001f\u007f]/.test(clientId)) {
+    throw oauthError("LUMIN_OAUTH_CONFIGURATION_INVALID", "Invalid client ID.");
+  }
+  return clientId;
+}
+
+function validateScopes(value) {
+  if (!Array.isArray(value) || value.length === 0 || value.length > MAX_SCOPES) {
+    throw oauthError("LUMIN_OAUTH_CONFIGURATION_INVALID", "Invalid OAuth scopes.");
+  }
+  const scopes = value.map(scope => {
+    if (typeof scope !== "string" || !SCOPE_PATTERN.test(scope)) {
+      throw oauthError("LUMIN_OAUTH_CONFIGURATION_INVALID", "Invalid OAuth scopes.");
+    }
+    return scope;
+  });
+  if (new Set(scopes).size !== scopes.length) {
+    throw oauthError("LUMIN_OAUTH_CONFIGURATION_INVALID", "Invalid OAuth scopes.");
+  }
+  return Object.freeze([...scopes]);
+}
+
+function validateTimeoutMs(value) {
+  if (!Number.isSafeInteger(value) || value < MIN_TIMEOUT_MS || value > MAX_TIMEOUT_MS) {
+    throw oauthError("LUMIN_OAUTH_CONFIGURATION_INVALID", "Invalid OAuth callback timeout.");
+  }
+  return value;
+}
+
+function base64Url(bytes) {
+  return Buffer.from(bytes).toString("base64url");
+}
+
+function secureEqual(left, right) {
+  const leftBytes = Buffer.from(left, "utf8");
+  const rightBytes = Buffer.from(right, "utf8");
+  return leftBytes.length === rightBytes.length && timingSafeEqual(leftBytes, rightBytes);
+}
+
+function onlyValue(searchParams, name) {
+  const values = searchParams.getAll(name);
+  return values.length === 1 ? values[0] : null;
+}
+
+function hasOnlyCallbackParameters(searchParams) {
+  const allowed = new Set(["code", "error", "error_description", "state"]);
+  for (const key of searchParams.keys()) {
+    if (!allowed.has(key)) return false;
+  }
+  for (const key of allowed) {
+    if (searchParams.getAll(key).length > 1) return false;
+  }
+  return true;
+}
+
+function respond(response, statusCode, message) {
+  const body = `${message}\n`;
+  response.writeHead(statusCode, {
+    "cache-control": "no-store",
+    "content-length": Buffer.byteLength(body),
+    "content-type": "text/plain; charset=utf-8",
+    "x-content-type-options": "nosniff",
+  });
+  response.end(body);
+}
+
+async function listenOnLoopback(server) {
+  await new Promise((resolve, reject) => {
+    const onError = error => {
+      server.off("listening", onListening);
+      reject(error);
+    };
+    const onListening = () => {
+      server.off("error", onError);
+      resolve();
+    };
+    server.once("error", onError);
+    server.once("listening", onListening);
+    server.listen({ host: CALLBACK_HOST, port: 0, exclusive: true });
+  });
+}
+
+async function closeServer(server) {
+  if (!server.listening) return;
+  await new Promise(resolve => server.close(() => resolve()));
+}
+
+async function readBoundedResponse(response) {
+  const declaredLength = response.headers.get("content-length");
+  if (declaredLength !== null) {
+    if (!/^\d+$/.test(declaredLength) || Number(declaredLength) > MAX_TOKEN_RESPONSE_BYTES) {
+      throw oauthError("LUMIN_OAUTH_TOKEN_RESPONSE_INVALID", "Lumin returned an invalid token response.");
+    }
+  }
+  if (!response.body || typeof response.body.getReader !== "function") {
+    throw oauthError("LUMIN_OAUTH_TOKEN_RESPONSE_INVALID", "Lumin returned an invalid token response.");
+  }
+  const reader = response.body.getReader();
+  const chunks = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!(value instanceof Uint8Array)) {
+        throw oauthError("LUMIN_OAUTH_TOKEN_RESPONSE_INVALID", "Lumin returned an invalid token response.");
+      }
+      total += value.byteLength;
+      if (total > MAX_TOKEN_RESPONSE_BYTES) {
+        throw oauthError("LUMIN_OAUTH_TOKEN_RESPONSE_INVALID", "Lumin returned an invalid token response.");
+      }
+      chunks.push(Buffer.from(value));
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return Buffer.concat(chunks, total).toString("utf8");
+}
+
+function normalizeTokenResponse(value, expectedScopes) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw oauthError("LUMIN_OAUTH_TOKEN_RESPONSE_INVALID", "Lumin returned an invalid token response.");
+  }
+  let accessToken;
+  let refreshToken = null;
+  let scope = expectedScopes.join(" ");
+  try {
+    accessToken = assertBoundedString(value.access_token, {
+      maxBytes: 16 * 1024,
+      name: "access token",
+    });
+    if (value.refresh_token !== undefined) {
+      refreshToken = assertBoundedString(value.refresh_token, {
+        maxBytes: 16 * 1024,
+        name: "refresh token",
+      });
+    }
+    if (value.scope !== undefined) {
+      const observedScope = assertBoundedString(value.scope, { maxBytes: 4096, name: "token scope" });
+      const observedScopes = observedScope.split(/\s+/);
+      if (
+        observedScopes.length !== expectedScopes.length
+        || new Set(observedScopes).size !== observedScopes.length
+        || expectedScopes.some(expectedScope => !observedScopes.includes(expectedScope))
+      ) {
+        throw new Error("scope mismatch");
+      }
+    }
+  } catch {
+    throw oauthError("LUMIN_OAUTH_TOKEN_RESPONSE_INVALID", "Lumin returned an invalid token response.");
+  }
+  if (value.token_type !== "Bearer") {
+    throw oauthError("LUMIN_OAUTH_TOKEN_RESPONSE_INVALID", "Lumin returned an invalid token response.");
+  }
+  if (!Number.isSafeInteger(value.expires_in) || value.expires_in <= 0 || value.expires_in > 31_536_000) {
+    throw oauthError("LUMIN_OAUTH_TOKEN_RESPONSE_INVALID", "Lumin returned an invalid token response.");
+  }
+  return Object.freeze({
+    accessToken,
+    expiresIn: value.expires_in,
+    refreshToken,
+    scope,
+    tokenType: "Bearer",
+  });
+}
+
+export async function createLuminOAuthLoopbackSession({
+  clientId,
+  scopes,
+  timeoutMs = 5 * 60 * 1000,
+}) {
+  const validatedClientId = validateClientId(clientId);
+  const validatedScopes = validateScopes(scopes);
+  const validatedTimeoutMs = validateTimeoutMs(timeoutMs);
+  const codeVerifier = base64Url(randomBytes(32));
+  const codeChallenge = base64Url(createHash("sha256").update(codeVerifier, "ascii").digest());
+  const expectedState = base64Url(randomBytes(32));
+  let consumed = false;
+  let callbackResult = null;
+  let tokenExchangeStarted = false;
+  let timeout = null;
+  let settleCallback;
+  let rejectCallback;
+
+  const callbackPromise = new Promise((resolve, reject) => {
+    settleCallback = resolve;
+    rejectCallback = reject;
+  });
+  callbackPromise.catch(() => {});
+
+  const server = http.createServer((request, response) => {
+    const rejectRequest = (statusCode, message) => respond(response, statusCode, message);
+    if (consumed) {
+      rejectRequest(410, "This authorization callback has already been used.");
+      return;
+    }
+    if (request.socket.remoteAddress !== CALLBACK_HOST) {
+      rejectRequest(403, "Authorization callback rejected.");
+      return;
+    }
+    if (request.method !== "GET") {
+      rejectRequest(405, "Authorization callback rejected.");
+      return;
+    }
+    if (typeof request.url !== "string" || Buffer.byteLength(request.url, "utf8") > MAX_CALLBACK_URL_BYTES) {
+      rejectRequest(414, "Authorization callback rejected.");
+      return;
+    }
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      rejectRequest(500, "Authorization callback unavailable.");
+      return;
+    }
+    const expectedHost = `${CALLBACK_HOST}:${address.port}`;
+    if (request.headers.host !== expectedHost) {
+      rejectRequest(400, "Authorization callback rejected.");
+      return;
+    }
+    let callbackUrl;
+    try {
+      callbackUrl = new URL(request.url, `http://${expectedHost}`);
+    } catch {
+      rejectRequest(400, "Authorization callback rejected.");
+      return;
+    }
+    if (callbackUrl.pathname !== CALLBACK_PATH) {
+      rejectRequest(404, "Authorization callback rejected.");
+      return;
+    }
+    if (!hasOnlyCallbackParameters(callbackUrl.searchParams)) {
+      rejectRequest(400, "Authorization callback rejected.");
+      return;
+    }
+    const state = onlyValue(callbackUrl.searchParams, "state");
+    if (!state || !secureEqual(state, expectedState)) {
+      rejectRequest(400, "Authorization callback rejected.");
+      return;
+    }
+    const code = onlyValue(callbackUrl.searchParams, "code");
+    const providerError = onlyValue(callbackUrl.searchParams, "error");
+    if ((code && providerError) || (!code && !providerError)) {
+      rejectRequest(400, "Authorization callback rejected.");
+      return;
+    }
+    if (code && Buffer.byteLength(code, "utf8") > MAX_CODE_BYTES) {
+      rejectRequest(400, "Authorization callback rejected.");
+      return;
+    }
+    if (providerError && Buffer.byteLength(providerError, "utf8") > MAX_ERROR_BYTES) {
+      rejectRequest(400, "Authorization callback rejected.");
+      return;
+    }
+    consumed = true;
+    clearTimeout(timeout);
+    if (providerError) {
+      respond(response, 400, "Lumin authorization was not completed. You can close this window.");
+      rejectCallback(oauthError("LUMIN_OAUTH_PROVIDER_ERROR", "Lumin authorization was not completed."));
+    } else {
+      callbackResult = Object.freeze({ code, redirectUri });
+      respond(response, 200, "Lumin authorization completed. You can close this window.");
+      settleCallback(callbackResult);
+    }
+    void closeServer(server);
+  });
+  server.requestTimeout = 10_000;
+  server.headersTimeout = 10_000;
+  server.keepAliveTimeout = 1_000;
+  server.maxRequestsPerSocket = 10;
+
+  try {
+    await listenOnLoopback(server);
+  } catch {
+    throw oauthError("LUMIN_OAUTH_CALLBACK_UNAVAILABLE", "Unable to open the local Lumin authorization callback.");
+  }
+  const address = server.address();
+  if (!address || typeof address === "string" || address.address !== CALLBACK_HOST || address.port <= 0) {
+    await closeServer(server);
+    throw oauthError("LUMIN_OAUTH_CALLBACK_UNAVAILABLE", "Unable to open the local Lumin authorization callback.");
+  }
+  const redirectUri = `http://${CALLBACK_HOST}:${address.port}${CALLBACK_PATH}`;
+  const authorizationUrl = new URL(LUMIN_OAUTH_AUTHORIZATION_ENDPOINT);
+  authorizationUrl.searchParams.set("client_id", validatedClientId);
+  authorizationUrl.searchParams.set("code_challenge", codeChallenge);
+  authorizationUrl.searchParams.set("code_challenge_method", "S256");
+  authorizationUrl.searchParams.set("redirect_uri", redirectUri);
+  authorizationUrl.searchParams.set("response_type", "code");
+  authorizationUrl.searchParams.set("scope", validatedScopes.join(" "));
+  authorizationUrl.searchParams.set("state", expectedState);
+
+  server.on("error", () => {
+    if (consumed) return;
+    consumed = true;
+    clearTimeout(timeout);
+    rejectCallback(oauthError("LUMIN_OAUTH_CALLBACK_UNAVAILABLE", "The local Lumin authorization callback failed."));
+  });
+
+  timeout = setTimeout(() => {
+    if (consumed) return;
+    consumed = true;
+    rejectCallback(oauthError("LUMIN_OAUTH_CALLBACK_TIMEOUT", "Lumin authorization timed out."));
+    void closeServer(server);
+  }, validatedTimeoutMs);
+  timeout.unref();
+
+  return Object.freeze({
+    authorizationUrl: authorizationUrl.href,
+    callbackPort: address.port,
+    redirectUri,
+    registeredRedirectUri: LUMIN_OAUTH_REGISTERED_REDIRECT_URI,
+    scopes: validatedScopes,
+    async close() {
+      if (!consumed) {
+        consumed = true;
+        clearTimeout(timeout);
+        rejectCallback(oauthError("LUMIN_OAUTH_SESSION_CLOSED", "Lumin authorization was closed."));
+      }
+      await closeServer(server);
+    },
+    async exchangeToken(result, { fetchFn = globalThis.fetch } = {}) {
+      if (!callbackResult || result !== callbackResult || tokenExchangeStarted || typeof fetchFn !== "function") {
+        throw oauthError("LUMIN_OAUTH_TOKEN_REQUEST_INVALID", "Invalid Lumin token request.");
+      }
+      tokenExchangeStarted = true;
+      const form = new URLSearchParams();
+      form.set("client_id", validatedClientId);
+      form.set("code", callbackResult.code);
+      form.set("code_verifier", codeVerifier);
+      form.set("grant_type", "authorization_code");
+      form.set("redirect_uri", redirectUri);
+      let response;
+      try {
+        response = await fetchFn(LUMIN_OAUTH_TOKEN_ENDPOINT, {
+          method: "POST",
+          headers: {
+            accept: "application/json",
+            "content-type": "application/x-www-form-urlencoded",
+          },
+          body: form.toString(),
+          redirect: "error",
+        });
+      } catch {
+        throw oauthError("LUMIN_OAUTH_TOKEN_REQUEST_FAILED", "Lumin token exchange failed.");
+      }
+      if (!(response instanceof Response) || !response.ok) {
+        throw oauthError("LUMIN_OAUTH_TOKEN_REQUEST_FAILED", "Lumin token exchange failed.");
+      }
+      const contentType = response.headers.get("content-type")?.split(";", 1)[0].trim().toLowerCase();
+      if (contentType !== "application/json") {
+        throw oauthError("LUMIN_OAUTH_TOKEN_RESPONSE_INVALID", "Lumin returned an invalid token response.");
+      }
+      let parsed;
+      try {
+        parsed = JSON.parse(await readBoundedResponse(response));
+      } catch (error) {
+        if (error?.code === "LUMIN_OAUTH_TOKEN_RESPONSE_INVALID") throw error;
+        throw oauthError("LUMIN_OAUTH_TOKEN_RESPONSE_INVALID", "Lumin returned an invalid token response.");
+      }
+      return normalizeTokenResponse(parsed, validatedScopes);
+    },
+    waitForCallback() {
+      return callbackPromise;
+    },
+  });
+}

--- a/scripts/build-mcpb.mjs
+++ b/scripts/build-mcpb.mjs
@@ -78,6 +78,7 @@ export const SERVER_FILES = [
   "helpers.js",
   "index.js",
   "layout-extraction.js",
+  "lumin-oauth-loopback.js",
   "lumin-sign-v1-mapper.js",
   "markdown-conversion.js",
   "markdown-output-transaction.js",

--- a/server/lumin-oauth-loopback.js
+++ b/server/lumin-oauth-loopback.js
@@ -1,0 +1,406 @@
+import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
+import http from "node:http";
+
+export const LUMIN_OAUTH_AUTHORIZATION_ENDPOINT = "https://auth.luminpdf.com/oauth2/auth";
+export const LUMIN_OAUTH_TOKEN_ENDPOINT = "https://auth.luminpdf.com/oauth2/token";
+export const LUMIN_OAUTH_REGISTERED_REDIRECT_URI = "http://127.0.0.1/callback";
+
+const CALLBACK_HOST = "127.0.0.1";
+const CALLBACK_PATH = "/callback";
+const MAX_CALLBACK_URL_BYTES = 8 * 1024;
+const MAX_TOKEN_RESPONSE_BYTES = 64 * 1024;
+const MAX_CLIENT_ID_BYTES = 512;
+const MAX_CODE_BYTES = 4096;
+const MAX_ERROR_BYTES = 256;
+const MAX_SCOPES = 32;
+const MIN_TIMEOUT_MS = 10;
+const MAX_TIMEOUT_MS = 10 * 60 * 1000;
+const SCOPE_PATTERN = /^[A-Za-z0-9][A-Za-z0-9:._-]{0,127}$/;
+
+function oauthError(code, message) {
+  const error = new Error(message);
+  Object.defineProperty(error, "code", {
+    value: code,
+    enumerable: true,
+    writable: false,
+    configurable: false,
+  });
+  return error;
+}
+
+function assertBoundedString(value, { maxBytes, name }) {
+  if (typeof value !== "string" || value !== value.trim() || value.length === 0) {
+    throw oauthError("LUMIN_OAUTH_CONFIGURATION_INVALID", `Invalid ${name}.`);
+  }
+  if (Buffer.byteLength(value, "utf8") > maxBytes) {
+    throw oauthError("LUMIN_OAUTH_CONFIGURATION_INVALID", `Invalid ${name}.`);
+  }
+  return value;
+}
+
+function validateClientId(value) {
+  const clientId = assertBoundedString(value, { maxBytes: MAX_CLIENT_ID_BYTES, name: "client ID" });
+  if (/\s/.test(clientId) || /[\u0000-\u001f\u007f]/.test(clientId)) {
+    throw oauthError("LUMIN_OAUTH_CONFIGURATION_INVALID", "Invalid client ID.");
+  }
+  return clientId;
+}
+
+function validateScopes(value) {
+  if (!Array.isArray(value) || value.length === 0 || value.length > MAX_SCOPES) {
+    throw oauthError("LUMIN_OAUTH_CONFIGURATION_INVALID", "Invalid OAuth scopes.");
+  }
+  const scopes = value.map(scope => {
+    if (typeof scope !== "string" || !SCOPE_PATTERN.test(scope)) {
+      throw oauthError("LUMIN_OAUTH_CONFIGURATION_INVALID", "Invalid OAuth scopes.");
+    }
+    return scope;
+  });
+  if (new Set(scopes).size !== scopes.length) {
+    throw oauthError("LUMIN_OAUTH_CONFIGURATION_INVALID", "Invalid OAuth scopes.");
+  }
+  return Object.freeze([...scopes]);
+}
+
+function validateTimeoutMs(value) {
+  if (!Number.isSafeInteger(value) || value < MIN_TIMEOUT_MS || value > MAX_TIMEOUT_MS) {
+    throw oauthError("LUMIN_OAUTH_CONFIGURATION_INVALID", "Invalid OAuth callback timeout.");
+  }
+  return value;
+}
+
+function base64Url(bytes) {
+  return Buffer.from(bytes).toString("base64url");
+}
+
+function secureEqual(left, right) {
+  const leftBytes = Buffer.from(left, "utf8");
+  const rightBytes = Buffer.from(right, "utf8");
+  return leftBytes.length === rightBytes.length && timingSafeEqual(leftBytes, rightBytes);
+}
+
+function onlyValue(searchParams, name) {
+  const values = searchParams.getAll(name);
+  return values.length === 1 ? values[0] : null;
+}
+
+function hasOnlyCallbackParameters(searchParams) {
+  const allowed = new Set(["code", "error", "error_description", "state"]);
+  for (const key of searchParams.keys()) {
+    if (!allowed.has(key)) return false;
+  }
+  for (const key of allowed) {
+    if (searchParams.getAll(key).length > 1) return false;
+  }
+  return true;
+}
+
+function respond(response, statusCode, message) {
+  const body = `${message}\n`;
+  response.writeHead(statusCode, {
+    "cache-control": "no-store",
+    "content-length": Buffer.byteLength(body),
+    "content-type": "text/plain; charset=utf-8",
+    "x-content-type-options": "nosniff",
+  });
+  response.end(body);
+}
+
+async function listenOnLoopback(server) {
+  await new Promise((resolve, reject) => {
+    const onError = error => {
+      server.off("listening", onListening);
+      reject(error);
+    };
+    const onListening = () => {
+      server.off("error", onError);
+      resolve();
+    };
+    server.once("error", onError);
+    server.once("listening", onListening);
+    server.listen({ host: CALLBACK_HOST, port: 0, exclusive: true });
+  });
+}
+
+async function closeServer(server) {
+  if (!server.listening) return;
+  await new Promise(resolve => server.close(() => resolve()));
+}
+
+async function readBoundedResponse(response) {
+  const declaredLength = response.headers.get("content-length");
+  if (declaredLength !== null) {
+    if (!/^\d+$/.test(declaredLength) || Number(declaredLength) > MAX_TOKEN_RESPONSE_BYTES) {
+      throw oauthError("LUMIN_OAUTH_TOKEN_RESPONSE_INVALID", "Lumin returned an invalid token response.");
+    }
+  }
+  if (!response.body || typeof response.body.getReader !== "function") {
+    throw oauthError("LUMIN_OAUTH_TOKEN_RESPONSE_INVALID", "Lumin returned an invalid token response.");
+  }
+  const reader = response.body.getReader();
+  const chunks = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!(value instanceof Uint8Array)) {
+        throw oauthError("LUMIN_OAUTH_TOKEN_RESPONSE_INVALID", "Lumin returned an invalid token response.");
+      }
+      total += value.byteLength;
+      if (total > MAX_TOKEN_RESPONSE_BYTES) {
+        throw oauthError("LUMIN_OAUTH_TOKEN_RESPONSE_INVALID", "Lumin returned an invalid token response.");
+      }
+      chunks.push(Buffer.from(value));
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return Buffer.concat(chunks, total).toString("utf8");
+}
+
+function normalizeTokenResponse(value, expectedScopes) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw oauthError("LUMIN_OAUTH_TOKEN_RESPONSE_INVALID", "Lumin returned an invalid token response.");
+  }
+  let accessToken;
+  let refreshToken = null;
+  let scope = expectedScopes.join(" ");
+  try {
+    accessToken = assertBoundedString(value.access_token, {
+      maxBytes: 16 * 1024,
+      name: "access token",
+    });
+    if (value.refresh_token !== undefined) {
+      refreshToken = assertBoundedString(value.refresh_token, {
+        maxBytes: 16 * 1024,
+        name: "refresh token",
+      });
+    }
+    if (value.scope !== undefined) {
+      const observedScope = assertBoundedString(value.scope, { maxBytes: 4096, name: "token scope" });
+      const observedScopes = observedScope.split(/\s+/);
+      if (
+        observedScopes.length !== expectedScopes.length
+        || new Set(observedScopes).size !== observedScopes.length
+        || expectedScopes.some(expectedScope => !observedScopes.includes(expectedScope))
+      ) {
+        throw new Error("scope mismatch");
+      }
+    }
+  } catch {
+    throw oauthError("LUMIN_OAUTH_TOKEN_RESPONSE_INVALID", "Lumin returned an invalid token response.");
+  }
+  if (value.token_type !== "Bearer") {
+    throw oauthError("LUMIN_OAUTH_TOKEN_RESPONSE_INVALID", "Lumin returned an invalid token response.");
+  }
+  if (!Number.isSafeInteger(value.expires_in) || value.expires_in <= 0 || value.expires_in > 31_536_000) {
+    throw oauthError("LUMIN_OAUTH_TOKEN_RESPONSE_INVALID", "Lumin returned an invalid token response.");
+  }
+  return Object.freeze({
+    accessToken,
+    expiresIn: value.expires_in,
+    refreshToken,
+    scope,
+    tokenType: "Bearer",
+  });
+}
+
+export async function createLuminOAuthLoopbackSession({
+  clientId,
+  scopes,
+  timeoutMs = 5 * 60 * 1000,
+}) {
+  const validatedClientId = validateClientId(clientId);
+  const validatedScopes = validateScopes(scopes);
+  const validatedTimeoutMs = validateTimeoutMs(timeoutMs);
+  const codeVerifier = base64Url(randomBytes(32));
+  const codeChallenge = base64Url(createHash("sha256").update(codeVerifier, "ascii").digest());
+  const expectedState = base64Url(randomBytes(32));
+  let consumed = false;
+  let callbackResult = null;
+  let tokenExchangeStarted = false;
+  let timeout = null;
+  let settleCallback;
+  let rejectCallback;
+
+  const callbackPromise = new Promise((resolve, reject) => {
+    settleCallback = resolve;
+    rejectCallback = reject;
+  });
+  callbackPromise.catch(() => {});
+
+  const server = http.createServer((request, response) => {
+    const rejectRequest = (statusCode, message) => respond(response, statusCode, message);
+    if (consumed) {
+      rejectRequest(410, "This authorization callback has already been used.");
+      return;
+    }
+    if (request.socket.remoteAddress !== CALLBACK_HOST) {
+      rejectRequest(403, "Authorization callback rejected.");
+      return;
+    }
+    if (request.method !== "GET") {
+      rejectRequest(405, "Authorization callback rejected.");
+      return;
+    }
+    if (typeof request.url !== "string" || Buffer.byteLength(request.url, "utf8") > MAX_CALLBACK_URL_BYTES) {
+      rejectRequest(414, "Authorization callback rejected.");
+      return;
+    }
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      rejectRequest(500, "Authorization callback unavailable.");
+      return;
+    }
+    const expectedHost = `${CALLBACK_HOST}:${address.port}`;
+    if (request.headers.host !== expectedHost) {
+      rejectRequest(400, "Authorization callback rejected.");
+      return;
+    }
+    let callbackUrl;
+    try {
+      callbackUrl = new URL(request.url, `http://${expectedHost}`);
+    } catch {
+      rejectRequest(400, "Authorization callback rejected.");
+      return;
+    }
+    if (callbackUrl.pathname !== CALLBACK_PATH) {
+      rejectRequest(404, "Authorization callback rejected.");
+      return;
+    }
+    if (!hasOnlyCallbackParameters(callbackUrl.searchParams)) {
+      rejectRequest(400, "Authorization callback rejected.");
+      return;
+    }
+    const state = onlyValue(callbackUrl.searchParams, "state");
+    if (!state || !secureEqual(state, expectedState)) {
+      rejectRequest(400, "Authorization callback rejected.");
+      return;
+    }
+    const code = onlyValue(callbackUrl.searchParams, "code");
+    const providerError = onlyValue(callbackUrl.searchParams, "error");
+    if ((code && providerError) || (!code && !providerError)) {
+      rejectRequest(400, "Authorization callback rejected.");
+      return;
+    }
+    if (code && Buffer.byteLength(code, "utf8") > MAX_CODE_BYTES) {
+      rejectRequest(400, "Authorization callback rejected.");
+      return;
+    }
+    if (providerError && Buffer.byteLength(providerError, "utf8") > MAX_ERROR_BYTES) {
+      rejectRequest(400, "Authorization callback rejected.");
+      return;
+    }
+    consumed = true;
+    clearTimeout(timeout);
+    if (providerError) {
+      respond(response, 400, "Lumin authorization was not completed. You can close this window.");
+      rejectCallback(oauthError("LUMIN_OAUTH_PROVIDER_ERROR", "Lumin authorization was not completed."));
+    } else {
+      callbackResult = Object.freeze({ code, redirectUri });
+      respond(response, 200, "Lumin authorization completed. You can close this window.");
+      settleCallback(callbackResult);
+    }
+    void closeServer(server);
+  });
+  server.requestTimeout = 10_000;
+  server.headersTimeout = 10_000;
+  server.keepAliveTimeout = 1_000;
+  server.maxRequestsPerSocket = 10;
+
+  try {
+    await listenOnLoopback(server);
+  } catch {
+    throw oauthError("LUMIN_OAUTH_CALLBACK_UNAVAILABLE", "Unable to open the local Lumin authorization callback.");
+  }
+  const address = server.address();
+  if (!address || typeof address === "string" || address.address !== CALLBACK_HOST || address.port <= 0) {
+    await closeServer(server);
+    throw oauthError("LUMIN_OAUTH_CALLBACK_UNAVAILABLE", "Unable to open the local Lumin authorization callback.");
+  }
+  const redirectUri = `http://${CALLBACK_HOST}:${address.port}${CALLBACK_PATH}`;
+  const authorizationUrl = new URL(LUMIN_OAUTH_AUTHORIZATION_ENDPOINT);
+  authorizationUrl.searchParams.set("client_id", validatedClientId);
+  authorizationUrl.searchParams.set("code_challenge", codeChallenge);
+  authorizationUrl.searchParams.set("code_challenge_method", "S256");
+  authorizationUrl.searchParams.set("redirect_uri", redirectUri);
+  authorizationUrl.searchParams.set("response_type", "code");
+  authorizationUrl.searchParams.set("scope", validatedScopes.join(" "));
+  authorizationUrl.searchParams.set("state", expectedState);
+
+  server.on("error", () => {
+    if (consumed) return;
+    consumed = true;
+    clearTimeout(timeout);
+    rejectCallback(oauthError("LUMIN_OAUTH_CALLBACK_UNAVAILABLE", "The local Lumin authorization callback failed."));
+  });
+
+  timeout = setTimeout(() => {
+    if (consumed) return;
+    consumed = true;
+    rejectCallback(oauthError("LUMIN_OAUTH_CALLBACK_TIMEOUT", "Lumin authorization timed out."));
+    void closeServer(server);
+  }, validatedTimeoutMs);
+  timeout.unref();
+
+  return Object.freeze({
+    authorizationUrl: authorizationUrl.href,
+    callbackPort: address.port,
+    redirectUri,
+    registeredRedirectUri: LUMIN_OAUTH_REGISTERED_REDIRECT_URI,
+    scopes: validatedScopes,
+    async close() {
+      if (!consumed) {
+        consumed = true;
+        clearTimeout(timeout);
+        rejectCallback(oauthError("LUMIN_OAUTH_SESSION_CLOSED", "Lumin authorization was closed."));
+      }
+      await closeServer(server);
+    },
+    async exchangeToken(result, { fetchFn = globalThis.fetch } = {}) {
+      if (!callbackResult || result !== callbackResult || tokenExchangeStarted || typeof fetchFn !== "function") {
+        throw oauthError("LUMIN_OAUTH_TOKEN_REQUEST_INVALID", "Invalid Lumin token request.");
+      }
+      tokenExchangeStarted = true;
+      const form = new URLSearchParams();
+      form.set("client_id", validatedClientId);
+      form.set("code", callbackResult.code);
+      form.set("code_verifier", codeVerifier);
+      form.set("grant_type", "authorization_code");
+      form.set("redirect_uri", redirectUri);
+      let response;
+      try {
+        response = await fetchFn(LUMIN_OAUTH_TOKEN_ENDPOINT, {
+          method: "POST",
+          headers: {
+            accept: "application/json",
+            "content-type": "application/x-www-form-urlencoded",
+          },
+          body: form.toString(),
+          redirect: "error",
+        });
+      } catch {
+        throw oauthError("LUMIN_OAUTH_TOKEN_REQUEST_FAILED", "Lumin token exchange failed.");
+      }
+      if (!(response instanceof Response) || !response.ok) {
+        throw oauthError("LUMIN_OAUTH_TOKEN_REQUEST_FAILED", "Lumin token exchange failed.");
+      }
+      const contentType = response.headers.get("content-type")?.split(";", 1)[0].trim().toLowerCase();
+      if (contentType !== "application/json") {
+        throw oauthError("LUMIN_OAUTH_TOKEN_RESPONSE_INVALID", "Lumin returned an invalid token response.");
+      }
+      let parsed;
+      try {
+        parsed = JSON.parse(await readBoundedResponse(response));
+      } catch (error) {
+        if (error?.code === "LUMIN_OAUTH_TOKEN_RESPONSE_INVALID") throw error;
+        throw oauthError("LUMIN_OAUTH_TOKEN_RESPONSE_INVALID", "Lumin returned an invalid token response.");
+      }
+      return normalizeTokenResponse(parsed, validatedScopes);
+    },
+    waitForCallback() {
+      return callbackPromise;
+    },
+  });
+}

--- a/test/lumin-oauth-loopback.test.js
+++ b/test/lumin-oauth-loopback.test.js
@@ -1,0 +1,264 @@
+import http from "node:http";
+import { createHash } from "node:crypto";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  LUMIN_OAUTH_AUTHORIZATION_ENDPOINT,
+  LUMIN_OAUTH_REGISTERED_REDIRECT_URI,
+  LUMIN_OAUTH_TOKEN_ENDPOINT,
+  createLuminOAuthLoopbackSession,
+} from "../server/lumin-oauth-loopback.js";
+
+const sessions = new Set();
+
+async function createSession(options = {}) {
+  const session = await createLuminOAuthLoopbackSession({
+    clientId: "pdf-tools-public-client",
+    scopes: ["openid", "profile.read", "sign:requests", "sign:requests.read"],
+    timeoutMs: 10_000,
+    ...options,
+  });
+  sessions.add(session);
+  return session;
+}
+
+async function request(url, options = {}) {
+  const response = await fetch(url, { redirect: "manual", ...options });
+  return { status: response.status, text: await response.text() };
+}
+
+async function rawRequest({ port, path, method = "GET", host }) {
+  return new Promise((resolve, reject) => {
+    const request = http.request({
+      host: "127.0.0.1",
+      port,
+      path,
+      method,
+      headers: host === undefined ? undefined : { host },
+    }, response => {
+      const chunks = [];
+      response.on("data", chunk => chunks.push(chunk));
+      response.on("end", () => resolve({
+        status: response.statusCode,
+        text: Buffer.concat(chunks).toString("utf8"),
+      }));
+    });
+    request.on("error", reject);
+    request.end();
+  });
+}
+
+function callbackParameters(session) {
+  const authorizationUrl = new URL(session.authorizationUrl);
+  return {
+    state: authorizationUrl.searchParams.get("state"),
+    challenge: authorizationUrl.searchParams.get("code_challenge"),
+  };
+}
+
+afterEach(async () => {
+  await Promise.all([...sessions].map(session => session.close()));
+  sessions.clear();
+});
+
+describe("Lumin OAuth loopback PKCE", () => {
+  it("binds only an ephemeral IPv4 loopback port and builds Lumin's confirmed redirect pattern", async () => {
+    const session = await createSession();
+    const authorizationUrl = new URL(session.authorizationUrl);
+    const { challenge, state } = callbackParameters(session);
+
+    expect(authorizationUrl.origin + authorizationUrl.pathname).toBe(LUMIN_OAUTH_AUTHORIZATION_ENDPOINT);
+    expect(session.registeredRedirectUri).toBe(LUMIN_OAUTH_REGISTERED_REDIRECT_URI);
+    expect(session.redirectUri).toBe(`http://127.0.0.1:${session.callbackPort}/callback`);
+    expect(session.callbackPort).toBeGreaterThan(0);
+    expect(authorizationUrl.searchParams.get("client_id")).toBe("pdf-tools-public-client");
+    expect(authorizationUrl.searchParams.get("redirect_uri")).toBe(session.redirectUri);
+    expect(authorizationUrl.searchParams.get("response_type")).toBe("code");
+    expect(authorizationUrl.searchParams.get("scope")).toBe(
+      "openid profile.read sign:requests sign:requests.read",
+    );
+    expect(authorizationUrl.searchParams.get("code_challenge_method")).toBe("S256");
+    expect(challenge).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(state).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(challenge).not.toBe(state);
+  });
+
+  it("accepts one exact state-bound callback and closes the listener", async () => {
+    const session = await createSession();
+    const { state } = callbackParameters(session);
+    const response = await request(`${session.redirectUri}?code=authorization-code&state=${state}`);
+    const result = await session.waitForCallback();
+
+    expect(response).toEqual({
+      status: 200,
+      text: "Lumin authorization completed. You can close this window.\n",
+    });
+    expect(result).toEqual({ code: "authorization-code", redirectUri: session.redirectUri });
+    await expect(fetch(session.redirectUri)).rejects.toThrow();
+  });
+
+  it("does not consume the session on wrong path, method, host, state, or unknown parameters", async () => {
+    const session = await createSession();
+    const { state } = callbackParameters(session);
+    expect((await request(`http://127.0.0.1:${session.callbackPort}/wrong?code=x&state=${state}`)).status).toBe(404);
+    expect((await rawRequest({ port: session.callbackPort, path: `/callback?code=x&state=${state}`, method: "POST" })).status).toBe(405);
+    expect((await rawRequest({ port: session.callbackPort, path: `/callback?code=x&state=${state}`, host: "attacker.example" })).status).toBe(400);
+    expect((await request(`${session.redirectUri}?code=x&state=wrong`)).status).toBe(400);
+    expect((await request(`${session.redirectUri}?code=x&state=${state}&credential=smuggled`)).status).toBe(400);
+
+    expect((await request(`${session.redirectUri}?code=right&state=${state}`)).status).toBe(200);
+    await expect(session.waitForCallback()).resolves.toMatchObject({ code: "right" });
+  });
+
+  it("rejects duplicate, mixed, missing, and oversized callback values without consuming the session", async () => {
+    const session = await createSession();
+    const { state } = callbackParameters(session);
+    const attacks = [
+      `?code=one&code=two&state=${state}`,
+      `?code=one&state=${state}&state=${state}`,
+      `?code=one&error=denied&state=${state}`,
+      `?state=${state}`,
+      `?code=${"x".repeat(4097)}&state=${state}`,
+    ];
+    for (const query of attacks) {
+      expect((await request(`${session.redirectUri}${query}`)).status).toBe(400);
+    }
+    expect((await request(`${session.redirectUri}?code=valid&state=${state}`)).status).toBe(200);
+    await expect(session.waitForCallback()).resolves.toMatchObject({ code: "valid" });
+  });
+
+  it("returns a sanitized failure for an exact state-bound provider denial", async () => {
+    const session = await createSession();
+    const { state } = callbackParameters(session);
+    const response = await request(
+      `${session.redirectUri}?error=access_denied&error_description=${encodeURIComponent("secret provider detail")}&state=${state}`,
+    );
+    expect(response.status).toBe(400);
+    await expect(session.waitForCallback()).rejects.toMatchObject({
+      code: "LUMIN_OAUTH_PROVIDER_ERROR",
+      message: "Lumin authorization was not completed.",
+    });
+  });
+
+  it("times out or closes without leaving a listening callback", async () => {
+    const timed = await createSession({ timeoutMs: 20 });
+    await expect(timed.waitForCallback()).rejects.toMatchObject({ code: "LUMIN_OAUTH_CALLBACK_TIMEOUT" });
+    await expect(fetch(timed.redirectUri)).rejects.toThrow();
+
+    const closed = await createSession();
+    const wait = closed.waitForCallback();
+    await closed.close();
+    await expect(wait).rejects.toMatchObject({ code: "LUMIN_OAUTH_SESSION_CLOSED" });
+    await expect(fetch(closed.redirectUri)).rejects.toThrow();
+  });
+
+  it("exchanges the exact callback code with PKCE and no client secret", async () => {
+    const session = await createSession();
+    const { state, challenge } = callbackParameters(session);
+    await request(`${session.redirectUri}?code=one-time-code&state=${state}`);
+    const callback = await session.waitForCallback();
+    const fetchFn = vi.fn(async (url, options) => {
+      const body = new URLSearchParams(options.body);
+      const verifier = body.get("code_verifier");
+      expect(url).toBe(LUMIN_OAUTH_TOKEN_ENDPOINT);
+      expect(options).toMatchObject({
+        method: "POST",
+        redirect: "error",
+        headers: {
+          accept: "application/json",
+          "content-type": "application/x-www-form-urlencoded",
+        },
+      });
+      expect(body.get("client_id")).toBe("pdf-tools-public-client");
+      expect(body.get("code")).toBe("one-time-code");
+      expect(body.get("grant_type")).toBe("authorization_code");
+      expect(body.get("redirect_uri")).toBe(session.redirectUri);
+      expect(body.has("client_secret")).toBe(false);
+      expect(verifier).toMatch(/^[A-Za-z0-9_-]{43}$/);
+      expect(createHash("sha256").update(verifier, "ascii").digest("base64url")).toBe(challenge);
+      return new Response(JSON.stringify({
+        access_token: "access-token",
+        expires_in: 3600,
+        refresh_token: "refresh-token",
+        scope: "sign:requests.read sign:requests profile.read openid",
+        token_type: "Bearer",
+      }), { headers: { "content-type": "application/json" } });
+    });
+
+    await expect(session.exchangeToken(callback, { fetchFn })).resolves.toEqual({
+      accessToken: "access-token",
+      expiresIn: 3600,
+      refreshToken: "refresh-token",
+      scope: "openid profile.read sign:requests sign:requests.read",
+      tokenType: "Bearer",
+    });
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    await expect(session.exchangeToken(callback, { fetchFn })).rejects.toMatchObject({
+      code: "LUMIN_OAUTH_TOKEN_REQUEST_INVALID",
+    });
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("will not exchange a copied, forged, or pre-callback authorization code", async () => {
+    const session = await createSession();
+    await expect(session.exchangeToken({ code: "forged", redirectUri: session.redirectUri }, {
+      fetchFn: vi.fn(),
+    })).rejects.toMatchObject({ code: "LUMIN_OAUTH_TOKEN_REQUEST_INVALID" });
+    const { state } = callbackParameters(session);
+    await request(`${session.redirectUri}?code=real&state=${state}`);
+    const callback = await session.waitForCallback();
+    await expect(session.exchangeToken({ ...callback }, { fetchFn: vi.fn() })).rejects.toMatchObject({
+      code: "LUMIN_OAUTH_TOKEN_REQUEST_INVALID",
+    });
+  });
+
+  it("fails closed on transport, status, media type, size, JSON, and token-shape errors", async () => {
+    async function acceptedSession() {
+      const session = await createSession();
+      const { state } = callbackParameters(session);
+      await request(`${session.redirectUri}?code=real&state=${state}`);
+      return { session, callback: await session.waitForCallback() };
+    }
+    const cases = [
+      async () => { throw new Error("network detail"); },
+      async () => new Response("denied", { status: 401, headers: { "content-type": "application/json" } }),
+      async () => new Response("{}", { headers: { "content-type": "text/html" } }),
+      async () => new Response("{}", {
+        headers: { "content-length": String(64 * 1024 + 1), "content-type": "application/json" },
+      }),
+      async () => new Response("{", { headers: { "content-type": "application/json" } }),
+      async () => new Response(JSON.stringify({ expires_in: 3600, token_type: "Bearer" }), {
+        headers: { "content-type": "application/json" },
+      }),
+      async () => new Response(JSON.stringify({
+        access_token: "x",
+        expires_in: 3600,
+        scope: "openid",
+        token_type: "Bearer",
+      }), { headers: { "content-type": "application/json" } }),
+      async () => new Response(JSON.stringify({ access_token: "x", expires_in: 3600, token_type: "MAC" }), {
+        headers: { "content-type": "application/json" },
+      }),
+    ];
+    for (const fetchFn of cases) {
+      const { session, callback } = await acceptedSession();
+      await expect(session.exchangeToken(callback, { fetchFn })).rejects.toMatchObject({
+        code: expect.stringMatching(/^LUMIN_OAUTH_TOKEN_/),
+      });
+    }
+  });
+
+  it("fails closed on malformed local configuration", async () => {
+    await expect(createLuminOAuthLoopbackSession({ clientId: " id ", scopes: ["openid"] })).rejects.toMatchObject({
+      code: "LUMIN_OAUTH_CONFIGURATION_INVALID",
+    });
+    await expect(createLuminOAuthLoopbackSession({ clientId: "id", scopes: ["openid", "openid"] })).rejects.toMatchObject({
+      code: "LUMIN_OAUTH_CONFIGURATION_INVALID",
+    });
+    await expect(createLuminOAuthLoopbackSession({ clientId: "id", scopes: ["bad scope"] })).rejects.toMatchObject({
+      code: "LUMIN_OAUTH_CONFIGURATION_INVALID",
+    });
+    await expect(createLuminOAuthLoopbackSession({ clientId: "id", scopes: ["openid"], timeoutMs: 0 })).rejects.toMatchObject({
+      code: "LUMIN_OAUTH_CONFIGURATION_INVALID",
+    });
+  });
+});

--- a/test/mcp-contract.test.js
+++ b/test/mcp-contract.test.js
@@ -419,6 +419,7 @@ describe("MCPB static declarations", () => {
       "layout-extraction.js",
       "type3-cm-reference.js",
       "type3-cm-pk-reference.js",
+      "lumin-oauth-loopback.js",
       "lumin-sign-v1-mapper.js",
       "markdown-conversion.js",
       "markdown-output-transaction.js",
@@ -440,7 +441,7 @@ describe("MCPB static declarations", () => {
     }
     // A new server file must be added to the list above, not silently shipped
     // in the mirror unchecked. Two already had been.
-    expect(mirrored).toHaveLength(25);
+    expect(mirrored).toHaveLength(26);
     for (const relativePath of [
       "scripts/eval-strict-json.mjs",
       "scripts/verified-extraction-proposal.mjs",


### PR DESCRIPTION
## Summary

- add an internal IPv4 loopback OAuth callback for the Lumin public PKCE client
- bind an ephemeral 127.0.0.1 port to the exact registered /callback path
- enforce PKCE S256, independent state, one-use callback and token exchange, strict callback validation, response bounds, and exact scope preservation
- mirror and package the helper without registering a new MCP tool or enabling provider transport

This PR is stacked on #181, which adds the disabled Lumin Sign v1 request mapper.

## Verification

- focused and adjoining tests: 104/104 passed
- exact-lock affected rerun: 111/111 passed
- extraction Phase 1 isolated control: 21/21 passed
- Node-native partition: 61 passed, 10 intentional platform skips
- reproducible share contract passed with 51 tools, 14 prompts, and 122 licensed components
- MCPB built twice byte-identically, SHA-256 646b7235962f19179b16daa9f8c91a4583a8fb3f16175614ba434e3ffb03ec7d
- packed MCPB smoke passed

## Qualification

The VM-wide aggregate is not claimed green. Two existing malformed-PDF mutation sweeps each exceeded their fixed 180-second timeout even in isolation. A later aggregate reran those cases despite a command-line exclusion and was killed by the host with exit 137 after 22 minutes. No Lumin-specific, mirror, inventory, package, or smoke check failed.

No OAuth endpoint, signing request, credential persistence, provider action, release, or production activation occurred.