### PR TITLE
Bound retained Lumin status history

### DIFF
--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -118,10 +118,19 @@ or was never retained is explicitly `outcome_not_retained`; the state cannot
 distinguish those cases, but re-reading is safe. Typed errors carry `reconciliation_class`,
 `read_retry_safe`, and the invariant `create_retry_allowed: false`. Retrying
 those read-only observations cannot submit a second signing request. Polling
-may append bounded status observations, and artifact access retains only the
-signed URL digest and expiry. The signed URL is returned only for immediate
-caller consumption and is never written. App webhooks are accepted only after a
-constant-time HMAC-SHA256 check over the exact raw body; the app signing secret
+keeps the earliest timestamped observation for the audit origin plus the newest
+63, using the digest to break timestamp ties. Cleanup runs before each provider
+read and again after publication. Completed cleanup retains at most 64 poll
+observations; concurrent or interrupted publication can temporarily exceed that
+cap until cleanup or the next poll. Damaged local poll history fails safely
+before contacting Lumin. A failed or duplicate read does not evict history that
+already fits the cap, and a delayed check can still return its verified response
+if newer checks have already pruned its older receipt. Artifact and webhook
+observations are not removed by this policy.
+Artifact access retains only the signed URL digest and expiry. The signed URL is
+returned only for immediate caller consumption and is never written. App
+webhooks are accepted only after a constant-time HMAC-SHA256 check over the
+exact raw body; the app signing secret
 and body are not persisted. Duplicate webhook delivery follows Lumin's published
 `signature_request_id` plus `event_type` idempotency rule, while conflicting
 bytes for the same pair fail closed.

--- a/pdf-toolkit-mcp-share/server/lumin-sign-v1-operation.js
+++ b/pdf-toolkit-mcp-share/server/lumin-sign-v1-operation.js
@@ -38,6 +38,8 @@ const QUARANTINE_DIRECTORY = ".quarantine";
 const CLAIM_FILE = "claim.v1.json";
 const OUTCOME_FILE = "outcome.v1.json";
 const OBSERVATIONS_DIRECTORY = "observations";
+const MAX_RETAINED_POLL_OBSERVATIONS = 64;
+const POLL_OBSERVATION_FILE_PATTERN = /^poll-([a-f0-9]{64})\.v1\.json$/;
 const MAX_STATE_FILE_BYTES = 1024 * 1024;
 const MAX_PROVIDER_RESPONSE_BYTES = 256 * 1024;
 const MAX_WEBHOOK_BYTES = 1024 * 1024;
@@ -423,7 +425,7 @@ async function writeExclusiveJson(filePath, value) {
   return bytes;
 }
 
