### PR TITLE
Handle live Lumin OAuth and signed-file responses

### DIFF
--- a/pdf-toolkit-mcp-share/server/lumin-oauth-loopback.js
+++ b/pdf-toolkit-mcp-share/server/lumin-oauth-loopback.js
@@ -85,7 +85,7 @@ function onlyValue(searchParams, name) {
 }
 
 function hasOnlyCallbackParameters(searchParams) {
-  const allowed = new Set(["code", "error", "error_description", "state"]);
+  const allowed = new Set(["code", "error", "error_description", "scope", "state"]);
   for (const key of searchParams.keys()) {
     if (!allowed.has(key)) return false;
   }
@@ -93,6 +93,22 @@ function hasOnlyCallbackParameters(searchParams) {
     if (searchParams.getAll(key).length > 1) return false;
   }
   return true;
+}
+
+function hasExactReturnedScopes(value, expectedScopes) {
+  if (
+    typeof value !== "string"
+    || value !== value.trim()
+    || value.length === 0
+    || Buffer.byteLength(value, "utf8") > 4096
+  ) return false;
+  const returnedScopes = value.split(/\s+/);
+  return (
+    returnedScopes.every(scope => SCOPE_PATTERN.test(scope))
+    && returnedScopes.length === expectedScopes.length
+    && new Set(returnedScopes).size === returnedScopes.length
+    && expectedScopes.every(scope => returnedScopes.includes(scope))
+  );
 }
 
 function respond(response, statusCode, message) {
@@ -191,7 +207,7 @@ function normalizeTokenResponse(value, expectedScopes) {
   } catch {
     throw oauthError("LUMIN_OAUTH_TOKEN_RESPONSE_INVALID", "Lumin returned an invalid token response.");
   }
-  if (value.token_type !== "Bearer") {
+  if (typeof value.token_type !== "string" || value.token_type.toLowerCase() !== "bearer") {
     throw oauthError("LUMIN_OAUTH_TOKEN_RESPONSE_INVALID", "Lumin returned an invalid token response.");
   }
   if (!Number.isSafeInteger(value.expires_in) || value.expires_in <= 0 || value.expires_in > 31_536_000) {
@@ -280,7 +296,13 @@ export async function createLuminOAuthLoopbackSession({
     }
     const code = onlyValue(callbackUrl.searchParams, "code");
     const providerError = onlyValue(callbackUrl.searchParams, "error");
+    const hasReturnedScope = callbackUrl.searchParams.has("scope");
+    const returnedScope = onlyValue(callbackUrl.searchParams, "scope");
     if ((code && providerError) || (!code && !providerError)) {
+      rejectRequest(400, "Authorization callback rejected.");
+      return;
+    }
+    if (hasReturnedScope && (!code || !hasExactReturnedScopes(returnedScope, validatedScopes))) {
       rejectRequest(400, "Authorization callback rejected.");
       return;
     }

--- a/pdf-toolkit-mcp-share/server/lumin-sign-v1-operation.js
+++ b/pdf-toolkit-mcp-share/server/lumin-sign-v1-operation.js
@@ -1184,7 +1184,15 @@ export async function requestAndRecordLuminSignV1ArtifactAccess(input, options =
       throw new Error("artifact request rejected");
     }
     const provider = await readBoundedProviderJson(response, "Lumin artifact response");
-    const envelope = assertRecord(provider.value, ["expires_at", "signed_url"]);
+    const envelope = assertRecord(provider.value, ["expires_at", "signed_url"], ["download_url"]);
+    // The live endpoint also supplies a download URL. Validate its shape but
+    // use only signed_url; neither URL may enter durable state or tool output.
+    if (Object.hasOwn(envelope, "download_url")) {
+      const downloadUrl = new URL(assertString(envelope.download_url, { max: 4096 }));
+      if (downloadUrl.protocol !== "https:" || downloadUrl.username || downloadUrl.password || downloadUrl.hash || !downloadUrl.hostname) {
+        throw new Error("invalid optional artifact download URL");
+      }
+    }
     accessUrl = assertString(envelope.signed_url, { max: 4096 });
     const parsedUrl = new URL(accessUrl);
     if (
@@ -1194,11 +1202,14 @@ export async function requestAndRecordLuminSignV1ArtifactAccess(input, options =
       || parsedUrl.hash
       || !parsedUrl.hostname
     ) throw new Error("invalid artifact access URL");
-    if (
-      !Number.isSafeInteger(envelope.expires_at)
-      || envelope.expires_at <= Math.floor(nowMs / 1000)
-      || envelope.expires_at > Math.ceil(nowMs / 1000) + (31 * 60)
-    ) throw new Error("invalid artifact expiry");
+    if (!Number.isSafeInteger(envelope.expires_at)) throw new Error("invalid artifact expiry");
+    // The documented epoch value historically used seconds; live responses
+    // use milliseconds. Admit only a uniquely valid interpretation within the
+    // same short lifetime, and retain seconds for existing observation readers.
+    const expiryCandidates = [envelope.expires_at, Math.floor(envelope.expires_at / 1000)]
+      .filter(value => value > Math.floor(nowMs / 1000) && value <= Math.ceil(nowMs / 1000) + (31 * 60));
+    if (expiryCandidates.length !== 1) throw new Error("invalid artifact expiry");
+    const expiresAt = expiryCandidates[0];
     const unsigned = {
       schema_version: 1,
       provider: "lumin_sign",
@@ -1212,7 +1223,7 @@ export async function requestAndRecordLuminSignV1ArtifactAccess(input, options =
       endpoint_path: "/signature_request/{signature_request_id}/file",
       provider_response_sha256: sha256(provider.bytes),
       access_url_sha256: sha256(Buffer.from(accessUrl, "utf8")),
-      access_url_expires_at: envelope.expires_at,
+      access_url_expires_at: expiresAt,
       access_token_persisted: false,
       access_url_persisted: false,
       response_body_persisted: false,
@@ -1227,7 +1238,7 @@ export async function requestAndRecordLuminSignV1ArtifactAccess(input, options =
       schema_version: 1,
       file_type: fileType,
       signed_url: accessUrl,
-      expires_at: envelope.expires_at,
+      expires_at: expiresAt,
       observation,
       persistence_policy: "ephemeral_caller_consumption_only",
     }));

--- a/server/lumin-oauth-loopback.js
+++ b/server/lumin-oauth-loopback.js
@@ -85,7 +85,7 @@ function onlyValue(searchParams, name) {
 }
 
 function hasOnlyCallbackParameters(searchParams) {
-  const allowed = new Set(["code", "error", "error_description", "state"]);
+  const allowed = new Set(["code", "error", "error_description", "scope", "state"]);
   for (const key of searchParams.keys()) {
     if (!allowed.has(key)) return false;
   }
@@ -93,6 +93,22 @@ function hasOnlyCallbackParameters(searchParams) {
     if (searchParams.getAll(key).length > 1) return false;
   }
   return true;
+}
+
+function hasExactReturnedScopes(value, expectedScopes) {
+  if (
+    typeof value !== "string"
+    || value !== value.trim()
+    || value.length === 0
+    || Buffer.byteLength(value, "utf8") > 4096
+  ) return false;
+  const returnedScopes = value.split(/\s+/);
+  return (
+    returnedScopes.every(scope => SCOPE_PATTERN.test(scope))
+    && returnedScopes.length === expectedScopes.length
+    && new Set(returnedScopes).size === returnedScopes.length
+    && expectedScopes.every(scope => returnedScopes.includes(scope))
+  );
 }
 
 function respond(response, statusCode, message) {
@@ -191,7 +207,7 @@ function normalizeTokenResponse(value, expectedScopes) {
   } catch {
     throw oauthError("LUMIN_OAUTH_TOKEN_RESPONSE_INVALID", "Lumin returned an invalid token response.");
   }
-  if (value.token_type !== "Bearer") {
+  if (typeof value.token_type !== "string" || value.token_type.toLowerCase() !== "bearer") {
     throw oauthError("LUMIN_OAUTH_TOKEN_RESPONSE_INVALID", "Lumin returned an invalid token response.");
   }
   if (!Number.isSafeInteger(value.expires_in) || value.expires_in <= 0 || value.expires_in > 31_536_000) {
@@ -280,7 +296,13 @@ export async function createLuminOAuthLoopbackSession({
     }
     const code = onlyValue(callbackUrl.searchParams, "code");
     const providerError = onlyValue(callbackUrl.searchParams, "error");
+    const hasReturnedScope = callbackUrl.searchParams.has("scope");
+    const returnedScope = onlyValue(callbackUrl.searchParams, "scope");
     if ((code && providerError) || (!code && !providerError)) {
+      rejectRequest(400, "Authorization callback rejected.");
+      return;
+    }
+    if (hasReturnedScope && (!code || !hasExactReturnedScopes(returnedScope, validatedScopes))) {
       rejectRequest(400, "Authorization callback rejected.");
       return;
     }

--- a/server/lumin-sign-v1-operation.js
+++ b/server/lumin-sign-v1-operation.js
@@ -1184,7 +1184,15 @@ export async function requestAndRecordLuminSignV1ArtifactAccess(input, options =
       throw new Error("artifact request rejected");
     }
     const provider = await readBoundedProviderJson(response, "Lumin artifact response");
-    const envelope = assertRecord(provider.value, ["expires_at", "signed_url"]);
+    const envelope = assertRecord(provider.value, ["expires_at", "signed_url"], ["download_url"]);
+    // The live endpoint also supplies a download URL. Validate its shape but
+    // use only signed_url; neither URL may enter durable state or tool output.
+    if (Object.hasOwn(envelope, "download_url")) {
+      const downloadUrl = new URL(assertString(envelope.download_url, { max: 4096 }));
+      if (downloadUrl.protocol !== "https:" || downloadUrl.username || downloadUrl.password || downloadUrl.hash || !downloadUrl.hostname) {
+        throw new Error("invalid optional artifact download URL");
+      }
+    }
     accessUrl = assertString(envelope.signed_url, { max: 4096 });
     const parsedUrl = new URL(accessUrl);
     if (
@@ -1194,11 +1202,14 @@ export async function requestAndRecordLuminSignV1ArtifactAccess(input, options =
       || parsedUrl.hash
       || !parsedUrl.hostname
     ) throw new Error("invalid artifact access URL");
-    if (
-      !Number.isSafeInteger(envelope.expires_at)
-      || envelope.expires_at <= Math.floor(nowMs / 1000)
-      || envelope.expires_at > Math.ceil(nowMs / 1000) + (31 * 60)
-    ) throw new Error("invalid artifact expiry");
+    if (!Number.isSafeInteger(envelope.expires_at)) throw new Error("invalid artifact expiry");
+    // The documented epoch value historically used seconds; live responses
+    // use milliseconds. Admit only a uniquely valid interpretation within the
+    // same short lifetime, and retain seconds for existing observation readers.
+    const expiryCandidates = [envelope.expires_at, Math.floor(envelope.expires_at / 1000)]
+      .filter(value => value > Math.floor(nowMs / 1000) && value <= Math.ceil(nowMs / 1000) + (31 * 60));
+    if (expiryCandidates.length !== 1) throw new Error("invalid artifact expiry");
+    const expiresAt = expiryCandidates[0];
     const unsigned = {
       schema_version: 1,
       provider: "lumin_sign",
@@ -1212,7 +1223,7 @@ export async function requestAndRecordLuminSignV1ArtifactAccess(input, options =
       endpoint_path: "/signature_request/{signature_request_id}/file",
       provider_response_sha256: sha256(provider.bytes),
       access_url_sha256: sha256(Buffer.from(accessUrl, "utf8")),
-      access_url_expires_at: envelope.expires_at,
+      access_url_expires_at: expiresAt,
       access_token_persisted: false,
       access_url_persisted: false,
       response_body_persisted: false,
@@ -1227,7 +1238,7 @@ export async function requestAndRecordLuminSignV1ArtifactAccess(input, options =
       schema_version: 1,
       file_type: fileType,
       signed_url: accessUrl,
-      expires_at: envelope.expires_at,
+      expires_at: expiresAt,
       observation,
       persistence_policy: "ephemeral_caller_consumption_only",
     }));

--- a/test/lumin-oauth-loopback.test.js
+++ b/test/lumin-oauth-loopback.test.js
@@ -96,6 +96,21 @@ describe("Lumin OAuth loopback PKCE", () => {
     await expect(fetch(session.redirectUri)).rejects.toThrow();
   });
 
+  it("accepts Lumin's exact granted scope callback without weakening scope binding", async () => {
+    const session = await createSession();
+    const { state } = callbackParameters(session);
+    const grantedScope = "openid profile.read sign:requests sign:requests.read";
+    const response = await request(
+      `${session.redirectUri}?code=authorization-code&scope=${encodeURIComponent(grantedScope)}&state=${state}`,
+    );
+
+    expect(response.status).toBe(200);
+    await expect(session.waitForCallback()).resolves.toEqual({
+      code: "authorization-code",
+      redirectUri: session.redirectUri,
+    });
+  });
+
   it("does not consume the session on wrong path, method, host, state, or unknown parameters", async () => {
     const session = await createSession();
     const { state } = callbackParameters(session);
@@ -118,6 +133,13 @@ describe("Lumin OAuth loopback PKCE", () => {
       `?code=one&error=denied&state=${state}`,
       `?state=${state}`,
       `?code=${"x".repeat(4097)}&state=${state}`,
+      `?code=one&scope=&state=${state}`,
+      `?code=one&scope=openid&state=${state}`,
+      `?code=one&scope=${encodeURIComponent("openid profile.read sign:requests sign:requests.read extra")}&state=${state}`,
+      `?code=one&scope=${encodeURIComponent("openid profile.read sign:requests sign:requests")}&state=${state}`,
+      `?code=one&scope=${encodeURIComponent("openid profile.read sign:requests bad/scope")}&state=${state}`,
+      `?code=one&scope=openid&scope=openid&state=${state}`,
+      `?error=access_denied&scope=${encodeURIComponent("openid profile.read sign:requests sign:requests.read")}&state=${state}`,
     ];
     for (const query of attacks) {
       expect((await request(`${session.redirectUri}${query}`)).status).toBe(400);
@@ -180,7 +202,7 @@ describe("Lumin OAuth loopback PKCE", () => {
         expires_in: 3600,
         refresh_token: "refresh-token",
         scope: "sign:requests.read sign:requests profile.read openid",
-        token_type: "Bearer",
+        token_type: "bearer",
       }), { headers: { "content-type": "application/json" } });
     });
 

--- a/test/lumin-sign-v1-transport.test.js
+++ b/test/lumin-sign-v1-transport.test.js
@@ -1292,10 +1292,12 @@ describe("durable Lumin Sign v1 operation lifecycle", () => {
     });
   });
 
-  it("records an artifact access identity without persisting the signed URL or token", async () => {
+  it.each(["seconds", "milliseconds", "live-milliseconds-with-download-url"])("records %s artifact access without persisting URLs or token", async (shape) => {
     await withLifecycleState(async ({ stateRoot }) => {
       const { authoritySha256: authorityDigest } = await createDurableOperation(stateRoot);
       const signedUrl = "https://files.luminpdf.com/download/synthetic.pdf?token=private";
+      const downloadUrl = "https://files.luminpdf.com/download/synthetic.pdf?token=other-private";
+      const expiresAtSeconds = Math.floor((NOW_MS + 1_000) / 1000) + 1_800;
       const artifact = await requestAndRecordLuminSignV1ArtifactAccess({
         access_token: ACCESS_TOKEN,
         authority_sha256: authorityDigest,
@@ -1308,11 +1310,15 @@ describe("durable Lumin Sign v1 operation lifecycle", () => {
           expect(options.headers.authorization).toBe(`Bearer ${ACCESS_TOKEN}`);
           return new Response(JSON.stringify({
             signed_url: signedUrl,
-            expires_at: Math.floor((NOW_MS + 1_000) / 1000) + 1_800,
+            expires_at: shape === "seconds" ? expiresAtSeconds : expiresAtSeconds * 1000 + 123,
+            ...(shape === "live-milliseconds-with-download-url" ? { download_url: downloadUrl } : {}),
           }), { status: 200, headers: { "content-type": "application/json" } });
         },
       });
       expect(artifact.signed_url).toBe(signedUrl);
+      expect(artifact.expires_at).toBe(expiresAtSeconds);
+      expect(artifact.observation.access_url_expires_at).toBe(expiresAtSeconds);
+      expect(artifact).not.toHaveProperty("download_url");
       expect(artifact.persistence_policy).toBe("ephemeral_caller_consumption_only");
       const observationPath = path.join(
         stateRoot,
@@ -1323,6 +1329,7 @@ describe("durable Lumin Sign v1 operation lifecycle", () => {
       );
       const retained = await fs.readFile(observationPath, "utf8");
       expect(retained).not.toContain(signedUrl);
+      expect(retained).not.toContain(downloadUrl);
       expect(retained).not.toContain(ACCESS_TOKEN);
       expect(retained).toContain(createHash("sha256").update(signedUrl).digest("hex"));
     });
@@ -1331,6 +1338,14 @@ describe("durable Lumin Sign v1 operation lifecycle", () => {
   it.each([
     ["non-HTTPS URL", { signed_url: "http://files.luminpdf.com/private", expires_at: Math.floor((NOW_MS + 1_000) / 1000) + 1_800 }],
     ["overlong expiry", { signed_url: "https://files.luminpdf.com/private", expires_at: Math.floor((NOW_MS + 1_000) / 1000) + 3_600 }],
+    ["overlong millisecond expiry", { signed_url: "https://files.luminpdf.com/private", expires_at: NOW_MS + 3_600_000 }],
+    ["expired millisecond expiry", { signed_url: "https://files.luminpdf.com/private", expires_at: NOW_MS }],
+    ["fractional millisecond expiry", { signed_url: "https://files.luminpdf.com/private", expires_at: NOW_MS + 900_000.5 }],
+    ["string expiry", { signed_url: "https://files.luminpdf.com/private", expires_at: String(NOW_MS + 900_000) }],
+    ["non-HTTPS alternate URL", { signed_url: "https://files.luminpdf.com/private", download_url: "http://files.luminpdf.com/private", expires_at: NOW_MS + 900_000 }],
+    ["malformed alternate URL", { signed_url: "https://files.luminpdf.com/private", download_url: 17, expires_at: NOW_MS + 900_000 }],
+    ["credential-bearing alternate URL", { signed_url: "https://files.luminpdf.com/private", download_url: "https://user:pass@files.luminpdf.com/private", expires_at: NOW_MS + 900_000 }],
+    ["extra envelope field", { signed_url: "https://files.luminpdf.com/private", extra: true, expires_at: NOW_MS + 900_000 }],
   ])("rejects %s artifact access without persisting it", async (_label, providerBody) => {
     await withLifecycleState(async ({ stateRoot }) => {
       const { authoritySha256: authorityDigest } = await createDurableOperation(stateRoot);


### PR DESCRIPTION
## Problem and change

Live Lumin responses exposed three compatibility gaps: authorization includes a `scope` callback parameter, bearer token type is lowercase, and completed artifact metadata includes `download_url` with expiry in epoch milliseconds. PDF Tools previously rejected these responses, preventing login and completed-file retrieval.

Accept the optional successful callback scope only when it matches the requested scope set exactly, rejecting missing, extra, duplicate, or malformed scopes. Accept bearer token type case-insensitively while retaining normalized output.

Validate the optional artifact URL without using or persisting it. Accept seconds or milliseconds only when exactly one interpretation lies within the existing short expiry window; retain normalized seconds for existing readers. Signed URL, credential, no-retry, and output-retention boundaries remain enforced. Mirror both implementations in the share bundle.

## Validation

- macOS arm64, Node 22.23.2, exact commit `8ad8527c554ee6f711f7a9109fa3f5b1e83c418f`: OAuth, signing tools, transport/lifecycle, OpenAPI, and MCP contract tests passed 153/153, including expiry-format and alternate-URL rejection tests and URL non-persistence.
- Preceding OAuth-only commit: Node native partition passed 62, with 9 intentional skips. Full Vitest had one extraction-phase1 failure whose complete file passed 21/21 in isolation. Initial CI Node 20 had an unrelated concurrent-save ENOENT failure; Node 22 passed. Those runs are historical, not claimed as final-head validation.
- Live synthetic test completed public MCP OAuth and one request creation, delivered the invitation, and completed signing in the Lumin UI under maintainer authorization. The repaired public MCP tools independently observed `APPROVED` and downloaded the signed agreement, certificate of completion, and merged PDF. No request resend occurred.
- Source/share bytes match and `git diff --check` passes.
- Exact final-head independent source review passed with no blocking findings. Native Mac tests also passed 62 with 9 intentional skips. Downloaded PDFs were physically rehashed and reopened, with expected page counts and completion text; this does not claim cryptographic signature verification.
- A bounded scan of the live operation's 152 durable JSON records found no populated known credential/URL fields, bearer strings, or signed-query patterns. Temporary browser sessions and OAuth/invitation-link scratch were removed after completion.
