### PR TITLE
Add gated Lumin signing transport

### DIFF
--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -70,12 +70,21 @@ host and operating system being claimed.
 - PDF.js text extraction and canvas-backed page/region rendering are lazy loaded to avoid startup overhead.
 - Interactive viewer UI lives in `ui/`, built to `dist-ui/` via Vite.
 
-### Lumin OAuth preparation
+### Lumin signing preparation
 
-`server/lumin-oauth-loopback.js` is an internal native-app OAuth helper. It is
-packaged for source parity but is not registered as an MCP tool and does not
-run merely because the server starts. Provider request transport remains
-disabled in `server/lumin-sign-v1-mapper.js`.
+`server/lumin-oauth-loopback.js` is an internal native-app OAuth helper.
+`server/lumin-sign-v1-mapper.js` validates and maps the narrow request shape,
+and `server/lumin-sign-v1-transport.js` can execute one explicitly authorized
+direct-PDF request through an injected transport. All three are packaged for
+source parity, but none is registered as an MCP tool or runs merely because the
+server starts. The mapper itself continues to return `transport_allowed: false`.
+Calling the transport requires a separate, short-lived authority object that
+binds the exact prepared-PDF receipt, PDF digest, complete validated request
+mapping, mapper contract, and participant identities. One invocation makes at
+most one request and never retries it automatically. Authority reuse is not
+durably prevented by this internal module,
+so a future public workflow must add persistent attempt consumption before it can
+claim one-use execution authority.
 
 Lumin currently registers `http://127.0.0.1/callback` for public PKCE clients
 and ignores the loopback port when matching the redirect. At authorization
@@ -84,12 +93,22 @@ sends `http://127.0.0.1:<port>/callback` in the request. Keep the IP literal
 and `/callback` path exact. Do not switch this to `localhost`, a fixed port, a
 non-loopback listener, or a custom URI scheme without new provider evidence.
 
-The helper uses PKCE S256, a separate random state value, a one-use callback,
+The OAuth helper uses PKCE S256, a separate random state value, a one-use callback,
 strict callback parameter and Host validation, bounded inputs and responses,
 and a public-client token exchange with no client secret. It never writes or
 logs the verifier, authorization code, or returned tokens. Credential storage,
-refresh, revocation, signing request transport, callback verification, and
-provider artifact handling are separate incomplete product boundaries.
+refresh, revocation, callback verification, and provider artifact handling are
+separate incomplete product boundaries.
+
+The direct-PDF transport is pinned to Lumin's exact multipart example at Git
+commit `cd8ddd73e32c016038691dad21d0e4594c8eeebb`. It accepts an access token only
+as an ephemeral argument, injects no client secret, bounds the PDF and response,
+keeps the timeout active through response-body consumption, rejects redirects,
+and returns only a digest-bound provider identity receipt. A transport or
+response ambiguity is never retried. This is an internal vertical slice, not a
+shipped signing feature: there is no public tool, token store, webhook verifier,
+status lifecycle, cancellation path, or release claim yet. Tests inject a fake
+transport and must not make a live Lumin request.
 
 ## Data flow (ASCII map)
 

