### PR TITLE
Harden Lumin operation reconciliation

### DIFF
--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -83,9 +83,13 @@ or runs merely because the server starts. The mapper itself continues to return
 Calling the transport requires a separate, short-lived authority object that
 binds the exact prepared-PDF receipt, PDF digest, complete validated request
 mapping, mapper contract, and participant identities. The low-level transport
-also requires a pre-request hook; future product wiring must use the durable
-wrapper rather than treating an arbitrary hook as persistence. One invocation
-makes at most one request and never retries it automatically.
+requires the pre-request hook to return a content-bound acknowledgement of the
+exact durable claim file. A no-op hook, mismatched claim, or invalid
+acknowledgement digest fails before provider entry. This keyless acknowledgement
+binds content but cannot prove that an arbitrary callback persisted it. Future
+product wiring must therefore use the durable wrapper, which creates and reopens
+the acknowledged file.
+One invocation makes at most one request and never retries it automatically.
 
 The durable wrapper creates a private operation directory keyed by the exact
 execution-authority digest and atomically links a fully synced exclusive claim
@@ -95,13 +99,25 @@ provider authority consumed; a crash after it remains a consumed, inspectable
 unknown operation instead of becoming retry permission. Claims, outcomes, and
 observations become visible only as complete files. Created, rejected, and
 unknown outcomes are content-bound and retained with 0600 files under 0700
-directories on POSIX hosts. An unknown outcome has no safely bound provider
-request ID, so polling, artifact access, and webhooks cannot reconcile it
+directories owned by the current POSIX user. Incomplete staging files younger
+than five minutes are left untouched so reconciliation cannot race an active
+writer. A fully linked stage is safely removed, while an older unlinked stage
+is moved into a private quarantine on the next operation. Quarantine is retained
+for operator review rather than silently discarded, and its contents are inert
+to execution. An unknown outcome has no
+safely bound provider request ID, so polling, artifact access, and webhooks
+cannot reconcile it
 automatically. Manual provider-side investigation is required without turning
-ambiguity into retry permission. Polling may
-append bounded status observations, and artifact access retains only the signed
-URL digest and expiry. The signed URL is returned only for immediate caller
-consumption and is never written. App webhooks are accepted only after a
+ambiguity into retry permission. Status and artifact APIs distinguish that
+terminally unreconcilable state from retry-safe failures while reading an
+already created request. A read while the create outcome is still being retained
+or was never retained is explicitly `outcome_not_retained`; the state cannot
+distinguish those cases, but re-reading is safe. Typed errors carry `reconciliation_class`,
+`read_retry_safe`, and the invariant `create_retry_allowed: false`. Retrying
+those read-only observations cannot submit a second signing request. Polling
+may append bounded status observations, and artifact access retains only the
+signed URL digest and expiry. The signed URL is returned only for immediate
+caller consumption and is never written. App webhooks are accepted only after a
 constant-time HMAC-SHA256 check over the exact raw body; the app signing secret
 and body are not persisted. Duplicate webhook delivery follows Lumin's published
 `signature_request_id` plus `event_type` idempotency rule, while conflicting

--- a/pdf-toolkit-mcp-share/server/lumin-sign-v1-operation.js
+++ b/pdf-toolkit-mcp-share/server/lumin-sign-v1-operation.js
@@ -34,6 +34,7 @@ const WEBHOOK_EVENT_TYPES = new Set([
 ]);
 const OPERATION_DIRECTORY = "lumin-sign-v1-operations";
 const STAGING_DIRECTORY = ".staging";
+const QUARANTINE_DIRECTORY = ".quarantine";
 const CLAIM_FILE = "claim.v1.json";
 const OUTCOME_FILE = "outcome.v1.json";
 const OBSERVATIONS_DIRECTORY = "observations";
@@ -41,6 +42,37 @@ const MAX_STATE_FILE_BYTES = 1024 * 1024;
 const MAX_PROVIDER_RESPONSE_BYTES = 256 * 1024;
 const MAX_WEBHOOK_BYTES = 1024 * 1024;
 const DEFAULT_TIMEOUT_MS = 60_000;