-async function commitExclusiveJson(filePath, value, stagingRoot) {
+async function commitExclusiveJson(filePath, value, stagingRoot, { allowPrunedPoll = false } = {}) {
   await ensurePrivateDirectory(stagingRoot, { create: false });
   const stagedPath = path.join(
     stagingRoot,
@@ -435,7 +437,17 @@ async function commitExclusiveJson(filePath, value, stagingRoot) {
     staged = true;
     await fs.link(stagedPath, filePath);
     await syncDirectory(path.dirname(filePath));
-    const committed = await readPrivateJson(filePath);
+    let committed;
+    try {
+      committed = await readPrivateJson(filePath);
+    } catch (error) {
+      // A poll's exact staged bytes have already been atomically linked and
+      // the directory flushed. Another poll may now prune that older entry.
+      // Only disposable poll observations permit this race; claims, outcomes,
+      // artifacts, and webhooks still require the published-file readback.
+      if (allowPrunedPoll && error?.code === "ENOENT") return bytes;
+      throw error;
+    }
     if (
       committed.bytes.length !== bytes.length
       || !timingSafeEqual(committed.bytes, bytes)
@@ -468,7 +480,7 @@ async function readPrivateJson(filePath) {
     assertPrivateMode(stats, 0o600, "state file");
     const bytes = await handle.readFile();
     if (bytes.length !== stats.size || bytes[bytes.length - 1] !== 0x0a) throw new Error("invalid state bytes");
-    return { bytes, value: parseStrictJson(bytes, "state file") };
+    return { bytes, stats, value: parseStrictJson(bytes, "state file") };
   } finally {
     await handle?.close().catch(() => {});
   }
@@ -1022,15 +1034,144 @@ async function writeObservation(operationPath, prefix, observation) {
       filePath,
       observation,
       path.join(path.dirname(operationPath), STAGING_DIRECTORY),
+      { allowPrunedPoll: prefix === "poll" },
     );
   } catch (error) {
     if (error?.code !== "EEXIST") throw error;
-    const existing = await readPrivateJson(filePath);
+    let existing;
+    try {
+      existing = await readPrivateJson(filePath);
+    } catch (readError) {
+      // A duplicate older poll can disappear after EEXIST for the same
+      // reason as a newly published older poll: concurrent retention removed
+      // it. Other observation types still require exact collision readback.
+      if (prefix === "poll" && readError?.code === "ENOENT") return observation;
+      throw readError;
+    }
     if (`${canonicalJson(existing.value)}\n` !== existing.bytes.toString("utf8") || canonicalJson(existing.value) !== canonicalJson(observation)) {
       throw new Error("observation identity collision");
     }
   }
   return observation;
+}
+
+function validateStatusObservation(value, binding, expectedDigest) {
+  const observation = assertRecord(value, [
+    "schema_version",
+    "provider",
+    "observation_source",
+    "authority_sha256",
+    "claim_sha256",
+    "outcome_sha256",
+    "signature_request_id",
+    "status",
+    "observed_at",
+    "endpoint_path",
+    "provider_response_sha256",
+    "access_token_persisted",
+    "response_body_persisted",
+    "automatic_retry_performed",
+    "observation_sha256",
+  ]);
+  if (
+    observation.schema_version !== 1
+    || observation.provider !== "lumin_sign"
+    || observation.observation_source !== "authenticated_poll"
+    || observation.authority_sha256 !== binding.authority_sha256
+    || observation.claim_sha256 !== binding.claim_sha256
+    || observation.outcome_sha256 !== binding.outcome_sha256
+    || observation.signature_request_id !== binding.signature_request_id
+    || !STATUS_VALUES.has(observation.status)
+    || observation.endpoint_path !== "/signature_request/{signature_request_id}"
+    || observation.access_token_persisted !== false
+    || observation.response_body_persisted !== false
+    || observation.automatic_retry_performed !== false
+  ) throw new Error("invalid status observation");
+  const observedAtMs = assertIsoTimestamp(observation.observed_at);
+  assertSha256(observation.provider_response_sha256);
+  const digest = assertSha256(observation.observation_sha256);
+  const unsigned = { ...observation };
+  delete unsigned.observation_sha256;
+  if (
+    digest !== expectedDigest
+    || digest !== lifecycleDigest("pdf-tools.lumin-sign-v1-status-observation.v1", unsigned)
+  ) throw new Error("status observation digest mismatch");
+  return { observedAtMs };
+}
+
+async function readRetainedPollObservations(operationPath, binding) {
+  const observationsPath = path.join(operationPath, OBSERVATIONS_DIRECTORY);
+  await ensurePrivateDirectory(observationsPath, { create: true });
+  const directoryEntries = await fs.readdir(observationsPath, { withFileTypes: true });
+  const retained = [];
+  for (const directoryEntry of directoryEntries) {
+    if (!directoryEntry.name.startsWith("poll-")) continue;
+    const match = directoryEntry.name.match(POLL_OBSERVATION_FILE_PATTERN);
+    if (!match || !directoryEntry.isFile() || directoryEntry.isSymbolicLink()) {
+      throw new Error("invalid retained poll observation entry");
+    }
+    const filePath = path.join(observationsPath, directoryEntry.name);
+    let read;
+    try {
+      read = await readPrivateJson(filePath);
+    } catch (error) {
+      if (error?.code === "ENOENT") continue;
+      throw error;
+    }
+    const { observedAtMs } = validateStatusObservation(read.value, binding, match[1]);
+    retained.push({
+      digest: match[1],
+      filePath,
+      observedAtMs,
+      stats: read.stats,
+    });
+  }
+  retained.sort((left, right) => left.observedAtMs - right.observedAtMs
+    || (left.digest < right.digest ? -1 : left.digest > right.digest ? 1 : 0));
+  return { observationsPath, retained };
+}
+
+async function unlinkRetainedPollObservation(observation) {
+  let currentStats;
+  try {
+    currentStats = await fs.lstat(observation.filePath);
+  } catch (error) {
+    if (error?.code === "ENOENT") return false;
+    throw error;
+  }
+  if (!currentStats.isFile() || currentStats.isSymbolicLink()) {
+    throw new Error("retained poll observation changed before cleanup");
+  }
+  assertPrivateMode(currentStats, 0o600, "state file");
+  if (!sameFileIdentity(currentStats, observation.stats)) {
+    throw new Error("retained poll observation identity changed before cleanup");
+  }
+  try {
+    await fs.unlink(observation.filePath);
+    return true;
+  } catch (error) {
+    if (error?.code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+async function prunePollObservations(operationPath, binding, retainedLimit) {
+  if (!Number.isSafeInteger(retainedLimit) || retainedLimit < 2 || retainedLimit > MAX_RETAINED_POLL_OBSERVATIONS) {
+    throw new Error("invalid poll observation retention limit");
+  }
+  const { observationsPath, retained } = await readRetainedPollObservations(operationPath, binding);
+  if (retained.length <= retainedLimit) return;
+  const keep = new Set([retained[0].filePath]);
+  for (const observation of retained.slice(-(retainedLimit - 1))) keep.add(observation.filePath);
+  let deleted = false;
+  try {
+    for (const observation of retained) {
+      if (keep.has(observation.filePath)) continue;
+      deleted = await unlinkRetainedPollObservation(observation) || deleted;
+    }
+  } finally {
+    if (deleted) await syncDirectory(observationsPath);
+  }
 }
 
 export async function pollAndRecordLuminSignV1Status(input, options = {}) {
@@ -1059,6 +1200,20 @@ export async function pollAndRecordLuminSignV1Status(input, options = {}) {
     const transportReceipt = validateTransportReceipt(loaded.outcome.transport_receipt, loaded.claim);
     const signatureRequestId = transportReceipt.response.signature_request_id;
     failureClass = "retryable";
+    const observationBinding = {
+      authority_sha256: loaded.claim.authority_sha256,
+      claim_sha256: loaded.claim.claim_sha256,
+      outcome_sha256: loaded.outcome.outcome_sha256,
+      signature_request_id: signatureRequestId,
+    };
+    // Compact before contacting the provider so invalid retained state cannot
+    // cause another network read or continue growing. Do not reserve a slot:
+    // failed or duplicate reads must not evict useful retained history.
+    await prunePollObservations(
+      loaded.operationPath,
+      observationBinding,
+      MAX_RETAINED_POLL_OBSERVATIONS,
+    );
     controller = new AbortController();
     timer = setTimeout(() => controller.abort(), timeoutMs);
     const response = await validatedOptions.fetchImpl(
@@ -1102,6 +1257,11 @@ export async function pollAndRecordLuminSignV1Status(input, options = {}) {
       observation_sha256: lifecycleDigest("pdf-tools.lumin-sign-v1-status-observation.v1", unsigned),
     }));
     await writeObservation(loaded.operationPath, "poll", observation);
+    await prunePollObservations(
+      loaded.operationPath,
+      observationBinding,
+      MAX_RETAINED_POLL_OBSERVATIONS,
+    );
     return observation;
   } catch {
     if (failureClass === "input") {

--- a/scripts/test-suite-classification.mjs
+++ b/scripts/test-suite-classification.mjs
@@ -349,6 +349,13 @@ export const SERIAL_RESOURCE_TEST_SUITES = Object.freeze([
       + "contention.",
   }),
   Object.freeze({
+    file: "test/lumin-sign-v1-transport.test.js",
+    reason: "Builds and validates full durable poll histories with repeated "
+      + "fsync and concurrent publication. Four existing five-second windows "
+      + "timed out under sibling-suite contention but passed unchanged with "
+      + "an exclusive worker.",
+  }),
+  Object.freeze({
     file: "test/mcp-contract.test.js",
     reason: "Loads and compares both committed runtimes and exercises their MCP "
       + "contracts; sibling-suite contention exhausted an existing five-second "

--- a/server/lumin-sign-v1-operation.js
+++ b/server/lumin-sign-v1-operation.js
@@ -38,6 +38,8 @@ const QUARANTINE_DIRECTORY = ".quarantine";
 const CLAIM_FILE = "claim.v1.json";
 const OUTCOME_FILE = "outcome.v1.json";
 const OBSERVATIONS_DIRECTORY = "observations";
+const MAX_RETAINED_POLL_OBSERVATIONS = 64;
+const POLL_OBSERVATION_FILE_PATTERN = /^poll-([a-f0-9]{64})\.v1\.json$/;
 const MAX_STATE_FILE_BYTES = 1024 * 1024;
 const MAX_PROVIDER_RESPONSE_BYTES = 256 * 1024;
 const MAX_WEBHOOK_BYTES = 1024 * 1024;
@@ -423,7 +425,7 @@ async function writeExclusiveJson(filePath, value) {
   return bytes;
 }
 
-async function commitExclusiveJson(filePath, value, stagingRoot) {
+async function commitExclusiveJson(filePath, value, stagingRoot, { allowPrunedPoll = false } = {}) {
   await ensurePrivateDirectory(stagingRoot, { create: false });
   const stagedPath = path.join(
     stagingRoot,
@@ -435,7 +437,17 @@ async function commitExclusiveJson(filePath, value, stagingRoot) {
     staged = true;
     await fs.link(stagedPath, filePath);
     await syncDirectory(path.dirname(filePath));
-    const committed = await readPrivateJson(filePath);
+    let committed;
+    try {
+      committed = await readPrivateJson(filePath);
+    } catch (error) {
+      // A poll's exact staged bytes have already been atomically linked and
+      // the directory flushed. Another poll may now prune that older entry.
+      // Only disposable poll observations permit this race; claims, outcomes,
+      // artifacts, and webhooks still require the published-file readback.
+      if (allowPrunedPoll && error?.code === "ENOENT") return bytes;
+      throw error;
+    }
     if (
       committed.bytes.length !== bytes.length
       || !timingSafeEqual(committed.bytes, bytes)
@@ -468,7 +480,7 @@ async function readPrivateJson(filePath) {
     assertPrivateMode(stats, 0o600, "state file");
     const bytes = await handle.readFile();
     if (bytes.length !== stats.size || bytes[bytes.length - 1] !== 0x0a) throw new Error("invalid state bytes");
-    return { bytes, value: parseStrictJson(bytes, "state file") };
+    return { bytes, stats, value: parseStrictJson(bytes, "state file") };
   } finally {
     await handle?.close().catch(() => {});
   }
@@ -1022,15 +1034,144 @@ async function writeObservation(operationPath, prefix, observation) {
       filePath,
       observation,
       path.join(path.dirname(operationPath), STAGING_DIRECTORY),
+      { allowPrunedPoll: prefix === "poll" },
     );
   } catch (error) {
     if (error?.code !== "EEXIST") throw error;
-    const existing = await readPrivateJson(filePath);
+    let existing;
+    try {
+      existing = await readPrivateJson(filePath);
+    } catch (readError) {
+      // A duplicate older poll can disappear after EEXIST for the same
+      // reason as a newly published older poll: concurrent retention removed
+      // it. Other observation types still require exact collision readback.
+      if (prefix === "poll" && readError?.code === "ENOENT") return observation;
+      throw readError;
+    }
     if (`${canonicalJson(existing.value)}\n` !== existing.bytes.toString("utf8") || canonicalJson(existing.value) !== canonicalJson(observation)) {
       throw new Error("observation identity collision");
     }
   }
   return observation;
+}
+
+function validateStatusObservation(value, binding, expectedDigest) {
+  const observation = assertRecord(value, [
+    "schema_version",
+    "provider",
+    "observation_source",
+    "authority_sha256",
+    "claim_sha256",
+    "outcome_sha256",
+    "signature_request_id",
+    "status",
+    "observed_at",
+    "endpoint_path",
+    "provider_response_sha256",
+    "access_token_persisted",
+    "response_body_persisted",
+    "automatic_retry_performed",
+    "observation_sha256",
+  ]);
+  if (
+    observation.schema_version !== 1
+    || observation.provider !== "lumin_sign"
+    || observation.observation_source !== "authenticated_poll"
+    || observation.authority_sha256 !== binding.authority_sha256
+    || observation.claim_sha256 !== binding.claim_sha256
+    || observation.outcome_sha256 !== binding.outcome_sha256
+    || observation.signature_request_id !== binding.signature_request_id
+    || !STATUS_VALUES.has(observation.status)
+    || observation.endpoint_path !== "/signature_request/{signature_request_id}"
+    || observation.access_token_persisted !== false
+    || observation.response_body_persisted !== false
+    || observation.automatic_retry_performed !== false
+  ) throw new Error("invalid status observation");
+  const observedAtMs = assertIsoTimestamp(observation.observed_at);
+  assertSha256(observation.provider_response_sha256);
+  const digest = assertSha256(observation.observation_sha256);
+  const unsigned = { ...observation };
+  delete unsigned.observation_sha256;
+  if (
+    digest !== expectedDigest
+    || digest !== lifecycleDigest("pdf-tools.lumin-sign-v1-status-observation.v1", unsigned)
+  ) throw new Error("status observation digest mismatch");
+  return { observedAtMs };
+}
+
+async function readRetainedPollObservations(operationPath, binding) {
+  const observationsPath = path.join(operationPath, OBSERVATIONS_DIRECTORY);
+  await ensurePrivateDirectory(observationsPath, { create: true });
+  const directoryEntries = await fs.readdir(observationsPath, { withFileTypes: true });
+  const retained = [];
+  for (const directoryEntry of directoryEntries) {
+    if (!directoryEntry.name.startsWith("poll-")) continue;
+    const match = directoryEntry.name.match(POLL_OBSERVATION_FILE_PATTERN);
+    if (!match || !directoryEntry.isFile() || directoryEntry.isSymbolicLink()) {
+      throw new Error("invalid retained poll observation entry");
+    }
+    const filePath = path.join(observationsPath, directoryEntry.name);
+    let read;
+    try {
+      read = await readPrivateJson(filePath);
+    } catch (error) {
+      if (error?.code === "ENOENT") continue;
+      throw error;
+    }
+    const { observedAtMs } = validateStatusObservation(read.value, binding, match[1]);
+    retained.push({
+      digest: match[1],
+      filePath,
+      observedAtMs,
+      stats: read.stats,
+    });
+  }
+  retained.sort((left, right) => left.observedAtMs - right.observedAtMs
+    || (left.digest < right.digest ? -1 : left.digest > right.digest ? 1 : 0));
+  return { observationsPath, retained };
+}
+
+async function unlinkRetainedPollObservation(observation) {
+  let currentStats;
+  try {
+    currentStats = await fs.lstat(observation.filePath);
+  } catch (error) {
+    if (error?.code === "ENOENT") return false;
+    throw error;
+  }
+  if (!currentStats.isFile() || currentStats.isSymbolicLink()) {
+    throw new Error("retained poll observation changed before cleanup");
+  }
+  assertPrivateMode(currentStats, 0o600, "state file");
+  if (!sameFileIdentity(currentStats, observation.stats)) {
+    throw new Error("retained poll observation identity changed before cleanup");
+  }
+  try {
+    await fs.unlink(observation.filePath);
+    return true;
+  } catch (error) {
+    if (error?.code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+async function prunePollObservations(operationPath, binding, retainedLimit) {
+  if (!Number.isSafeInteger(retainedLimit) || retainedLimit < 2 || retainedLimit > MAX_RETAINED_POLL_OBSERVATIONS) {
+    throw new Error("invalid poll observation retention limit");
+  }
+  const { observationsPath, retained } = await readRetainedPollObservations(operationPath, binding);
+  if (retained.length <= retainedLimit) return;
+  const keep = new Set([retained[0].filePath]);
+  for (const observation of retained.slice(-(retainedLimit - 1))) keep.add(observation.filePath);
+  let deleted = false;
+  try {
+    for (const observation of retained) {
+      if (keep.has(observation.filePath)) continue;
+      deleted = await unlinkRetainedPollObservation(observation) || deleted;
+    }
+  } finally {
+    if (deleted) await syncDirectory(observationsPath);
+  }
 }
 
 export async function pollAndRecordLuminSignV1Status(input, options = {}) {
@@ -1059,6 +1200,20 @@ export async function pollAndRecordLuminSignV1Status(input, options = {}) {
     const transportReceipt = validateTransportReceipt(loaded.outcome.transport_receipt, loaded.claim);
     const signatureRequestId = transportReceipt.response.signature_request_id;
     failureClass = "retryable";
+    const observationBinding = {
+      authority_sha256: loaded.claim.authority_sha256,
+      claim_sha256: loaded.claim.claim_sha256,
+      outcome_sha256: loaded.outcome.outcome_sha256,
+      signature_request_id: signatureRequestId,
+    };
+    // Compact before contacting the provider so invalid retained state cannot
+    // cause another network read or continue growing. Do not reserve a slot:
+    // failed or duplicate reads must not evict useful retained history.
+    await prunePollObservations(
+      loaded.operationPath,
+      observationBinding,
+      MAX_RETAINED_POLL_OBSERVATIONS,
+    );
     controller = new AbortController();
     timer = setTimeout(() => controller.abort(), timeoutMs);
     const response = await validatedOptions.fetchImpl(
@@ -1102,6 +1257,11 @@ export async function pollAndRecordLuminSignV1Status(input, options = {}) {
       observation_sha256: lifecycleDigest("pdf-tools.lumin-sign-v1-status-observation.v1", unsigned),
     }));
     await writeObservation(loaded.operationPath, "poll", observation);
+    await prunePollObservations(
+      loaded.operationPath,
+      observationBinding,
+      MAX_RETAINED_POLL_OBSERVATIONS,
+    );
     return observation;
   } catch {
     if (failureClass === "input") {

--- a/test/lumin-sign-v1-transport.test.js
+++ b/test/lumin-sign-v1-transport.test.js
@@ -204,6 +204,18 @@ function successResponse(overrides = {}) {
   });
 }
 
+function statusResponse(status = "APPROVED") {
+  return new Response(JSON.stringify({
+    signature_request: {
+      signature_request_id: "sigreq.synthetic-123",
+      status,
+    },
+  }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
 function durableClaimAcknowledgement(requestIdentity, startedAt = new Date(NOW_MS).toISOString()) {
   const claimUnsigned = {
     schema_version: 1,
@@ -1126,6 +1138,268 @@ describe("durable Lumin Sign v1 operation lifecycle", () => {
       expect(operationBytes).not.toContain(ACCESS_TOKEN);
       expect(operationBytes).not.toContain("private@example.com");
       expect(operationBytes).not.toContain("Private title");
+    });
+  });
+
+  it("retains the audit origin and newest 63 polls without removing artifact observations", async () => {
+    await withLifecycleState(async ({ stateRoot }) => {
+      const { authoritySha256: authorityDigest } = await createDurableOperation(stateRoot);
+      const artifact = await requestAndRecordLuminSignV1ArtifactAccess({
+        access_token: ACCESS_TOKEN,
+        authority_sha256: authorityDigest,
+        file_type: "merged",
+        state_root: stateRoot,
+      }, {
+        nowMs: NOW_MS + 500,
+        fetchImpl: async () => new Response(JSON.stringify({
+          signed_url: "https://files.luminpdf.com/download/synthetic.pdf?token=private",
+          expires_at: Math.floor((NOW_MS + 500) / 1000) + 1_800,
+        }), { status: 200, headers: { "content-type": "application/json" } }),
+      });
+      const observations = [];
+      for (let index = 0; index < 70; index += 1) {
+        observations.push(await pollAndRecordLuminSignV1Status({
+          access_token: ACCESS_TOKEN,
+          authority_sha256: authorityDigest,
+          state_root: stateRoot,
+        }, {
+          nowMs: NOW_MS + 1_000 + index,
+          fetchImpl: async () => statusResponse(index % 2 === 0 ? "APPROVED" : "WAITING_FOR_OTHERS"),
+        }));
+      }
+      const observationsPath = path.join(
+        stateRoot,
+        "lumin-sign-v1-operations",
+        authorityDigest,
+        "observations",
+      );
+      const retainedNames = await fs.readdir(observationsPath);
+      const retainedPollNames = retainedNames.filter(name => name.startsWith("poll-")).sort();
+      const expectedPollNames = [observations[0], ...observations.slice(-63)]
+        .map(observation => `poll-${observation.observation_sha256}.v1.json`)
+        .sort();
+      expect(retainedPollNames).toEqual(expectedPollNames);
+      expect(retainedNames).toContain(
+        `artifact-merged-${artifact.observation.observation_sha256}.v1.json`,
+      );
+    });
+  });
+
+  it("concurrent polling converges on the same bounded history", async () => {
+    await withLifecycleState(async ({ stateRoot }) => {
+      const { authoritySha256: authorityDigest } = await createDurableOperation(stateRoot);
+      const observations = await Promise.all(Array.from({ length: 70 }, async (_value, index) => (
+        pollAndRecordLuminSignV1Status({
+          access_token: ACCESS_TOKEN,
+          authority_sha256: authorityDigest,
+          state_root: stateRoot,
+        }, {
+          nowMs: NOW_MS + 10_000 + index,
+          fetchImpl: async () => statusResponse(index % 2 === 0 ? "APPROVED" : "WAITING_FOR_OTHERS"),
+        })
+      )));
+      const retainedNames = (await fs.readdir(path.join(
+        stateRoot,
+        "lumin-sign-v1-operations",
+        authorityDigest,
+        "observations",
+      ))).filter(name => name.startsWith("poll-")).sort();
+      const expectedNames = [observations[0], ...observations.slice(-63)]
+        .map(observation => `poll-${observation.observation_sha256}.v1.json`)
+        .sort();
+      expect(retainedNames).toEqual(expectedNames);
+    });
+  });
+
+  it("keeps a full history intact when a provider read fails", async () => {
+    await withLifecycleState(async ({ stateRoot }) => {
+      const { authoritySha256: authorityDigest } = await createDurableOperation(stateRoot);
+      const request = {
+        access_token: ACCESS_TOKEN,
+        authority_sha256: authorityDigest,
+        state_root: stateRoot,
+      };
+      for (let index = 0; index < 64; index += 1) {
+        await pollAndRecordLuminSignV1Status(request, {
+          nowMs: NOW_MS + 1_000 + index,
+          fetchImpl: async () => statusResponse(),
+        });
+      }
+      const observationsPath = path.join(stateRoot, "lumin-sign-v1-operations", authorityDigest, "observations");
+      const namesBefore = (await fs.readdir(observationsPath)).sort();
+      expect(namesBefore).toHaveLength(64);
+      await expect(pollAndRecordLuminSignV1Status(request, {
+        nowMs: NOW_MS + 2_000,
+        fetchImpl: async () => { throw new Error("synthetic outage"); },
+      })).rejects.toMatchObject({ code: "LUMIN_STATUS_OBSERVATION_RETRYABLE" });
+      expect((await fs.readdir(observationsPath)).sort()).toEqual(namesBefore);
+      // Repeating the same exact observation also needs no new history slot.
+      await pollAndRecordLuminSignV1Status(request, {
+        nowMs: NOW_MS + 1_063,
+        fetchImpl: async () => statusResponse(),
+      });
+      expect((await fs.readdir(observationsPath)).sort()).toEqual(namesBefore);
+    });
+  });
+
+  it("allows an older published poll to finish after concurrent checks prune its receipt", async () => {
+    await withLifecycleState(async ({ stateRoot }) => {
+      const { authoritySha256: authorityDigest } = await createDurableOperation(stateRoot);
+      const request = {
+        access_token: ACCESS_TOKEN,
+        authority_sha256: authorityDigest,
+        state_root: stateRoot,
+      };
+      const origin = await pollAndRecordLuminSignV1Status(request, {
+        nowMs: NOW_MS + 1_000,
+        fetchImpl: async () => statusResponse(),
+      });
+      const realLink = fs.link.bind(fs);
+      let releasePublication;
+      let markPublished;
+      const published = new Promise(resolve => { markPublished = resolve; });
+      const resume = new Promise(resolve => { releasePublication = resolve; });
+      let pausedPath;
+      const linkSpy = vi.spyOn(fs, "link").mockImplementation(async (source, destination) => {
+        await realLink(source, destination);
+        if (!pausedPath && path.basename(destination).startsWith("poll-")) {
+          pausedPath = destination;
+          markPublished();
+          await resume;
+        }
+      });
+      const delayed = pollAndRecordLuminSignV1Status(request, {
+        nowMs: NOW_MS + 2_000,
+        fetchImpl: async () => statusResponse("WAITING_FOR_OTHERS"),
+      });
+      // Attach a handler immediately so cleanup also settles a failing run.
+      const settled = delayed.then(value => ({ value }), error => ({ error }));
+      try {
+        await published;
+        for (let index = 0; index < 64; index += 1) {
+          await pollAndRecordLuminSignV1Status(request, {
+            nowMs: NOW_MS + 3_000 + index,
+            fetchImpl: async () => statusResponse(),
+          });
+        }
+        await expect(fs.lstat(pausedPath)).rejects.toMatchObject({ code: "ENOENT" });
+        releasePublication();
+        expect(await settled).toMatchObject({ value: { status: "WAITING_FOR_OTHERS" } });
+        const names = await fs.readdir(path.dirname(pausedPath));
+        expect(names).toHaveLength(64);
+        expect(names).toContain(`poll-${origin.observation_sha256}.v1.json`);
+      } finally {
+        releasePublication();
+        await settled;
+        linkSpy.mockRestore();
+      }
+    });
+  });
+
+  it("allows a duplicate poll to finish when cleanup wins its collision readback", async () => {
+    await withLifecycleState(async ({ stateRoot }) => {
+      const { authoritySha256: authorityDigest } = await createDurableOperation(stateRoot);
+      const request = { access_token: ACCESS_TOKEN, authority_sha256: authorityDigest, state_root: stateRoot };
+      const observations = [];
+      for (let index = 0; index < 64; index += 1) {
+        observations.push(await pollAndRecordLuminSignV1Status(request, {
+          nowMs: NOW_MS + 1_000 + index,
+          fetchImpl: async () => statusResponse(),
+        }));
+      }
+      const duplicatePath = path.join(stateRoot, "lumin-sign-v1-operations", authorityDigest,
+        "observations", `poll-${observations[1].observation_sha256}.v1.json`);
+      const realLink = fs.link.bind(fs);
+      let markCollision;
+      let releaseCollision;
+      const collided = new Promise(resolve => { markCollision = resolve; });
+      const resume = new Promise(resolve => { releaseCollision = resolve; });
+      const linkSpy = vi.spyOn(fs, "link").mockImplementation(async (source, destination) => {
+        try {
+          await realLink(source, destination);
+        } catch (error) {
+          if (destination === duplicatePath && error.code === "EEXIST") {
+            markCollision();
+            await resume;
+          }
+          throw error;
+        }
+      });
+      const settled = pollAndRecordLuminSignV1Status(request, {
+        nowMs: NOW_MS + 1_001,
+        fetchImpl: async () => statusResponse(),
+      }).then(value => ({ value }), error => ({ error }));
+      try {
+        await collided;
+        await pollAndRecordLuminSignV1Status(request, {
+          nowMs: NOW_MS + 2_000,
+          fetchImpl: async () => statusResponse(),
+        });
+        await expect(fs.lstat(duplicatePath)).rejects.toMatchObject({ code: "ENOENT" });
+        releaseCollision();
+        expect(await settled).toMatchObject({ value: observations[1] });
+        expect(await fs.readdir(path.dirname(duplicatePath))).toHaveLength(64);
+      } finally {
+        releaseCollision();
+        await settled;
+        linkSpy.mockRestore();
+      }
+    });
+  });
+
+  it.each(["invalid content", "invalid name", "unsafe mode", "symlink"])(
+    "rejects retained poll history with %s before another provider read", async kind => {
+    await withLifecycleState(async ({ stateRoot }) => {
+      const { authoritySha256: authorityDigest } = await createDurableOperation(stateRoot);
+      const original = await pollAndRecordLuminSignV1Status({
+        access_token: ACCESS_TOKEN,
+        authority_sha256: authorityDigest,
+        state_root: stateRoot,
+      }, {
+        nowMs: NOW_MS + 1_000,
+        fetchImpl: async () => statusResponse(),
+      });
+      const observationsPath = path.join(
+        stateRoot,
+        "lumin-sign-v1-operations",
+        authorityDigest,
+        "observations",
+      );
+      const corruptPath = path.join(observationsPath,
+        kind === "invalid name" ? "poll-invalid.json" : `poll-${"a".repeat(64)}.v1.json`);
+      if (kind === "symlink") {
+        await fs.symlink(path.join(observationsPath, `poll-${original.observation_sha256}.v1.json`), corruptPath);
+      } else {
+        await fs.writeFile(corruptPath, "{}\n", { mode: 0o600 });
+        if (kind === "unsafe mode") await fs.chmod(corruptPath, 0o644);
+      }
+      const namesBefore = (await fs.readdir(observationsPath)).sort();
+      let calls = 0;
+      await expect(pollAndRecordLuminSignV1Status({
+        access_token: ACCESS_TOKEN,
+        authority_sha256: authorityDigest,
+        state_root: stateRoot,
+      }, {
+        nowMs: NOW_MS + 2_000,
+        fetchImpl: async () => {
+          calls += 1;
+          return statusResponse();
+        },
+      })).rejects.toMatchObject({
+        code: "LUMIN_STATUS_OBSERVATION_RETRYABLE",
+        reconciliation_class: "retryable_read_failure",
+        read_retry_safe: true,
+        create_retry_allowed: false,
+      });
+      expect(calls).toBe(0);
+      expect((await fs.readdir(observationsPath)).sort()).toEqual(namesBefore);
+      await expect(inspectLuminSignV1Operation({
+        state_root: stateRoot,
+        authority_sha256: authorityDigest,
+      })).resolves.toMatchObject({
+        operation_status: "request_created",
+        create_retry_allowed: false,
+      });
     });
   });
 

--- a/test/test-runner-contract.test.js
+++ b/test/test-runner-contract.test.js
@@ -605,6 +605,7 @@ describe("aggregate test-runner contract", () => {
       "test/eval/extraction-phase1-publisher.test.js",
       "test/eval/extraction-phase1-scorer.test.js",
       "test/fuzz-malformed-pdfs.test.js",
+      "test/lumin-sign-v1-transport.test.js",
       "test/mcp-contract.test.js",
       "test/pdfjs-worker-contract.test.js",
       "test/read-pdf-layout.test.js",


### PR DESCRIPTION
## Outcome

Bound the local history written by repeated Lumin status checks. Keep the earliest timestamped poll observation and newest 63, using digest ordering for ties. Completed cleanup leaves at most 64 poll observations; concurrent publication can temporarily exceed that limit. Artifact and webhook observations are not pruned.

The cleanup validates physical files and record bindings before removal, tolerates only a concurrently pruned poll disappearing, and preserves strict handling for claims, outcomes and other observations. Source and packaged-share implementations are byte-identical. This is not a tamper-proof audit-log claim.

## Verification

- Independent exact-head source review: GO at `ba2aedc30a8e3aa7901d235a63c218c52c2c50c4`.
- Mac arm64, Node 22.23.2: six focused files passed 180/180, with one test worker.
- New tests cover full histories, tie ordering, concurrent pruning, failed provider reads, duplicate publication, malformed retained records and unrelated observation retention.
- Mac full `npm run test:all`: 2,978 passed, one failed, 99 skipped. All changed Lumin tests passed. The sole failure was an untouched extraction-workspace concurrent-creator test expecting `EEXIST` but receiving `workspace root changed during inspection`. The workspace source and test are byte-identical to the prerequisite. Two subsequent exact-head whole-file runs passed 35/35 each. Independent review classified the source-supported race as pre-existing; it is separately tracked, not fixed or hidden here.
- Exact-head native partition: 62 passed, nine intentional skips, zero failed.
- Mac share contract and packed MCPB smoke passed: 57 tools, 14 prompts, native rendering and verified extraction. Two clean MCPB builds were byte-identical, SHA-256 `9941d17eed9b353207008a8dbee69bef471a3b64ac5466a24b5c61d46a506cd6`.
- GitHub run `33982164279` passed on both Node 20.19 and Node 22.12, including test suites, share contract, MCPB build and packed smoke. The orchestrator accepts the explicitly qualified unrelated local aggregate exception for integration. This is not a fully green Mac aggregate or release qualification.

The first full local run ended in SIGKILL without a final aggregate; its cause was not established. An unchanged rerun exposed four new full-history tests exceeding their existing 5-second timeout when run alongside other resource-heavy files. The final commit moves this file to the existing exclusive serial-resource partition and updates the exact test-runner contract. No assertion, timeout, test body, runtime behavior, or test inventory was weakened or removed. The corrected full run passed those history tests; its separate workspace failure is reported above.

## Scope

Builds on the merged OAuth/artifact-response fixes in #190. No live provider request, invitation, signature, artifact download, release, or public capability claim is part of this change.
