### PR TITLE
Fix concurrent PDF save and workspace initialization races

### DIFF
--- a/pdf-toolkit-mcp-share/scripts/verified-extraction-workspace.mjs
+++ b/pdf-toolkit-mcp-share/scripts/verified-extraction-workspace.mjs
@@ -260,28 +260,51 @@ function sameFileIdentity(left, right) {
   return sameWorkspaceFileIdentityForPlatform(left, right);
 }
 
-async function assertPrivateDirectory(directory, label) {
+export function sameWorkspaceDirectoryIdentityForPlatform(left, right,
+  platform = process.platform) {
+  const deviceMatches = left.dev === right.dev || (
+    platform === "win32" && (zeroDevice(left.dev) !== zeroDevice(right.dev))
+  );
+  // A shared root's entries may change while another creator publishes its
+  // claim. Size, link count and modification/change times describe that mutable
+  // inventory, not replacement of the directory. Keep object identity, owner,
+  // permissions and birth time exact. Retained files still use the full guard.
+  return deviceMatches && left.ino === right.ino && left.mode === right.mode
+    && left.uid === right.uid && left.gid === right.gid
+    && left.birthtimeNs === right.birthtimeNs;
+}
+
+async function assertPrivateDirectory(directory, label, {
+  concurrentEntries = false,
+  faultInjector = null,
+} = {}) {
   const resolved = resolvedAbsolute(directory, label);
   const before = await lstat(resolved, { bigint: true });
   assertion(before.isDirectory() && !before.isSymbolicLink(), `${label} is not a physical directory`);
   assertion(workspacePrivateModeMatchesForPlatform(before, 0o700),
     `${label} mode must be 0700`);
+  if (label === "workspace root") {
+    await inject(faultInjector, "after_workspace_root_lstat", { directory: resolved });
+  }
   assertion(await realpath(resolved) === resolved, `${label} uses a symlinked or aliased path`);
   const after = await lstat(resolved, { bigint: true });
-  assertion(sameFileIdentity(before, after), `${label} changed during inspection`);
+  assertion(after.isDirectory() && !after.isSymbolicLink(), `${label} is not a physical directory`);
+  assertion(concurrentEntries
+    ? sameWorkspaceDirectoryIdentityForPlatform(before, after)
+    : sameFileIdentity(before, after), `${label} changed during inspection`);
   return before;
 }
 
-async function ensurePrivateRoot(rootPath) {
+async function ensurePrivateRoot(rootPath, faultInjector = null) {
   const resolved = resolvedAbsolute(rootPath, "workspace root");
   try {
     await access(resolved, constants.F_OK);
   } catch {
     const parent = path.dirname(resolved);
-    await assertPrivateDirectory(parent, "workspace root parent");
+    await assertPrivateDirectory(parent, "workspace root parent", { concurrentEntries: true });
     await mkdir(resolved, { mode: 0o700 });
   }
-  await assertPrivateDirectory(resolved, "workspace root");
+  await assertPrivateDirectory(resolved, "workspace root", { concurrentEntries: true, faultInjector });
   return resolved;
 }
 
@@ -1326,7 +1349,7 @@ export async function createExtractionWorkspace({
   transactionId = null,
   faultInjector = null,
 }) {
-  const root = await ensurePrivateRoot(rootPath);
+  const root = await ensurePrivateRoot(rootPath, faultInjector);
   workspaceDirectoryName(workspaceId);
   const policy = normalizePolicy(workspacePolicy);
   const leaves = normalizeLeaves(leafObligations, policy);

--- a/pdf-toolkit-mcp-share/server/index.js
+++ b/pdf-toolkit-mcp-share/server/index.js
@@ -2643,6 +2643,11 @@ async function buildSigningPreparationReceipt({
   };
 }
 
+// The errno shapes a path can take while another writer replaces the file
+// under it. Mirrors PATH_RACE_ERROR_CODES in bounded-pdf-file.js, which maps
+// the same set to PDF_CHANGED_DURING_READ on the read side.
+const PDF_INPUT_PATH_RACE_CODES = new Set(["ELOOP", "ENOENT", "ENOTDIR", "ESTALE"]);
+
 function backupIdentityError(code, message, cause) {
   const error = new Error(`${code}: ${message}`);
   error.code = code;
@@ -3184,9 +3189,33 @@ async function persistPdfMutation({
   initialPage = 1,
   extraPayload = {},
 }) {
-  const resolvedInputPath = resolvePath(inputPath);
+  // The input was read, bound and revalidated before this function is
+  // reached, so a path that no longer resolves here is a document that changed
+  // under this mutation, not a missing file. The ordering that produces it is
+  // a second writer between the two steps of its activation: writePdfOutputAtomic
+  // moves the existing output to its rollback name and then links the staged
+  // bytes in under a no-clobber link, and the document path does not exist in
+  // between. A loser whose commit begins inside that window used to surface the
+  // raw ENOENT from realpath, which is a third answer to the race the
+  // revalidateSources and commit-time identity detectors already report as
+  // CONCURRENT_MODIFICATION. Report it in the same shape, and keep the errno
+  // as the cause so the boundary suites can still say which check fired.
+  let resolvedInputPath;
+  let inputCanonical;
+  try {
+    resolvedInputPath = resolvePath(inputPath);
+    inputCanonical = await fs.realpath(resolvedInputPath);
+  } catch (error) {
+    if (PDF_INPUT_PATH_RACE_CODES.has(error?.code)) {
+      throw backupIdentityError(
+        "CONCURRENT_MODIFICATION",
+        "The PDF changed after this mutation loaded its input. Reload the current document and retry.",
+        error,
+      );
+    }
+    throw error;
+  }
   const resolvedOutputPath = resolvePath(outputPath);
-  const inputCanonical = await fs.realpath(resolvedInputPath);
   let outputCanonical = null;
   try { outputCanonical = await fs.realpath(resolvedOutputPath); } catch {}
   const sameDocument = inputCanonical === outputCanonical;

--- a/scripts/verified-extraction-workspace.mjs
+++ b/scripts/verified-extraction-workspace.mjs
@@ -260,28 +260,51 @@ function sameFileIdentity(left, right) {
   return sameWorkspaceFileIdentityForPlatform(left, right);
 }
 
-async function assertPrivateDirectory(directory, label) {
+export function sameWorkspaceDirectoryIdentityForPlatform(left, right,
+  platform = process.platform) {
+  const deviceMatches = left.dev === right.dev || (
+    platform === "win32" && (zeroDevice(left.dev) !== zeroDevice(right.dev))
+  );
+  // A shared root's entries may change while another creator publishes its
+  // claim. Size, link count and modification/change times describe that mutable
+  // inventory, not replacement of the directory. Keep object identity, owner,
+  // permissions and birth time exact. Retained files still use the full guard.
+  return deviceMatches && left.ino === right.ino && left.mode === right.mode
+    && left.uid === right.uid && left.gid === right.gid
+    && left.birthtimeNs === right.birthtimeNs;
+}
+
+async function assertPrivateDirectory(directory, label, {
+  concurrentEntries = false,
+  faultInjector = null,
+} = {}) {
   const resolved = resolvedAbsolute(directory, label);
   const before = await lstat(resolved, { bigint: true });
   assertion(before.isDirectory() && !before.isSymbolicLink(), `${label} is not a physical directory`);
   assertion(workspacePrivateModeMatchesForPlatform(before, 0o700),
     `${label} mode must be 0700`);
+  if (label === "workspace root") {
+    await inject(faultInjector, "after_workspace_root_lstat", { directory: resolved });
+  }
   assertion(await realpath(resolved) === resolved, `${label} uses a symlinked or aliased path`);
   const after = await lstat(resolved, { bigint: true });
-  assertion(sameFileIdentity(before, after), `${label} changed during inspection`);
+  assertion(after.isDirectory() && !after.isSymbolicLink(), `${label} is not a physical directory`);
+  assertion(concurrentEntries
+    ? sameWorkspaceDirectoryIdentityForPlatform(before, after)
+    : sameFileIdentity(before, after), `${label} changed during inspection`);
   return before;
 }
 
-async function ensurePrivateRoot(rootPath) {
+async function ensurePrivateRoot(rootPath, faultInjector = null) {
   const resolved = resolvedAbsolute(rootPath, "workspace root");
   try {
     await access(resolved, constants.F_OK);
   } catch {
     const parent = path.dirname(resolved);
-    await assertPrivateDirectory(parent, "workspace root parent");
+    await assertPrivateDirectory(parent, "workspace root parent", { concurrentEntries: true });
     await mkdir(resolved, { mode: 0o700 });
   }
-  await assertPrivateDirectory(resolved, "workspace root");
+  await assertPrivateDirectory(resolved, "workspace root", { concurrentEntries: true, faultInjector });
   return resolved;
 }
 
@@ -1326,7 +1349,7 @@ export async function createExtractionWorkspace({
   transactionId = null,
   faultInjector = null,
 }) {
-  const root = await ensurePrivateRoot(rootPath);
+  const root = await ensurePrivateRoot(rootPath, faultInjector);
   workspaceDirectoryName(workspaceId);
   const policy = normalizePolicy(workspacePolicy);
   const leaves = normalizeLeaves(leafObligations, policy);

--- a/server/index.js
+++ b/server/index.js
@@ -2643,6 +2643,11 @@ async function buildSigningPreparationReceipt({
   };
 }
 
+// The errno shapes a path can take while another writer replaces the file
+// under it. Mirrors PATH_RACE_ERROR_CODES in bounded-pdf-file.js, which maps
+// the same set to PDF_CHANGED_DURING_READ on the read side.
+const PDF_INPUT_PATH_RACE_CODES = new Set(["ELOOP", "ENOENT", "ENOTDIR", "ESTALE"]);
+
 function backupIdentityError(code, message, cause) {
   const error = new Error(`${code}: ${message}`);
   error.code = code;
@@ -3184,9 +3189,33 @@ async function persistPdfMutation({
   initialPage = 1,
   extraPayload = {},
 }) {
-  const resolvedInputPath = resolvePath(inputPath);
+  // The input was read, bound and revalidated before this function is
+  // reached, so a path that no longer resolves here is a document that changed
+  // under this mutation, not a missing file. The ordering that produces it is
+  // a second writer between the two steps of its activation: writePdfOutputAtomic
+  // moves the existing output to its rollback name and then links the staged
+  // bytes in under a no-clobber link, and the document path does not exist in
+  // between. A loser whose commit begins inside that window used to surface the
+  // raw ENOENT from realpath, which is a third answer to the race the
+  // revalidateSources and commit-time identity detectors already report as
+  // CONCURRENT_MODIFICATION. Report it in the same shape, and keep the errno
+  // as the cause so the boundary suites can still say which check fired.
+  let resolvedInputPath;
+  let inputCanonical;
+  try {
+    resolvedInputPath = resolvePath(inputPath);
+    inputCanonical = await fs.realpath(resolvedInputPath);
+  } catch (error) {
+    if (PDF_INPUT_PATH_RACE_CODES.has(error?.code)) {
+      throw backupIdentityError(
+        "CONCURRENT_MODIFICATION",
+        "The PDF changed after this mutation loaded its input. Reload the current document and retry.",
+        error,
+      );
+    }
+    throw error;
+  }
   const resolvedOutputPath = resolvePath(outputPath);
-  const inputCanonical = await fs.realpath(resolvedInputPath);
   let outputCanonical = null;
   try { outputCanonical = await fs.realpath(resolvedOutputPath); } catch {}
   const sameDocument = inputCanonical === outputCanonical;

--- a/test/save-lifecycle.test.js
+++ b/test/save-lifecycle.test.js
@@ -20,11 +20,11 @@ let PROFILE_DIR;
 let client;
 let transport;
 
-async function connectClient(name = "pdf-tools-save-lifecycle-test-client") {
+async function connectClient(name = "pdf-tools-save-lifecycle-test-client", nodeArguments = []) {
   client = new Client({ name, version: "1.0.0" });
   transport = new StdioClientTransport({
     command: process.execPath,
-    args: [path.join(REPO_ROOT, "server", "index.js")],
+    args: [...nodeArguments, path.join(REPO_ROOT, "server", "index.js")],
     cwd: REPO_ROOT,
     env: {
       ALLOWED_DIRECTORIES: TMP_DIR,
@@ -35,11 +35,11 @@ async function connectClient(name = "pdf-tools-save-lifecycle-test-client") {
   await client.connect(transport);
 }
 
-async function restartServer(name) {
+async function restartServer(name, nodeArguments = []) {
   await transport.close();
   client = undefined;
   transport = undefined;
-  await connectClient(name);
+  await connectClient(name, nodeArguments);
 }
 
 async function sha256(filePath) {
@@ -815,6 +815,56 @@ describe("canonical save lifecycle", () => {
     expect(result.content?.[0]?.text).toContain("CONCURRENT_MODIFICATION");
     await expect(fs.stat(lockPath)).resolves.toBeTruthy();
     await fs.unlink(lockPath);
+  }, 30_000);
+
+  it.each([
+    ["ENOENT", "CONCURRENT_MODIFICATION"],
+    ["ELOOP", "CONCURRENT_MODIFICATION"],
+    ["ENOTDIR", "CONCURRENT_MODIFICATION"],
+    ["ESTALE", "CONCURRENT_MODIFICATION"],
+    ["EACCES", "injected-input-EACCES"],
+    ["path_policy_denied", "injected-input-path_policy_denied"],
+  ])("preserves the exact input-canonicalization refusal for %s", async (code, expected) => {
+    const pdfPath = path.join(TMP_DIR, "w9-working.pdf");
+    const originalHash = await sha256(pdfPath);
+    const backupState = await snapshotBackupState();
+    const markerPath = path.join(TMP_DIR, "input-fault-observed.json");
+    const preloadPath = path.join(TMP_DIR, "input-path-fault.mjs");
+    // Patch only the child process, after its isolated mutation has returned.
+    // Earlier source reads and policy checks retain their real implementation.
+    await fs.writeFile(preloadPath, `
+import fs from "node:fs/promises";
+const realpath = fs.realpath;
+fs.realpath = async function (filename, ...args) {
+  if (filename === ${JSON.stringify(pdfPath)}
+      && new Error().stack.includes("persistPdfMutation")) {
+    await fs.writeFile(${JSON.stringify(markerPath)}, JSON.stringify({ code: ${JSON.stringify(code)} }),
+      { flag: "wx", mode: 0o600 });
+    throw Object.assign(new Error(${JSON.stringify(`injected-input-${code}`)}),
+      { code: ${JSON.stringify(code)} });
+  }
+  return realpath.call(this, filename, ...args);
+};
+`, { flag: "wx", mode: 0o600 });
+    await restartServer("pdf-tools-input-canonicalization-fault", ["--import", preloadPath]);
+    const result = await client.callTool({
+      name: "fill_pdf",
+      arguments: {
+        pdf_path: pdfPath,
+        output_path: pdfPath,
+        force_xfa: true,
+        field_data: { [NAME_FIELD]: "Must not commit after input failure" },
+      },
+    });
+    expect(JSON.parse(await fs.readFile(markerPath, "utf8"))).toEqual({ code });
+    expect(result.isError).toBe(true);
+    expect(result.content?.[0]?.text).toContain(expected);
+    if (expected !== "CONCURRENT_MODIFICATION") {
+      expect(result.content?.[0]?.text).not.toContain("CONCURRENT_MODIFICATION");
+    }
+    expect(await sha256(pdfPath)).toBe(originalHash);
+    expect(await snapshotBackupState()).toEqual(backupState);
+    expect((await fs.readdir(TMP_DIR)).filter(name => name.startsWith(".pdf-tools-"))).toEqual([]);
   }, 30_000);
 
   /**

--- a/test/verified-extraction-workspace.test.js
+++ b/test/verified-extraction-workspace.test.js
@@ -19,6 +19,7 @@ import {
   inspectExtractionWorkspace,
   readExtractionWorkspacePage,
   recoverExtractionWorkspace,
+  sameWorkspaceDirectoryIdentityForPlatform,
   sameWorkspaceFileIdentityForPlatform,
   workspaceDirectoryFsyncSupportedForPlatform,
   workspacePrivateModeMatchesForPlatform,
@@ -56,11 +57,34 @@ function portableWorkspaceStat(overrides = {}) {
     mtimeNs: 123456789n,
     ctimeNs: 123456780n,
     birthtimeNs: 123456700n,
+    uid: 501n,
+    gid: 20n,
     ...overrides,
   };
 }
 
 describe("verified extraction platform filesystem contracts", () => {
+  it("separates mutable directory entries from the retained-file identity guard", () => {
+    const before = portableWorkspaceStat({ mode: 0o40700n });
+    const after = { ...before, size: 4096n, nlink: 4n, mtimeNs: 999n, ctimeNs: 1000n };
+    for (const platform of ["darwin", "linux", "win32"]) {
+      expect(sameWorkspaceDirectoryIdentityForPlatform(before, after, platform)).toBe(true);
+      expect(sameWorkspaceFileIdentityForPlatform(before, after, platform)).toBe(false);
+      for (const drift of [
+        { dev: 42n }, { ino: 9002n }, { mode: 0o40755n },
+        { uid: 502n }, { gid: 21n }, { birthtimeNs: 123456701n },
+      ]) {
+        expect(sameWorkspaceDirectoryIdentityForPlatform(before, { ...after, ...drift }, platform))
+          .toBe(false);
+      }
+    }
+    expect(sameWorkspaceDirectoryIdentityForPlatform(
+      { ...before, dev: 0n }, { ...after, dev: 2660852064n }, "win32",
+    )).toBe(true);
+    expect(sameWorkspaceDirectoryIdentityForPlatform(
+      { ...before, dev: 0n }, { ...after, dev: 2660852064n, birthtimeNs: 1n }, "win32",
+    )).toBe(false);
+  });
   it("uses NTFS physical identity facts when POSIX device and mode bits are unavailable", () => {
     expect(workspaceDirectoryFsyncSupportedForPlatform("win32")).toBe(false);
     expect(workspaceDirectoryFsyncSupportedForPlatform("darwin")).toBe(true);
@@ -906,6 +930,71 @@ describe("transactional verified extraction workspace", () => {
       expectedWorkspaceIdentitySha256: pointer.workspace_identity_sha256,
     })).resolves.toMatchObject({ state: "complete" });
   });
+
+  it("retains a recoverable loser when another creator publishes during root inspection", async () => {
+    await fs.mkdir(rootPath, { mode: 0o700 });
+    let releaseInspection;
+    const inspectionBarrier = new Promise(resolve => { releaseInspection = resolve; });
+    let enteredInspection;
+    const entered = new Promise(resolve => { enteredInspection = resolve; });
+    const loserTransactionId = "a".repeat(32);
+    const workspaceId = "root-inspection-race";
+    const loser = create({
+      workspaceId,
+      transactionId: loserTransactionId,
+      faultInjector: async phase => {
+        if (phase === "after_workspace_root_lstat") {
+          enteredInspection();
+          await inspectionBarrier;
+        }
+      },
+    }).then(value => ({ value }), error => ({ error }));
+    await entered;
+    let winner;
+    try {
+      winner = await create({ workspaceId, transactionId: "b".repeat(32) });
+    } finally {
+      releaseInspection();
+    }
+    expect((await loser).error).toMatchObject({ code: "EEXIST" });
+    const { pointer } = await workspaceFromRoot(rootPath);
+    const initializations = (await fs.readdir(rootPath)).filter(name => name.startsWith(".initializing-"));
+    expect(initializations).toHaveLength(2);
+    const loserDirectory = initializations.find(name => name !== pointer.workspace_directory_name);
+    const authority = await initializationAbandonmentAuthority(rootPath, workspaceId, loserTransactionId);
+    await expect(abandonExtractionWorkspaceInitialization({
+      rootPath,
+      workspaceId,
+      transactionId: loserTransactionId,
+      initializationDirectoryName: loserDirectory,
+      ...authority,
+      expectedCurrentWorkspaceIdentitySha256: winner.workspace_identity_sha256,
+    })).resolves.toMatchObject({ state: "abandoned_initialization" });
+    expect((await inspectExtractionWorkspace({ rootPath, workspaceId })).state).toBe("complete");
+  });
+
+  it.each(["replacement", "symlink", "file", ...(process.platform === "win32" ? [] : ["mode"])])(
+    "rejects %s of the shared root during inspection without publishing a claim",
+    async kind => {
+      await fs.mkdir(rootPath, { mode: 0o700 });
+      const originalPath = path.join(parentPath, "original-root");
+      await expect(create({
+        faultInjector: async phase => {
+          if (phase !== "after_workspace_root_lstat") return;
+          if (kind === "mode") {
+            await fs.chmod(rootPath, 0o755);
+            return;
+          }
+          await fs.rename(rootPath, originalPath);
+          if (kind === "replacement") await fs.mkdir(rootPath, { mode: 0o700 });
+          else if (kind === "symlink") await fs.symlink(originalPath, rootPath, "junction");
+          else await fs.writeFile(rootPath, "not a directory", { mode: 0o600, flag: "wx" });
+        },
+      })).rejects.toThrow(/changed during inspection|symlinked or aliased|not a physical directory/u);
+      const physicalRoot = kind === "mode" ? rootPath : originalPath;
+      expect(await fs.readdir(physicalRoot)).toEqual([]);
+    },
+  );
 
   it("binds the pointer to the exact private data directory in the workspace identity", async () => {
     const created = await create();

--- a/test/verified-extraction-workspace.test.js
+++ b/test/verified-extraction-workspace.test.js
@@ -970,7 +970,11 @@ describe("transactional verified extraction workspace", () => {
       ...authority,
       expectedCurrentWorkspaceIdentitySha256: winner.workspace_identity_sha256,
     })).resolves.toMatchObject({ state: "abandoned_initialization" });
-    expect((await inspectExtractionWorkspace({ rootPath, workspaceId })).state).toBe("complete");
+    expect((await inspectExtractionWorkspace({
+      rootPath,
+      workspaceId,
+      expectedWorkspaceIdentitySha256: winner.workspace_identity_sha256,
+    })).state).toBe("complete");
   });
 
   it.each(["replacement", "symlink", "file", ...(process.platform === "win32" ? [] : ["mode"])])(


### PR DESCRIPTION
## Summary

- Classify input-path disappearance races during PDF save as concurrent modification without masking permission or policy errors.
- Keep shared extraction-root identity checks strict about replacement while allowing legitimate concurrent entry creation.
- Add deterministic real-server save fault injection and creator interleaving/replacement regressions.
- Keep source/share copies identical and preserve executable entrypoint modes.

## Verification

- Independent exact-source review GO at 548935b8867c341695ee2dcd5a670b6e635f5d1a.
- macOS arm64, Node 22.23.2: 7 focused/adjoining files, 157/157 tests passed with one worker.
- Full unfiltered Mac aggregate passed at the exact head: 2,991 Vitest tests passed, 99 skipped; 62 native tests passed, 9 skipped. No failures. Source remained clean.
- Final package and installed-host qualification are separate pending gates; no release is claimed.
- Source/share parity and git diff --check pass.

The earlier intermediate checkpoint had a missing share mirror and missing required test inspection identity; both are corrected in this head without weakening the API.

No new Lumin invitation, signing action, release, or customer announcement. Installed desktop-app verification is a separate candidate gate and remains pending.