+const STAGING_QUARANTINE_AFTER_MS = 5 * 60 * 1000;
+const STAGING_FUTURE_MTIME_TOLERANCE_MS = 60_000;
+const STAGING_FILE_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,220}-[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.tmp$/;
+const TERMINAL_STATE_ERROR_DETAILS = Object.freeze({
+  reconciliation_class: "terminal_state_invalid",
+  read_retry_safe: false,
+  create_retry_allowed: false,
+});
+const TERMINAL_UNRECONCILABLE_ERROR_DETAILS = Object.freeze({
+  reconciliation_class: "terminal_unreconcilable",
+  read_retry_safe: false,
+  create_retry_allowed: false,
+});
+const RETRYABLE_READ_ERROR_DETAILS = Object.freeze({
+  reconciliation_class: "retryable_read_failure",
+  read_retry_safe: true,
+  create_retry_allowed: false,
+});
+// A committed claim with no outcome file is either a create still in flight or
+// a process that stopped between claim and outcome. The retained state cannot
+// tell those apart, so the class names only what was observed: nothing has been
+// retained. Re-reading is safe; creating again never is.
+const OUTCOME_NOT_RETAINED_ERROR_DETAILS = Object.freeze({
+  reconciliation_class: "outcome_not_retained",
+  read_retry_safe: true,
+  create_retry_allowed: false,
+});
+const OUTCOME_NOT_RETAINED_MESSAGE =
+  "This Lumin operation consumed its authority, but no create outcome has been retained. "
+  + "The create may still be in flight, or the process may have stopped before retaining its outcome; "
+  + "the retained state cannot distinguish them. Re-reading is safe and never creates a second signing request.";
 
 export const LUMIN_SIGN_V1_OPERATION_REFERENCES = deepFreeze({
   observed_at: "2026-09-04",
@@ -86,7 +118,7 @@ function lifecycleDigest(domain, value) {
   return sha256(Buffer.from(`${domain}\0${canonicalJson(value)}`, "utf8"));
 }
 
-function operationError(code, message) {
+function operationError(code, message, details = null) {
   const error = new Error(`${code}: ${message}`);
   Object.defineProperty(error, "code", {
     value: code,
@@ -94,6 +126,16 @@ function operationError(code, message) {
     writable: false,
     configurable: false,
   });
+  if (details !== null) {
+    for (const [key, value] of Object.entries(details)) {
+      Object.defineProperty(error, key, {
+        value,
+        enumerable: true,
+        writable: false,
+        configurable: false,
+      });
+    }
+  }
   return error;
 }
 
@@ -317,6 +359,16 @@ function assertPrivateMode(stats, expected, label) {
   if (process.platform !== "win32" && (stats.mode & 0o777) !== expected) {
     throw new Error(`${label} has unsafe permissions`);
   }
+  if (process.platform !== "win32") {
+    const userId = typeof process.geteuid === "function"
+      ? process.geteuid()
+      : typeof process.getuid === "function"
+        ? process.getuid()
+        : null;
+    if (userId === null || stats.uid !== userId) {
+      throw new Error(`${label} is owned by another user`);
+    }
+  }
 }
 
 async function ensurePrivateDirectory(directoryPath, { create }) {
@@ -422,15 +474,134 @@ async function readPrivateJson(filePath) {
   }
 }
 
+async function validateStagingEntry(filePath) {
+  const stats = await fs.lstat(filePath);
+  if (!stats.isFile() || stats.isSymbolicLink()) throw new Error("invalid staging entry");
+  assertPrivateMode(stats, 0o600, "staging file");
+  if (!Number.isSafeInteger(stats.nlink) || stats.nlink < 1 || stats.nlink > 2) {
+    throw new Error("invalid staging link count");
+  }
+  if (!Number.isFinite(stats.mtimeMs)) throw new Error("invalid staging timestamp");
+  return stats;
+}
+
+function sameFileIdentity(left, right) {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+async function unlinkMatchingStagingEntry(filePath, expectedStats) {
+  let currentStats;
+  try {
+    currentStats = await validateStagingEntry(filePath);
+  } catch (error) {
+    if (error?.code === "ENOENT") return false;
+    throw error;
+  }
+  if (!sameFileIdentity(currentStats, expectedStats)) {
+    throw new Error("staging entry identity changed before cleanup");
+  }
+  try {
+    await fs.unlink(filePath);
+    return true;
+  } catch (error) {
+    if (error?.code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+async function reconcileStagingRoot(stagingRoot) {
+  const entries = await fs.readdir(stagingRoot, { withFileTypes: true });
+  const quarantineEntry = entries.find(entry => entry.name === QUARANTINE_DIRECTORY);
+  if (quarantineEntry) {
+    if (!quarantineEntry.isDirectory() || quarantineEntry.isSymbolicLink()) {
+      throw new Error("invalid staging quarantine");
+    }
+    const quarantinePath = path.join(stagingRoot, QUARANTINE_DIRECTORY);
+    await ensurePrivateDirectory(quarantinePath, { create: false });
+  }
+  const observedAt = Date.now();
+  for (const entry of entries) {
+    if (entry.name === QUARANTINE_DIRECTORY) continue;
+    if (!STAGING_FILE_PATTERN.test(entry.name) || !entry.isFile() || entry.isSymbolicLink()) {
+      throw new Error("invalid staging entry");
+    }
+    const stagedPath = path.join(stagingRoot, entry.name);
+    let stats;
+    try {
+      stats = await validateStagingEntry(stagedPath);
+    } catch (error) {
+      if (error?.code === "ENOENT") continue;
+      throw error;
+    }
+    if (stats.nlink === 2) {
+      if (await unlinkMatchingStagingEntry(stagedPath, stats)) {
+        await syncDirectory(stagingRoot);
+      }
+      continue;
+    }
+    if (stats.mtimeMs > observedAt + STAGING_FUTURE_MTIME_TOLERANCE_MS) {
+      throw new Error("staging timestamp is in the future");
+    }
+    if (observedAt - stats.mtimeMs < STAGING_QUARANTINE_AFTER_MS) continue;
+    const quarantinePath = path.join(stagingRoot, QUARANTINE_DIRECTORY);
+    await ensurePrivateDirectory(quarantinePath, { create: true });
+    const quarantinedPath = path.join(quarantinePath, entry.name);
+    try {
+      await fs.link(stagedPath, quarantinedPath);
+    } catch (error) {
+      if (!new Set(["EEXIST", "ENOENT"]).has(error?.code)) throw error;
+      // Something already occupies the quarantine name. Only the same inode
+      // (a concurrent reconciler's link) may proceed; a symlink, a foreign
+      // file, or an unsafe entry at that exact name fails this create closed
+      // and is left in place for operator review.
+      const quarantinedStats = await validateStagingEntry(quarantinedPath);
+      if (!sameFileIdentity(quarantinedStats, stats)) {
+        throw new Error("staging quarantine identity collision");
+      }
+    }
+    await unlinkMatchingStagingEntry(stagedPath, stats);
+    await syncDirectory(quarantinePath);
+    await syncDirectory(stagingRoot);
+  }
+}
+
 async function prepareStateRoot(stateRoot) {
   await ensurePrivateDirectory(stateRoot, { create: true });
   const operationsRoot = path.join(stateRoot, OPERATION_DIRECTORY);
   await ensurePrivateDirectory(operationsRoot, { create: true });
   const stagingRoot = path.join(operationsRoot, STAGING_DIRECTORY);
   await ensurePrivateDirectory(stagingRoot, { create: true });
+  await reconcileStagingRoot(stagingRoot);
   await syncDirectory(stateRoot);
   await syncDirectory(operationsRoot);
   return { operationsRoot, stagingRoot };
+}
+
+function buildDurableClaimAcknowledgement(identity, claim, claimBytes) {
+  const unsigned = {
+    schema_version: 1,
+    provider: "lumin_sign",
+    action: "create_signature_request",
+    commit_status: "durable_claim_committed",
+    authority_sha256: identity.authority_sha256,
+    preparation_receipt_sha256: identity.preparation_receipt_sha256,
+    mapper_contract_sha256: identity.mapper_contract_sha256,
+    request_mapping_sha256: identity.request_mapping_sha256,
+    prepared_document_sha256: identity.prepared_document_sha256,
+    prepared_document_size_bytes: identity.prepared_document_size_bytes,
+    participant_ids: [...identity.participant_ids],
+    claim_started_at: claim.started_at,
+    claim_sha256: claim.claim_sha256,
+    claim_file_sha256: sha256(claimBytes),
+    claim_file_size_bytes: claimBytes.length,
+  };
+  return deepFreeze(isolateOutput({
+    ...unsigned,
+    acknowledgement_sha256: lifecycleDigest(
+      "pdf-tools.lumin-sign-v1-durable-claim-acknowledgement.v1",
+      unsigned,
+    ),
+  }));
 }
 
 function validateRequestIdentity(value) {
@@ -505,7 +676,14 @@ async function acquireOperationClaim(stateRoot, rawIdentity, startedAt) {
     claim_sha256: lifecycleDigest("pdf-tools.lumin-sign-v1-operation-claim.v1", unsigned),
   };
   try {
-    await commitExclusiveJson(path.join(operationPath, CLAIM_FILE), claim, stagingRoot);
+    const claimBytes = await commitExclusiveJson(path.join(operationPath, CLAIM_FILE), claim, stagingRoot);
+    const acknowledgement = buildDurableClaimAcknowledgement(identity, claim, claimBytes);
+    return {
+      acknowledgement,
+      claim: deepFreeze(isolateOutput(claim)),
+      operationPath,
+      stagingRoot,
+    };
   } catch (error) {
     if (error?.code === "EEXIST") {
       throw operationError(
@@ -515,7 +693,6 @@ async function acquireOperationClaim(stateRoot, rawIdentity, startedAt) {
     }
     throw error;
   }
-  return { claim: deepFreeze(isolateOutput(claim)), operationPath, stagingRoot };
 }
 
 function buildOutcome({ claim, completedAt, result, failureCode }) {
@@ -601,8 +778,10 @@ function validateTransportReceipt(receipt, claim) {
     || value.automatic_retry_performed !== false
   ) throw new Error("invalid transport receipt");
   const request = assertJsonRecord(value.request);
+  assertSha256(request.durable_claim_acknowledgement_sha256);
   if (
     request.execution_authority_sha256 !== claim.authority_sha256
+    || request.durable_claim_sha256 !== claim.claim_sha256
     || request.preparation_receipt_sha256 !== claim.preparation_receipt_sha256
     || request.mapper_contract_sha256 !== claim.mapper_contract_sha256
     || request.request_mapping_sha256 !== claim.request_mapping_sha256
@@ -696,13 +875,17 @@ export async function executeDurableLuminSignV1DirectUpload(input, options = {})
   } catch {
     throw operationError("LUMIN_OPERATION_INPUT_INVALID", "The Lumin operation configuration is invalid.");
   }
+  // One clock instant for the whole create. The claim's started_at and the
+  // transport's acknowledgement check must read the same millisecond; letting
+  // the transport sample Date.now() again would commit the claim and then
+  // refuse provider entry whenever the two reads straddled a tick.
   const startedMs = validatedOptions.nowMs === undefined ? Date.now() : validatedOptions.nowMs;
   let claimed = null;
   let claimError = null;
   try {
     const result = await executeAuthorizedLuminSignV1DirectUpload(input, {
       fetchImpl: validatedOptions.fetchImpl,
-      ...(validatedOptions.nowMs === undefined ? {} : { nowMs: validatedOptions.nowMs }),
+      nowMs: startedMs,
       ...(validatedOptions.timeoutMs === undefined ? {} : { timeoutMs: validatedOptions.timeoutMs }),
       beforeRequest: async requestIdentity => {
         try {
@@ -716,6 +899,7 @@ export async function executeDurableLuminSignV1DirectUpload(input, options = {})
               );
           throw claimError;
         }
+        return claimed.acknowledgement;
       },
     });
     if (!claimed) throw new Error("provider result exists without durable claim");
@@ -761,20 +945,32 @@ export async function executeDurableLuminSignV1DirectUpload(input, options = {})
   }
 }
 
+function classifyRetainedOutcome(outcome) {
+  if (outcome === null) return OUTCOME_NOT_RETAINED_ERROR_DETAILS.reconciliation_class;
+  if (outcome.operation_status === "request_created") return "reconcilable_by_request_id";
+  return TERMINAL_UNRECONCILABLE_ERROR_DETAILS.reconciliation_class;
+}
+
 export async function inspectLuminSignV1Operation(input) {
   let request;
   try {
     request = assertRecord(input, ["state_root", "authority_sha256"]);
     const loaded = await loadOperation(request.state_root, request.authority_sha256);
+    // "outcome_unknown" is a retained, terminal verdict written by the wrapper.
+    // A claim with no outcome file is not that: it is the claim's own status,
+    // authority_consumed, with nothing retained yet or ever.
     return deepFreeze(isolateOutput({
       schema_version: 1,
       provider: "lumin_sign",
       authority_sha256: loaded.claim.authority_sha256,
       claim_sha256: loaded.claim.claim_sha256,
-      operation_status: loaded.outcome?.operation_status ?? "outcome_unknown",
+      operation_status: loaded.outcome ? loaded.outcome.operation_status : loaded.claim.operation_status,
+      outcome_status: loaded.outcome ? "retained" : "not_retained",
+      reconciliation_class: classifyRetainedOutcome(loaded.outcome),
       outcome_sha256: loaded.outcome?.outcome_sha256 ?? null,
       transport_receipt: loaded.outcome?.transport_receipt ?? null,
       automatic_retry_allowed: false,
+      create_retry_allowed: false,
     }));
   } catch (error) {
     if (error?.code?.startsWith?.("LUMIN_")) throw error;
@@ -840,6 +1036,7 @@ async function writeObservation(operationPath, prefix, observation) {
 export async function pollAndRecordLuminSignV1Status(input, options = {}) {
   let accessToken;
   let controller;
+  let failureClass = "input";
   let timer;
   try {
     const request = assertRecord(input, ["access_token", "authority_sha256", "state_root"]);
@@ -851,10 +1048,17 @@ export async function pollAndRecordLuminSignV1Status(input, options = {}) {
       throw new Error("invalid polling timeout");
     }
     accessToken = assertString(request.access_token, { max: 8192, pattern: TOKEN_PATTERN });
+    failureClass = "state";
     const loaded = await loadOperation(request.state_root, request.authority_sha256);
-    if (loaded.outcome?.operation_status !== "request_created") throw new Error("operation is not reconcilable by ID");
+    if (loaded.outcome === null) {
+      failureClass = "not_retained";
+      throw new Error("operation outcome is not retained");
+    }
+    failureClass = "unreconcilable";
+    if (loaded.outcome.operation_status !== "request_created") throw new Error("operation is not reconcilable by ID");
     const transportReceipt = validateTransportReceipt(loaded.outcome.transport_receipt, loaded.claim);
     const signatureRequestId = transportReceipt.response.signature_request_id;
+    failureClass = "retryable";
     controller = new AbortController();
     timer = setTimeout(() => controller.abort(), timeoutMs);
     const response = await validatedOptions.fetchImpl(
@@ -900,9 +1104,34 @@ export async function pollAndRecordLuminSignV1Status(input, options = {}) {
     await writeObservation(loaded.operationPath, "poll", observation);
     return observation;
   } catch {
+    if (failureClass === "input") {
+      throw operationError("LUMIN_STATUS_INPUT_INVALID", "The Lumin status request is invalid.");
+    }
+    if (failureClass === "state") {
+      throw operationError(
+        "LUMIN_OPERATION_STATE_INVALID",
+        "The retained Lumin operation state is missing or invalid and cannot be reconciled.",
+        TERMINAL_STATE_ERROR_DETAILS,
+      );
+    }
+    if (failureClass === "unreconcilable") {
+      throw operationError(
+        "LUMIN_OPERATION_UNRECONCILABLE",
+        "This operation has no verified Lumin request identity and cannot be reconciled by polling.",
+        TERMINAL_UNRECONCILABLE_ERROR_DETAILS,
+      );
+    }
+    if (failureClass === "not_retained") {
+      throw operationError(
+        "LUMIN_OPERATION_OUTCOME_NOT_RETAINED",
+        OUTCOME_NOT_RETAINED_MESSAGE,
+        OUTCOME_NOT_RETAINED_ERROR_DETAILS,
+      );
+    }
     throw operationError(
-      "LUMIN_STATUS_OBSERVATION_FAILED",
-      "The Lumin signing status could not be verified or retained.",
+      "LUMIN_STATUS_OBSERVATION_RETRYABLE",
+      "The existing Lumin request status could not be verified or retained. Retrying this read will not create a new signing request.",
+      RETRYABLE_READ_ERROR_DETAILS,
     );
   } finally {
     if (timer) clearTimeout(timer);
@@ -914,6 +1143,7 @@ export async function requestAndRecordLuminSignV1ArtifactAccess(input, options =
   let accessToken;
   let accessUrl;
   let controller;
+  let failureClass = "input";
   let timer;
   try {
     const request = assertRecord(input, ["access_token", "authority_sha256", "file_type", "state_root"]);
@@ -927,10 +1157,17 @@ export async function requestAndRecordLuminSignV1ArtifactAccess(input, options =
     const fileType = assertString(request.file_type, { max: 16 });
     if (!ARTIFACT_FILE_TYPES.has(fileType)) throw new Error("invalid artifact type");
     accessToken = assertString(request.access_token, { max: 8192, pattern: TOKEN_PATTERN });
+    failureClass = "state";
     const loaded = await loadOperation(request.state_root, request.authority_sha256);
-    if (loaded.outcome?.operation_status !== "request_created") throw new Error("operation has no provider identity");
+    if (loaded.outcome === null) {
+      failureClass = "not_retained";
+      throw new Error("operation outcome is not retained");
+    }
+    failureClass = "unreconcilable";
+    if (loaded.outcome.operation_status !== "request_created") throw new Error("operation has no provider identity");
     const transportReceipt = validateTransportReceipt(loaded.outcome.transport_receipt, loaded.claim);
     const signatureRequestId = transportReceipt.response.signature_request_id;
+    failureClass = "retryable";
     controller = new AbortController();
     timer = setTimeout(() => controller.abort(), timeoutMs);
     const response = await validatedOptions.fetchImpl(
@@ -995,9 +1232,34 @@ export async function requestAndRecordLuminSignV1ArtifactAccess(input, options =
       persistence_policy: "ephemeral_caller_consumption_only",
     }));
   } catch {
+    if (failureClass === "input") {
+      throw operationError("LUMIN_ARTIFACT_INPUT_INVALID", "The Lumin artifact request is invalid.");
+    }
+    if (failureClass === "state") {
+      throw operationError(
+        "LUMIN_OPERATION_STATE_INVALID",
+        "The retained Lumin operation state is missing or invalid and cannot be reconciled.",
+        TERMINAL_STATE_ERROR_DETAILS,
+      );
+    }
+    if (failureClass === "unreconcilable") {
+      throw operationError(
+        "LUMIN_OPERATION_UNRECONCILABLE",
+        "This operation has no verified Lumin request identity and cannot provide signed artifacts.",
+        TERMINAL_UNRECONCILABLE_ERROR_DETAILS,
+      );
+    }
+    if (failureClass === "not_retained") {
+      throw operationError(
+        "LUMIN_OPERATION_OUTCOME_NOT_RETAINED",
+        OUTCOME_NOT_RETAINED_MESSAGE,
+        OUTCOME_NOT_RETAINED_ERROR_DETAILS,
+      );
+    }
     throw operationError(
-      "LUMIN_ARTIFACT_OBSERVATION_FAILED",
-      "The Lumin artifact access response could not be verified or safely retained.",
+      "LUMIN_ARTIFACT_OBSERVATION_RETRYABLE",
+      "The existing Lumin request artifact could not be verified or safely retained. Retrying this read will not create a new signing request.",
+      RETRYABLE_READ_ERROR_DETAILS,
     );
   } finally {
     if (timer) clearTimeout(timer);

--- a/pdf-toolkit-mcp-share/server/lumin-sign-v1-transport.js
+++ b/pdf-toolkit-mcp-share/server/lumin-sign-v1-transport.js
@@ -132,6 +132,91 @@ function assertIsoTimestamp(value) {
   return parsed.getTime();
 }
 
+function validateDurableClaimAcknowledgement(value, requestIdentity, nowMs) {
+  const acknowledgement = assertRecord(value, [
+    "schema_version",
+    "provider",
+    "action",
+    "commit_status",
+    "authority_sha256",
+    "preparation_receipt_sha256",
+    "mapper_contract_sha256",
+    "request_mapping_sha256",
+    "prepared_document_sha256",
+    "prepared_document_size_bytes",
+    "participant_ids",
+    "claim_started_at",
+    "claim_sha256",
+    "claim_file_sha256",
+    "claim_file_size_bytes",
+    "acknowledgement_sha256",
+  ]);
+  const participantIds = assertDenseArray(acknowledgement.participant_ids, {
+    min: 1,
+    max: MAX_PARTICIPANTS,
+  });
+  if (
+    acknowledgement.schema_version !== 1
+    || acknowledgement.provider !== "lumin_sign"
+    || acknowledgement.action !== "create_signature_request"
+    || acknowledgement.commit_status !== "durable_claim_committed"
+    || acknowledgement.authority_sha256 !== requestIdentity.authority_sha256
+    || acknowledgement.preparation_receipt_sha256 !== requestIdentity.preparation_receipt_sha256
+    || acknowledgement.mapper_contract_sha256 !== requestIdentity.mapper_contract_sha256
+    || acknowledgement.request_mapping_sha256 !== requestIdentity.request_mapping_sha256
+    || acknowledgement.prepared_document_sha256 !== requestIdentity.prepared_document_sha256
+    || acknowledgement.prepared_document_size_bytes !== requestIdentity.prepared_document_size_bytes
+    || participantIds.length !== requestIdentity.participant_ids.length
+    || participantIds.some((participantId, index) => participantId !== requestIdentity.participant_ids[index])
+  ) {
+    throw new Error("durable claim acknowledgement binding mismatch");
+  }
+  const startedAt = assertIsoTimestamp(acknowledgement.claim_started_at);
+  if (!Number.isSafeInteger(startedAt) || startedAt !== nowMs) {
+    throw new Error("invalid durable claim timestamp");
+  }
+  const claimUnsigned = {
+    schema_version: 1,
+    provider: "lumin_sign",
+    action: "create_signature_request",
+    operation_status: "authority_consumed",
+    automatic_retry_allowed: false,
+    authority_sha256: requestIdentity.authority_sha256,
+    preparation_receipt_sha256: requestIdentity.preparation_receipt_sha256,
+    mapper_contract_sha256: requestIdentity.mapper_contract_sha256,
+    request_mapping_sha256: requestIdentity.request_mapping_sha256,
+    prepared_document_sha256: requestIdentity.prepared_document_sha256,
+    prepared_document_size_bytes: requestIdentity.prepared_document_size_bytes,
+    participant_ids: [...participantIds],
+    started_at: acknowledgement.claim_started_at,
+  };
+  const expectedClaimSha256 = sha256(Buffer.from(
+    `pdf-tools.lumin-sign-v1-operation-claim.v1\0${canonicalJson(claimUnsigned)}`,
+    "utf8",
+  ));
+  if (assertSha256(acknowledgement.claim_sha256) !== expectedClaimSha256) {
+    throw new Error("durable claim acknowledgement digest mismatch");
+  }
+  const claim = { ...claimUnsigned, claim_sha256: expectedClaimSha256 };
+  const claimBytes = Buffer.from(`${canonicalJson(claim)}\n`, "utf8");
+  if (
+    acknowledgement.claim_file_size_bytes !== claimBytes.length
+    || assertSha256(acknowledgement.claim_file_sha256) !== sha256(claimBytes)
+  ) {
+    throw new Error("durable claim file acknowledgement mismatch");
+  }
+  const unsigned = { ...acknowledgement };
+  delete unsigned.acknowledgement_sha256;
+  const expectedAcknowledgementSha256 = sha256(Buffer.from(
+    `pdf-tools.lumin-sign-v1-durable-claim-acknowledgement.v1\0${canonicalJson(unsigned)}`,
+    "utf8",
+  ));
+  if (assertSha256(acknowledgement.acknowledgement_sha256) !== expectedAcknowledgementSha256) {
+    throw new Error("durable claim acknowledgement identity mismatch");
+  }
+  return acknowledgement;
+}
+
 function isolateOutput(value) {
   if (Array.isArray(value)) {
     const normalized = new Array(value.length);
@@ -571,6 +656,7 @@ function appendPerson(form, prefix, person) {
 export async function executeAuthorizedLuminSignV1DirectUpload(input, options = {}) {
   let validated;
   let accessToken;
+  let durableClaimAcknowledgement;
   let fetchImpl;
   let beforeRequest;
   let preparedPdfBytes;
@@ -648,8 +734,7 @@ export async function executeAuthorizedLuminSignV1DirectUpload(input, options = 
   form.append("use_text_tags", "true");
   form.append("signing_type", "SAME_TIME");
 
-  try {
-    await beforeRequest(deepFreeze(isolateOutput({
+  const requestIdentity = deepFreeze(isolateOutput({
       schema_version: 1,
       provider: "lumin_sign",
       action: "create_signature_request",
@@ -660,7 +745,14 @@ export async function executeAuthorizedLuminSignV1DirectUpload(input, options = 
       prepared_document_sha256: validated.mapping.preparedDocumentSha256,
       prepared_document_size_bytes: validated.mapping.preparedDocumentSizeBytes,
       participant_ids: [...validated.mapping.participantIds],
-    })));
+  }));
+  try {
+    const acknowledgement = await beforeRequest(requestIdentity);
+    durableClaimAcknowledgement = validateDurableClaimAcknowledgement(
+      acknowledgement,
+      requestIdentity,
+      nowMs,
+    );
   } catch {
     throw transportError(
       "LUMIN_OPERATION_STATE_REJECTED",
@@ -738,6 +830,8 @@ export async function executeAuthorizedLuminSignV1DirectUpload(input, options = 
         request_mapping_sha256: validated.mapping.requestMappingSha256,
         direct_upload_reference: LUMIN_SIGN_V1_DIRECT_UPLOAD_REFERENCE,
         execution_authority_sha256: validated.authority.authoritySha256,
+        durable_claim_sha256: durableClaimAcknowledgement.claim_sha256,
+        durable_claim_acknowledgement_sha256: durableClaimAcknowledgement.acknowledgement_sha256,
         participant_ids: [...validated.mapping.participantIds],
       },
       response: {

--- a/server/lumin-sign-v1-operation.js
+++ b/server/lumin-sign-v1-operation.js
@@ -34,6 +34,7 @@ const WEBHOOK_EVENT_TYPES = new Set([
 ]);
 const OPERATION_DIRECTORY = "lumin-sign-v1-operations";
 const STAGING_DIRECTORY = ".staging";
+const QUARANTINE_DIRECTORY = ".quarantine";
 const CLAIM_FILE = "claim.v1.json";
 const OUTCOME_FILE = "outcome.v1.json";
 const OBSERVATIONS_DIRECTORY = "observations";
@@ -41,6 +42,37 @@ const MAX_STATE_FILE_BYTES = 1024 * 1024;
 const MAX_PROVIDER_RESPONSE_BYTES = 256 * 1024;
 const MAX_WEBHOOK_BYTES = 1024 * 1024;
 const DEFAULT_TIMEOUT_MS = 60_000;
+const STAGING_QUARANTINE_AFTER_MS = 5 * 60 * 1000;
+const STAGING_FUTURE_MTIME_TOLERANCE_MS = 60_000;
+const STAGING_FILE_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,220}-[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.tmp$/;
+const TERMINAL_STATE_ERROR_DETAILS = Object.freeze({
+  reconciliation_class: "terminal_state_invalid",
+  read_retry_safe: false,
+  create_retry_allowed: false,
+});
+const TERMINAL_UNRECONCILABLE_ERROR_DETAILS = Object.freeze({
+  reconciliation_class: "terminal_unreconcilable",
+  read_retry_safe: false,
+  create_retry_allowed: false,
+});
+const RETRYABLE_READ_ERROR_DETAILS = Object.freeze({
+  reconciliation_class: "retryable_read_failure",
+  read_retry_safe: true,
+  create_retry_allowed: false,
+});
+// A committed claim with no outcome file is either a create still in flight or
+// a process that stopped between claim and outcome. The retained state cannot
+// tell those apart, so the class names only what was observed: nothing has been
+// retained. Re-reading is safe; creating again never is.
+const OUTCOME_NOT_RETAINED_ERROR_DETAILS = Object.freeze({
+  reconciliation_class: "outcome_not_retained",
+  read_retry_safe: true,
+  create_retry_allowed: false,
+});
+const OUTCOME_NOT_RETAINED_MESSAGE =
+  "This Lumin operation consumed its authority, but no create outcome has been retained. "
+  + "The create may still be in flight, or the process may have stopped before retaining its outcome; "
+  + "the retained state cannot distinguish them. Re-reading is safe and never creates a second signing request.";
 
 export const LUMIN_SIGN_V1_OPERATION_REFERENCES = deepFreeze({
   observed_at: "2026-09-04",
@@ -86,7 +118,7 @@ function lifecycleDigest(domain, value) {
   return sha256(Buffer.from(`${domain}\0${canonicalJson(value)}`, "utf8"));
 }
 
-function operationError(code, message) {
+function operationError(code, message, details = null) {
   const error = new Error(`${code}: ${message}`);
   Object.defineProperty(error, "code", {
     value: code,
@@ -94,6 +126,16 @@ function operationError(code, message) {
     writable: false,
     configurable: false,
   });
+  if (details !== null) {
+    for (const [key, value] of Object.entries(details)) {
+      Object.defineProperty(error, key, {
+        value,
+        enumerable: true,
+        writable: false,
+        configurable: false,
+      });
+    }
+  }
   return error;
 }
 
@@ -317,6 +359,16 @@ function assertPrivateMode(stats, expected, label) {
   if (process.platform !== "win32" && (stats.mode & 0o777) !== expected) {
     throw new Error(`${label} has unsafe permissions`);
   }
+  if (process.platform !== "win32") {
+    const userId = typeof process.geteuid === "function"
+      ? process.geteuid()
+      : typeof process.getuid === "function"
+        ? process.getuid()
+        : null;
+    if (userId === null || stats.uid !== userId) {
+      throw new Error(`${label} is owned by another user`);
+    }
+  }
 }
 
 async function ensurePrivateDirectory(directoryPath, { create }) {
@@ -422,15 +474,134 @@ async function readPrivateJson(filePath) {
   }
 }
 
+async function validateStagingEntry(filePath) {
+  const stats = await fs.lstat(filePath);
+  if (!stats.isFile() || stats.isSymbolicLink()) throw new Error("invalid staging entry");
+  assertPrivateMode(stats, 0o600, "staging file");
+  if (!Number.isSafeInteger(stats.nlink) || stats.nlink < 1 || stats.nlink > 2) {
+    throw new Error("invalid staging link count");
+  }
+  if (!Number.isFinite(stats.mtimeMs)) throw new Error("invalid staging timestamp");
+  return stats;
+}
+
+function sameFileIdentity(left, right) {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+async function unlinkMatchingStagingEntry(filePath, expectedStats) {
+  let currentStats;
+  try {
+    currentStats = await validateStagingEntry(filePath);
+  } catch (error) {
+    if (error?.code === "ENOENT") return false;
+    throw error;
+  }
+  if (!sameFileIdentity(currentStats, expectedStats)) {
+    throw new Error("staging entry identity changed before cleanup");
+  }
+  try {
+    await fs.unlink(filePath);
+    return true;
+  } catch (error) {
+    if (error?.code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+async function reconcileStagingRoot(stagingRoot) {
+  const entries = await fs.readdir(stagingRoot, { withFileTypes: true });
+  const quarantineEntry = entries.find(entry => entry.name === QUARANTINE_DIRECTORY);
+  if (quarantineEntry) {
+    if (!quarantineEntry.isDirectory() || quarantineEntry.isSymbolicLink()) {
+      throw new Error("invalid staging quarantine");
+    }
+    const quarantinePath = path.join(stagingRoot, QUARANTINE_DIRECTORY);
+    await ensurePrivateDirectory(quarantinePath, { create: false });
+  }
+  const observedAt = Date.now();
+  for (const entry of entries) {
+    if (entry.name === QUARANTINE_DIRECTORY) continue;
+    if (!STAGING_FILE_PATTERN.test(entry.name) || !entry.isFile() || entry.isSymbolicLink()) {
+      throw new Error("invalid staging entry");
+    }
+    const stagedPath = path.join(stagingRoot, entry.name);
+    let stats;
+    try {
+      stats = await validateStagingEntry(stagedPath);
+    } catch (error) {
+      if (error?.code === "ENOENT") continue;
+      throw error;
+    }
+    if (stats.nlink === 2) {
+      if (await unlinkMatchingStagingEntry(stagedPath, stats)) {
+        await syncDirectory(stagingRoot);
+      }
+      continue;
+    }
+    if (stats.mtimeMs > observedAt + STAGING_FUTURE_MTIME_TOLERANCE_MS) {
+      throw new Error("staging timestamp is in the future");
+    }
+    if (observedAt - stats.mtimeMs < STAGING_QUARANTINE_AFTER_MS) continue;
+    const quarantinePath = path.join(stagingRoot, QUARANTINE_DIRECTORY);
+    await ensurePrivateDirectory(quarantinePath, { create: true });
+    const quarantinedPath = path.join(quarantinePath, entry.name);
+    try {
+      await fs.link(stagedPath, quarantinedPath);
+    } catch (error) {
+      if (!new Set(["EEXIST", "ENOENT"]).has(error?.code)) throw error;
+      // Something already occupies the quarantine name. Only the same inode
+      // (a concurrent reconciler's link) may proceed; a symlink, a foreign
+      // file, or an unsafe entry at that exact name fails this create closed
+      // and is left in place for operator review.
+      const quarantinedStats = await validateStagingEntry(quarantinedPath);
+      if (!sameFileIdentity(quarantinedStats, stats)) {
+        throw new Error("staging quarantine identity collision");
+      }
+    }
+    await unlinkMatchingStagingEntry(stagedPath, stats);
+    await syncDirectory(quarantinePath);
+    await syncDirectory(stagingRoot);
+  }
+}
+
 async function prepareStateRoot(stateRoot) {
   await ensurePrivateDirectory(stateRoot, { create: true });
   const operationsRoot = path.join(stateRoot, OPERATION_DIRECTORY);
   await ensurePrivateDirectory(operationsRoot, { create: true });
   const stagingRoot = path.join(operationsRoot, STAGING_DIRECTORY);
   await ensurePrivateDirectory(stagingRoot, { create: true });
+  await reconcileStagingRoot(stagingRoot);
   await syncDirectory(stateRoot);
   await syncDirectory(operationsRoot);
   return { operationsRoot, stagingRoot };
+}
+
+function buildDurableClaimAcknowledgement(identity, claim, claimBytes) {
+  const unsigned = {
+    schema_version: 1,
+    provider: "lumin_sign",
+    action: "create_signature_request",
+    commit_status: "durable_claim_committed",
+    authority_sha256: identity.authority_sha256,
+    preparation_receipt_sha256: identity.preparation_receipt_sha256,
+    mapper_contract_sha256: identity.mapper_contract_sha256,
+    request_mapping_sha256: identity.request_mapping_sha256,
+    prepared_document_sha256: identity.prepared_document_sha256,
+    prepared_document_size_bytes: identity.prepared_document_size_bytes,
+    participant_ids: [...identity.participant_ids],
+    claim_started_at: claim.started_at,
+    claim_sha256: claim.claim_sha256,
+    claim_file_sha256: sha256(claimBytes),
+    claim_file_size_bytes: claimBytes.length,
+  };
+  return deepFreeze(isolateOutput({
+    ...unsigned,
+    acknowledgement_sha256: lifecycleDigest(
+      "pdf-tools.lumin-sign-v1-durable-claim-acknowledgement.v1",
+      unsigned,
+    ),
+  }));
 }
 
 function validateRequestIdentity(value) {
@@ -505,7 +676,14 @@ async function acquireOperationClaim(stateRoot, rawIdentity, startedAt) {
     claim_sha256: lifecycleDigest("pdf-tools.lumin-sign-v1-operation-claim.v1", unsigned),
   };
   try {
-    await commitExclusiveJson(path.join(operationPath, CLAIM_FILE), claim, stagingRoot);
+    const claimBytes = await commitExclusiveJson(path.join(operationPath, CLAIM_FILE), claim, stagingRoot);
+    const acknowledgement = buildDurableClaimAcknowledgement(identity, claim, claimBytes);
+    return {
+      acknowledgement,
+      claim: deepFreeze(isolateOutput(claim)),
+      operationPath,
+      stagingRoot,
+    };
   } catch (error) {
     if (error?.code === "EEXIST") {
       throw operationError(
@@ -515,7 +693,6 @@ async function acquireOperationClaim(stateRoot, rawIdentity, startedAt) {
     }
     throw error;
   }
-  return { claim: deepFreeze(isolateOutput(claim)), operationPath, stagingRoot };
 }
 
 function buildOutcome({ claim, completedAt, result, failureCode }) {
@@ -601,8 +778,10 @@ function validateTransportReceipt(receipt, claim) {
     || value.automatic_retry_performed !== false
   ) throw new Error("invalid transport receipt");
   const request = assertJsonRecord(value.request);
+  assertSha256(request.durable_claim_acknowledgement_sha256);
   if (
     request.execution_authority_sha256 !== claim.authority_sha256
+    || request.durable_claim_sha256 !== claim.claim_sha256
     || request.preparation_receipt_sha256 !== claim.preparation_receipt_sha256
     || request.mapper_contract_sha256 !== claim.mapper_contract_sha256
     || request.request_mapping_sha256 !== claim.request_mapping_sha256
@@ -696,13 +875,17 @@ export async function executeDurableLuminSignV1DirectUpload(input, options = {})
   } catch {
     throw operationError("LUMIN_OPERATION_INPUT_INVALID", "The Lumin operation configuration is invalid.");
   }
+  // One clock instant for the whole create. The claim's started_at and the
+  // transport's acknowledgement check must read the same millisecond; letting
+  // the transport sample Date.now() again would commit the claim and then
+  // refuse provider entry whenever the two reads straddled a tick.
   const startedMs = validatedOptions.nowMs === undefined ? Date.now() : validatedOptions.nowMs;
   let claimed = null;
   let claimError = null;
   try {
     const result = await executeAuthorizedLuminSignV1DirectUpload(input, {
       fetchImpl: validatedOptions.fetchImpl,
-      ...(validatedOptions.nowMs === undefined ? {} : { nowMs: validatedOptions.nowMs }),
+      nowMs: startedMs,
       ...(validatedOptions.timeoutMs === undefined ? {} : { timeoutMs: validatedOptions.timeoutMs }),
       beforeRequest: async requestIdentity => {
         try {
@@ -716,6 +899,7 @@ export async function executeDurableLuminSignV1DirectUpload(input, options = {})
               );
           throw claimError;
         }
+        return claimed.acknowledgement;
       },
     });
     if (!claimed) throw new Error("provider result exists without durable claim");
@@ -761,20 +945,32 @@ export async function executeDurableLuminSignV1DirectUpload(input, options = {})
   }
 }
 
+function classifyRetainedOutcome(outcome) {
+  if (outcome === null) return OUTCOME_NOT_RETAINED_ERROR_DETAILS.reconciliation_class;
+  if (outcome.operation_status === "request_created") return "reconcilable_by_request_id";
+  return TERMINAL_UNRECONCILABLE_ERROR_DETAILS.reconciliation_class;
+}
+
 export async function inspectLuminSignV1Operation(input) {
   let request;
   try {
     request = assertRecord(input, ["state_root", "authority_sha256"]);
     const loaded = await loadOperation(request.state_root, request.authority_sha256);
+    // "outcome_unknown" is a retained, terminal verdict written by the wrapper.
+    // A claim with no outcome file is not that: it is the claim's own status,
+    // authority_consumed, with nothing retained yet or ever.
     return deepFreeze(isolateOutput({
       schema_version: 1,
       provider: "lumin_sign",
       authority_sha256: loaded.claim.authority_sha256,
       claim_sha256: loaded.claim.claim_sha256,
-      operation_status: loaded.outcome?.operation_status ?? "outcome_unknown",
+      operation_status: loaded.outcome ? loaded.outcome.operation_status : loaded.claim.operation_status,
+      outcome_status: loaded.outcome ? "retained" : "not_retained",
+      reconciliation_class: classifyRetainedOutcome(loaded.outcome),
       outcome_sha256: loaded.outcome?.outcome_sha256 ?? null,
       transport_receipt: loaded.outcome?.transport_receipt ?? null,
       automatic_retry_allowed: false,
+      create_retry_allowed: false,
     }));
   } catch (error) {
     if (error?.code?.startsWith?.("LUMIN_")) throw error;
@@ -840,6 +1036,7 @@ async function writeObservation(operationPath, prefix, observation) {
 export async function pollAndRecordLuminSignV1Status(input, options = {}) {
   let accessToken;
   let controller;
+  let failureClass = "input";
   let timer;
   try {
     const request = assertRecord(input, ["access_token", "authority_sha256", "state_root"]);
@@ -851,10 +1048,17 @@ export async function pollAndRecordLuminSignV1Status(input, options = {}) {
       throw new Error("invalid polling timeout");
     }
     accessToken = assertString(request.access_token, { max: 8192, pattern: TOKEN_PATTERN });
+    failureClass = "state";
     const loaded = await loadOperation(request.state_root, request.authority_sha256);
-    if (loaded.outcome?.operation_status !== "request_created") throw new Error("operation is not reconcilable by ID");
+    if (loaded.outcome === null) {
+      failureClass = "not_retained";
+      throw new Error("operation outcome is not retained");
+    }
+    failureClass = "unreconcilable";
+    if (loaded.outcome.operation_status !== "request_created") throw new Error("operation is not reconcilable by ID");
     const transportReceipt = validateTransportReceipt(loaded.outcome.transport_receipt, loaded.claim);
     const signatureRequestId = transportReceipt.response.signature_request_id;
+    failureClass = "retryable";
     controller = new AbortController();
     timer = setTimeout(() => controller.abort(), timeoutMs);
     const response = await validatedOptions.fetchImpl(
@@ -900,9 +1104,34 @@ export async function pollAndRecordLuminSignV1Status(input, options = {}) {
     await writeObservation(loaded.operationPath, "poll", observation);
     return observation;
   } catch {
+    if (failureClass === "input") {
+      throw operationError("LUMIN_STATUS_INPUT_INVALID", "The Lumin status request is invalid.");
+    }
+    if (failureClass === "state") {
+      throw operationError(
+        "LUMIN_OPERATION_STATE_INVALID",
+        "The retained Lumin operation state is missing or invalid and cannot be reconciled.",
+        TERMINAL_STATE_ERROR_DETAILS,
+      );
+    }
+    if (failureClass === "unreconcilable") {
+      throw operationError(
+        "LUMIN_OPERATION_UNRECONCILABLE",
+        "This operation has no verified Lumin request identity and cannot be reconciled by polling.",
+        TERMINAL_UNRECONCILABLE_ERROR_DETAILS,
+      );
+    }
+    if (failureClass === "not_retained") {
+      throw operationError(
+        "LUMIN_OPERATION_OUTCOME_NOT_RETAINED",
+        OUTCOME_NOT_RETAINED_MESSAGE,
+        OUTCOME_NOT_RETAINED_ERROR_DETAILS,
+      );
+    }
     throw operationError(
-      "LUMIN_STATUS_OBSERVATION_FAILED",
-      "The Lumin signing status could not be verified or retained.",
+      "LUMIN_STATUS_OBSERVATION_RETRYABLE",
+      "The existing Lumin request status could not be verified or retained. Retrying this read will not create a new signing request.",
+      RETRYABLE_READ_ERROR_DETAILS,
     );
   } finally {
     if (timer) clearTimeout(timer);
@@ -914,6 +1143,7 @@ export async function requestAndRecordLuminSignV1ArtifactAccess(input, options =
   let accessToken;
   let accessUrl;
   let controller;
+  let failureClass = "input";
   let timer;
   try {
     const request = assertRecord(input, ["access_token", "authority_sha256", "file_type", "state_root"]);
@@ -927,10 +1157,17 @@ export async function requestAndRecordLuminSignV1ArtifactAccess(input, options =
     const fileType = assertString(request.file_type, { max: 16 });
     if (!ARTIFACT_FILE_TYPES.has(fileType)) throw new Error("invalid artifact type");
     accessToken = assertString(request.access_token, { max: 8192, pattern: TOKEN_PATTERN });
+    failureClass = "state";
     const loaded = await loadOperation(request.state_root, request.authority_sha256);
-    if (loaded.outcome?.operation_status !== "request_created") throw new Error("operation has no provider identity");
+    if (loaded.outcome === null) {
+      failureClass = "not_retained";
+      throw new Error("operation outcome is not retained");
+    }
+    failureClass = "unreconcilable";
+    if (loaded.outcome.operation_status !== "request_created") throw new Error("operation has no provider identity");
     const transportReceipt = validateTransportReceipt(loaded.outcome.transport_receipt, loaded.claim);
     const signatureRequestId = transportReceipt.response.signature_request_id;
+    failureClass = "retryable";
     controller = new AbortController();
     timer = setTimeout(() => controller.abort(), timeoutMs);
     const response = await validatedOptions.fetchImpl(
@@ -995,9 +1232,34 @@ export async function requestAndRecordLuminSignV1ArtifactAccess(input, options =
       persistence_policy: "ephemeral_caller_consumption_only",
     }));
   } catch {
+    if (failureClass === "input") {
+      throw operationError("LUMIN_ARTIFACT_INPUT_INVALID", "The Lumin artifact request is invalid.");
+    }
+    if (failureClass === "state") {
+      throw operationError(
+        "LUMIN_OPERATION_STATE_INVALID",
+        "The retained Lumin operation state is missing or invalid and cannot be reconciled.",
+        TERMINAL_STATE_ERROR_DETAILS,
+      );
+    }
+    if (failureClass === "unreconcilable") {
+      throw operationError(
+        "LUMIN_OPERATION_UNRECONCILABLE",
+        "This operation has no verified Lumin request identity and cannot provide signed artifacts.",
+        TERMINAL_UNRECONCILABLE_ERROR_DETAILS,
+      );
+    }
+    if (failureClass === "not_retained") {
+      throw operationError(
+        "LUMIN_OPERATION_OUTCOME_NOT_RETAINED",
+        OUTCOME_NOT_RETAINED_MESSAGE,
+        OUTCOME_NOT_RETAINED_ERROR_DETAILS,
+      );
+    }
     throw operationError(
-      "LUMIN_ARTIFACT_OBSERVATION_FAILED",
-      "The Lumin artifact access response could not be verified or safely retained.",
+      "LUMIN_ARTIFACT_OBSERVATION_RETRYABLE",
+      "The existing Lumin request artifact could not be verified or safely retained. Retrying this read will not create a new signing request.",
+      RETRYABLE_READ_ERROR_DETAILS,
     );
   } finally {
     if (timer) clearTimeout(timer);

--- a/server/lumin-sign-v1-transport.js
+++ b/server/lumin-sign-v1-transport.js
@@ -132,6 +132,91 @@ function assertIsoTimestamp(value) {
   return parsed.getTime();
 }
 
+function validateDurableClaimAcknowledgement(value, requestIdentity, nowMs) {
+  const acknowledgement = assertRecord(value, [
+    "schema_version",
+    "provider",
+    "action",
+    "commit_status",
+    "authority_sha256",
+    "preparation_receipt_sha256",
+    "mapper_contract_sha256",
+    "request_mapping_sha256",
+    "prepared_document_sha256",
+    "prepared_document_size_bytes",
+    "participant_ids",
+    "claim_started_at",
+    "claim_sha256",
+    "claim_file_sha256",
+    "claim_file_size_bytes",
+    "acknowledgement_sha256",
+  ]);
+  const participantIds = assertDenseArray(acknowledgement.participant_ids, {
+    min: 1,
+    max: MAX_PARTICIPANTS,
+  });
+  if (
+    acknowledgement.schema_version !== 1
+    || acknowledgement.provider !== "lumin_sign"
+    || acknowledgement.action !== "create_signature_request"
+    || acknowledgement.commit_status !== "durable_claim_committed"
+    || acknowledgement.authority_sha256 !== requestIdentity.authority_sha256
+    || acknowledgement.preparation_receipt_sha256 !== requestIdentity.preparation_receipt_sha256
+    || acknowledgement.mapper_contract_sha256 !== requestIdentity.mapper_contract_sha256
+    || acknowledgement.request_mapping_sha256 !== requestIdentity.request_mapping_sha256
+    || acknowledgement.prepared_document_sha256 !== requestIdentity.prepared_document_sha256
+    || acknowledgement.prepared_document_size_bytes !== requestIdentity.prepared_document_size_bytes
+    || participantIds.length !== requestIdentity.participant_ids.length
+    || participantIds.some((participantId, index) => participantId !== requestIdentity.participant_ids[index])
+  ) {
+    throw new Error("durable claim acknowledgement binding mismatch");
+  }
+  const startedAt = assertIsoTimestamp(acknowledgement.claim_started_at);
+  if (!Number.isSafeInteger(startedAt) || startedAt !== nowMs) {
+    throw new Error("invalid durable claim timestamp");
+  }
+  const claimUnsigned = {
+    schema_version: 1,
+    provider: "lumin_sign",
+    action: "create_signature_request",
+    operation_status: "authority_consumed",
+    automatic_retry_allowed: false,
+    authority_sha256: requestIdentity.authority_sha256,
+    preparation_receipt_sha256: requestIdentity.preparation_receipt_sha256,
+    mapper_contract_sha256: requestIdentity.mapper_contract_sha256,
+    request_mapping_sha256: requestIdentity.request_mapping_sha256,
+    prepared_document_sha256: requestIdentity.prepared_document_sha256,
+    prepared_document_size_bytes: requestIdentity.prepared_document_size_bytes,
+    participant_ids: [...participantIds],
+    started_at: acknowledgement.claim_started_at,
+  };
+  const expectedClaimSha256 = sha256(Buffer.from(
+    `pdf-tools.lumin-sign-v1-operation-claim.v1\0${canonicalJson(claimUnsigned)}`,
+    "utf8",
+  ));
+  if (assertSha256(acknowledgement.claim_sha256) !== expectedClaimSha256) {
+    throw new Error("durable claim acknowledgement digest mismatch");
+  }
+  const claim = { ...claimUnsigned, claim_sha256: expectedClaimSha256 };
+  const claimBytes = Buffer.from(`${canonicalJson(claim)}\n`, "utf8");
+  if (
+    acknowledgement.claim_file_size_bytes !== claimBytes.length
+    || assertSha256(acknowledgement.claim_file_sha256) !== sha256(claimBytes)
+  ) {
+    throw new Error("durable claim file acknowledgement mismatch");
+  }
+  const unsigned = { ...acknowledgement };
+  delete unsigned.acknowledgement_sha256;
+  const expectedAcknowledgementSha256 = sha256(Buffer.from(
+    `pdf-tools.lumin-sign-v1-durable-claim-acknowledgement.v1\0${canonicalJson(unsigned)}`,
+    "utf8",
+  ));
+  if (assertSha256(acknowledgement.acknowledgement_sha256) !== expectedAcknowledgementSha256) {
+    throw new Error("durable claim acknowledgement identity mismatch");
+  }
+  return acknowledgement;
+}
+
 function isolateOutput(value) {
   if (Array.isArray(value)) {
     const normalized = new Array(value.length);
@@ -571,6 +656,7 @@ function appendPerson(form, prefix, person) {
 export async function executeAuthorizedLuminSignV1DirectUpload(input, options = {}) {
   let validated;
   let accessToken;
+  let durableClaimAcknowledgement;
   let fetchImpl;
   let beforeRequest;
   let preparedPdfBytes;
@@ -648,8 +734,7 @@ export async function executeAuthorizedLuminSignV1DirectUpload(input, options = 
   form.append("use_text_tags", "true");
   form.append("signing_type", "SAME_TIME");
 
-  try {
-    await beforeRequest(deepFreeze(isolateOutput({
+  const requestIdentity = deepFreeze(isolateOutput({
       schema_version: 1,
       provider: "lumin_sign",
       action: "create_signature_request",
@@ -660,7 +745,14 @@ export async function executeAuthorizedLuminSignV1DirectUpload(input, options = 
       prepared_document_sha256: validated.mapping.preparedDocumentSha256,
       prepared_document_size_bytes: validated.mapping.preparedDocumentSizeBytes,
       participant_ids: [...validated.mapping.participantIds],
-    })));
+  }));
+  try {
+    const acknowledgement = await beforeRequest(requestIdentity);
+    durableClaimAcknowledgement = validateDurableClaimAcknowledgement(
+      acknowledgement,
+      requestIdentity,
+      nowMs,
+    );
   } catch {
     throw transportError(
       "LUMIN_OPERATION_STATE_REJECTED",
@@ -738,6 +830,8 @@ export async function executeAuthorizedLuminSignV1DirectUpload(input, options = 
         request_mapping_sha256: validated.mapping.requestMappingSha256,
         direct_upload_reference: LUMIN_SIGN_V1_DIRECT_UPLOAD_REFERENCE,
         execution_authority_sha256: validated.authority.authoritySha256,
+        durable_claim_sha256: durableClaimAcknowledgement.claim_sha256,
+        durable_claim_acknowledgement_sha256: durableClaimAcknowledgement.acknowledgement_sha256,
         participant_ids: [...validated.mapping.participantIds],
       },
       response: {

--- a/test/lumin-sign-v1-transport.test.js
+++ b/test/lumin-sign-v1-transport.test.js
@@ -2,7 +2,7 @@ import { createHash, createHmac } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   LUMIN_SIGN_V1_MAPPER_CONTRACT_SHA256,
   mapLuminSignV1SignatureRequest,
@@ -204,9 +204,54 @@ function successResponse(overrides = {}) {
   });
 }
 
+function durableClaimAcknowledgement(requestIdentity, startedAt = new Date(NOW_MS).toISOString()) {
+  const claimUnsigned = {
+    schema_version: 1,
+    provider: "lumin_sign",
+    action: "create_signature_request",
+    operation_status: "authority_consumed",
+    automatic_retry_allowed: false,
+    authority_sha256: requestIdentity.authority_sha256,
+    preparation_receipt_sha256: requestIdentity.preparation_receipt_sha256,
+    mapper_contract_sha256: requestIdentity.mapper_contract_sha256,
+    request_mapping_sha256: requestIdentity.request_mapping_sha256,
+    prepared_document_sha256: requestIdentity.prepared_document_sha256,
+    prepared_document_size_bytes: requestIdentity.prepared_document_size_bytes,
+    participant_ids: Array.from(requestIdentity.participant_ids),
+    started_at: startedAt,
+  };
+  const claimSha256 = createHash("sha256")
+    .update(`pdf-tools.lumin-sign-v1-operation-claim.v1\0${canonicalJson(claimUnsigned)}`)
+    .digest("hex");
+  const claimBytes = Buffer.from(`${canonicalJson({ ...claimUnsigned, claim_sha256: claimSha256 })}\n`);
+  const unsigned = {
+    schema_version: 1,
+    provider: "lumin_sign",
+    action: "create_signature_request",
+    commit_status: "durable_claim_committed",
+    authority_sha256: requestIdentity.authority_sha256,
+    preparation_receipt_sha256: requestIdentity.preparation_receipt_sha256,
+    mapper_contract_sha256: requestIdentity.mapper_contract_sha256,
+    request_mapping_sha256: requestIdentity.request_mapping_sha256,
+    prepared_document_sha256: requestIdentity.prepared_document_sha256,
+    prepared_document_size_bytes: requestIdentity.prepared_document_size_bytes,
+    participant_ids: Array.from(requestIdentity.participant_ids),
+    claim_started_at: startedAt,
+    claim_sha256: claimSha256,
+    claim_file_sha256: createHash("sha256").update(claimBytes).digest("hex"),
+    claim_file_size_bytes: claimBytes.length,
+  };
+  return {
+    ...unsigned,
+    acknowledgement_sha256: createHash("sha256")
+      .update(`pdf-tools.lumin-sign-v1-durable-claim-acknowledgement.v1\0${canonicalJson(unsigned)}`)
+      .digest("hex"),
+  };
+}
+
 async function execute(value, fetchImpl) {
   return executeAuthorizedLuminSignV1DirectUpload(value, {
-    beforeRequest: async () => {},
+    beforeRequest: async requestIdentity => durableClaimAcknowledgement(requestIdentity),
     fetchImpl,
     nowMs: NOW_MS,
     timeoutMs: 5_000,
@@ -272,6 +317,8 @@ describe("executeAuthorizedLuminSignV1DirectUpload", () => {
         request_mapping_sha256: createHash("sha256")
           .update(`pdf-tools.lumin-sign-v1-request-mapping.v1\0${canonicalJson(mapping())}`)
           .digest("hex"),
+        durable_claim_sha256: expect.stringMatching(/^[a-f0-9]{64}$/),
+        durable_claim_acknowledgement_sha256: expect.stringMatching(/^[a-f0-9]{64}$/),
       },
       response: {
         status_code: 201,
@@ -334,6 +381,27 @@ describe("executeAuthorizedLuminSignV1DirectUpload", () => {
     expect(calls).toBe(0);
   });
 
+  it("rejects a no-op or drifted durable-claim acknowledgement before provider entry", async () => {
+    for (const beforeRequest of [
+      async () => undefined,
+      async requestIdentity => ({
+        ...durableClaimAcknowledgement(requestIdentity),
+        claim_file_sha256: "f".repeat(64),
+      }),
+    ]) {
+      let calls = 0;
+      await expect(executeAuthorizedLuminSignV1DirectUpload(input(), {
+        beforeRequest,
+        fetchImpl: async () => {
+          calls += 1;
+          return successResponse();
+        },
+        nowMs: NOW_MS,
+      })).rejects.toMatchObject({ code: "LUMIN_OPERATION_STATE_REJECTED" });
+      expect(calls).toBe(0);
+    }
+  });
+
   it("materializes the validated PDF before the asynchronous persistence hook", async () => {
     const value = input();
     const expectedBytes = Buffer.from(value.prepared_pdf_bytes);
@@ -341,9 +409,10 @@ describe("executeAuthorizedLuminSignV1DirectUpload", () => {
     const result = await executeAuthorizedLuminSignV1DirectUpload(value, {
       nowMs: NOW_MS,
       timeoutMs: 5_000,
-      beforeRequest: async () => {
+      beforeRequest: async requestIdentity => {
         originalBuffer.fill(0x58);
         value.prepared_pdf_bytes = Buffer.from("%PDF-substituted\n%%EOF\n");
+        return durableClaimAcknowledgement(requestIdentity);
       },
       fetchImpl: async (_url, options) => {
         const uploaded = Buffer.from(await options.body.get("file").arrayBuffer());
@@ -365,7 +434,7 @@ describe("executeAuthorizedLuminSignV1DirectUpload", () => {
   it("keeps the timeout active while reading the provider response body", async () => {
     let calls = 0;
     await expect(executeAuthorizedLuminSignV1DirectUpload(input(), {
-      beforeRequest: async () => {},
+      beforeRequest: async requestIdentity => durableClaimAcknowledgement(requestIdentity),
       nowMs: NOW_MS,
       timeoutMs: 5,
       fetchImpl: async (_url, options) => {
@@ -541,8 +610,11 @@ describe("durable Lumin Sign v1 operation lifecycle", () => {
           });
           expect(entered).toMatchObject({
             authority_sha256: authorityDigest,
-            operation_status: "outcome_unknown",
+            operation_status: "authority_consumed",
+            outcome_status: "not_retained",
+            reconciliation_class: "outcome_not_retained",
             automatic_retry_allowed: false,
+            create_retry_allowed: false,
           });
           return successResponse();
         },
@@ -584,6 +656,31 @@ describe("durable Lumin Sign v1 operation lifecycle", () => {
           return successResponse();
         },
       })).rejects.toMatchObject({ code: "LUMIN_OPERATION_ALREADY_CONSUMED" });
+      expect(calls).toBe(1);
+    });
+  });
+
+  it("uses one exact clock observation for the durable claim and transport acknowledgement", async () => {
+    await withLifecycleState(async ({ stateRoot }) => {
+      const clock = vi.spyOn(Date, "now")
+        .mockReturnValueOnce(NOW_MS)
+        .mockReturnValueOnce(NOW_MS + 1)
+        .mockReturnValue(NOW_MS + 2);
+      let calls = 0;
+      try {
+        await expect(executeDurableLuminSignV1DirectUpload(input(), {
+          stateRoot,
+          timeoutMs: 5_000,
+          fetchImpl: async () => {
+            calls += 1;
+            return successResponse();
+          },
+        })).resolves.toMatchObject({
+          operation: { operation_status: "request_created" },
+        });
+      } finally {
+        clock.mockRestore();
+      }
       expect(calls).toBe(1);
     });
   });
@@ -780,6 +877,183 @@ describe("durable Lumin Sign v1 operation lifecycle", () => {
     });
   });
 
+  it("rejects private state owned by a different effective POSIX user before provider entry", async () => {
+    if (process.platform === "win32" || typeof process.getuid !== "function") return;
+    await withLifecycleState(async ({ stateRoot }) => {
+      const userIdMethod = typeof process.geteuid === "function" ? "geteuid" : "getuid";
+      const actualUid = process[userIdMethod]();
+      const getuid = vi.spyOn(process, userIdMethod).mockReturnValue(actualUid + 1);
+      let calls = 0;
+      try {
+        await expect(executeDurableLuminSignV1DirectUpload(input(), {
+          stateRoot,
+          nowMs: NOW_MS,
+          fetchImpl: async () => {
+            calls += 1;
+            return successResponse();
+          },
+        })).rejects.toMatchObject({ code: "LUMIN_OPERATION_STATE_REJECTED" });
+      } finally {
+        getuid.mockRestore();
+      }
+      expect(calls).toBe(0);
+    });
+  });
+
+  it("quarantines a stale uncommitted stage without blocking a new exact authority", async () => {
+    await withLifecycleState(async ({ stateRoot }) => {
+      const operationsRoot = path.join(stateRoot, "lumin-sign-v1-operations");
+      const stagingRoot = path.join(operationsRoot, ".staging");
+      await fs.mkdir(stateRoot, { mode: 0o700 });
+      await fs.mkdir(operationsRoot, { mode: 0o700 });
+      await fs.mkdir(stagingRoot, { mode: 0o700 });
+      const stageName = "claim.v1.json-11111111-1111-4111-8111-111111111111.tmp";
+      const stagePath = path.join(stagingRoot, stageName);
+      await fs.writeFile(stagePath, "{\"stale\":true}\n", { mode: 0o600 });
+      await fs.utimes(stagePath, new Date(0), new Date(0));
+      let calls = 0;
+      await expect(executeDurableLuminSignV1DirectUpload(input(), {
+        stateRoot,
+        nowMs: NOW_MS,
+        fetchImpl: async () => {
+          calls += 1;
+          return successResponse();
+        },
+      })).resolves.toMatchObject({ operation: { operation_status: "request_created" } });
+      expect(calls).toBe(1);
+      await expect(fs.lstat(stagePath)).rejects.toMatchObject({ code: "ENOENT" });
+      const quarantinedPath = path.join(stagingRoot, ".quarantine", stageName);
+      const quarantined = await fs.lstat(quarantinedPath);
+      expect(quarantined.isFile()).toBe(true);
+      expect(quarantined.mode & 0o777).toBe(0o600);
+      expect(quarantined.nlink).toBe(1);
+    });
+  });
+
+  it("reconciles one stale stage concurrently without blocking distinct authorities", async () => {
+    await withLifecycleState(async ({ stateRoot }) => {
+      const operationsRoot = path.join(stateRoot, "lumin-sign-v1-operations");
+      const stagingRoot = path.join(operationsRoot, ".staging");
+      await fs.mkdir(stagingRoot, { recursive: true, mode: 0o700 });
+      const stageName = "claim.v1.json-aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa.tmp";
+      const stagePath = path.join(stagingRoot, stageName);
+      await fs.writeFile(stagePath, "{\"stale\":true}\n", { mode: 0o600 });
+      await fs.utimes(stagePath, new Date(0), new Date(0));
+      const values = Array.from({ length: 4 }, (_, index) => {
+        const value = input();
+        value.execution_authority.approved_at = new Date(
+          Date.parse("2030-01-01T00:00:00.000Z") + index,
+        ).toISOString();
+        return value;
+      });
+      let calls = 0;
+      const settled = await Promise.allSettled(values.map(value =>
+        executeDurableLuminSignV1DirectUpload(value, {
+          stateRoot,
+          nowMs: NOW_MS,
+          fetchImpl: async () => {
+            calls += 1;
+            return successResponse();
+          },
+        })));
+      expect(settled.every(result => result.status === "fulfilled")).toBe(true);
+      expect(calls).toBe(4);
+      await expect(fs.lstat(stagePath)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(fs.lstat(path.join(stagingRoot, ".quarantine", stageName)))
+        .resolves.toMatchObject({ nlink: 1 });
+    });
+  });
+
+  it("treats quarantine contents as inert operator evidence", async () => {
+    await withLifecycleState(async ({ stateRoot }) => {
+      const quarantineRoot = path.join(
+        stateRoot,
+        "lumin-sign-v1-operations",
+        ".staging",
+        ".quarantine",
+      );
+      await fs.mkdir(quarantineRoot, { recursive: true, mode: 0o700 });
+      const notePath = path.join(quarantineRoot, "operator-review.txt");
+      await fs.writeFile(notePath, "retained for manual review\n", { mode: 0o600 });
+      let calls = 0;
+      await expect(executeDurableLuminSignV1DirectUpload(input(), {
+        stateRoot,
+        nowMs: NOW_MS,
+        fetchImpl: async () => {
+          calls += 1;
+          return successResponse();
+        },
+      })).resolves.toMatchObject({ operation: { operation_status: "request_created" } });
+      expect(calls).toBe(1);
+      await expect(fs.readFile(notePath, "utf8")).resolves.toBe("retained for manual review\n");
+    });
+  });
+
+  it("rejects a staging timestamp materially in the future", async () => {
+    await withLifecycleState(async ({ stateRoot }) => {
+      const stagingRoot = path.join(stateRoot, "lumin-sign-v1-operations", ".staging");
+      await fs.mkdir(stagingRoot, { recursive: true, mode: 0o700 });
+      const stagePath = path.join(
+        stagingRoot,
+        "claim.v1.json-bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb.tmp",
+      );
+      await fs.writeFile(stagePath, "{\"future\":true}\n", { mode: 0o600 });
+      const future = new Date(Date.now() + 2 * 60 * 1000);
+      await fs.utimes(stagePath, future, future);
+      let calls = 0;
+      await expect(executeDurableLuminSignV1DirectUpload(input(), {
+        stateRoot,
+        nowMs: NOW_MS,
+        fetchImpl: async () => {
+          calls += 1;
+          return successResponse();
+        },
+      })).rejects.toMatchObject({ code: "LUMIN_OPERATION_STATE_REJECTED" });
+      expect(calls).toBe(0);
+    });
+  });
+
+  it("leaves a fresh unlinked stage untouched so reconciliation cannot race its writer", async () => {
+    await withLifecycleState(async ({ stateRoot }) => {
+      const stagingRoot = path.join(stateRoot, "lumin-sign-v1-operations", ".staging");
+      await fs.mkdir(stagingRoot, { recursive: true, mode: 0o700 });
+      const stageName = "outcome.v1.json-22222222-2222-4222-8222-222222222222.tmp";
+      const stagePath = path.join(stagingRoot, stageName);
+      await fs.writeFile(stagePath, "{\"active\":true}\n", { mode: 0o600 });
+      let calls = 0;
+      await expect(executeDurableLuminSignV1DirectUpload(input(), {
+        stateRoot,
+        nowMs: NOW_MS,
+        fetchImpl: async () => {
+          calls += 1;
+          return successResponse();
+        },
+      })).resolves.toMatchObject({ operation: { operation_status: "request_created" } });
+      expect(calls).toBe(1);
+      await expect(fs.readFile(stagePath, "utf8")).resolves.toBe("{\"active\":true}\n");
+      await expect(fs.lstat(path.join(stagingRoot, ".quarantine")))
+        .rejects.toMatchObject({ code: "ENOENT" });
+    });
+  });
+
+  it("rejects unsafe staging entries before a provider call", async () => {
+    await withLifecycleState(async ({ stateRoot }) => {
+      const stagingRoot = path.join(stateRoot, "lumin-sign-v1-operations", ".staging");
+      await fs.mkdir(stagingRoot, { recursive: true, mode: 0o700 });
+      await fs.writeFile(path.join(stagingRoot, "unexpected.txt"), "unsafe\n", { mode: 0o600 });
+      let calls = 0;
+      await expect(executeDurableLuminSignV1DirectUpload(input(), {
+        stateRoot,
+        nowMs: NOW_MS,
+        fetchImpl: async () => {
+          calls += 1;
+          return successResponse();
+        },
+      })).rejects.toMatchObject({ code: "LUMIN_OPERATION_STATE_REJECTED" });
+      expect(calls).toBe(0);
+    });
+  });
+
   it("rejects retained state drift, unsafe modes, and symlink substitution", async () => {
     await withLifecycleState(async ({ stateRoot }) => {
       const { authoritySha256: authorityDigest } = await createDurableOperation(stateRoot);
@@ -855,6 +1129,147 @@ describe("durable Lumin Sign v1 operation lifecycle", () => {
     });
   });
 
+  it("distinguishes an unreconcilable create from retry-safe status and artifact reads", async () => {
+    await withLifecycleState(async ({ stateRoot }) => {
+      const value = input();
+      const authorityDigest = authoritySha256(value.execution_authority);
+      await expect(executeDurableLuminSignV1DirectUpload(value, {
+        stateRoot,
+        nowMs: NOW_MS,
+        fetchImpl: async () => {
+          throw new Error("synthetic ambiguous create");
+        },
+      })).rejects.toMatchObject({ code: "LUMIN_CREATE_OUTCOME_UNKNOWN" });
+      let readCalls = 0;
+      await expect(pollAndRecordLuminSignV1Status({
+        access_token: ACCESS_TOKEN,
+        authority_sha256: authorityDigest,
+        state_root: stateRoot,
+      }, {
+        nowMs: NOW_MS + 1_000,
+        fetchImpl: async () => {
+          readCalls += 1;
+          return new Response("{}");
+        },
+      })).rejects.toMatchObject({
+        code: "LUMIN_OPERATION_UNRECONCILABLE",
+        reconciliation_class: "terminal_unreconcilable",
+        read_retry_safe: false,
+        create_retry_allowed: false,
+      });
+      await expect(requestAndRecordLuminSignV1ArtifactAccess({
+        access_token: ACCESS_TOKEN,
+        authority_sha256: authorityDigest,
+        file_type: "merged",
+        state_root: stateRoot,
+      }, {
+        nowMs: NOW_MS + 1_000,
+        fetchImpl: async () => {
+          readCalls += 1;
+          return new Response("{}");
+        },
+      })).rejects.toMatchObject({
+        code: "LUMIN_OPERATION_UNRECONCILABLE",
+        reconciliation_class: "terminal_unreconcilable",
+        read_retry_safe: false,
+        create_retry_allowed: false,
+      });
+      expect(readCalls).toBe(0);
+    });
+
+    await withLifecycleState(async ({ stateRoot }) => {
+      const { authoritySha256: authorityDigest } = await createDurableOperation(stateRoot);
+      let readCalls = 0;
+      const unavailable = async () => {
+        readCalls += 1;
+        throw new Error("synthetic read outage");
+      };
+      await expect(pollAndRecordLuminSignV1Status({
+        access_token: ACCESS_TOKEN,
+        authority_sha256: authorityDigest,
+        state_root: stateRoot,
+      }, {
+        nowMs: NOW_MS + 1_000,
+        fetchImpl: unavailable,
+      })).rejects.toMatchObject({
+        code: "LUMIN_STATUS_OBSERVATION_RETRYABLE",
+        reconciliation_class: "retryable_read_failure",
+        read_retry_safe: true,
+        create_retry_allowed: false,
+      });
+      await expect(requestAndRecordLuminSignV1ArtifactAccess({
+        access_token: ACCESS_TOKEN,
+        authority_sha256: authorityDigest,
+        file_type: "merged",
+        state_root: stateRoot,
+      }, {
+        nowMs: NOW_MS + 1_000,
+        fetchImpl: unavailable,
+      })).rejects.toMatchObject({
+        code: "LUMIN_ARTIFACT_OBSERVATION_RETRYABLE",
+        reconciliation_class: "retryable_read_failure",
+        read_retry_safe: true,
+        create_retry_allowed: false,
+      });
+      expect(readCalls).toBe(2);
+      await expect(inspectLuminSignV1Operation({
+        state_root: stateRoot,
+        authority_sha256: authorityDigest,
+      })).resolves.toMatchObject({ operation_status: "request_created" });
+    });
+  });
+
+  it("classifies reads during an in-flight create as safe to retry without allowing create retry", async () => {
+    await withLifecycleState(async ({ stateRoot }) => {
+      const value = input();
+      const authorityDigest = authoritySha256(value.execution_authority);
+      let releaseCreate;
+      let markEntered;
+      const entered = new Promise(resolve => { markEntered = resolve; });
+      const creation = executeDurableLuminSignV1DirectUpload(value, {
+        stateRoot,
+        nowMs: NOW_MS,
+        fetchImpl: async () => {
+          markEntered();
+          return new Promise(resolve => { releaseCreate = () => resolve(successResponse()); });
+        },
+      });
+      await entered;
+      let readCalls = 0;
+      for (const read of [
+        () => pollAndRecordLuminSignV1Status({
+          access_token: ACCESS_TOKEN,
+          authority_sha256: authorityDigest,
+          state_root: stateRoot,
+        }, {
+          nowMs: NOW_MS + 1,
+          fetchImpl: async () => { readCalls += 1; return new Response("{}"); },
+        }),
+        () => requestAndRecordLuminSignV1ArtifactAccess({
+          access_token: ACCESS_TOKEN,
+          authority_sha256: authorityDigest,
+          file_type: "merged",
+          state_root: stateRoot,
+        }, {
+          nowMs: NOW_MS + 1,
+          fetchImpl: async () => { readCalls += 1; return new Response("{}"); },
+        }),
+      ]) {
+        await expect(read()).rejects.toMatchObject({
+          code: "LUMIN_OPERATION_OUTCOME_NOT_RETAINED",
+          reconciliation_class: "outcome_not_retained",
+          read_retry_safe: true,
+          create_retry_allowed: false,
+        });
+      }
+      expect(readCalls).toBe(0);
+      releaseCreate();
+      await expect(creation).resolves.toMatchObject({
+        operation: { operation_status: "request_created" },
+      });
+    });
+  });
+
   it("rejects ambiguous duplicate members and request-ID drift in status responses", async () => {
     await withLifecycleState(async ({ stateRoot }) => {
       const { authoritySha256: authorityDigest } = await createDurableOperation(stateRoot);
@@ -872,7 +1287,7 @@ describe("durable Lumin Sign v1 operation lifecycle", () => {
             status: 200,
             headers: { "content-type": "application/json" },
           }),
-        })).rejects.toMatchObject({ code: "LUMIN_STATUS_OBSERVATION_FAILED" });
+        })).rejects.toMatchObject({ code: "LUMIN_STATUS_OBSERVATION_RETRYABLE" });
       }
     });
   });
@@ -930,7 +1345,7 @@ describe("durable Lumin Sign v1 operation lifecycle", () => {
           status: 200,
           headers: { "content-type": "application/json" },
         }),
-      })).rejects.toMatchObject({ code: "LUMIN_ARTIFACT_OBSERVATION_FAILED" });
+      })).rejects.toMatchObject({ code: "LUMIN_ARTIFACT_OBSERVATION_RETRYABLE" });
       const observationsPath = path.join(
         stateRoot,
         "lumin-sign-v1-operations",


### PR DESCRIPTION
## Summary

- require a content-bound acknowledgement of the durable one-use claim before Lumin request entry
- distinguish terminal unreconcilable outcomes from retry-safe status and artifact reads
- preserve consumed authority when an outcome was not retained, without allowing another create attempt
- recover crash-orphaned staging safely through private quarantine with exact file, link, owner, and time checks
- enforce same-user ownership through the effective POSIX uid
- keep source and packaged-share implementations byte-identical
- keep all Lumin lifecycle modules internal and unregistered

## Verification

- exact implementation commit: `a8b04ff4b43376d27efc14e9c2547d4b5220a975`
- independent adversarial review: GO, no P0, P1, or P2 findings
- focused and adjoining VM tests: 137/137
- focused and adjoining macOS tests: 137/137
- full macOS Vitest inventory with one worker: 180 files passed, 2,929 tests passed, 107 intentional skips
- macOS native partition: 62 passed, 9 intentional skips
- reproducible MCPB build: `068bca3ac896534bf5e3e85f0334dc2b21238b1f6028ac14fabdf406c0365dee`, 74,447,961 bytes, 3,036 files
- packaged macOS arm64 smoke: 51 tools, 14 prompts, native raster rendering, verified extraction workspace
- source and share lifecycle files are byte-identical

The first unconstrained aggregate Vitest process was killed by macOS resource pressure near completion. The exact same commit then passed the complete 3,036-test inventory with one worker.

## Boundaries

This is internal lifecycle hardening only. It does not register a public Lumin tool, read production credentials, call Lumin, create or sign a request, alter external data, publish a release, or make a public capability claim. Polling remains the current public PKCE reconciliation path. Webhook verification remains future-server-only because Lumin app webhooks require a private server application.