--- a/package-for-friend.js
+++ b/package-for-friend.js
@@ -60,6 +60,7 @@ export const SHARE_FILES = [
   "server/layout-extraction.js",
   "server/lumin-oauth-loopback.js",
   "server/lumin-sign-v1-mapper.js",
+  "server/lumin-sign-v1-transport.js",
   "server/markdown-conversion.js",
   "server/markdown-output-transaction.js",
   "server/output-schemas.js",

--- a/pdf-toolkit-mcp-share/server/lumin-sign-v1-mapper.js
+++ b/pdf-toolkit-mcp-share/server/lumin-sign-v1-mapper.js
@@ -6,6 +6,15 @@ const MAX_LOCAL_PREPARED_DOCUMENT_BYTES = 200 * 1024 * 1024;
 const MAX_LOCAL_PARTICIPANTS = 100;
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const SHA256_PATTERN = /^[a-f0-9]{64}$/;
+
+export const LUMIN_SIGN_V1_DIRECT_UPLOAD_REFERENCE = Object.freeze({
+  repository: "https://github.com/luminpdf/lumin-sign-api-docs",
+  commit: "cd8ddd73e32c016038691dad21d0e4594c8eeebb",
+  path: "src/theme/ApiDemoPanel/signature-request.multipart.js",
+  bytes: 7_288,
+  sha256: "8b82481c0c06bd560e1e107c08ed90b31640d9bd4cd3941635bbf4d328c814c4",
+});
+
 function canonicalJson(value) {
   if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
   if (value && typeof value === "object") {
@@ -25,6 +34,7 @@ const MAPPER_CONTRACT = Object.freeze({
   official_openapi_source_bytes: 118_174,
   official_openapi_source_sha256: "8842b7938870ea05b8c8d5869a33cc16b33b2eb0b8f2b1c60607203e39bfd037",
   official_openapi_projection_sha256: "8f3fb987391ce1552ff25c8784b9dc2725cac9b2f833abe005e9f2569a9b2701",
+  official_direct_upload_reference: LUMIN_SIGN_V1_DIRECT_UPLOAD_REFERENCE,
   official_reference_identity_status: "exact_snapshot_pinned",
   authentication_alternatives: [
     {
@@ -41,13 +51,12 @@ const MAPPER_CONTRACT = Object.freeze({
       required_scopes: ["sign:requests"],
     },
   ],
-  supported_transfer: "https_url",
+  supported_transfers: ["https_url", "direct_file"],
   supported_field_mapping: "lumin_text_tags",
   supported_signing_types: ["SAME_TIME"],
   blocked_signing_types: ["ORDER"],
   unmapped_official_request_options: [
     "custom_email",
-    "file",
     "file_urls",
     "files",
     "signer_verification",
@@ -247,9 +256,17 @@ export function mapLuminSignV1SignatureRequest(intent, options = {}) {
     ) {
       throw new Error("invalid prepared size");
     }
-    const transfer = assertExactKeys(preparedDocument.transfer, ["kind", "url"]);
-    if (transfer.kind !== "https_url") throw new Error("unsupported transfer");
-    const fileUrl = assertPublicHttpsUrl(transfer.url);
+    const transferKind = preparedDocument.transfer?.kind;
+    let transfer;
+    let fileUrl = null;
+    if (transferKind === "https_url") {
+      transfer = assertExactKeys(preparedDocument.transfer, ["kind", "url"]);
+      fileUrl = assertPublicHttpsUrl(transfer.url);
+    } else if (transferKind === "direct_file") {
+      transfer = assertExactKeys(preparedDocument.transfer, ["kind"]);
+    } else {
+      throw new Error("unsupported transfer");
+    }
 
     const fieldMapping = assertExactKeys(requestIntent.field_mapping, ["evidence_status", "method"]);
     if (fieldMapping.method !== "lumin_text_tags" || fieldMapping.evidence_status !== "caller_asserted") {
@@ -276,7 +293,7 @@ export function mapLuminSignV1SignatureRequest(intent, options = {}) {
     const participantIds = [...mappedSigners, ...mappedViewers].map(value => value.participantId);
     if (new Set(participantIds).size !== participantIds.length) throw new Error("duplicate participant binding");
     const body = {
-      file_url: fileUrl,
+      ...(fileUrl === null ? {} : { file_url: fileUrl }),
       title,
       signers: mappedSigners.map(value => value.signer),
       expires_at: requestIntent.expires_at_ms,
@@ -297,6 +314,7 @@ export function mapLuminSignV1SignatureRequest(intent, options = {}) {
         source_bytes: MAPPER_CONTRACT.official_openapi_source_bytes,
         source_sha256: MAPPER_CONTRACT.official_openapi_source_sha256,
         contract_projection_sha256: MAPPER_CONTRACT.official_openapi_projection_sha256,
+        direct_upload_reference: { ...MAPPER_CONTRACT.official_direct_upload_reference },
         openapi_document_version: "3.1.0",
         provider_info_version: "1.0.0",
         discrepancy_codes: ["SIGNER_GROUP_SCHEMA_EXAMPLE_TYPE_MISMATCH"],
@@ -312,7 +330,18 @@ export function mapLuminSignV1SignatureRequest(intent, options = {}) {
         base_url: MAPPER_CONTRACT.base_url,
         method: MAPPER_CONTRACT.method,
         path: MAPPER_CONTRACT.path,
-        content_type: "application/json",
+        content_type: transfer.kind === "direct_file" ? "multipart/form-data" : "application/json",
+        file_transfer: transfer.kind === "direct_file"
+          ? {
+              kind: "direct_file",
+              form_field: "file",
+              filename: "prepared-document.pdf",
+              media_type: "application/pdf",
+            }
+          : {
+              kind: "https_url",
+              body_field: "file_url",
+            },
         authentication_alternatives: MAPPER_CONTRACT.authentication_alternatives.map(alternative => ({
           ...alternative,
           required_scopes: [...alternative.required_scopes],
@@ -322,6 +351,8 @@ export function mapLuminSignV1SignatureRequest(intent, options = {}) {
       bindings: {
         prepared_document_sha256: preparedDocument.sha256,
         prepared_document_size_bytes: preparedDocument.size_bytes,
+        signer_participant_ids: mappedSigners.map(value => value.participantId),
+        viewer_participant_ids: mappedViewers.map(value => value.participantId),
         participant_ids: participantIds,
       },
       limitations: [
@@ -336,7 +367,9 @@ export function mapLuminSignV1SignatureRequest(intent, options = {}) {
         "participant_field_constraints_are_local_narrowing",
         "provider_expiry_horizon_not_established",
         "plan_specific_upload_limit_not_established",
-        "transfer_url_destination_not_resolved",
+        ...(transfer.kind === "https_url"
+          ? ["transfer_url_destination_not_resolved"]
+          : ["direct_file_bytes_not_attached_by_mapper"]),
         "transport_not_requested",
       ],
     }));

--- a/pdf-toolkit-mcp-share/server/lumin-sign-v1-transport.js
+++ b/pdf-toolkit-mcp-share/server/lumin-sign-v1-transport.js
@@ -1,0 +1,739 @@
+import { createHash } from "node:crypto";
+import { types as utilTypes } from "node:util";
+import {
+  LUMIN_SIGN_V1_DIRECT_UPLOAD_REFERENCE,
+  LUMIN_SIGN_V1_MAPPER_CONTRACT_SHA256,
+  mapLuminSignV1SignatureRequest,
+} from "./lumin-sign-v1-mapper.js";
+
+const MAX_PREPARED_PDF_BYTES = 200 * 1024 * 1024;
+const MAX_PROVIDER_RESPONSE_BYTES = 256 * 1024;
+const MAX_PARTICIPANTS = 100;
+const MAX_AUTHORITY_LIFETIME_MS = 10 * 60 * 1000;
+const DEFAULT_TIMEOUT_MS = 60_000;
+const SHA256_PATTERN = /^[a-f0-9]{64}$/;
+const TOKEN_PATTERN = /^[A-Za-z0-9._~+\/-]+={0,2}$/;
+const IDENTIFIER_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$/;
+const STATUS_PATTERN = /^[A-Z][A-Z0-9_]{0,127}$/;
+
+export const LUMIN_SIGN_V1_DIRECT_UPLOAD_CONFIRMATION =
+  "I authorize PDF Tools to send this prepared PDF to Lumin and email the listed signers.";
+
+export { LUMIN_SIGN_V1_DIRECT_UPLOAD_REFERENCE };
+
+function canonicalJson(value) {
+  if (Array.isArray(value)) {
+    const items = [];
+    for (let index = 0; index < value.length; index += 1) items.push(canonicalJson(value[index]));
+    return `[${items.join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value).sort().map(key => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function transportError(code, message) {
+  const error = new Error(`${code}: ${message}`);
+  Object.defineProperty(error, "code", {
+    value: code,
+    enumerable: true,
+    writable: false,
+    configurable: false,
+  });
+  return error;
+}
+
+function assertRecord(value, required, optional = []) {
+  if (!value || typeof value !== "object" || Array.isArray(value) || utilTypes.isProxy(value)) {
+    throw new Error("invalid object");
+  }
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) throw new Error("invalid object prototype");
+  const ownKeys = Reflect.ownKeys(value);
+  const allowed = [...required, ...optional].sort();
+  if (
+    ownKeys.length < required.length
+    || ownKeys.length > allowed.length
+    || ownKeys.some(key => typeof key !== "string")
+  ) {
+    throw new Error("invalid object keys");
+  }
+  const actual = [...ownKeys].sort();
+  if (actual.some(key => !allowed.includes(key)) || required.some(key => !actual.includes(key))) {
+    throw new Error("invalid object keys");
+  }
+  const normalized = Object.create(null);
+  for (const key of actual) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (!descriptor?.enumerable || !("value" in descriptor)) throw new Error("invalid object property");
+    Object.defineProperty(normalized, key, {
+      value: descriptor.value,
+      enumerable: true,
+      writable: false,
+      configurable: false,
+    });
+  }
+  return Object.freeze(normalized);
+}
+
+function assertDenseArray(value, { min = 0, max }) {
+  const prototype = value && typeof value === "object" ? Object.getPrototypeOf(value) : undefined;
+  if (
+    !Array.isArray(value)
+    || utilTypes.isProxy(value)
+    || (prototype !== Array.prototype && prototype !== null)
+  ) {
+    throw new Error("invalid array");
+  }
+  if (!Number.isSafeInteger(value.length) || value.length < min || value.length > max) {
+    throw new Error("invalid array length");
+  }
+  const ownKeys = Reflect.ownKeys(value);
+  if (ownKeys.length !== value.length + 1 || ownKeys.some(key => typeof key !== "string")) {
+    throw new Error("invalid array keys");
+  }
+  const normalized = [];
+  for (let index = 0; index < value.length; index += 1) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
+    if (!descriptor?.enumerable || !("value" in descriptor)) throw new Error("invalid array element");
+    normalized.push(descriptor.value);
+  }
+  return Object.freeze(normalized);
+}
+
+function assertString(value, { max, pattern = null }) {
+  if (
+    typeof value !== "string"
+    || value !== value.trim()
+    || value.length < 1
+    || value.length > max
+    || (pattern && !pattern.test(value))
+  ) {
+    throw new Error("invalid string");
+  }
+  return value;
+}
+
+function assertSha256(value) {
+  return assertString(value, { max: 64, pattern: SHA256_PATTERN });
+}
+
+function assertIsoTimestamp(value) {
+  const timestamp = assertString(value, { max: 32 });
+  const parsed = new Date(timestamp);
+  if (Number.isNaN(parsed.getTime()) || parsed.toISOString() !== timestamp) {
+    throw new Error("invalid timestamp");
+  }
+  return parsed.getTime();
+}
+
+function isolateOutput(value) {
+  if (Array.isArray(value)) {
+    const normalized = new Array(value.length);
+    Object.setPrototypeOf(normalized, null);
+    for (let index = 0; index < value.length; index += 1) {
+      Object.defineProperty(normalized, String(index), {
+        value: isolateOutput(value[index]),
+        enumerable: true,
+        writable: true,
+        configurable: true,
+      });
+    }
+    return normalized;
+  }
+  if (!value || typeof value !== "object") return value;
+  const normalized = Object.create(null);
+  for (const key of Object.keys(value)) {
+    Object.defineProperty(normalized, key, {
+      value: isolateOutput(value[key]),
+      enumerable: true,
+      writable: true,
+      configurable: true,
+    });
+  }
+  return normalized;
+}
+
+function deepFreeze(value) {
+  if (!value || typeof value !== "object" || Object.isFrozen(value)) return value;
+  for (const key of Reflect.ownKeys(value)) deepFreeze(value[key]);
+  return Object.freeze(value);
+}
+
+function validatePreparationReceipt(value) {
+  const receipt = assertRecord(value, [
+    "schema_version",
+    "preparation_engine",
+    "source_document",
+    "prepared_document",
+    "source_preservation",
+    "output_commit",
+    "page_count",
+    "geometry_policy",
+    "pages",
+    "field_outcomes",
+    "zones",
+    "existing_signature_observation",
+    "xfa_observation",
+    "handoff_status",
+    "missing_inputs",
+    "limitations",
+    "provider_execution_status",
+    "receipt_sha256",
+  ]);
+  if (
+    receipt.schema_version !== "1.0"
+    || receipt.preparation_engine !== "pdf-tools.prepare-signing-packet.v1"
+    || receipt.handoff_status !== "ready_for_provider_mapping"
+    || receipt.provider_execution_status !== "not_requested"
+  ) {
+    throw new Error("invalid preparation state");
+  }
+  if (!Number.isSafeInteger(receipt.page_count) || receipt.page_count < 1) {
+    throw new Error("invalid page count");
+  }
+  const pages = assertDenseArray(receipt.pages, { min: receipt.page_count, max: receipt.page_count });
+  const missingInputs = assertDenseArray(receipt.missing_inputs, { max: 0 });
+  if (pages.length !== receipt.page_count || missingInputs.length !== 0) {
+    throw new Error("incomplete preparation");
+  }
+  const preparedDocument = assertRecord(receipt.prepared_document, [
+    "canonical_path",
+    "size_bytes",
+    "sha256",
+    "identity_method",
+  ]);
+  assertString(preparedDocument.canonical_path, { max: 32_768 });
+  assertSha256(preparedDocument.sha256);
+  if (
+    !Number.isSafeInteger(preparedDocument.size_bytes)
+    || preparedDocument.size_bytes < 1
+    || preparedDocument.size_bytes > MAX_PREPARED_PDF_BYTES
+    || preparedDocument.identity_method !== "race_aware_descriptor_sha256"
+  ) {
+    throw new Error("invalid prepared document");
+  }
+  const outputCommit = assertRecord(receipt.output_commit, [
+    "status",
+    "protocol",
+    "target_mode",
+    "source_binding_verified_at_commit",
+    "prepared_identity_verified_after_commit",
+    "replacement_identity_supplied",
+  ]);
+  if (
+    outputCommit.status !== "committed"
+    || outputCommit.protocol !== "pdf-tools.atomic-output-transaction.v1"
+    || outputCommit.source_binding_verified_at_commit !== true
+    || outputCommit.prepared_identity_verified_after_commit !== true
+  ) {
+    throw new Error("uncommitted preparation");
+  }
+  const zones = assertDenseArray(receipt.zones, { min: 1, max: MAX_PARTICIPANTS * 10 });
+  const signerParticipantIds = [];
+  for (const rawZone of zones) {
+    const zone = assertRecord(rawZone, [
+      "zone_id",
+      "label",
+      "field_type",
+      "page",
+      "native_region",
+      "display_region",
+      "visibility_status",
+      "coordinate_space_version",
+      "evidence_source",
+      "evidence_binding_status",
+      "participant_binding",
+    ]);
+    if (zone.field_type === "unspecified" || zone.visibility_status !== "visible") {
+      throw new Error("invalid provider zone");
+    }
+    const binding = assertRecord(zone.participant_binding, [
+      "status",
+      "participant_id",
+      "participant_role",
+    ]);
+    if (
+      binding.status !== "bound"
+      || binding.participant_role !== "signer"
+      || !IDENTIFIER_PATTERN.test(binding.participant_id)
+    ) {
+      throw new Error("invalid signer binding");
+    }
+    signerParticipantIds.push(binding.participant_id);
+  }
+  const receiptSha256 = assertSha256(receipt.receipt_sha256);
+  const unsigned = Object.create(null);
+  for (const key of Object.keys(receipt)) {
+    if (key !== "receipt_sha256") unsigned[key] = receipt[key];
+  }
+  const canonical = canonicalJson(unsigned);
+  if (Buffer.byteLength(canonical, "utf8") > 4 * 1024 * 1024) throw new Error("oversized receipt");
+  const expected = sha256(Buffer.from(`pdf-tools.signing-preparation-receipt.v1\0${canonical}`, "utf8"));
+  if (receiptSha256 !== expected) throw new Error("preparation digest mismatch");
+  return Object.freeze({
+    receiptSha256,
+    preparedDocument,
+    signerParticipantIds: Object.freeze([...new Set(signerParticipantIds)].sort()),
+  });
+}
+
+function validateDirectUploadMapping(value, nowMs) {
+  const mapping = assertRecord(value, [
+    "schema_version",
+    "provider",
+    "provider_api_path_version",
+    "mapper_contract_sha256",
+    "request_mapping_status",
+    "official_reference_identity_status",
+    "official_reference",
+    "transport_allowed",
+    "transport_status",
+    "provider_execution_status",
+    "field_mapping_status",
+    "idempotency_status",
+    "automatic_retry_allowed",
+    "request",
+    "bindings",
+    "limitations",
+  ]);
+  if (
+    mapping.schema_version !== 1
+    || mapping.provider !== "lumin_sign"
+    || mapping.provider_api_path_version !== "v1"
+    || mapping.request_mapping_status !== "provisional_unverified"
+    || mapping.transport_allowed !== false
+    || mapping.transport_status !== "not_requested"
+    || mapping.provider_execution_status !== "not_requested"
+    || mapping.automatic_retry_allowed !== false
+  ) {
+    throw new Error("invalid mapping state");
+  }
+  const mapperContractSha256 = assertSha256(mapping.mapper_contract_sha256);
+  if (mapperContractSha256 !== LUMIN_SIGN_V1_MAPPER_CONTRACT_SHA256) {
+    throw new Error("mapper contract mismatch");
+  }
+  const request = assertRecord(mapping.request, [
+    "base_url",
+    "method",
+    "path",
+    "content_type",
+    "file_transfer",
+    "authentication_alternatives",
+    "body",
+  ]);
+  if (
+    request.base_url !== "https://api.luminpdf.com/v1"
+    || request.method !== "POST"
+    || request.path !== "/signature_request/send"
+    || request.content_type !== "multipart/form-data"
+  ) {
+    throw new Error("invalid request target");
+  }
+  const fileTransfer = assertRecord(request.file_transfer, [
+    "kind",
+    "form_field",
+    "filename",
+    "media_type",
+  ]);
+  if (
+    fileTransfer.kind !== "direct_file"
+    || fileTransfer.form_field !== "file"
+    || fileTransfer.filename !== "prepared-document.pdf"
+    || fileTransfer.media_type !== "application/pdf"
+  ) {
+    throw new Error("invalid file transfer");
+  }
+  const body = assertRecord(request.body, [
+    "title",
+    "signers",
+    "expires_at",
+    "use_text_tags",
+    "signing_type",
+  ], ["viewers"]);
+  if (body.use_text_tags !== true || body.signing_type !== "SAME_TIME") {
+    throw new Error("unsupported signing mode");
+  }
+  const signers = assertDenseArray(body.signers, { min: 1, max: MAX_PARTICIPANTS });
+  const viewers = body.viewers === undefined
+    ? Object.freeze([])
+    : assertDenseArray(body.viewers, { max: MAX_PARTICIPANTS });
+  if (signers.length + viewers.length > MAX_PARTICIPANTS) throw new Error("too many participants");
+  const bindings = assertRecord(mapping.bindings, [
+    "prepared_document_sha256",
+    "prepared_document_size_bytes",
+    "signer_participant_ids",
+    "viewer_participant_ids",
+    "participant_ids",
+  ]);
+  const signerParticipantIds = assertDenseArray(bindings.signer_participant_ids, {
+    min: signers.length,
+    max: signers.length,
+  });
+  const viewerParticipantIds = assertDenseArray(bindings.viewer_participant_ids, {
+    min: viewers.length,
+    max: viewers.length,
+  });
+  const participantIds = assertDenseArray(bindings.participant_ids, {
+    min: signers.length + viewers.length,
+    max: signers.length + viewers.length,
+  });
+  const joined = [...signerParticipantIds, ...viewerParticipantIds];
+  if (
+    joined.some((participantId, index) => participantId !== participantIds[index])
+    || new Set(participantIds).size !== participantIds.length
+    || participantIds.some(participantId => !IDENTIFIER_PATTERN.test(participantId))
+  ) {
+    throw new Error("invalid participant bindings");
+  }
+  if (
+    !Number.isSafeInteger(bindings.prepared_document_size_bytes)
+    || bindings.prepared_document_size_bytes < 1
+    || bindings.prepared_document_size_bytes > MAX_PREPARED_PDF_BYTES
+  ) {
+    throw new Error("invalid prepared document size");
+  }
+  const signerValues = signers.map((person, index) => {
+    const record = assertRecord(person, ["email_address", "name"]);
+    return {
+      participant_id: signerParticipantIds[index],
+      email_address: assertString(record.email_address, { max: 320 }),
+      name: assertString(record.name, { max: 255 }),
+    };
+  });
+  const viewerValues = viewers.map((person, index) => {
+    const record = assertRecord(person, ["email_address", "name"]);
+    return {
+      participant_id: viewerParticipantIds[index],
+      email_address: assertString(record.email_address, { max: 320 }),
+      name: assertString(record.name, { max: 255 }),
+    };
+  });
+  const replayed = mapLuminSignV1SignatureRequest({
+    schema_version: 1,
+    prepared_document: {
+      sha256: bindings.prepared_document_sha256,
+      size_bytes: bindings.prepared_document_size_bytes,
+      transfer: { kind: "direct_file" },
+    },
+    field_mapping: {
+      method: "lumin_text_tags",
+      evidence_status: "caller_asserted",
+    },
+    title: body.title,
+    expires_at_ms: body.expires_at,
+    signing_type: body.signing_type,
+    signers: signerValues,
+    ...(viewerValues.length ? { viewers: viewerValues } : {}),
+  }, { nowMs });
+  if (canonicalJson(replayed) !== canonicalJson(mapping)) {
+    throw new Error("mapping replay mismatch");
+  }
+  const requestMappingSha256 = sha256(Buffer.from(
+    `pdf-tools.lumin-sign-v1-request-mapping.v1\0${canonicalJson(replayed)}`,
+    "utf8",
+  ));
+  return Object.freeze({
+    mapping: replayed,
+    mapperContractSha256,
+    request: replayed.request,
+    body: replayed.request.body,
+    signers: signerValues,
+    viewers: viewerValues,
+    signerParticipantIds,
+    participantIds,
+    requestMappingSha256,
+    preparedDocumentSha256: assertSha256(bindings.prepared_document_sha256),
+    preparedDocumentSizeBytes: bindings.prepared_document_size_bytes,
+  });
+}
+
+function validateExecutionAuthority(value, validated, nowMs) {
+  const authority = assertRecord(value, [
+    "schema_version",
+    "provider",
+    "action",
+    "transport",
+    "confirmation",
+    "approved_at",
+    "expires_at",
+    "preparation_receipt_sha256",
+    "mapper_contract_sha256",
+    "request_mapping_sha256",
+    "prepared_document_sha256",
+    "participant_ids",
+    "automatic_retry_allowed",
+  ]);
+  if (
+    authority.schema_version !== 1
+    || authority.provider !== "lumin_sign"
+    || authority.action !== "create_signature_request"
+    || authority.transport !== "direct_pdf_multipart"
+    || authority.confirmation !== LUMIN_SIGN_V1_DIRECT_UPLOAD_CONFIRMATION
+    || authority.automatic_retry_allowed !== false
+  ) {
+    throw new Error("invalid execution authority");
+  }
+  const approvedAt = assertIsoTimestamp(authority.approved_at);
+  const expiresAt = assertIsoTimestamp(authority.expires_at);
+  if (
+    approvedAt > nowMs
+    || expiresAt <= nowMs
+    || expiresAt <= approvedAt
+    || expiresAt - approvedAt > MAX_AUTHORITY_LIFETIME_MS
+  ) {
+    throw new Error("invalid authority chronology");
+  }
+  const participantIds = assertDenseArray(authority.participant_ids, {
+    min: validated.mapping.participantIds.length,
+    max: validated.mapping.participantIds.length,
+  });
+  if (
+    authority.preparation_receipt_sha256 !== validated.preparation.receiptSha256
+    || authority.mapper_contract_sha256 !== validated.mapping.mapperContractSha256
+    || authority.request_mapping_sha256 !== validated.mapping.requestMappingSha256
+    || authority.prepared_document_sha256 !== validated.mapping.preparedDocumentSha256
+    || participantIds.some((participantId, index) => participantId !== validated.mapping.participantIds[index])
+  ) {
+    throw new Error("authority binding mismatch");
+  }
+  return Object.freeze({
+    authority,
+    authoritySha256: sha256(Buffer.from(
+      `pdf-tools.lumin-sign-v1-execution-authority.v1\0${canonicalJson(authority)}`,
+      "utf8",
+    )),
+  });
+}
+
+async function readBoundedJsonResponse(response) {
+  const contentType = response.headers?.get?.("content-type")?.split(";", 1)[0]?.trim()?.toLowerCase();
+  if (contentType !== "application/json") throw new Error("invalid response media type");
+  const declaredLength = response.headers.get("content-length");
+  if (declaredLength !== null) {
+    if (!/^\d+$/.test(declaredLength) || Number(declaredLength) > MAX_PROVIDER_RESPONSE_BYTES) {
+      throw new Error("invalid response length");
+    }
+  }
+  const reader = response.body?.getReader?.();
+  if (!reader) throw new Error("invalid response body");
+  const chunks = [];
+  let total = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (!(value instanceof Uint8Array)) throw new Error("invalid response chunk");
+    total += value.byteLength;
+    if (total > MAX_PROVIDER_RESPONSE_BYTES) {
+      await reader.cancel().catch(() => {});
+      throw new Error("provider response too large");
+    }
+    chunks.push(Buffer.from(value));
+  }
+  const bytes = Buffer.concat(chunks, total);
+  let parsed;
+  try {
+    parsed = JSON.parse(bytes.toString("utf8"));
+  } catch {
+    throw new Error("invalid provider JSON");
+  }
+  return { bytes, parsed };
+}
+
+function validateCreateResponse(value) {
+  const envelope = assertRecord(value, ["signature_request"]);
+  const request = assertRecord(envelope.signature_request, [
+    "signature_request_id",
+    "status",
+    "created_at",
+  ]);
+  const signatureRequestId = assertString(request.signature_request_id, {
+    max: 256,
+    pattern: IDENTIFIER_PATTERN,
+  });
+  const status = assertString(request.status, { max: 128, pattern: STATUS_PATTERN });
+  if (!Number.isSafeInteger(request.created_at) || request.created_at < 0) {
+    throw new Error("invalid provider timestamp");
+  }
+  return Object.freeze({ signatureRequestId, status, createdAt: request.created_at });
+}
+
+function appendPerson(form, prefix, person) {
+  form.append(`${prefix}[email_address]`, person.email_address);
+  form.append(`${prefix}[name]`, person.name);
+}
+
+export async function executeAuthorizedLuminSignV1DirectUpload(input, options = {}) {
+  let validated;
+  let accessToken;
+  let fetchImpl;
+  let nowMs;
+  let timeoutMs;
+  try {
+    const execution = assertRecord(input, [
+      "access_token",
+      "execution_authority",
+      "mapping",
+      "preparation_receipt",
+      "prepared_pdf_bytes",
+    ]);
+    const validatedOptions = assertRecord(options, ["fetchImpl"], ["nowMs", "timeoutMs"]);
+    fetchImpl = validatedOptions.fetchImpl;
+    if (typeof fetchImpl !== "function") throw new Error("missing transport implementation");
+    nowMs = validatedOptions.nowMs === undefined ? Date.now() : validatedOptions.nowMs;
+    timeoutMs = validatedOptions.timeoutMs === undefined ? DEFAULT_TIMEOUT_MS : validatedOptions.timeoutMs;
+    if (!Number.isSafeInteger(nowMs) || nowMs < 0) throw new Error("invalid clock");
+    if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 1 || timeoutMs > DEFAULT_TIMEOUT_MS) {
+      throw new Error("invalid timeout");
+    }
+    accessToken = assertString(execution.access_token, { max: 8192, pattern: TOKEN_PATTERN });
+    if (!Buffer.isBuffer(execution.prepared_pdf_bytes)) throw new Error("invalid PDF bytes");
+    const preparedPdfBytes = execution.prepared_pdf_bytes;
+    if (
+      preparedPdfBytes.length < 5
+      || preparedPdfBytes.length > MAX_PREPARED_PDF_BYTES
+      || preparedPdfBytes.subarray(0, 5).toString("ascii") !== "%PDF-"
+    ) {
+      throw new Error("invalid PDF bytes");
+    }
+    const preparation = validatePreparationReceipt(execution.preparation_receipt);
+    const mapping = validateDirectUploadMapping(execution.mapping, nowMs);
+    if (
+      preparation.preparedDocument.sha256 !== mapping.preparedDocumentSha256
+      || preparation.preparedDocument.size_bytes !== mapping.preparedDocumentSizeBytes
+      || preparedPdfBytes.length !== mapping.preparedDocumentSizeBytes
+      || sha256(preparedPdfBytes) !== mapping.preparedDocumentSha256
+    ) {
+      throw new Error("prepared document binding mismatch");
+    }
+    const mappedSignerIds = [...mapping.signerParticipantIds].sort();
+    if (
+      mappedSignerIds.length !== preparation.signerParticipantIds.length
+      || mappedSignerIds.some((participantId, index) => participantId !== preparation.signerParticipantIds[index])
+    ) {
+      throw new Error("signer zone binding mismatch");
+    }
+    validated = { preparation, mapping };
+    validated.authority = validateExecutionAuthority(
+      execution.execution_authority,
+      validated,
+      nowMs,
+    );
+  } catch {
+    throw transportError(
+      "LUMIN_TRANSPORT_INPUT_INVALID",
+      "The Lumin signing request failed local validation before any provider call.",
+    );
+  }
+
+  const form = new FormData();
+  form.append(
+    validated.mapping.request.file_transfer.form_field,
+    new Blob([input.prepared_pdf_bytes], { type: "application/pdf" }),
+    validated.mapping.request.file_transfer.filename,
+  );
+  form.append("title", validated.mapping.body.title);
+  form.append("expires_at", String(validated.mapping.body.expires_at));
+  validated.mapping.signers.forEach((person, index) => appendPerson(form, `signers[${index}]`, person));
+  validated.mapping.viewers.forEach((person, index) => appendPerson(form, `viewers[${index}]`, person));
+  form.append("use_text_tags", "true");
+  form.append("signing_type", "SAME_TIME");
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    let response;
+    try {
+      response = await fetchImpl("https://api.luminpdf.com/v1/signature_request/send", {
+        method: "POST",
+        headers: {
+          accept: "application/json",
+          authorization: `Bearer ${accessToken}`,
+        },
+        body: form,
+        redirect: "error",
+        signal: controller.signal,
+      });
+    } catch {
+      throw transportError(
+        "LUMIN_CREATE_OUTCOME_UNKNOWN",
+        "The Lumin request outcome is unknown. It was not retried automatically.",
+      );
+    }
+
+    if (response.status !== 201) {
+      await response.body?.cancel?.().catch(() => {});
+      throw transportError(
+        "LUMIN_CREATE_REJECTED",
+        "Lumin did not accept the signing request. It was not retried automatically.",
+      );
+    }
+
+    let responseBytes;
+    let responseValue;
+    try {
+      const bounded = await readBoundedJsonResponse(response);
+      responseBytes = bounded.bytes;
+      responseValue = bounded.parsed;
+    } catch {
+      throw transportError(
+        "LUMIN_CREATE_OUTCOME_UNKNOWN",
+        "Lumin may have created the signing request, but its response could not be verified. It was not retried automatically.",
+      );
+    }
+
+    let created;
+    try {
+      created = validateCreateResponse(responseValue);
+    } catch {
+      throw transportError(
+        "LUMIN_CREATE_OUTCOME_UNKNOWN",
+        "Lumin may have created the signing request, but its response could not be verified. It was not retried automatically.",
+      );
+    }
+    const receipt = isolateOutput({
+      schema_version: 1,
+      provider: "lumin_sign",
+      action: "create_signature_request",
+      provider_execution_status: "request_created",
+      attempt_count: 1,
+      automatic_retry_performed: false,
+      request: {
+        method: "POST",
+        url: "https://api.luminpdf.com/v1/signature_request/send",
+        content_type: "multipart/form-data",
+        preparation_receipt_sha256: validated.preparation.receiptSha256,
+        prepared_document_sha256: validated.mapping.preparedDocumentSha256,
+        prepared_document_size_bytes: validated.mapping.preparedDocumentSizeBytes,
+        mapper_contract_sha256: validated.mapping.mapperContractSha256,
+        request_mapping_sha256: validated.mapping.requestMappingSha256,
+        direct_upload_reference: LUMIN_SIGN_V1_DIRECT_UPLOAD_REFERENCE,
+        execution_authority_sha256: validated.authority.authoritySha256,
+        participant_ids: [...validated.mapping.participantIds],
+      },
+      response: {
+        status_code: 201,
+        body_sha256: sha256(responseBytes),
+        signature_request_id: created.signatureRequestId,
+        status: created.status,
+        created_at: created.createdAt,
+      },
+    });
+    const transportReceiptSha256 = sha256(Buffer.from(
+      `pdf-tools.lumin-sign-v1-transport-receipt.v1\0${canonicalJson(receipt)}`,
+      "utf8",
+    ));
+    return deepFreeze(isolateOutput({
+      ...receipt,
+      transport_receipt_sha256: transportReceiptSha256,
+    }));
+  } finally {
+    clearTimeout(timer);
+    accessToken = null;
+  }
+}

--- a/scripts/build-mcpb.mjs
+++ b/scripts/build-mcpb.mjs
@@ -80,6 +80,7 @@ export const SERVER_FILES = [
   "layout-extraction.js",
   "lumin-oauth-loopback.js",
   "lumin-sign-v1-mapper.js",
+  "lumin-sign-v1-transport.js",
   "markdown-conversion.js",
   "markdown-output-transaction.js",
   "output-schemas.js",

--- a/server/lumin-sign-v1-mapper.js
+++ b/server/lumin-sign-v1-mapper.js
@@ -6,6 +6,15 @@ const MAX_LOCAL_PREPARED_DOCUMENT_BYTES = 200 * 1024 * 1024;
 const MAX_LOCAL_PARTICIPANTS = 100;
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const SHA256_PATTERN = /^[a-f0-9]{64}$/;
+
+export const LUMIN_SIGN_V1_DIRECT_UPLOAD_REFERENCE = Object.freeze({
+  repository: "https://github.com/luminpdf/lumin-sign-api-docs",
+  commit: "cd8ddd73e32c016038691dad21d0e4594c8eeebb",
+  path: "src/theme/ApiDemoPanel/signature-request.multipart.js",
+  bytes: 7_288,
+  sha256: "8b82481c0c06bd560e1e107c08ed90b31640d9bd4cd3941635bbf4d328c814c4",
+});
+
 function canonicalJson(value) {
   if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
   if (value && typeof value === "object") {
@@ -25,6 +34,7 @@ const MAPPER_CONTRACT = Object.freeze({
   official_openapi_source_bytes: 118_174,
   official_openapi_source_sha256: "8842b7938870ea05b8c8d5869a33cc16b33b2eb0b8f2b1c60607203e39bfd037",
   official_openapi_projection_sha256: "8f3fb987391ce1552ff25c8784b9dc2725cac9b2f833abe005e9f2569a9b2701",
+  official_direct_upload_reference: LUMIN_SIGN_V1_DIRECT_UPLOAD_REFERENCE,
   official_reference_identity_status: "exact_snapshot_pinned",
   authentication_alternatives: [
     {
@@ -41,13 +51,12 @@ const MAPPER_CONTRACT = Object.freeze({
       required_scopes: ["sign:requests"],
     },
   ],
-  supported_transfer: "https_url",
+  supported_transfers: ["https_url", "direct_file"],
   supported_field_mapping: "lumin_text_tags",
   supported_signing_types: ["SAME_TIME"],
   blocked_signing_types: ["ORDER"],
   unmapped_official_request_options: [
     "custom_email",
-    "file",
     "file_urls",
     "files",
     "signer_verification",
@@ -247,9 +256,17 @@ export function mapLuminSignV1SignatureRequest(intent, options = {}) {
     ) {
       throw new Error("invalid prepared size");
     }
-    const transfer = assertExactKeys(preparedDocument.transfer, ["kind", "url"]);
-    if (transfer.kind !== "https_url") throw new Error("unsupported transfer");
-    const fileUrl = assertPublicHttpsUrl(transfer.url);
+    const transferKind = preparedDocument.transfer?.kind;
+    let transfer;
+    let fileUrl = null;
+    if (transferKind === "https_url") {
+      transfer = assertExactKeys(preparedDocument.transfer, ["kind", "url"]);
+      fileUrl = assertPublicHttpsUrl(transfer.url);
+    } else if (transferKind === "direct_file") {
+      transfer = assertExactKeys(preparedDocument.transfer, ["kind"]);
+    } else {
+      throw new Error("unsupported transfer");
+    }
 
     const fieldMapping = assertExactKeys(requestIntent.field_mapping, ["evidence_status", "method"]);
     if (fieldMapping.method !== "lumin_text_tags" || fieldMapping.evidence_status !== "caller_asserted") {
@@ -276,7 +293,7 @@ export function mapLuminSignV1SignatureRequest(intent, options = {}) {
     const participantIds = [...mappedSigners, ...mappedViewers].map(value => value.participantId);
     if (new Set(participantIds).size !== participantIds.length) throw new Error("duplicate participant binding");
     const body = {
-      file_url: fileUrl,
+      ...(fileUrl === null ? {} : { file_url: fileUrl }),
       title,
       signers: mappedSigners.map(value => value.signer),
       expires_at: requestIntent.expires_at_ms,
@@ -297,6 +314,7 @@ export function mapLuminSignV1SignatureRequest(intent, options = {}) {
         source_bytes: MAPPER_CONTRACT.official_openapi_source_bytes,
         source_sha256: MAPPER_CONTRACT.official_openapi_source_sha256,
         contract_projection_sha256: MAPPER_CONTRACT.official_openapi_projection_sha256,
+        direct_upload_reference: { ...MAPPER_CONTRACT.official_direct_upload_reference },
         openapi_document_version: "3.1.0",
         provider_info_version: "1.0.0",
         discrepancy_codes: ["SIGNER_GROUP_SCHEMA_EXAMPLE_TYPE_MISMATCH"],
@@ -312,7 +330,18 @@ export function mapLuminSignV1SignatureRequest(intent, options = {}) {
         base_url: MAPPER_CONTRACT.base_url,
         method: MAPPER_CONTRACT.method,
         path: MAPPER_CONTRACT.path,
-        content_type: "application/json",
+        content_type: transfer.kind === "direct_file" ? "multipart/form-data" : "application/json",
+        file_transfer: transfer.kind === "direct_file"
+          ? {
+              kind: "direct_file",
+              form_field: "file",
+              filename: "prepared-document.pdf",
+              media_type: "application/pdf",
+            }
+          : {
+              kind: "https_url",
+              body_field: "file_url",
+            },
         authentication_alternatives: MAPPER_CONTRACT.authentication_alternatives.map(alternative => ({
           ...alternative,
           required_scopes: [...alternative.required_scopes],
@@ -322,6 +351,8 @@ export function mapLuminSignV1SignatureRequest(intent, options = {}) {
       bindings: {
         prepared_document_sha256: preparedDocument.sha256,
         prepared_document_size_bytes: preparedDocument.size_bytes,
+        signer_participant_ids: mappedSigners.map(value => value.participantId),
+        viewer_participant_ids: mappedViewers.map(value => value.participantId),
         participant_ids: participantIds,
       },
       limitations: [
@@ -336,7 +367,9 @@ export function mapLuminSignV1SignatureRequest(intent, options = {}) {
         "participant_field_constraints_are_local_narrowing",
         "provider_expiry_horizon_not_established",
         "plan_specific_upload_limit_not_established",
-        "transfer_url_destination_not_resolved",
+        ...(transfer.kind === "https_url"
+          ? ["transfer_url_destination_not_resolved"]
+          : ["direct_file_bytes_not_attached_by_mapper"]),
         "transport_not_requested",
       ],
     }));

--- a/server/lumin-sign-v1-transport.js
+++ b/server/lumin-sign-v1-transport.js
@@ -1,0 +1,739 @@
+import { createHash } from "node:crypto";
+import { types as utilTypes } from "node:util";
+import {
+  LUMIN_SIGN_V1_DIRECT_UPLOAD_REFERENCE,
+  LUMIN_SIGN_V1_MAPPER_CONTRACT_SHA256,
+  mapLuminSignV1SignatureRequest,
+} from "./lumin-sign-v1-mapper.js";
+
+const MAX_PREPARED_PDF_BYTES = 200 * 1024 * 1024;
+const MAX_PROVIDER_RESPONSE_BYTES = 256 * 1024;
+const MAX_PARTICIPANTS = 100;
+const MAX_AUTHORITY_LIFETIME_MS = 10 * 60 * 1000;
+const DEFAULT_TIMEOUT_MS = 60_000;
+const SHA256_PATTERN = /^[a-f0-9]{64}$/;
+const TOKEN_PATTERN = /^[A-Za-z0-9._~+\/-]+={0,2}$/;
+const IDENTIFIER_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$/;
+const STATUS_PATTERN = /^[A-Z][A-Z0-9_]{0,127}$/;
+
+export const LUMIN_SIGN_V1_DIRECT_UPLOAD_CONFIRMATION =
+  "I authorize PDF Tools to send this prepared PDF to Lumin and email the listed signers.";
+
+export { LUMIN_SIGN_V1_DIRECT_UPLOAD_REFERENCE };
+
+function canonicalJson(value) {
+  if (Array.isArray(value)) {
+    const items = [];
+    for (let index = 0; index < value.length; index += 1) items.push(canonicalJson(value[index]));
+    return `[${items.join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value).sort().map(key => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function transportError(code, message) {
+  const error = new Error(`${code}: ${message}`);
+  Object.defineProperty(error, "code", {
+    value: code,
+    enumerable: true,
+    writable: false,
+    configurable: false,
+  });
+  return error;
+}
+
+function assertRecord(value, required, optional = []) {
+  if (!value || typeof value !== "object" || Array.isArray(value) || utilTypes.isProxy(value)) {
+    throw new Error("invalid object");
+  }
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) throw new Error("invalid object prototype");
+  const ownKeys = Reflect.ownKeys(value);
+  const allowed = [...required, ...optional].sort();
+  if (
+    ownKeys.length < required.length
+    || ownKeys.length > allowed.length
+    || ownKeys.some(key => typeof key !== "string")
+  ) {
+    throw new Error("invalid object keys");
+  }
+  const actual = [...ownKeys].sort();
+  if (actual.some(key => !allowed.includes(key)) || required.some(key => !actual.includes(key))) {
+    throw new Error("invalid object keys");
+  }
+  const normalized = Object.create(null);
+  for (const key of actual) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (!descriptor?.enumerable || !("value" in descriptor)) throw new Error("invalid object property");
+    Object.defineProperty(normalized, key, {
+      value: descriptor.value,
+      enumerable: true,
+      writable: false,
+      configurable: false,
+    });
+  }
+  return Object.freeze(normalized);
+}
+
+function assertDenseArray(value, { min = 0, max }) {
+  const prototype = value && typeof value === "object" ? Object.getPrototypeOf(value) : undefined;
+  if (
+    !Array.isArray(value)
+    || utilTypes.isProxy(value)
+    || (prototype !== Array.prototype && prototype !== null)
+  ) {
+    throw new Error("invalid array");
+  }
+  if (!Number.isSafeInteger(value.length) || value.length < min || value.length > max) {
+    throw new Error("invalid array length");
+  }
+  const ownKeys = Reflect.ownKeys(value);
+  if (ownKeys.length !== value.length + 1 || ownKeys.some(key => typeof key !== "string")) {
+    throw new Error("invalid array keys");
+  }
+  const normalized = [];
+  for (let index = 0; index < value.length; index += 1) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
+    if (!descriptor?.enumerable || !("value" in descriptor)) throw new Error("invalid array element");
+    normalized.push(descriptor.value);
+  }
+  return Object.freeze(normalized);
+}
+
+function assertString(value, { max, pattern = null }) {
+  if (
+    typeof value !== "string"
+    || value !== value.trim()
+    || value.length < 1
+    || value.length > max
+    || (pattern && !pattern.test(value))
+  ) {
+    throw new Error("invalid string");
+  }
+  return value;
+}
+
+function assertSha256(value) {
+  return assertString(value, { max: 64, pattern: SHA256_PATTERN });
+}
+
+function assertIsoTimestamp(value) {
+  const timestamp = assertString(value, { max: 32 });
+  const parsed = new Date(timestamp);
+  if (Number.isNaN(parsed.getTime()) || parsed.toISOString() !== timestamp) {
+    throw new Error("invalid timestamp");
+  }
+  return parsed.getTime();
+}
+
+function isolateOutput(value) {
+  if (Array.isArray(value)) {
+    const normalized = new Array(value.length);
+    Object.setPrototypeOf(normalized, null);
+    for (let index = 0; index < value.length; index += 1) {
+      Object.defineProperty(normalized, String(index), {
+        value: isolateOutput(value[index]),
+        enumerable: true,
+        writable: true,
+        configurable: true,
+      });
+    }
+    return normalized;
+  }
+  if (!value || typeof value !== "object") return value;
+  const normalized = Object.create(null);
+  for (const key of Object.keys(value)) {
+    Object.defineProperty(normalized, key, {
+      value: isolateOutput(value[key]),
+      enumerable: true,
+      writable: true,
+      configurable: true,
+    });
+  }
+  return normalized;
+}
+
+function deepFreeze(value) {
+  if (!value || typeof value !== "object" || Object.isFrozen(value)) return value;
+  for (const key of Reflect.ownKeys(value)) deepFreeze(value[key]);
+  return Object.freeze(value);
+}
+
+function validatePreparationReceipt(value) {
+  const receipt = assertRecord(value, [
+    "schema_version",
+    "preparation_engine",
+    "source_document",
+    "prepared_document",
+    "source_preservation",
+    "output_commit",
+    "page_count",
+    "geometry_policy",
+    "pages",
+    "field_outcomes",
+    "zones",
+    "existing_signature_observation",
+    "xfa_observation",
+    "handoff_status",
+    "missing_inputs",
+    "limitations",
+    "provider_execution_status",
+    "receipt_sha256",
+  ]);
+  if (
+    receipt.schema_version !== "1.0"
+    || receipt.preparation_engine !== "pdf-tools.prepare-signing-packet.v1"
+    || receipt.handoff_status !== "ready_for_provider_mapping"
+    || receipt.provider_execution_status !== "not_requested"
+  ) {
+    throw new Error("invalid preparation state");
+  }
+  if (!Number.isSafeInteger(receipt.page_count) || receipt.page_count < 1) {
+    throw new Error("invalid page count");
+  }
+  const pages = assertDenseArray(receipt.pages, { min: receipt.page_count, max: receipt.page_count });
+  const missingInputs = assertDenseArray(receipt.missing_inputs, { max: 0 });
+  if (pages.length !== receipt.page_count || missingInputs.length !== 0) {
+    throw new Error("incomplete preparation");
+  }
+  const preparedDocument = assertRecord(receipt.prepared_document, [
+    "canonical_path",
+    "size_bytes",
+    "sha256",
+    "identity_method",
+  ]);
+  assertString(preparedDocument.canonical_path, { max: 32_768 });
+  assertSha256(preparedDocument.sha256);
+  if (
+    !Number.isSafeInteger(preparedDocument.size_bytes)
+    || preparedDocument.size_bytes < 1
+    || preparedDocument.size_bytes > MAX_PREPARED_PDF_BYTES
+    || preparedDocument.identity_method !== "race_aware_descriptor_sha256"
+  ) {
+    throw new Error("invalid prepared document");
+  }
+  const outputCommit = assertRecord(receipt.output_commit, [
+    "status",
+    "protocol",
+    "target_mode",
+    "source_binding_verified_at_commit",
+    "prepared_identity_verified_after_commit",
+    "replacement_identity_supplied",
+  ]);
+  if (
+    outputCommit.status !== "committed"
+    || outputCommit.protocol !== "pdf-tools.atomic-output-transaction.v1"
+    || outputCommit.source_binding_verified_at_commit !== true
+    || outputCommit.prepared_identity_verified_after_commit !== true
+  ) {
+    throw new Error("uncommitted preparation");
+  }
+  const zones = assertDenseArray(receipt.zones, { min: 1, max: MAX_PARTICIPANTS * 10 });
+  const signerParticipantIds = [];
+  for (const rawZone of zones) {
+    const zone = assertRecord(rawZone, [
+      "zone_id",
+      "label",
+      "field_type",
+      "page",
+      "native_region",
+      "display_region",
+      "visibility_status",
+      "coordinate_space_version",
+      "evidence_source",
+      "evidence_binding_status",
+      "participant_binding",
+    ]);
+    if (zone.field_type === "unspecified" || zone.visibility_status !== "visible") {
+      throw new Error("invalid provider zone");
+    }
+    const binding = assertRecord(zone.participant_binding, [
+      "status",
+      "participant_id",
+      "participant_role",
+    ]);
+    if (
+      binding.status !== "bound"
+      || binding.participant_role !== "signer"
+      || !IDENTIFIER_PATTERN.test(binding.participant_id)
+    ) {
+      throw new Error("invalid signer binding");
+    }
+    signerParticipantIds.push(binding.participant_id);
+  }
+  const receiptSha256 = assertSha256(receipt.receipt_sha256);
+  const unsigned = Object.create(null);
+  for (const key of Object.keys(receipt)) {
+    if (key !== "receipt_sha256") unsigned[key] = receipt[key];
+  }
+  const canonical = canonicalJson(unsigned);
+  if (Buffer.byteLength(canonical, "utf8") > 4 * 1024 * 1024) throw new Error("oversized receipt");
+  const expected = sha256(Buffer.from(`pdf-tools.signing-preparation-receipt.v1\0${canonical}`, "utf8"));
+  if (receiptSha256 !== expected) throw new Error("preparation digest mismatch");
+  return Object.freeze({
+    receiptSha256,
+    preparedDocument,
+    signerParticipantIds: Object.freeze([...new Set(signerParticipantIds)].sort()),
+  });
+}
+
+function validateDirectUploadMapping(value, nowMs) {
+  const mapping = assertRecord(value, [
+    "schema_version",
+    "provider",
+    "provider_api_path_version",
+    "mapper_contract_sha256",
+    "request_mapping_status",
+    "official_reference_identity_status",
+    "official_reference",
+    "transport_allowed",
+    "transport_status",
+    "provider_execution_status",
+    "field_mapping_status",
+    "idempotency_status",
+    "automatic_retry_allowed",
+    "request",
+    "bindings",
+    "limitations",
+  ]);
+  if (
+    mapping.schema_version !== 1
+    || mapping.provider !== "lumin_sign"
+    || mapping.provider_api_path_version !== "v1"
+    || mapping.request_mapping_status !== "provisional_unverified"
+    || mapping.transport_allowed !== false
+    || mapping.transport_status !== "not_requested"
+    || mapping.provider_execution_status !== "not_requested"
+    || mapping.automatic_retry_allowed !== false
+  ) {
+    throw new Error("invalid mapping state");
+  }
+  const mapperContractSha256 = assertSha256(mapping.mapper_contract_sha256);
+  if (mapperContractSha256 !== LUMIN_SIGN_V1_MAPPER_CONTRACT_SHA256) {
+    throw new Error("mapper contract mismatch");
+  }
+  const request = assertRecord(mapping.request, [
+    "base_url",
+    "method",
+    "path",
+    "content_type",
+    "file_transfer",
+    "authentication_alternatives",
+    "body",
+  ]);
+  if (
+    request.base_url !== "https://api.luminpdf.com/v1"
+    || request.method !== "POST"
+    || request.path !== "/signature_request/send"
+    || request.content_type !== "multipart/form-data"
+  ) {
+    throw new Error("invalid request target");
+  }
+  const fileTransfer = assertRecord(request.file_transfer, [
+    "kind",
+    "form_field",
+    "filename",
+    "media_type",
+  ]);
+  if (
+    fileTransfer.kind !== "direct_file"
+    || fileTransfer.form_field !== "file"
+    || fileTransfer.filename !== "prepared-document.pdf"
+    || fileTransfer.media_type !== "application/pdf"
+  ) {
+    throw new Error("invalid file transfer");
+  }
+  const body = assertRecord(request.body, [
+    "title",
+    "signers",
+    "expires_at",
+    "use_text_tags",
+    "signing_type",
+  ], ["viewers"]);
+  if (body.use_text_tags !== true || body.signing_type !== "SAME_TIME") {
+    throw new Error("unsupported signing mode");
+  }
+  const signers = assertDenseArray(body.signers, { min: 1, max: MAX_PARTICIPANTS });
+  const viewers = body.viewers === undefined
+    ? Object.freeze([])
+    : assertDenseArray(body.viewers, { max: MAX_PARTICIPANTS });
+  if (signers.length + viewers.length > MAX_PARTICIPANTS) throw new Error("too many participants");
+  const bindings = assertRecord(mapping.bindings, [
+    "prepared_document_sha256",
+    "prepared_document_size_bytes",
+    "signer_participant_ids",
+    "viewer_participant_ids",
+    "participant_ids",
+  ]);
+  const signerParticipantIds = assertDenseArray(bindings.signer_participant_ids, {
+    min: signers.length,
+    max: signers.length,
+  });
+  const viewerParticipantIds = assertDenseArray(bindings.viewer_participant_ids, {
+    min: viewers.length,
+    max: viewers.length,
+  });
+  const participantIds = assertDenseArray(bindings.participant_ids, {
+    min: signers.length + viewers.length,
+    max: signers.length + viewers.length,
+  });
+  const joined = [...signerParticipantIds, ...viewerParticipantIds];
+  if (
+    joined.some((participantId, index) => participantId !== participantIds[index])
+    || new Set(participantIds).size !== participantIds.length
+    || participantIds.some(participantId => !IDENTIFIER_PATTERN.test(participantId))
+  ) {
+    throw new Error("invalid participant bindings");
+  }
+  if (
+    !Number.isSafeInteger(bindings.prepared_document_size_bytes)
+    || bindings.prepared_document_size_bytes < 1
+    || bindings.prepared_document_size_bytes > MAX_PREPARED_PDF_BYTES
+  ) {
+    throw new Error("invalid prepared document size");
+  }
+  const signerValues = signers.map((person, index) => {
+    const record = assertRecord(person, ["email_address", "name"]);
+    return {
+      participant_id: signerParticipantIds[index],
+      email_address: assertString(record.email_address, { max: 320 }),
+      name: assertString(record.name, { max: 255 }),
+    };
+  });
+  const viewerValues = viewers.map((person, index) => {
+    const record = assertRecord(person, ["email_address", "name"]);
+    return {
+      participant_id: viewerParticipantIds[index],
+      email_address: assertString(record.email_address, { max: 320 }),
+      name: assertString(record.name, { max: 255 }),
+    };
+  });
+  const replayed = mapLuminSignV1SignatureRequest({
+    schema_version: 1,
+    prepared_document: {
+      sha256: bindings.prepared_document_sha256,
+      size_bytes: bindings.prepared_document_size_bytes,
+      transfer: { kind: "direct_file" },
+    },
+    field_mapping: {
+      method: "lumin_text_tags",
+      evidence_status: "caller_asserted",
+    },
+    title: body.title,
+    expires_at_ms: body.expires_at,
+    signing_type: body.signing_type,
+    signers: signerValues,
+    ...(viewerValues.length ? { viewers: viewerValues } : {}),
+  }, { nowMs });
+  if (canonicalJson(replayed) !== canonicalJson(mapping)) {
+    throw new Error("mapping replay mismatch");
+  }
+  const requestMappingSha256 = sha256(Buffer.from(
+    `pdf-tools.lumin-sign-v1-request-mapping.v1\0${canonicalJson(replayed)}`,
+    "utf8",
+  ));
+  return Object.freeze({
+    mapping: replayed,
+    mapperContractSha256,
+    request: replayed.request,
+    body: replayed.request.body,
+    signers: signerValues,
+    viewers: viewerValues,
+    signerParticipantIds,
+    participantIds,
+    requestMappingSha256,
+    preparedDocumentSha256: assertSha256(bindings.prepared_document_sha256),
+    preparedDocumentSizeBytes: bindings.prepared_document_size_bytes,
+  });
+}
+
+function validateExecutionAuthority(value, validated, nowMs) {
+  const authority = assertRecord(value, [
+    "schema_version",
+    "provider",
+    "action",
+    "transport",
+    "confirmation",
+    "approved_at",
+    "expires_at",
+    "preparation_receipt_sha256",
+    "mapper_contract_sha256",
+    "request_mapping_sha256",
+    "prepared_document_sha256",
+    "participant_ids",
+    "automatic_retry_allowed",
+  ]);
+  if (
+    authority.schema_version !== 1
+    || authority.provider !== "lumin_sign"
+    || authority.action !== "create_signature_request"
+    || authority.transport !== "direct_pdf_multipart"
+    || authority.confirmation !== LUMIN_SIGN_V1_DIRECT_UPLOAD_CONFIRMATION
+    || authority.automatic_retry_allowed !== false
+  ) {
+    throw new Error("invalid execution authority");
+  }
+  const approvedAt = assertIsoTimestamp(authority.approved_at);
+  const expiresAt = assertIsoTimestamp(authority.expires_at);
+  if (
+    approvedAt > nowMs
+    || expiresAt <= nowMs
+    || expiresAt <= approvedAt
+    || expiresAt - approvedAt > MAX_AUTHORITY_LIFETIME_MS
+  ) {
+    throw new Error("invalid authority chronology");
+  }
+  const participantIds = assertDenseArray(authority.participant_ids, {
+    min: validated.mapping.participantIds.length,
+    max: validated.mapping.participantIds.length,
+  });
+  if (
+    authority.preparation_receipt_sha256 !== validated.preparation.receiptSha256
+    || authority.mapper_contract_sha256 !== validated.mapping.mapperContractSha256
+    || authority.request_mapping_sha256 !== validated.mapping.requestMappingSha256
+    || authority.prepared_document_sha256 !== validated.mapping.preparedDocumentSha256
+    || participantIds.some((participantId, index) => participantId !== validated.mapping.participantIds[index])
+  ) {
+    throw new Error("authority binding mismatch");
+  }
+  return Object.freeze({
+    authority,
+    authoritySha256: sha256(Buffer.from(
+      `pdf-tools.lumin-sign-v1-execution-authority.v1\0${canonicalJson(authority)}`,
+      "utf8",
+    )),
+  });
+}
+
+async function readBoundedJsonResponse(response) {
+  const contentType = response.headers?.get?.("content-type")?.split(";", 1)[0]?.trim()?.toLowerCase();
+  if (contentType !== "application/json") throw new Error("invalid response media type");
+  const declaredLength = response.headers.get("content-length");
+  if (declaredLength !== null) {
+    if (!/^\d+$/.test(declaredLength) || Number(declaredLength) > MAX_PROVIDER_RESPONSE_BYTES) {
+      throw new Error("invalid response length");
+    }
+  }
+  const reader = response.body?.getReader?.();
+  if (!reader) throw new Error("invalid response body");
+  const chunks = [];
+  let total = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (!(value instanceof Uint8Array)) throw new Error("invalid response chunk");
+    total += value.byteLength;
+    if (total > MAX_PROVIDER_RESPONSE_BYTES) {
+      await reader.cancel().catch(() => {});
+      throw new Error("provider response too large");
+    }
+    chunks.push(Buffer.from(value));
+  }
+  const bytes = Buffer.concat(chunks, total);
+  let parsed;
+  try {
+    parsed = JSON.parse(bytes.toString("utf8"));
+  } catch {
+    throw new Error("invalid provider JSON");
+  }
+  return { bytes, parsed };
+}
+
+function validateCreateResponse(value) {
+  const envelope = assertRecord(value, ["signature_request"]);
+  const request = assertRecord(envelope.signature_request, [
+    "signature_request_id",
+    "status",
+    "created_at",
+  ]);
+  const signatureRequestId = assertString(request.signature_request_id, {
+    max: 256,
+    pattern: IDENTIFIER_PATTERN,
+  });
+  const status = assertString(request.status, { max: 128, pattern: STATUS_PATTERN });
+  if (!Number.isSafeInteger(request.created_at) || request.created_at < 0) {
+    throw new Error("invalid provider timestamp");
+  }
+  return Object.freeze({ signatureRequestId, status, createdAt: request.created_at });
+}
+
+function appendPerson(form, prefix, person) {
+  form.append(`${prefix}[email_address]`, person.email_address);
+  form.append(`${prefix}[name]`, person.name);
+}
+
+export async function executeAuthorizedLuminSignV1DirectUpload(input, options = {}) {
+  let validated;
+  let accessToken;
+  let fetchImpl;
+  let nowMs;
+  let timeoutMs;
+  try {
+    const execution = assertRecord(input, [
+      "access_token",
+      "execution_authority",
+      "mapping",
+      "preparation_receipt",
+      "prepared_pdf_bytes",
+    ]);
+    const validatedOptions = assertRecord(options, ["fetchImpl"], ["nowMs", "timeoutMs"]);
+    fetchImpl = validatedOptions.fetchImpl;
+    if (typeof fetchImpl !== "function") throw new Error("missing transport implementation");
+    nowMs = validatedOptions.nowMs === undefined ? Date.now() : validatedOptions.nowMs;
+    timeoutMs = validatedOptions.timeoutMs === undefined ? DEFAULT_TIMEOUT_MS : validatedOptions.timeoutMs;
+    if (!Number.isSafeInteger(nowMs) || nowMs < 0) throw new Error("invalid clock");
+    if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 1 || timeoutMs > DEFAULT_TIMEOUT_MS) {
+      throw new Error("invalid timeout");
+    }
+    accessToken = assertString(execution.access_token, { max: 8192, pattern: TOKEN_PATTERN });
+    if (!Buffer.isBuffer(execution.prepared_pdf_bytes)) throw new Error("invalid PDF bytes");
+    const preparedPdfBytes = execution.prepared_pdf_bytes;
+    if (
+      preparedPdfBytes.length < 5
+      || preparedPdfBytes.length > MAX_PREPARED_PDF_BYTES
+      || preparedPdfBytes.subarray(0, 5).toString("ascii") !== "%PDF-"
+    ) {
+      throw new Error("invalid PDF bytes");
+    }
+    const preparation = validatePreparationReceipt(execution.preparation_receipt);
+    const mapping = validateDirectUploadMapping(execution.mapping, nowMs);
+    if (
+      preparation.preparedDocument.sha256 !== mapping.preparedDocumentSha256
+      || preparation.preparedDocument.size_bytes !== mapping.preparedDocumentSizeBytes
+      || preparedPdfBytes.length !== mapping.preparedDocumentSizeBytes
+      || sha256(preparedPdfBytes) !== mapping.preparedDocumentSha256
+    ) {
+      throw new Error("prepared document binding mismatch");
+    }
+    const mappedSignerIds = [...mapping.signerParticipantIds].sort();
+    if (
+      mappedSignerIds.length !== preparation.signerParticipantIds.length
+      || mappedSignerIds.some((participantId, index) => participantId !== preparation.signerParticipantIds[index])
+    ) {
+      throw new Error("signer zone binding mismatch");
+    }
+    validated = { preparation, mapping };
+    validated.authority = validateExecutionAuthority(
+      execution.execution_authority,
+      validated,
+      nowMs,
+    );
+  } catch {
+    throw transportError(
+      "LUMIN_TRANSPORT_INPUT_INVALID",
+      "The Lumin signing request failed local validation before any provider call.",
+    );
+  }
+
+  const form = new FormData();
+  form.append(
+    validated.mapping.request.file_transfer.form_field,
+    new Blob([input.prepared_pdf_bytes], { type: "application/pdf" }),
+    validated.mapping.request.file_transfer.filename,
+  );
+  form.append("title", validated.mapping.body.title);
+  form.append("expires_at", String(validated.mapping.body.expires_at));
+  validated.mapping.signers.forEach((person, index) => appendPerson(form, `signers[${index}]`, person));
+  validated.mapping.viewers.forEach((person, index) => appendPerson(form, `viewers[${index}]`, person));
+  form.append("use_text_tags", "true");
+  form.append("signing_type", "SAME_TIME");
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    let response;
+    try {
+      response = await fetchImpl("https://api.luminpdf.com/v1/signature_request/send", {
+        method: "POST",
+        headers: {
+          accept: "application/json",
+          authorization: `Bearer ${accessToken}`,
+        },
+        body: form,
+        redirect: "error",
+        signal: controller.signal,
+      });
+    } catch {
+      throw transportError(
+        "LUMIN_CREATE_OUTCOME_UNKNOWN",
+        "The Lumin request outcome is unknown. It was not retried automatically.",
+      );
+    }
+
+    if (response.status !== 201) {
+      await response.body?.cancel?.().catch(() => {});
+      throw transportError(
+        "LUMIN_CREATE_REJECTED",
+        "Lumin did not accept the signing request. It was not retried automatically.",
+      );
+    }
+
+    let responseBytes;
+    let responseValue;
+    try {
+      const bounded = await readBoundedJsonResponse(response);
+      responseBytes = bounded.bytes;
+      responseValue = bounded.parsed;
+    } catch {
+      throw transportError(
+        "LUMIN_CREATE_OUTCOME_UNKNOWN",
+        "Lumin may have created the signing request, but its response could not be verified. It was not retried automatically.",
+      );
+    }
+
+    let created;
+    try {
+      created = validateCreateResponse(responseValue);
+    } catch {
+      throw transportError(
+        "LUMIN_CREATE_OUTCOME_UNKNOWN",
+        "Lumin may have created the signing request, but its response could not be verified. It was not retried automatically.",
+      );
+    }
+    const receipt = isolateOutput({
+      schema_version: 1,
+      provider: "lumin_sign",
+      action: "create_signature_request",
+      provider_execution_status: "request_created",
+      attempt_count: 1,
+      automatic_retry_performed: false,
+      request: {
+        method: "POST",
+        url: "https://api.luminpdf.com/v1/signature_request/send",
+        content_type: "multipart/form-data",
+        preparation_receipt_sha256: validated.preparation.receiptSha256,
+        prepared_document_sha256: validated.mapping.preparedDocumentSha256,
+        prepared_document_size_bytes: validated.mapping.preparedDocumentSizeBytes,
+        mapper_contract_sha256: validated.mapping.mapperContractSha256,
+        request_mapping_sha256: validated.mapping.requestMappingSha256,
+        direct_upload_reference: LUMIN_SIGN_V1_DIRECT_UPLOAD_REFERENCE,
+        execution_authority_sha256: validated.authority.authoritySha256,
+        participant_ids: [...validated.mapping.participantIds],
+      },
+      response: {
+        status_code: 201,
+        body_sha256: sha256(responseBytes),
+        signature_request_id: created.signatureRequestId,
+        status: created.status,
+        created_at: created.createdAt,
+      },
+    });
+    const transportReceiptSha256 = sha256(Buffer.from(
+      `pdf-tools.lumin-sign-v1-transport-receipt.v1\0${canonicalJson(receipt)}`,
+      "utf8",
+    ));
+    return deepFreeze(isolateOutput({
+      ...receipt,
+      transport_receipt_sha256: transportReceiptSha256,
+    }));
+  } finally {
+    clearTimeout(timer);
+    accessToken = null;
+  }
+}

--- a/test/lumin-sign-v1-mapper.test.js
+++ b/test/lumin-sign-v1-mapper.test.js
@@ -91,12 +91,18 @@ describe("mapLuminSignV1SignatureRequest", () => {
         source_bytes: LUMIN_SIGN_V1_OPENAPI_SOURCE.bytes,
         source_sha256: LUMIN_SIGN_V1_OPENAPI_SOURCE.sha256,
         contract_projection_sha256: LUMIN_SIGN_V1_OPENAPI_PROJECTION_SHA256,
+        direct_upload_reference: {
+          repository: "https://github.com/luminpdf/lumin-sign-api-docs",
+          commit: "cd8ddd73e32c016038691dad21d0e4594c8eeebb",
+          path: "src/theme/ApiDemoPanel/signature-request.multipart.js",
+          bytes: 7_288,
+          sha256: "8b82481c0c06bd560e1e107c08ed90b31640d9bd4cd3941635bbf4d328c814c4",
+        },
         openapi_document_version: "3.1.0",
         provider_info_version: "1.0.0",
         discrepancy_codes: ["SIGNER_GROUP_SCHEMA_EXAMPLE_TYPE_MISMATCH"],
         unmapped_official_request_options: [
           "custom_email",
-          "file",
           "file_urls",
           "files",
           "signer_verification",
@@ -113,6 +119,10 @@ describe("mapLuminSignV1SignatureRequest", () => {
         method: "POST",
         path: "/signature_request/send",
         content_type: "application/json",
+        file_transfer: {
+          kind: "https_url",
+          body_field: "file_url",
+        },
         authentication_alternatives: [
           {
             scheme: "ApiKey",
@@ -146,6 +156,8 @@ describe("mapLuminSignV1SignatureRequest", () => {
       bindings: {
         prepared_document_sha256: "a".repeat(64),
         prepared_document_size_bytes: 12_345,
+        signer_participant_ids: ["signer.client", "signer.consultant"],
+        viewer_participant_ids: ["viewer.counsel"],
         participant_ids: ["signer.client", "signer.consultant", "viewer.counsel"],
       },
       limitations: [
@@ -168,8 +180,32 @@ describe("mapLuminSignV1SignatureRequest", () => {
     expect(result.request).not.toHaveProperty("authorization");
     expect(result.request.body).not.toHaveProperty("api_key");
     expect(LUMIN_SIGN_V1_MAPPER_CONTRACT_SHA256).toBe(
-      "cb9f421e408d9388d6ea2ba553e8d2731aceed0fc5d7264c7cbafb630a528c39",
+      "e9284f70d1acdc159a59fd2c2c0e0ead9fd194c957eb56e1f457026fc4e4af7a",
     );
+  });
+
+  it("maps direct PDF transfer metadata without embedding file bytes or enabling transport", () => {
+    const intent = validIntent();
+    intent.prepared_document.transfer = { kind: "direct_file" };
+    const result = map(intent);
+    expect(result.request).toMatchObject({
+      content_type: "multipart/form-data",
+      file_transfer: {
+        kind: "direct_file",
+        form_field: "file",
+        filename: "prepared-document.pdf",
+        media_type: "application/pdf",
+      },
+      body: {
+        title: "Consulting agreement",
+        signing_type: "SAME_TIME",
+      },
+    });
+    expect(result.request.body).not.toHaveProperty("file");
+    expect(result.request.body).not.toHaveProperty("file_url");
+    expect(result.transport_allowed).toBe(false);
+    expect(result.limitations).toContain("direct_file_bytes_not_attached_by_mapper");
+    expect(result.limitations).not.toContain("transfer_url_destination_not_resolved");
   });
 
   it("fails closed on ordered signing or any signer group until the official type conflict is resolved", () => {

--- a/test/lumin-sign-v1-transport.test.js
+++ b/test/lumin-sign-v1-transport.test.js
@@ -1,0 +1,411 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  LUMIN_SIGN_V1_MAPPER_CONTRACT_SHA256,
+  mapLuminSignV1SignatureRequest,
+} from "../server/lumin-sign-v1-mapper.js";
+import {
+  executeAuthorizedLuminSignV1DirectUpload,
+  LUMIN_SIGN_V1_DIRECT_UPLOAD_CONFIRMATION,
+  LUMIN_SIGN_V1_DIRECT_UPLOAD_REFERENCE,
+} from "../server/lumin-sign-v1-transport.js";
+
+const NOW_MS = Date.parse("2030-01-01T00:00:30.000Z");
+const PDF_BYTES = Buffer.from("%PDF-1.7\n%%EOF\n", "ascii");
+const PDF_SHA256 = createHash("sha256").update(PDF_BYTES).digest("hex");
+const ACCESS_TOKEN = "test-access-token-never-returned";
+
+function canonicalJson(value) {
+  if (Array.isArray(value)) {
+    const items = [];
+    for (let index = 0; index < value.length; index += 1) items.push(canonicalJson(value[index]));
+    return `[${items.join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value).sort().map(key => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function preparationReceipt() {
+  const receipt = {
+    schema_version: "1.0",
+    preparation_engine: "pdf-tools.prepare-signing-packet.v1",
+    source_document: {
+      canonical_path: "/synthetic/source.pdf",
+      size_bytes: PDF_BYTES.length,
+      sha256: PDF_SHA256,
+      identity_method: "race_aware_descriptor_sha256",
+    },
+    prepared_document: {
+      canonical_path: "/synthetic/prepared.pdf",
+      size_bytes: PDF_BYTES.length,
+      sha256: PDF_SHA256,
+      identity_method: "race_aware_descriptor_sha256",
+    },
+    source_preservation: {
+      mode: "source_path_unchanged",
+      source_path_reverified_after_commit: true,
+      backup_identity_verified_after_commit: false,
+      backup_path: null,
+      backup_document: null,
+    },
+    output_commit: {
+      status: "committed",
+      protocol: "pdf-tools.atomic-output-transaction.v1",
+      target_mode: "new_path",
+      source_binding_verified_at_commit: true,
+      prepared_identity_verified_after_commit: true,
+      replacement_identity_supplied: false,
+    },
+    page_count: 1,
+    geometry_policy: {
+      native_coordinate_space: "pdf-tools.media-box-top-left-points.v1",
+      display_coordinate_space: "pdf-tools.crop-box-rotated-top-left-points.v1",
+      page_box_basis: "MediaBox",
+      crop_box_observed: true,
+      rotation_policy: "clockwise_quarter_turns",
+    },
+    pages: [{ page: 1 }],
+    field_outcomes: [],
+    zones: [{
+      zone_id: "signature.client",
+      label: "Client signature",
+      field_type: "signature",
+      page: 1,
+      native_region: { x: 10, y: 20, width: 100, height: 30 },
+      display_region: { x: 10, y: 20, width: 100, height: 30 },
+      visibility_status: "visible",
+      coordinate_space_version: "pdf-tools.media-box-top-left-points.v1",
+      evidence_source: "caller_supplied",
+      evidence_binding_status: "caller_declared",
+      participant_binding: {
+        status: "bound",
+        participant_id: "signer.client",
+        participant_role: "signer",
+      },
+    }],
+    existing_signature_observation: {
+      present: false,
+      field_count: 0,
+      field_names: [],
+      allow_resign: false,
+    },
+    xfa_observation: {
+      present: false,
+      force_xfa: false,
+      stripping_authorized: false,
+    },
+    handoff_status: "ready_for_provider_mapping",
+    missing_inputs: [],
+    limitations: ["synthetic fixture"],
+    provider_execution_status: "not_requested",
+  };
+  return {
+    ...receipt,
+    receipt_sha256: createHash("sha256")
+      .update(`pdf-tools.signing-preparation-receipt.v1\0${canonicalJson(receipt)}`)
+      .digest("hex"),
+  };
+}
+
+function mapping() {
+  return mapLuminSignV1SignatureRequest({
+    schema_version: 1,
+    prepared_document: {
+      sha256: PDF_SHA256,
+      size_bytes: PDF_BYTES.length,
+      transfer: { kind: "direct_file" },
+    },
+    field_mapping: {
+      method: "lumin_text_tags",
+      evidence_status: "caller_asserted",
+    },
+    title: "Synthetic signing test",
+    expires_at_ms: NOW_MS + 86_400_000,
+    signing_type: "SAME_TIME",
+    signers: [{
+      participant_id: "signer.client",
+      email_address: "client@example.com",
+      name: "Client Signer",
+    }],
+    viewers: [{
+      participant_id: "viewer.audit",
+      email_address: "audit@example.com",
+      name: "Audit Viewer",
+    }],
+  }, { nowMs: NOW_MS });
+}
+
+function authority(receipt = preparationReceipt(), mapped = mapping()) {
+  const participantIds = Array.from(
+    { length: mapped.bindings.participant_ids.length },
+    (_, index) => mapped.bindings.participant_ids[index],
+  );
+  return {
+    schema_version: 1,
+    provider: "lumin_sign",
+    action: "create_signature_request",
+    transport: "direct_pdf_multipart",
+    confirmation: LUMIN_SIGN_V1_DIRECT_UPLOAD_CONFIRMATION,
+    approved_at: "2030-01-01T00:00:00.000Z",
+    expires_at: "2030-01-01T00:05:00.000Z",
+    preparation_receipt_sha256: receipt.receipt_sha256,
+    mapper_contract_sha256: LUMIN_SIGN_V1_MAPPER_CONTRACT_SHA256,
+    request_mapping_sha256: createHash("sha256")
+      .update(`pdf-tools.lumin-sign-v1-request-mapping.v1\0${canonicalJson(mapped)}`)
+      .digest("hex"),
+    prepared_document_sha256: PDF_SHA256,
+    participant_ids: participantIds,
+    automatic_retry_allowed: false,
+  };
+}
+
+function input() {
+  const receipt = preparationReceipt();
+  const mapped = structuredClone(mapping());
+  return {
+    access_token: ACCESS_TOKEN,
+    execution_authority: authority(receipt, mapped),
+    mapping: mapped,
+    preparation_receipt: receipt,
+    prepared_pdf_bytes: Buffer.from(PDF_BYTES),
+  };
+}
+
+function successResponse(overrides = {}) {
+  return new Response(JSON.stringify({
+    signature_request: {
+      signature_request_id: "sigreq.synthetic-123",
+      status: "WAITING_FOR_PROCESSING",
+      created_at: 1_893_456_030,
+      ...overrides,
+    },
+  }), {
+    status: 201,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+async function execute(value, fetchImpl) {
+  return executeAuthorizedLuminSignV1DirectUpload(value, {
+    fetchImpl,
+    nowMs: NOW_MS,
+    timeoutMs: 5_000,
+  });
+}
+
+describe("executeAuthorizedLuminSignV1DirectUpload", () => {
+  it("pins the exact official direct-upload example used by the transport contract", () => {
+    expect(LUMIN_SIGN_V1_DIRECT_UPLOAD_REFERENCE).toEqual({
+      repository: "https://github.com/luminpdf/lumin-sign-api-docs",
+      commit: "cd8ddd73e32c016038691dad21d0e4594c8eeebb",
+      path: "src/theme/ApiDemoPanel/signature-request.multipart.js",
+      bytes: 7_288,
+      sha256: "8b82481c0c06bd560e1e107c08ed90b31640d9bd4cd3941635bbf4d328c814c4",
+    });
+  });
+  it("sends one exact direct-file request and returns a token-free identity receipt", async () => {
+    let calls = 0;
+    const result = await execute(input(), async (url, options) => {
+      calls += 1;
+      expect(url).toBe("https://api.luminpdf.com/v1/signature_request/send");
+      expect(options).toMatchObject({ method: "POST", redirect: "error" });
+      expect(options.headers).toEqual({
+        accept: "application/json",
+        authorization: `Bearer ${ACCESS_TOKEN}`,
+      });
+      expect(options.headers).not.toHaveProperty("content-type");
+      expect(options.body).toBeInstanceOf(FormData);
+      expect([...options.body.keys()]).toEqual([
+        "file",
+        "title",
+        "expires_at",
+        "signers[0][email_address]",
+        "signers[0][name]",
+        "viewers[0][email_address]",
+        "viewers[0][name]",
+        "use_text_tags",
+        "signing_type",
+      ]);
+      const file = options.body.get("file");
+      expect(file).toBeInstanceOf(Blob);
+      expect(file.name).toBe("prepared-document.pdf");
+      expect(file.type).toBe("application/pdf");
+      expect(Buffer.from(await file.arrayBuffer())).toEqual(PDF_BYTES);
+      expect(options.body.get("title")).toBe("Synthetic signing test");
+      expect(options.body.get("signers[0][email_address]")).toBe("client@example.com");
+      expect(options.body.get("use_text_tags")).toBe("true");
+      return successResponse();
+    });
+
+    expect(calls).toBe(1);
+    expect(result).toMatchObject({
+      schema_version: 1,
+      provider: "lumin_sign",
+      provider_execution_status: "request_created",
+      attempt_count: 1,
+      automatic_retry_performed: false,
+      request: {
+        prepared_document_sha256: PDF_SHA256,
+        prepared_document_size_bytes: PDF_BYTES.length,
+        participant_ids: ["signer.client", "viewer.audit"],
+        direct_upload_reference: LUMIN_SIGN_V1_DIRECT_UPLOAD_REFERENCE,
+        request_mapping_sha256: createHash("sha256")
+          .update(`pdf-tools.lumin-sign-v1-request-mapping.v1\0${canonicalJson(mapping())}`)
+          .digest("hex"),
+      },
+      response: {
+        status_code: 201,
+        signature_request_id: "sigreq.synthetic-123",
+        status: "WAITING_FOR_PROCESSING",
+      },
+      transport_receipt_sha256: expect.stringMatching(/^[a-f0-9]{64}$/),
+    });
+    expect(JSON.stringify(result)).not.toContain(ACCESS_TOKEN);
+    expect(JSON.stringify(result)).not.toContain("client@example.com");
+    expect(Object.isFrozen(result)).toBe(true);
+    expect(Object.getPrototypeOf(result)).toBeNull();
+  });
+
+  it.each([
+    ["prepared bytes", value => { value.prepared_pdf_bytes = Buffer.from("%PDF-drift"); }],
+    ["receipt digest", value => { value.preparation_receipt.receipt_sha256 = "f".repeat(64); }],
+    ["prepared binding", value => { value.mapping.bindings.prepared_document_sha256 = "f".repeat(64); }],
+    ["mapper contract", value => {
+      value.mapping.mapper_contract_sha256 = "f".repeat(64);
+      value.execution_authority.mapper_contract_sha256 = "f".repeat(64);
+    }],
+    ["malformed signer", value => { value.mapping.request.body.signers[0].email_address = "not-an-email"; }],
+    ["signer binding", value => { value.preparation_receipt.zones[0].participant_binding.participant_id = "signer.other"; }],
+    ["authority confirmation", value => { value.execution_authority.confirmation = "yes"; }],
+    ["authority participant", value => { value.execution_authority.participant_ids[0] = "signer.other"; }],
+    ["authority request mapping", value => { value.mapping.request.body.title = "Unapproved title"; }],
+    ["expired authority", value => { value.execution_authority.expires_at = "2030-01-01T00:00:20.000Z"; }],
+    ["retry authority", value => { value.execution_authority.automatic_retry_allowed = true; }],
+    ["token whitespace", value => { value.access_token = ` ${ACCESS_TOKEN}`; }],
+    ["extra key", value => { value.client_secret = "must-not-be-consumed"; }],
+  ])("rejects %s before transport", async (_label, mutate) => {
+    const value = input();
+    mutate(value);
+    let calls = 0;
+    await expect(execute(value, async () => {
+      calls += 1;
+      return successResponse();
+    })).rejects.toMatchObject({
+      code: "LUMIN_TRANSPORT_INPUT_INVALID",
+      message: "LUMIN_TRANSPORT_INPUT_INVALID: The Lumin signing request failed local validation before any provider call.",
+    });
+    expect(calls).toBe(0);
+  });
+
+  it("requires an injected transport and never defaults to live fetch", async () => {
+    await expect(executeAuthorizedLuminSignV1DirectUpload(input())).rejects.toMatchObject({
+      code: "LUMIN_TRANSPORT_INPUT_INVALID",
+    });
+  });
+
+  it("accepts RFC bearer padding without exposing the access token", async () => {
+    const value = input();
+    value.access_token = "synthetic-token==";
+    const result = await execute(value, async () => successResponse());
+    expect(JSON.stringify(result)).not.toContain(value.access_token);
+  });
+
+  it("keeps the timeout active while reading the provider response body", async () => {
+    let calls = 0;
+    await expect(executeAuthorizedLuminSignV1DirectUpload(input(), {
+      nowMs: NOW_MS,
+      timeoutMs: 5,
+      fetchImpl: async (_url, options) => {
+        calls += 1;
+        const body = new ReadableStream({
+          start(controller) {
+            options.signal.addEventListener("abort", () => controller.error(new Error("aborted")));
+          },
+        });
+        return new Response(body, {
+          status: 201,
+          headers: { "content-type": "application/json" },
+        });
+      },
+    })).rejects.toMatchObject({ code: "LUMIN_CREATE_OUTCOME_UNKNOWN" });
+    expect(calls).toBe(1);
+  });
+
+  it("preserves an ambiguous one-attempt outcome without retrying or leaking causes", async () => {
+    let calls = 0;
+    const sentinel = "provider-secret-sentinel";
+    await expect(execute(input(), async () => {
+      calls += 1;
+      throw new Error(sentinel);
+    })).rejects.toMatchObject({
+      code: "LUMIN_CREATE_OUTCOME_UNKNOWN",
+      message: "LUMIN_CREATE_OUTCOME_UNKNOWN: The Lumin request outcome is unknown. It was not retried automatically.",
+    });
+    expect(calls).toBe(1);
+  });
+
+  it.each([
+    ["wrong status", () => new Response(JSON.stringify({ error: "no" }), {
+      status: 400,
+      headers: { "content-type": "application/json" },
+    }), "LUMIN_CREATE_REJECTED"],
+    ["wrong media", () => new Response("no", {
+      status: 201,
+      headers: { "content-type": "text/plain" },
+    }), "LUMIN_CREATE_OUTCOME_UNKNOWN"],
+    ["invalid JSON", () => new Response("{", {
+      status: 201,
+      headers: { "content-type": "application/json" },
+    }), "LUMIN_CREATE_OUTCOME_UNKNOWN"],
+    ["extra response key", () => new Response(JSON.stringify({
+      signature_request: {
+        signature_request_id: "sigreq.synthetic-123",
+        status: "WAITING_FOR_PROCESSING",
+        created_at: 1_893_456_030,
+        access_token: "secret",
+      },
+    }), {
+      status: 201,
+      headers: { "content-type": "application/json" },
+    }), "LUMIN_CREATE_OUTCOME_UNKNOWN"],
+    ["oversized declaration", () => new Response("{}", {
+      status: 201,
+      headers: {
+        "content-type": "application/json",
+        "content-length": String(256 * 1024 + 1),
+      },
+    }), "LUMIN_CREATE_OUTCOME_UNKNOWN"],
+  ])("fails closed on %s", async (_label, response, code) => {
+    let calls = 0;
+    await expect(execute(input(), async () => {
+      calls += 1;
+      return response();
+    })).rejects.toMatchObject({ code });
+    expect(calls).toBe(1);
+  });
+
+  it("keeps the source and share transport bytes identical", async () => {
+    const repoRoot = path.resolve(import.meta.dirname, "..");
+    const [source, share] = await Promise.all([
+      fs.readFile(path.join(repoRoot, "server/lumin-sign-v1-transport.js")),
+      fs.readFile(path.join(repoRoot, "pdf-toolkit-mcp-share/server/lumin-sign-v1-transport.js")),
+    ]);
+    expect(share.equals(source)).toBe(true);
+  });
+
+  it("keeps the provider transport internal and absent from both MCP entry points", async () => {
+    const repoRoot = path.resolve(import.meta.dirname, "..");
+    const [sourceIndex, shareIndex] = await Promise.all([
+      fs.readFile(path.join(repoRoot, "server/index.js"), "utf8"),
+      fs.readFile(path.join(repoRoot, "pdf-toolkit-mcp-share/server/index.js"), "utf8"),
+    ]);
+    expect(sourceIndex).not.toContain("lumin-sign-v1-transport");
+    expect(sourceIndex).not.toContain("executeAuthorizedLuminSignV1DirectUpload");
+    expect(shareIndex).not.toContain("lumin-sign-v1-transport");
+    expect(shareIndex).not.toContain("executeAuthorizedLuminSignV1DirectUpload");
+  });
+});

--- a/test/mcp-contract.test.js
+++ b/test/mcp-contract.test.js
@@ -428,6 +428,7 @@ describe("MCPB static declarations", () => {
       "type3-cm-pk-reference.js",
       "lumin-oauth-loopback.js",
       "lumin-sign-v1-mapper.js",
+      "lumin-sign-v1-transport.js",
       "markdown-conversion.js",
       "markdown-output-transaction.js",
       "pdf-lib-subprocess.js",
@@ -448,7 +449,7 @@ describe("MCPB static declarations", () => {
     }
     // A new server file must be added to the list above, not silently shipped
     // in the mirror unchecked. Two already had been.
-    expect(mirrored).toHaveLength(26);
+    expect(mirrored).toHaveLength(27);
     for (const relativePath of [
       "scripts/eval-strict-json.mjs",
       "scripts/verified-extraction-proposal.mjs",


### PR DESCRIPTION
## Summary

- add an internal direct-PDF Lumin transport and extend the signing mapper for direct file upload
- require exact prepared-document, participant, mapping, authority, and chronology bindings before any injected request
- retain a single-attempt, zero-retry, token-free result receipt with bounded response handling
- keep the capability unregistered and unavailable as a public MCP tool

## Verification

- VM focused and packaging suites: 158/158
- macOS exact-commit focused and packaging suites under Node 22.23.2: 158/158
- malformed-PDF fuzz cases on macOS: 6/6
- source and packaged mirrors byte-identical
- independent read-only review: GO for commit 016cb9a91007ec14ebd0890cb8b71755109f1a44

## Boundaries

This PR makes no live Lumin request, reads no credentials, and does not publish a signing tool. Durable one-use authority consumption and live provider lifecycle testing remain separate gates before public registration.